### PR TITLE
feat(core): add expert-aware runtime routing

### DIFF
--- a/packages/core/src/agent/agent-launcher.ts
+++ b/packages/core/src/agent/agent-launcher.ts
@@ -6,11 +6,14 @@ import {
 } from "../execution/context-id-resolver.ts";
 import type { ExpertAgentManagedTool, ExpertAgentToolCallResult } from "../tools/managed-tool.ts";
 
+export type RuntimeByExpert = Readonly<Record<string, string>>;
+
 export interface CreateAgentLauncherOptions {
   readonly experts: readonly Expert[];
   readonly maxConcurrency?: number | undefined;
   readonly maxDepth?: number | undefined;
   readonly contextId?: ContextIdResolver | undefined;
+  readonly runtimeByExpert?: RuntimeByExpert | undefined;
 }
 
 export type ExpertLifecycleToolName =
@@ -32,6 +35,7 @@ export interface AgentDelegationDefinition {
   readonly maxConcurrency: number;
   readonly maxDepth: number;
   readonly contextId: ContextIdResolver;
+  readonly runtimeByExpert: ReadonlyMap<string, string>;
 }
 
 const agentDelegationDefinition = Symbol("pragma.agent-delegation-definition");
@@ -52,6 +56,11 @@ export function createAgentLauncher(options: CreateAgentLauncherOptions): AgentL
       maxConcurrency: readPositiveInteger(options.maxConcurrency ?? 4, "maxConcurrency"),
       maxDepth: readPositiveInteger(options.maxDepth ?? 3, "maxDepth"),
       contextId: options.contextId ?? freshContextIdResolver,
+      runtimeByExpert: normalizeRuntimeByExpert(
+        options.runtimeByExpert,
+        experts,
+        "AgentLauncher",
+      ),
     }),
   });
 }
@@ -69,6 +78,9 @@ export function createTeamDelegationTools(
     maxConcurrency: team.delegation.maxConcurrency,
     maxDepth: team.delegation.maxDepth,
     contextId: team.delegation.contextId,
+    runtimeByExpert: new Map(
+      [...team.delegation.runtimeByExpert].filter(([expertId]) => allowed.has(expertId)),
+    ),
   });
 }
 
@@ -92,6 +104,7 @@ function createLifecycleTools(
     maxConcurrency: definition.maxConcurrency,
     maxDepth: definition.maxDepth,
     contextId: definition.contextId,
+    runtimeByExpert: new Map(definition.runtimeByExpert),
   });
   const available = [
     "Available Experts:",
@@ -106,7 +119,7 @@ function createLifecycleTools(
       name: "spawn_expert",
       description: `Spawn an Expert task in the background and return its agent and invocation ids immediately.\n${available}`,
       inputSchema: objectSchema(
-        { expertId: { type: "string" }, prompt: { type: "string" }, runtime: { type: "string" } },
+        { expertId: { type: "string" }, prompt: { type: "string" } },
         ["expertId", "prompt"],
       ),
       call: async (args, signal, context) =>
@@ -197,12 +210,11 @@ function objectSchema(properties: Record<string, unknown>, required: readonly st
   return { type: "object", properties, required, additionalProperties: false };
 }
 
-function readSpawn(value: unknown): { expertId: string; prompt: string; runtime?: string } {
+function readSpawn(value: unknown): { expertId: string; prompt: string } {
   const record = readRecord(value);
   return {
     expertId: readString(record["expertId"], "expertId"),
     prompt: readString(record["prompt"], "prompt"),
-    ...readOptionalString(record, "runtime"),
   };
 }
 
@@ -277,6 +289,25 @@ function readUniqueExperts(experts: readonly Expert[], owner: string): readonly 
   const ids = experts.map((expert) => expert.id);
   if (new Set(ids).size !== ids.length) throw new Error(`${owner} contains duplicate Expert ids.`);
   return Object.freeze([...experts]);
+}
+
+export function normalizeRuntimeByExpert(
+  runtimeByExpert: RuntimeByExpert | undefined,
+  experts: readonly Pick<Expert, "id">[],
+  owner: string,
+): ReadonlyMap<string, string> {
+  const knownExpertIds = new Set(experts.map((expert) => expert.id));
+  const normalized = new Map<string, string>();
+  for (const [expertId, runtimeId] of Object.entries(runtimeByExpert ?? {})) {
+    if (!knownExpertIds.has(expertId)) {
+      throw new Error(`${owner} runtimeByExpert target is unknown: ${expertId}`);
+    }
+    if (runtimeId.trim() === "") {
+      throw new Error(`${owner} runtimeByExpert value must not be empty: ${expertId}`);
+    }
+    normalized.set(expertId, runtimeId);
+  }
+  return normalized;
 }
 
 function readPositiveInteger(value: number, field: string): number {

--- a/packages/core/src/agent/agent-launcher.ts
+++ b/packages/core/src/agent/agent-launcher.ts
@@ -56,11 +56,7 @@ export function createAgentLauncher(options: CreateAgentLauncherOptions): AgentL
       maxConcurrency: readPositiveInteger(options.maxConcurrency ?? 4, "maxConcurrency"),
       maxDepth: readPositiveInteger(options.maxDepth ?? 3, "maxDepth"),
       contextId: options.contextId ?? freshContextIdResolver,
-      runtimeByExpert: normalizeRuntimeByExpert(
-        options.runtimeByExpert,
-        experts,
-        "AgentLauncher",
-      ),
+      runtimeByExpert: normalizeRuntimeByExpert(options.runtimeByExpert, experts, "AgentLauncher"),
     }),
   });
 }
@@ -118,10 +114,10 @@ function createLifecycleTools(
     tool({
       name: "spawn_expert",
       description: `Spawn an Expert task in the background and return its agent and invocation ids immediately.\n${available}`,
-      inputSchema: objectSchema(
-        { expertId: { type: "string" }, prompt: { type: "string" } },
-        ["expertId", "prompt"],
-      ),
+      inputSchema: objectSchema({ expertId: { type: "string" }, prompt: { type: "string" } }, [
+        "expertId",
+        "prompt",
+      ]),
       call: async (args, signal, context) =>
         await invoke("spawn_expert", signal, context?.execution?.spawnExpert, readSpawn(args)),
     }),

--- a/packages/core/src/agent/expert-definition-descriptor.ts
+++ b/packages/core/src/agent/expert-definition-descriptor.ts
@@ -32,6 +32,9 @@ function describeDefinition(definition: ExpertDefinition, ancestors: Set<string>
         maxConcurrency: definition.delegation.maxConcurrency,
         maxDepth: definition.delegation.maxDepth,
         contextId: describeContextIdResolver(definition.delegation.contextId),
+        runtimeByExpert: [...definition.delegation.runtimeByExpert.entries()].sort(
+          ([left], [right]) => left.localeCompare(right),
+        ),
       },
     };
   }
@@ -64,6 +67,9 @@ function describeLauncher(definition: Expert, ancestors: Set<string>): unknown {
     maxConcurrency: launcher.maxConcurrency,
     maxDepth: launcher.maxDepth,
     contextId: describeContextIdResolver(launcher.contextId),
+    runtimeByExpert: [...launcher.runtimeByExpert.entries()].sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
   };
 }
 

--- a/packages/core/src/agent/expert-team.ts
+++ b/packages/core/src/agent/expert-team.ts
@@ -1,8 +1,5 @@
 import type { Expert } from "./expert-agent.ts";
-import {
-  normalizeRuntimeByExpert,
-  type RuntimeByExpert,
-} from "./agent-launcher.ts";
+import { normalizeRuntimeByExpert, type RuntimeByExpert } from "./agent-launcher.ts";
 import {
   freshContextIdResolver,
   type ContextIdResolver,

--- a/packages/core/src/agent/expert-team.ts
+++ b/packages/core/src/agent/expert-team.ts
@@ -1,5 +1,9 @@
 import type { Expert } from "./expert-agent.ts";
 import {
+  normalizeRuntimeByExpert,
+  type RuntimeByExpert,
+} from "./agent-launcher.ts";
+import {
   freshContextIdResolver,
   type ContextIdResolver,
 } from "../execution/context-id-resolver.ts";
@@ -11,6 +15,7 @@ export interface ExpertTeamDelegationOptions {
   readonly maxConcurrency?: number | undefined;
   readonly maxDepth?: number | undefined;
   readonly contextId?: ContextIdResolver | undefined;
+  readonly runtimeByExpert?: RuntimeByExpert | undefined;
 }
 
 export interface DefineExpertTeamOptions {
@@ -36,6 +41,7 @@ export interface ExpertTeam {
     readonly maxConcurrency: number;
     readonly maxDepth: number;
     readonly contextId: ContextIdResolver;
+    readonly runtimeByExpert: ReadonlyMap<string, string>;
   };
 }
 
@@ -68,6 +74,14 @@ export function defineExpertTeam(options: DefineExpertTeamOptions): ExpertTeam {
     allow.set(source, targetSet);
   }
 
+  const routableExpertIds = new Set([...allow.values()].flatMap((targets) => [...targets]));
+  const routableExperts = participants.filter((expert) => routableExpertIds.has(expert.id));
+  const runtimeByExpert = normalizeRuntimeByExpert(
+    options.delegation.runtimeByExpert,
+    routableExperts,
+    `ExpertTeam ${options.id}`,
+  );
+
   const maxConcurrency = readPositiveInteger(
     options.delegation.maxConcurrency ?? 4,
     "maxConcurrency",
@@ -87,6 +101,7 @@ export function defineExpertTeam(options: DefineExpertTeamOptions): ExpertTeam {
       maxConcurrency,
       maxDepth,
       contextId: options.delegation.contextId ?? freshContextIdResolver,
+      runtimeByExpert,
     }),
   });
 }

--- a/packages/core/src/execution/expert-runner.ts
+++ b/packages/core/src/execution/expert-runner.ts
@@ -17,6 +17,7 @@ import {
   isAgentDelegationTool,
   readAgentDelegationDefinition,
   type AgentDelegationDefinition,
+  type RuntimeByExpert,
 } from "../agent/agent-launcher.ts";
 import { isExpertTeam, type ExpertDefinition, type ExpertTeam } from "../agent/expert-team.ts";
 import type { RuntimeAgentSession, RuntimeSubmitHandle } from "../runtime/runtime-adapter.ts";
@@ -324,6 +325,7 @@ export interface RunExpertInvocationOptions {
     | { readonly type: "expert-session"; readonly ownerId: string }
     | { readonly type: "flow-execution"; readonly ownerId: string };
   readonly runtimeId?: string | undefined;
+  readonly runtimeByExpert?: RuntimeByExpert | undefined;
   readonly context: RuntimeContextRecord;
   readonly controller: ExecutionController;
   readonly store: ExecutionStore;
@@ -405,6 +407,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
   const runtimeId =
     options.runtimeId ?? options.context.runtimeId ?? options.context.snapshot?.runtimeId;
   const runtime = options.runtimes.resolve(runtimeId);
+  validateDelegatedRuntimeRouting(options, delegation, runtime.descriptor.id);
   const runtimeIdentity = {
     contextId: options.context.contextId,
     expertId: nativeExpert.id,
@@ -449,6 +452,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
     delegation,
     orchestrator,
     depth,
+    runtime.descriptor.id,
   );
   const humanInteractionHandler = async (request: ExpertAgentHumanRequest) =>
     await options.controller.requestHumanInteraction(options.invocationId, request);
@@ -662,6 +666,9 @@ async function executeAgentJob(
     depth: await readAgentDepth(parent.store, parent.executionId, job.agent),
     orchestrator,
     delegationPermit: job.permit,
+    ...(parent.runtimeByExpert === undefined
+      ? {}
+      : { runtimeByExpert: parent.runtimeByExpert }),
     ...(parent.readContextScope === undefined
       ? {}
       : { readContextScope: parent.readContextScope }),
@@ -676,6 +683,7 @@ function createExecutionContext(
   delegation: AgentDelegationDefinition | undefined,
   orchestrator: ExpertOrchestrator | undefined,
   depth: number,
+  parentRuntimeId: string,
 ) {
   const base = { executionId: options.executionId, invocationId: options.invocationId, depth };
   if (delegation === undefined || orchestrator === undefined) return base;
@@ -684,12 +692,17 @@ function createExecutionContext(
     spawnExpert: async (request: {
       readonly expertId: string;
       readonly prompt: string;
-      readonly runtime?: string | undefined;
     }) => {
       const expert = delegation.experts.find((candidate) => candidate.id === request.expertId);
       if (expert === undefined) {
         throw new Error(`Expert ${nativeExpert.id} may not spawn ${request.expertId}.`);
       }
+      const childRuntimeId = resolveDelegatedRuntimeId(
+        options,
+        delegation,
+        expert.id,
+        parentRuntimeId,
+      );
       return await orchestrator.spawn({
         ownerContextId: options.context.contextId,
         createdByInvocationId: options.invocationId,
@@ -697,7 +710,7 @@ function createExecutionContext(
         depth,
         expert,
         prompt: request.prompt,
-        runtimeId: options.runtimes.resolve(request.runtime).descriptor.id,
+        runtimeId: childRuntimeId,
         owner: options.owner,
         resolver: delegation.contextId,
         source:
@@ -937,6 +950,30 @@ function throwIfAborted(signal: AbortSignal, invocationId: string): void {
   if (!signal.aborted) return;
   if (signal.reason instanceof Error) throw signal.reason;
   throw new Error(`Invocation interrupted: ${invocationId}`);
+}
+
+function resolveDelegatedRuntimeId(
+  options: RunExpertInvocationOptions,
+  delegation: AgentDelegationDefinition,
+  expertId: string,
+  parentRuntimeId: string,
+): string {
+  const configuredRuntimeId =
+    options.runtimeByExpert?.[expertId] ??
+    delegation.runtimeByExpert.get(expertId) ??
+    parentRuntimeId;
+  return options.runtimes.resolve(configuredRuntimeId).descriptor.id;
+}
+
+function validateDelegatedRuntimeRouting(
+  options: RunExpertInvocationOptions,
+  delegation: AgentDelegationDefinition | undefined,
+  parentRuntimeId: string,
+): void {
+  if (delegation === undefined) return;
+  for (const expert of delegation.experts) {
+    resolveDelegatedRuntimeId(options, delegation, expert.id, parentRuntimeId);
+  }
 }
 
 function isDurableRuntimeEvent(event: ExpertAgentStreamEvent): boolean {

--- a/packages/core/src/execution/expert-runner.ts
+++ b/packages/core/src/execution/expert-runner.ts
@@ -237,9 +237,10 @@ export class ExecutionController {
           invocationId: invocation.invocationId,
           patch: { status: "cancelled" as const, error: reason },
         }));
-      const closure = this.options.closeContextsOnCancel === true
-        ? await prepareExecutionContextClosure(this.store, this.executionId)
-        : { contextPatches: [], agentPatches: [], events: [] };
+      const closure =
+        this.options.closeContextsOnCancel === true
+          ? await prepareExecutionContextClosure(this.store, this.executionId)
+          : { contextPatches: [], agentPatches: [], events: [] };
       try {
         await this.store.commit({
           commitId: randomUUID(),
@@ -666,12 +667,8 @@ async function executeAgentJob(
     depth: await readAgentDepth(parent.store, parent.executionId, job.agent),
     orchestrator,
     delegationPermit: job.permit,
-    ...(parent.runtimeByExpert === undefined
-      ? {}
-      : { runtimeByExpert: parent.runtimeByExpert }),
-    ...(parent.readContextScope === undefined
-      ? {}
-      : { readContextScope: parent.readContextScope }),
+    ...(parent.runtimeByExpert === undefined ? {} : { runtimeByExpert: parent.runtimeByExpert }),
+    ...(parent.readContextScope === undefined ? {} : { readContextScope: parent.readContextScope }),
     ...(parent.persistContext === undefined ? {} : { persistContext: parent.persistContext }),
   });
 }
@@ -689,10 +686,7 @@ function createExecutionContext(
   if (delegation === undefined || orchestrator === undefined) return base;
   return {
     ...base,
-    spawnExpert: async (request: {
-      readonly expertId: string;
-      readonly prompt: string;
-    }) => {
+    spawnExpert: async (request: { readonly expertId: string; readonly prompt: string }) => {
       const expert = delegation.experts.find((candidate) => candidate.id === request.expertId);
       if (expert === undefined) {
         throw new Error(`Expert ${nativeExpert.id} may not spawn ${request.expertId}.`);

--- a/packages/core/src/flow/flow-execution.ts
+++ b/packages/core/src/flow/flow-execution.ts
@@ -75,6 +75,7 @@ export class FlowExecutionManager {
     const input = flow.input?.parse(request.input) ?? request.input;
     const executionId = request.executionId ?? randomUUID();
     const runtimeId = this.runtimes.resolve(request.runtime).descriptor.id;
+    validateFlowRuntimeConfiguration(flow, this.runtimes, runtimeId);
     const now = new Date().toISOString();
     const record: ExecutionRecord = {
       schemaVersion: "pragma.execution/v5",
@@ -137,6 +138,7 @@ export class FlowExecutionManager {
       throw new Error(`Flow definition graph mismatch for Execution ${request.executionId}.`);
     }
     const runtimeId = this.runtimes.resolve(request.runtime).descriptor.id;
+    validateFlowRuntimeConfiguration(flow, this.runtimes, runtimeId);
     if (record.state["__requestedRuntimeId"] !== runtimeId) {
       throw new Error(`Flow Runtime mismatch for Execution ${request.executionId}.`);
     }
@@ -442,6 +444,7 @@ async function runStep(
       return output;
     }
     const expert = step.definition as ExpertDefinition;
+    const nativeExpert = isExpertTeam(expert) ? expert.coordinator : expert;
     const context = await options.store.getContext(options.executionId, invocation.contextId);
     if (context === undefined) {
       throw new Error(`Runtime Context not found: ${invocation.contextId}.`);
@@ -453,7 +456,10 @@ async function runStep(
       expert,
       prompt: typeof input === "string" ? input : JSON.stringify(input),
       owner: { type: "flow-execution", ownerId: options.executionId },
-      runtimeId: ("runtime" in step.options ? step.options.runtime : undefined) ?? options.runtime,
+      runtimeId: resolveFlowStepRuntimeId(step, nativeExpert.id, options.runtime),
+      ...(readFlowStepRuntimeByExpert(step) === undefined
+        ? {}
+        : { runtimeByExpert: readFlowStepRuntimeByExpert(step) }),
       context,
       controller: options.controller,
       store: options.store,
@@ -661,7 +667,7 @@ async function createStepInvocation(
       owner: { type: "flow-execution", ownerId: options.executionId },
       expert: { id: nativeExpert.id, version: nativeExpert.version },
       requestedRuntimeId: options.runtimes.resolve(
-        ("runtime" in step.options ? step.options.runtime : undefined) ?? options.runtime,
+        resolveFlowStepRuntimeId(step, nativeExpert.id, options.runtime),
       ).descriptor.id,
       resolver:
         ("contextId" in step.options ? step.options.contextId : undefined) ??
@@ -820,10 +826,18 @@ function visitFlowDefinition(flow: Flow, ancestors: Set<Flow>): unknown {
         ? (("contextId" in step.options ? step.options.contextId : undefined) ??
           freshContextIdResolver)
         : undefined;
+    const runtimeByExpert = readFlowStepRuntimeByExpert(step);
     return {
       ...(!("runtime" in step.options) || step.options.runtime === undefined
         ? {}
         : { runtime: step.options.runtime }),
+      ...(runtimeByExpert === undefined
+        ? {}
+        : {
+            runtimeByExpert: Object.fromEntries(
+              Object.entries(runtimeByExpert).sort(([left], [right]) => left.localeCompare(right)),
+            ),
+          }),
       ...(resolver === undefined ? {} : { contextId: describeContextIdResolver(resolver) }),
     };
   }
@@ -838,6 +852,45 @@ function visitFlowDefinition(flow: Flow, ancestors: Set<Flow>): unknown {
       cases: [...transition.cases.entries()].sort(([left], [right]) => left.localeCompare(right)),
       ...(transition.fallback === undefined ? {} : { fallback: transition.fallback }),
     };
+  }
+}
+
+function readFlowStepRuntimeByExpert(
+  step: CompiledFlowStep,
+): Readonly<Record<string, string>> | undefined {
+  return "runtimeByExpert" in step.options ? step.options.runtimeByExpert : undefined;
+}
+
+function resolveFlowStepRuntimeId(
+  step: CompiledFlowStep,
+  expertId: string,
+  fallbackRuntimeId: string | undefined,
+): string | undefined {
+  const explicitRuntime = "runtime" in step.options ? step.options.runtime : undefined;
+  return explicitRuntime ?? readFlowStepRuntimeByExpert(step)?.[expertId] ?? fallbackRuntimeId;
+}
+
+function validateFlowRuntimeConfiguration(
+  flow: Flow,
+  runtimes: RuntimeRegistry,
+  fallbackRuntimeId: string,
+  visited: Set<Flow> = new Set(),
+): void {
+  if (visited.has(flow)) return;
+  visited.add(flow);
+  for (const step of flow.steps.values()) {
+    if ("kind" in step.definition && step.definition.kind === "flow") {
+      validateFlowRuntimeConfiguration(step.definition, runtimes, fallbackRuntimeId, visited);
+      continue;
+    }
+    const definition = definitionRef(step.definition);
+    if (definition.kind !== "expert" && definition.kind !== "expert-team") continue;
+    const expert = step.definition as ExpertDefinition;
+    const nativeExpert = isExpertTeam(expert) ? expert.coordinator : expert;
+    runtimes.resolve(resolveFlowStepRuntimeId(step, nativeExpert.id, fallbackRuntimeId));
+    for (const runtimeId of Object.values(readFlowStepRuntimeByExpert(step) ?? {})) {
+      runtimes.resolve(runtimeId);
+    }
   }
 }
 

--- a/packages/core/src/flow/flow.ts
+++ b/packages/core/src/flow/flow.ts
@@ -309,7 +309,7 @@ function validateFlowRuntimeByExpert(
 
 function collectReachableExpertIds(definition: ExpertDefinition): ReadonlySet<string> {
   const expertIds = new Set<string>();
-  const visitExpert = (expert: Expert): void => {
+  const visitStandaloneExpert = (expert: Expert): void => {
     if (expertIds.has(expert.id)) return;
     expertIds.add(expert.id);
     const launchers = new Set(
@@ -321,13 +321,26 @@ function collectReachableExpertIds(definition: ExpertDefinition): ReadonlySet<st
     if (launchers.size > 1) {
       throw new Error(`Expert ${expert.id} has multiple agent launchers.`);
     }
-    for (const target of [...launchers][0]?.experts ?? []) visitExpert(target);
+    for (const target of [...launchers][0]?.experts ?? []) visitStandaloneExpert(target);
   };
   if (isExpertTeam(definition)) {
-    visitExpert(definition.coordinator);
-    for (const member of definition.members) visitExpert(member);
+    const participants = new Map(
+      [definition.coordinator, ...definition.members].map((expert) => [expert.id, expert]),
+    );
+    const visitTeamExpert = (expertId: string): void => {
+      if (expertIds.has(expertId)) return;
+      const expert = participants.get(expertId);
+      if (expert === undefined) {
+        throw new Error(`ExpertTeam ${definition.id} delegation target is unknown: ${expertId}`);
+      }
+      expertIds.add(expert.id);
+      for (const targetId of definition.delegation.allow.get(expertId) ?? []) {
+        visitTeamExpert(targetId);
+      }
+    };
+    visitTeamExpert(definition.coordinator.id);
   } else {
-    visitExpert(definition);
+    visitStandaloneExpert(definition);
   }
   return expertIds;
 }

--- a/packages/core/src/flow/flow.ts
+++ b/packages/core/src/flow/flow.ts
@@ -1,7 +1,12 @@
 import type { HumanInteractionRequest, HumanInteractionResponse } from "@pragma/shared";
 import type { z } from "zod";
 
-import type { ExpertDefinition } from "../agent/expert-team.ts";
+import {
+  readAgentDelegationDefinition,
+  type RuntimeByExpert,
+} from "../agent/agent-launcher.ts";
+import type { Expert } from "../agent/expert-agent.ts";
+import { isExpertTeam, type ExpertDefinition } from "../agent/expert-team.ts";
 import type { ContextIdResolver } from "../execution/context-id-resolver.ts";
 
 export type FlowState = Record<string, unknown>;
@@ -56,6 +61,7 @@ export interface FlowExpertStepOptions<TInput = unknown, TOutput = unknown> exte
   TOutput
 > {
   readonly runtime?: string | undefined;
+  readonly runtimeByExpert?: RuntimeByExpert | undefined;
   readonly contextId?: ContextIdResolver | undefined;
 }
 
@@ -184,7 +190,19 @@ export class FlowSpec<TInput = unknown, TOutput = unknown> {
     if (!isExecutableDefinition(compiled)) {
       throw new Error(`Flow.use() only accepts Expert, ExpertTeam, or Flow: ${id}`);
     }
-    return this.addStep(id, compiled, options as unknown as FlowStepOptions);
+    if (!("kind" in compiled) || compiled.kind === "expert-team") {
+      validateFlowRuntimeByExpert(
+        compiled as ExpertDefinition,
+        (options as FlowExpertStepOptions).runtimeByExpert,
+        id,
+      );
+    }
+    const runtimeByExpert = (options as FlowExpertStepOptions).runtimeByExpert;
+    const normalizedOptions =
+      runtimeByExpert === undefined
+        ? options
+        : { ...options, runtimeByExpert: Object.freeze({ ...runtimeByExpert }) };
+    return this.addStep(id, compiled, normalizedOptions as unknown as FlowStepOptions);
   }
 
   compose(declare: (builder: FlowBuilder) => void): this {
@@ -273,6 +291,48 @@ export function defineFlow<TInput = unknown, TOutput = unknown>(
   options: DefineFlowOptions<TInput, TOutput>,
 ): FlowSpec<TInput, TOutput> {
   return new FlowSpec(options);
+}
+
+function validateFlowRuntimeByExpert(
+  definition: ExpertDefinition,
+  runtimeByExpert: RuntimeByExpert | undefined,
+  stepId: string,
+): void {
+  if (runtimeByExpert === undefined) return;
+  const knownExpertIds = collectReachableExpertIds(definition);
+  for (const [expertId, runtimeId] of Object.entries(runtimeByExpert)) {
+    if (!knownExpertIds.has(expertId)) {
+      throw new Error(`Flow step ${stepId} runtimeByExpert target is unknown: ${expertId}`);
+    }
+    if (runtimeId.trim() === "") {
+      throw new Error(`Flow step ${stepId} runtimeByExpert value must not be empty: ${expertId}`);
+    }
+  }
+}
+
+function collectReachableExpertIds(definition: ExpertDefinition): ReadonlySet<string> {
+  const expertIds = new Set<string>();
+  const visitExpert = (expert: Expert): void => {
+    if (expertIds.has(expert.id)) return;
+    expertIds.add(expert.id);
+    const launchers = new Set(
+      (expert.tools ?? []).flatMap((tool) => {
+        const launcher = readAgentDelegationDefinition(tool);
+        return launcher === undefined ? [] : [launcher];
+      }),
+    );
+    if (launchers.size > 1) {
+      throw new Error(`Expert ${expert.id} has multiple agent launchers.`);
+    }
+    for (const target of [...launchers][0]?.experts ?? []) visitExpert(target);
+  };
+  if (isExpertTeam(definition)) {
+    visitExpert(definition.coordinator);
+    for (const member of definition.members) visitExpert(member);
+  } else {
+    visitExpert(definition);
+  }
+  return expertIds;
 }
 
 function isExecutableDefinition(value: unknown): value is ExpertDefinition | Flow {

--- a/packages/core/src/flow/flow.ts
+++ b/packages/core/src/flow/flow.ts
@@ -1,10 +1,7 @@
 import type { HumanInteractionRequest, HumanInteractionResponse } from "@pragma/shared";
 import type { z } from "zod";
 
-import {
-  readAgentDelegationDefinition,
-  type RuntimeByExpert,
-} from "../agent/agent-launcher.ts";
+import { readAgentDelegationDefinition, type RuntimeByExpert } from "../agent/agent-launcher.ts";
 import type { Expert } from "../agent/expert-agent.ts";
 import { isExpertTeam, type ExpertDefinition } from "../agent/expert-team.ts";
 import type { ContextIdResolver } from "../execution/context-id-resolver.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export {
   type AgentLauncher,
   type CreateAgentLauncherOptions,
   type ExpertLifecycleToolName,
+  type RuntimeByExpert,
 } from "./agent/agent-launcher.ts";
 export * from "./agent/expert-agent.ts";
 export * from "./agent/expert-definition-descriptor.ts";

--- a/packages/core/src/tools/managed-tool.ts
+++ b/packages/core/src/tools/managed-tool.ts
@@ -15,7 +15,6 @@ export interface ExpertToolExecutionContext {
     | ((request: {
         readonly expertId: string;
         readonly prompt: string;
-        readonly runtime?: string | undefined;
       }) => Promise<unknown>)
     | undefined;
   readonly waitExperts?:

--- a/packages/core/src/tools/managed-tool.ts
+++ b/packages/core/src/tools/managed-tool.ts
@@ -12,10 +12,7 @@ export interface ExpertToolExecutionContext {
   readonly invocationId: string;
   readonly depth: number;
   readonly spawnExpert?:
-    | ((request: {
-        readonly expertId: string;
-        readonly prompt: string;
-      }) => Promise<unknown>)
+    | ((request: { readonly expertId: string; readonly prompt: string }) => Promise<unknown>)
     | undefined;
   readonly waitExperts?:
     | ((request: {

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -55,7 +55,6 @@ interface FakeRuntimeOptions {
   readonly closeError?: string;
   readonly createDelayMs?: number;
   readonly delayMs?: number;
-  readonly delegateRuntime?: (query: string) => string | undefined;
   readonly delegationTargets?: Readonly<Record<string, string>>;
   readonly failQuery?: string;
   readonly onSteer?: () => void;
@@ -107,7 +106,6 @@ function createFakeRuntime(options: FakeRuntimeOptions = {}) {
           {
             expertId: delegationTarget,
             prompt: "subtask",
-            runtime: options.delegateRuntime?.(turn.rawQuery),
           },
           turn.signal,
           { execution: session.context.request.executionContext },
@@ -981,13 +979,12 @@ describe("ExpertSession", () => {
     });
   });
 
-  it("allows each newly spawned agent to select its own Runtime", async () => {
-    const home = await mkdtemp(join(tmpdir(), "pragma-runtime-identity-"));
-    const runtimeA = createFakeRuntime({
-      runtimeId: "fake-a",
-      delegateRuntime: (query) => (query === "two" ? "fake-b" : "fake-a"),
-    });
-    const runtimeB = createFakeRuntime({ runtimeId: "fake-b" });
+  it("routes ExpertTeam members through configured runtimes", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-team-runtime-routing-"));
+    const statsA = createFakeRuntimeStats();
+    const statsB = createFakeRuntimeStats();
+    const runtimeA = createFakeRuntime({ runtimeId: "fake-a", stats: statsA });
+    const runtimeB = createFakeRuntime({ runtimeId: "fake-b", stats: statsB });
     const app = createPragma({
       pragmaHome: home,
       runtimes: createRuntimeRegistry({
@@ -1014,20 +1011,167 @@ describe("ExpertSession", () => {
       workspace: home,
     });
     const team = defineExpertTeam({
-      id: "runtime-switch-team",
+      id: "runtime-routing-team",
       version: "1.0.0",
       coordinator: lead,
       members: [member],
-      delegation: { allow: { lead: ["member"], member: [] } },
+      delegation: {
+        allow: { lead: ["member"], member: [] },
+        runtimeByExpert: { member: "fake-b" },
+      },
     });
     const session = await app.experts.createSession(team);
-    await (
-      await session.prompt("one", { requestId: "one" })
-    ).result;
-    await expect((await session.prompt("two", { requestId: "two" })).result).resolves.toBe(
-      "lead:member:subtask",
-    );
+    await expect(
+      (await session.prompt("coordinate", { requestId: "team-runtime-routing" })).result,
+    ).resolves.toBe("lead:member:subtask");
+    expect(statsA.createSessionCalls).toBe(1);
+    expect(statsB.createSessionCalls).toBe(1);
     await session.close();
+  });
+
+  it("routes standalone SubAgents through launcher runtimeByExpert", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-launcher-runtime-routing-"));
+    const statsA = createFakeRuntimeStats();
+    const statsB = createFakeRuntimeStats();
+    const runtimeA = createFakeRuntime({ runtimeId: "fake-a", stats: statsA });
+    const runtimeB = createFakeRuntime({ runtimeId: "fake-b", stats: statsB });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createRuntimeRegistry({
+        runtimes: [runtimeA, runtimeB],
+        defaultRuntime: "fake-a",
+      }),
+    });
+    const member = await defineExpert({
+      id: "member",
+      name: "Member",
+      description: "Member",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+    });
+    const lead = await defineExpert({
+      id: "lead",
+      name: "Lead",
+      description: "Lead",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+      tools: createAgentLauncher({
+        experts: [member],
+        runtimeByExpert: { member: "fake-b" },
+      }).tools,
+    });
+    const session = await app.experts.createSession(lead);
+    await expect(
+      (await session.prompt("coordinate", { requestId: "launcher-runtime-routing" })).result,
+    ).resolves.toBe("lead:member:subtask");
+    expect(statsA.createSessionCalls).toBe(1);
+    expect(statsB.createSessionCalls).toBe(1);
+    await session.close();
+  });
+
+  it("inherits the parent Runtime when runtimeByExpert is omitted", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-inherited-runtime-routing-"));
+    const statsA = createFakeRuntimeStats();
+    const statsB = createFakeRuntimeStats();
+    const runtimeA = createFakeRuntime({ runtimeId: "fake-a", stats: statsA });
+    const runtimeB = createFakeRuntime({ runtimeId: "fake-b", stats: statsB });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createRuntimeRegistry({
+        runtimes: [runtimeA, runtimeB],
+        defaultRuntime: "fake-a",
+      }),
+    });
+    const member = await defineExpert({
+      id: "member",
+      name: "Member",
+      description: "Member",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+    });
+    const lead = await defineExpert({
+      id: "lead",
+      name: "Lead",
+      description: "Lead",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+      tools: createAgentLauncher({ experts: [member] }).tools,
+    });
+    const session = await app.experts.createSession(lead, { runtime: "fake-b" });
+    await expect(
+      (await session.prompt("coordinate", { requestId: "inherited-runtime-routing" })).result,
+    ).resolves.toBe("lead:member:subtask");
+    expect(statsA.createSessionCalls).toBe(0);
+    expect(statsB.createSessionCalls).toBe(2);
+    await session.close();
+  });
+
+  it("lets Flow runtimeByExpert override ExpertTeam routing", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-flow-runtime-routing-"));
+    const statsA = createFakeRuntimeStats();
+    const statsB = createFakeRuntimeStats();
+    const statsC = createFakeRuntimeStats();
+    const runtimes = [
+      createFakeRuntime({ runtimeId: "fake-a", stats: statsA }),
+      createFakeRuntime({ runtimeId: "fake-b", stats: statsB }),
+      createFakeRuntime({ runtimeId: "fake-c", stats: statsC }),
+    ];
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createRuntimeRegistry({ runtimes, defaultRuntime: "fake-a" }),
+    });
+    const member = await defineExpert({
+      id: "member",
+      name: "Member",
+      description: "Member",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+    });
+    const lead = await defineExpert({
+      id: "lead",
+      name: "Lead",
+      description: "Lead",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+    });
+    const team = defineExpertTeam({
+      id: "flow-runtime-routing-team",
+      version: "1.0.0",
+      coordinator: lead,
+      members: [member],
+      delegation: { runtimeByExpert: { member: "fake-b" } },
+    });
+    const flow = defineFlow({
+      id: "flow-runtime-routing",
+      version: "1.0.0",
+      result: ({ state }) => state["review"],
+    });
+    const review = flow.use("review", team, {
+      runtime: "fake-a",
+      runtimeByExpert: { member: "fake-c" },
+      reduce: ({ state, output }) => {
+        state["review"] = output;
+      },
+    });
+    flow.compose(({ start, end }) => start(review).next(end()));
+
+    const execution = await app.flows.start(flow, { input: "coordinate" });
+    await expect(execution.result).resolves.toBe("lead:member:subtask");
+    expect(statsA.createSessionCalls).toBe(1);
+    expect(statsB.createSessionCalls).toBe(0);
+    expect(statsC.createSessionCalls).toBe(1);
   });
 
   it("claims concurrent steer requests once and checkpoints Runtime context before completion", async () => {
@@ -2049,7 +2193,10 @@ describe("Expert delegation declarations", () => {
       "maxConcurrency",
     );
     expect(() => createAgentLauncher({ experts: [expert], maxDepth: 0 })).toThrow("maxDepth");
-    const launcher = createAgentLauncher({ experts: [expert] });
+    const launcher = createAgentLauncher({
+      experts: [expert],
+      runtimeByExpert: { [expert.id]: "fake" },
+    });
     expect(launcher.tools.map((tool) => tool.name)).toEqual([
       "spawn_expert",
       "wait_experts",
@@ -2058,6 +2205,15 @@ describe("Expert delegation declarations", () => {
       "interrupt_expert",
     ]);
     expect(readAgentDelegationDefinition({ ...launcher.tools[0]! })?.experts).toEqual([expert]);
+    expect(readAgentDelegationDefinition(launcher.tools[0]!)?.runtimeByExpert).toEqual(
+      new Map([[expert.id, "fake"]]),
+    );
+    expect(
+      (launcher.tools[0]?.inputSchema as { properties: Record<string, unknown> }).properties,
+    ).not.toHaveProperty("runtime");
+    expect(() =>
+      createAgentLauncher({ experts: [expert], runtimeByExpert: { missing: "fake" } }),
+    ).toThrow("runtimeByExpert target is unknown");
     expect(launcher.tools[0]?.description).toContain(
       `- ${expert.id}: ${expert.name}. ${expert.description}`,
     );
@@ -2079,7 +2235,10 @@ describe("Expert delegation declarations", () => {
       version: "1.0.0",
       coordinator: lead,
       members: [member],
-      delegation: { allow: { solo: ["member"], member: ["solo"] } },
+      delegation: {
+        allow: { solo: ["member"], member: ["solo"] },
+        runtimeByExpert: { member: "fake-member", solo: "fake-lead" },
+      },
     });
     const leadTools = createTeamDelegationTools(team, "solo");
     const memberTools = createTeamDelegationTools(team, "member");
@@ -2088,6 +2247,12 @@ describe("Expert delegation declarations", () => {
 
     expect(readAgentDelegationDefinition(leadTool!)?.experts).toEqual([member]);
     expect(readAgentDelegationDefinition(memberTool!)?.experts).toEqual([lead]);
+    expect(readAgentDelegationDefinition(leadTool!)?.runtimeByExpert).toEqual(
+      new Map([["member", "fake-member"]]),
+    );
+    expect(readAgentDelegationDefinition(memberTool!)?.runtimeByExpert).toEqual(
+      new Map([["solo", "fake-lead"]]),
+    );
     expect(leadTools).toHaveLength(5);
     expect(memberTools).toHaveLength(5);
     expect(leadTool?.description).toContain(
@@ -2121,6 +2286,7 @@ describe("Expert delegation declarations", () => {
     expect(createTeamDelegationTools(team, "member")).toEqual([]);
     expect(team.delegation.maxConcurrency).toBe(4);
     expect(team.delegation.maxDepth).toBe(3);
+    expect(team.delegation.runtimeByExpert).toEqual(new Map());
   });
 
   it("validates allowlists and limits", async () => {
@@ -2134,6 +2300,15 @@ describe("Expert delegation declarations", () => {
         delegation: { allow: { solo: ["missing"] } },
       }),
     ).toThrow("unknown");
+    expect(() =>
+      defineExpertTeam({
+        id: "invalid-runtime-route",
+        version: "1.0.0",
+        coordinator: expert,
+        members: [],
+        delegation: { runtimeByExpert: { missing: "fake" } },
+      }),
+    ).toThrow("runtimeByExpert target is unknown");
   });
 });
 

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -260,10 +260,7 @@ function createOrchestrationRuntime(
         if (scenario === "followup-older") {
           const first = await spawn("member", "first");
           const second = await spawn("member", "second");
-          await wait([
-            first["invocationId"] as string,
-            second["invocationId"] as string,
-          ]);
+          await wait([first["invocationId"] as string, second["invocationId"] as string]);
           const followup = await call("followup_expert", {
             agentId: first["agentId"],
             prompt: "followup-first",
@@ -534,8 +531,7 @@ describe("ExpertSession", () => {
         contextId: defineContextIdResolver({
           id: "test.persistent-team-member",
           version: "1.0.0",
-          resolve: ({ ownerContextId, target }) =>
-            `${ownerContextId ?? "root"}:${target.expertId}`,
+          resolve: ({ ownerContextId, target }) => `${ownerContextId ?? "root"}:${target.expertId}`,
         }),
       },
     });

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -1370,6 +1370,50 @@ describe("ExpertSession", () => {
 });
 
 describe("FlowExecution", () => {
+  it("rejects Flow runtime routes hidden by ExpertTeam delegation", async () => {
+    const { home } = await fixture();
+    const hidden = await defineExpert({
+      id: "hidden",
+      name: "Hidden",
+      description: "Only reachable from the standalone launcher",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+    });
+    const member = await defineExpert({
+      id: "member",
+      name: "Member",
+      description: "Team member",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+    });
+    const coordinator = await defineExpert({
+      id: "coordinator",
+      name: "Coordinator",
+      description: "Team coordinator",
+      tags: [],
+      version: "1.0.0",
+      scope: "test",
+      workspace: home,
+      tools: createAgentLauncher({ experts: [hidden] }).tools,
+    });
+    const team = defineExpertTeam({
+      id: "governed-team",
+      version: "1.0.0",
+      coordinator,
+      members: [member],
+      delegation: { allow: { coordinator: ["member"] } },
+    });
+    const flow = defineFlow({ id: "governed-team-flow", version: "1.0.0" });
+
+    expect(() => flow.use("team", team, { runtimeByExpert: { hidden: "fake" } })).toThrow(
+      "runtimeByExpert target is unknown: hidden",
+    );
+  });
+
   it("keeps Runtime ownership scoped to the FlowExecution", async () => {
     const { home, app, expert, stats } = await trackedFixture();
     const flow = defineFlow({ id: "runtime-flow", version: "1.0.0" });


### PR DESCRIPTION
## Summary

- add declarative `runtimeByExpert` routing for standalone Expert launchers, ExpertTeams, and Flow expert steps
- remove model-selected Runtime input from `spawn_expert` and inherit the parent agent's actual Runtime when no route is configured
- apply deterministic precedence: Flow override, then Expert/Team route, then parent Runtime
- validate routing targets and Runtime configuration before execution
- include Runtime routing in ExpertSession fingerprints and Flow recovery graphs
- restrict Flow Team routing targets to Experts reachable from the coordinator through the Team allowlist

## Why

Runtime selection was previously exposed as a `spawn_expert` tool argument, which let the model choose execution infrastructure dynamically. Routing is now owned by declarative Expert, Team, and Flow configuration so orchestration remains deterministic and governable.

The final fix also closes a validation mismatch: Flow target discovery inspected participants' standalone launchers even though Team execution replaces those launchers with allowlist-governed delegation tools. Flow validation now follows the effective Team graph.

## Impact

Callers configure Runtime routes when declaring launchers, teams, or Flow steps. Unconfigured child Experts inherit the Runtime actually used by their parent. Existing `spawn_expert` callers no longer pass a Runtime argument.

## Validation

- `pnpm --filter @pragma/core exec vitest run test/execution-system.test.ts` — 49/49 passed
- `pnpm check` — passed
- `env -u NODE_OPTIONS pnpm build` — passed
