### PR TITLE
refactor(core): bind expert sessions to root contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,6 +474,11 @@ Expert API 设计要求：
   `ContextIdResolver`；是否复用只由最终 `contextId` 决定，不引入 `fresh/reuse` policy。
 - Runtime Context 的 identity、snapshot 和 lifecycle 只存放在 `RuntimeContextRecord`；Invocation 与
   AgentInstance 只引用 `contextId`，不得复制 Runtime snapshot。
+- ExpertSession 创建时必须同时创建唯一根 Runtime Context；同一 Session 的所有根 prompt 始终复用该
+  Context，需要 fresh root 时创建新的 ExpertSession。根 Context 是固定 Session binding，不属于 delegation，
+  不调用 `ContextIdResolver`。
+- Runtime routing 必须先完成并写入新 Context 的必填 `runtimeId`；执行时只读取
+  `RuntimeContextRecord.runtimeId`，Session、Invocation 和 snapshot 不复制 Runtime identity。
 - `ownerContextId` 是子 Agent 生命周期工具的权限边界；`createdByInvocationId` 只用于审计和树关系。
 - PragmaApp 只公开 `experts` 与 `flows` 两个执行 namespace。
 

--- a/docs/adr/006-runtime-session-ownership-and-leases.md
+++ b/docs/adr/006-runtime-session-ownership-and-leases.md
@@ -22,6 +22,18 @@ snapshot. Invocation and AgentInstance reference only `contextId`; neither store
 Once created, a Context cannot change owner, Expert, or Runtime. A fixed string therefore cannot
 cross FlowExecution or ExpertSession ownership boundaries.
 
+An ExpertSession creates exactly one root Runtime Context atomically with the Session. Every root
+prompt in that Session references the same Context; callers create another ExpertSession when they
+need a fresh root conversation. This fixed root binding is not delegation and does not invoke a
+`ContextIdResolver`. `CreateExpertSessionOptions.runtime` is only the routing input used to bind the
+root Context. After binding, execution reads Runtime identity exclusively from
+`RuntimeContextRecord.runtimeId`.
+
+Context provenance is explicit: an ExpertSession root Context has an ExpertSession origin, while
+Flow and delegated Contexts have an Invocation origin. Runtime Context snapshots contain only the
+system and native Runtime Session references; Expert and Runtime identity remain on the containing
+Runtime Context record.
+
 Agent ownership is distinct from Runtime Context identity. `ownerContextId` grants list, wait,
 follow-up, and interrupt authority; `createdByInvocationId` records provenance; `agentId` identifies
 the FIFO task lane. Concurrent dispatches that resolve to the same Context are atomically folded
@@ -37,8 +49,8 @@ active, released on close, and may be reclaimed after expiration when a process 
 
 ## Consequences
 
-- Multiple prompts in one ExpertSession can reuse the same native Runtime process and isolated MCP Gateway registration by resolving the same Context ID.
+- Multiple prompts in one ExpertSession reuse the same root Context and native Runtime process until the Session closes.
 - A second Worker cannot concurrently resume and execute the same ExpertSession.
-- Default resolution uses `pragma.context.fresh@v1`; deliberate reuse must be expressed by an identified resolver.
+- Flow and delegation default resolution uses `pragma.context.fresh@v1`; deliberate reuse must be expressed by an identified resolver.
 - Runtime cleanup failures are reported, and a Session is marked closed only after cleanup succeeds.
 - Runtime snapshots are stored only in validated RuntimeContext records, never copied into Invocation or AgentInstance.

--- a/docs/architecture/agent-core-architecture.md
+++ b/docs/architecture/agent-core-architecture.md
@@ -23,6 +23,10 @@ FIFO Invocation，`wait_experts` 按 Invocation ID 汇合结果。`list_experts`
 Core 提供的新 ID；返回既有 ID 时复用 Context，并把 dispatch 归并到该 Context 对应的 Agent FIFO。
 等待子孙时释放并发 permit，避免嵌套死锁。
 
+ExpertSession 根 Expert 不属于 delegation：Session 创建时同步建立唯一根 Runtime Context，所有根 prompt
+始终引用该 Context；需要 fresh root 时创建新的 ExpertSession。`createSession({ runtime })` 只负责在创建
+根 Context 前完成 Runtime routing，后续执行和恢复只读取 Context 上不可变的 `runtimeId`。
+
 ## InvocationService 与 ExpertOrchestrator
 
 `InvocationService` 统一承担 Invocation 的可靠创建、状态迁移和 Canonical Event 原子提交。
@@ -51,6 +55,9 @@ Invocation 的 `agentTaskSequence` 是 FIFO 的唯一顺序源，不另存一份
 ExpertSession 以 Session Context Registry 作为跨 prompt 的 Context/snapshot 来源；每个 prompt 的
 Execution 只物化本轮 AgentInstance、Invocation 及其 Context binding，因此跨 prompt 复用 Context
 不会把上一轮 Agent 的任务队列带入本轮。
+
+Runtime Context 使用显式 origin：根 Context 由 ExpertSession 创建，Flow 与 delegation Context 由
+Invocation 创建。Snapshot 只保存 `systemSessionId` 与 `RuntimeSessionRef`，不复制 Expert 或 Runtime identity。
 
 父 Runtime turn 返回后，若仍存在未 join 的直属 Invocation，父 Invocation 进入 `waiting`，释放 permit，
 等待全部结果并记录 `expert.children.completed`，然后在原 Context 中启动框架续跑。失败、取消和中断的

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -66,6 +66,11 @@ Agent contexts are fresh and Execution-scoped; FIFO followups reuse that Agent c
 Runtime snapshot. FlowExecution Runtime Sessions remain execution-scoped.
 Execution and human-interaction bindings are submitted atomically with each Runtime submission.
 
+ExpertSession creation atomically establishes one root Runtime Context. All root prompts in that
+Session reuse it, while a fresh root requires a new ExpertSession. Runtime routing completes before
+Context creation; afterward `RuntimeContextRecord.runtimeId` is the only execution-time Runtime
+identity source.
+
 Agent workspaces contain task inputs, repositories, artifacts, and task-authored files only. Runtime
 state, configuration, sessions, and installed plugin copies must never be derived from or written
 below the workspace. Agent plugin copies live under `~/.pragma/cache/agents/<agent>/plugins/`.

--- a/docs/usage/agents.md
+++ b/docs/usage/agents.md
@@ -22,6 +22,12 @@ const resumed = await app.experts.resumeSession(expert, { sessionId: session.ses
 await resumed.prompt("continue");
 ```
 
+`createSession()` 会在返回前创建唯一根 Runtime Context；同一 Session 的所有根 prompt 都延续这条
+Runtime 对话，进程恢复后也不变。需要完全独立的根对话时应创建新的 ExpertSession。
+`createSession({ sessionId })` 只是用指定 ID 创建新 Session，同 ID 已存在会报错；恢复已有 Session
+只能使用 `resumeSession()`。`createSession({ runtime })` 中的 Runtime 只用于首次绑定根 Context，绑定后
+Runtime identity 只保存在该 Context 上。
+
 普通 Expert 可以显式注入 subagent launcher：
 
 ```ts

--- a/packages/core/src/execution/context-id-resolver.ts
+++ b/packages/core/src/execution/context-id-resolver.ts
@@ -5,7 +5,7 @@ export interface ContextCandidate {
   readonly agentId?: string | undefined;
   readonly expertId: string;
   readonly expertVersion: string;
-  readonly runtimeId?: string | undefined;
+  readonly runtimeId: string;
   readonly lifecycle: "open" | "closed";
   readonly lastInvocationId: string;
   readonly lastInvocationStatus: ExecutionStatus;
@@ -38,7 +38,7 @@ export interface ContextIdResolutionContext {
   readonly target: {
     readonly expertId: string;
     readonly expertVersion: string;
-    readonly requestedRuntimeId?: string | undefined;
+    readonly runtimeId: string;
   };
   readonly invocation: {
     readonly parentInvocationId?: string | undefined;

--- a/packages/core/src/execution/context-resolution-service.ts
+++ b/packages/core/src/execution/context-resolution-service.ts
@@ -20,6 +20,10 @@ import type {
   ExecutionStore,
   NewExecutionEvent,
 } from "./execution-store.ts";
+import {
+  createRuntimeContextRecord,
+  requireInvocationContextOrigin,
+} from "./runtime-context-record.ts";
 
 export interface ResolveRuntimeContextRequest {
   readonly executionId: string;
@@ -31,7 +35,7 @@ export interface ResolveRuntimeContextRequest {
   readonly owner: RuntimeContextOwner;
   readonly ownerContextId?: string | undefined;
   readonly expert: { readonly id: string; readonly version: string };
-  readonly requestedRuntimeId?: string | undefined;
+  readonly runtimeId: string;
   readonly resolver: ContextIdResolver;
   readonly freshContextId?: string | undefined;
 }
@@ -75,11 +79,7 @@ export class ContextResolutionService {
       localInvocations,
       (invocation) => invocation.invocationId,
     );
-    const agents = mergeById(
-      ownerScope?.agents ?? [],
-      localAgents,
-      (agent) => agent.agentId,
-    );
+    const agents = mergeById(ownerScope?.agents ?? [], localAgents, (agent) => agent.agentId);
     const previousContexts = selectCompatibleCandidates(request, contexts, invocations, agents);
     const contextId = resolveContextId(request.resolver, {
       source: request.source,
@@ -89,9 +89,7 @@ export class ContextResolutionService {
       target: {
         expertId: request.expert.id,
         expertVersion: request.expert.version,
-        ...(request.requestedRuntimeId === undefined
-          ? {}
-          : { requestedRuntimeId: request.requestedRuntimeId }),
+        runtimeId: request.runtimeId,
       },
       invocation: {
         ...(request.parentInvocationId === undefined
@@ -109,19 +107,14 @@ export class ContextResolutionService {
     const now = new Date().toISOString();
     const context =
       existing ??
-      ({
-        schemaVersion: "pragma.runtime-context/v1",
+      createRuntimeContextRecord({
         contextId,
         owner: request.owner,
-        createdByInvocationId: request.invocationId,
+        origin: { type: "invocation", invocationId: request.invocationId },
         expert: request.expert,
-        ...(request.requestedRuntimeId === undefined
-          ? {}
-          : { runtimeId: request.requestedRuntimeId }),
-        lifecycle: "open",
-        createdAt: now,
-        updatedAt: now,
-      } satisfies RuntimeContextRecord);
+        runtimeId: request.runtimeId,
+        now,
+      });
     assertCompatibleContext(request, context, agents);
     const resolver = describeContextIdResolver(request.resolver);
     const eventData = {
@@ -203,7 +196,7 @@ export async function prepareExecutionContextClosure(
       patch: { lifecycle: "closed" as const, closedAt: now, activeInvocationId: undefined },
     })),
     events: openContexts.map((context) => ({
-      invocationId: context.createdByInvocationId,
+      invocationId: requireInvocationContextOrigin(context),
       type: "context.closed",
       data: { contextId: context.contextId },
     })),
@@ -224,12 +217,7 @@ function selectCompatibleCandidates(
       context.expert.version !== request.expert.version
     )
       return false;
-    if (
-      request.requestedRuntimeId !== undefined &&
-      context.runtimeId !== undefined &&
-      context.runtimeId !== request.requestedRuntimeId
-    )
-      return false;
+    if (context.runtimeId !== request.runtimeId) return false;
     if (flowStepId !== undefined) {
       return invocations.some(
         (invocation) =>
@@ -258,7 +246,7 @@ function selectCompatibleCandidates(
           ...(agent === undefined ? {} : { agentId: agent.agentId }),
           expertId: context.expert.id,
           expertVersion: context.expert.version,
-          ...(context.runtimeId === undefined ? {} : { runtimeId: context.runtimeId }),
+          runtimeId: context.runtimeId,
           lifecycle: context.lifecycle,
           lastInvocationId: last.invocationId,
           lastInvocationStatus: last.status,
@@ -292,11 +280,7 @@ function assertCompatibleContext(
   ) {
     throw new Error(`Runtime Context Expert identity conflict: ${context.contextId}.`);
   }
-  if (
-    request.requestedRuntimeId !== undefined &&
-    context.runtimeId !== undefined &&
-    context.runtimeId !== request.requestedRuntimeId
-  ) {
+  if (context.runtimeId !== request.runtimeId) {
     throw new Error(`Runtime Context Runtime identity conflict: ${context.contextId}.`);
   }
   if (context.lifecycle !== "open") {

--- a/packages/core/src/execution/execution-store.ts
+++ b/packages/core/src/execution/execution-store.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import { withFileLock } from "../storage/file-lock.ts";
 import { PragmaPaths } from "../storage/pragma-paths.ts";
 import { getExecutionLiveBus } from "./execution-live-bus.ts";
+import { sameRuntimeContextOrigin } from "./runtime-context-record.ts";
 
 export interface NewExecutionEvent {
   readonly eventId?: string | undefined;
@@ -115,7 +116,7 @@ const ExecutionCommitRecordSchema = z.object({
 });
 
 const ExecutionCommitJournalSchema = z.object({
-  schemaVersion: z.literal("pragma.execution-transaction/v5"),
+  schemaVersion: z.literal("pragma.execution-transaction/v6"),
   commitId: z.string().min(1),
   signature: z.string().length(64),
   execution: ExecutionRecordSchema,
@@ -243,7 +244,7 @@ export function createFileExecutionStore(
           updatedAt: now,
         });
         const journal = ExecutionCommitJournalSchema.parse({
-          schemaVersion: "pragma.execution-transaction/v5",
+          schemaVersion: "pragma.execution-transaction/v6",
           commitId: request.commitId,
           signature,
           execution: nextExecution,
@@ -433,11 +434,6 @@ function applyContextChanges(
     const next = RuntimeContextRecordSchema.parse({
       ...context,
       ...change.patch,
-      contextId: change.contextId,
-      owner: context.owner,
-      expert: context.expert,
-      runtimeId: context.runtimeId ?? change.patch.runtimeId,
-      createdByInvocationId: context.createdByInvocationId,
       updatedAt: change.patch.updatedAt ?? now,
     });
     assertContextIdentity(context, next);
@@ -474,11 +470,13 @@ function assertAgentContextBindings(
 
 function assertContextIdentity(current: RuntimeContextRecord, next: RuntimeContextRecord): void {
   if (
+    current.contextId !== next.contextId ||
     current.owner.type !== next.owner.type ||
     current.owner.ownerId !== next.owner.ownerId ||
+    !sameRuntimeContextOrigin(current.origin, next.origin) ||
     current.expert.id !== next.expert.id ||
     current.expert.version !== next.expert.version ||
-    (current.runtimeId !== undefined && next.runtimeId !== current.runtimeId)
+    next.runtimeId !== current.runtimeId
   ) {
     throw new Error(`Runtime Context identity cannot change: ${current.contextId}`);
   }

--- a/packages/core/src/execution/expert-orchestrator.ts
+++ b/packages/core/src/execution/expert-orchestrator.ts
@@ -36,7 +36,6 @@ export interface ExpertInvocationJob {
   readonly invocation: Invocation;
   readonly expert: Expert;
   readonly prompt: string;
-  readonly runtimeId?: string | undefined;
   readonly permit: DelegationPermit;
 }
 
@@ -90,7 +89,7 @@ export class ExpertOrchestrator {
     readonly depth: number;
     readonly expert: Expert;
     readonly prompt: string;
-    readonly runtimeId?: string | undefined;
+    readonly runtimeId: string;
     readonly owner: RuntimeContextOwner;
     readonly resolver: ContextIdResolver;
     readonly source: ContextIdResolutionSource;
@@ -129,7 +128,7 @@ export class ExpertOrchestrator {
         owner: request.owner,
         ownerContextId: request.ownerContextId,
         expert: { id: request.expert.id, version: request.expert.version },
-        requestedRuntimeId: request.runtimeId,
+        runtimeId: request.runtimeId,
         resolver: request.resolver,
         freshContextId,
       });
@@ -289,7 +288,7 @@ export class ExpertOrchestrator {
         owner: context.owner,
         ownerContextId,
         expert: context.expert,
-        requestedRuntimeId: context.runtimeId,
+        runtimeId: context.runtimeId,
         resolver: followupContextIdResolver,
         freshContextId: context.contextId,
       });
@@ -585,7 +584,6 @@ export class ExpertOrchestrator {
         invocation: latest,
         expert,
         prompt: String(latest.input),
-        runtimeId: context.runtimeId,
         permit,
       });
       this.activeJobs.set(next.invocationId, running);
@@ -604,7 +602,6 @@ export class ExpertOrchestrator {
     readonly invocation: Invocation;
     readonly expert: Expert;
     readonly prompt: string;
-    readonly runtimeId?: string | undefined;
     readonly permit: DelegationPermit;
   }): Promise<void> {
     try {
@@ -612,7 +609,10 @@ export class ExpertOrchestrator {
         commitId: `agent-activated:${options.invocation.invocationId}`,
         executionId: this.options.executionId,
         agentPatches: [
-          { agentId: options.agentId, patch: { activeInvocationId: options.invocation.invocationId } },
+          {
+            agentId: options.agentId,
+            patch: { activeInvocationId: options.invocation.invocationId },
+          },
         ],
         events: [
           {
@@ -631,7 +631,6 @@ export class ExpertOrchestrator {
         invocation: options.invocation,
         expert: options.expert,
         prompt: options.prompt,
-        runtimeId: options.runtimeId,
         permit: options.permit,
       });
     } catch {

--- a/packages/core/src/execution/expert-runner.ts
+++ b/packages/core/src/execution/expert-runner.ts
@@ -42,6 +42,7 @@ import {
 import { getExecutionLiveBus } from "./execution-live-bus.ts";
 import { projectRuntimeOutput } from "./execution-output.ts";
 import { RuntimeMessageAccumulator } from "./runtime-message-accumulator.ts";
+import { requireInvocationContextOrigin } from "./runtime-context-record.ts";
 import { RuntimeSessionPool, type RuntimeSessionIdentity } from "./runtime-session-pool.ts";
 
 export type RuntimeContextSnapshot = SharedRuntimeContextSnapshot;
@@ -325,7 +326,6 @@ export interface RunExpertInvocationOptions {
   readonly owner:
     | { readonly type: "expert-session"; readonly ownerId: string }
     | { readonly type: "flow-execution"; readonly ownerId: string };
-  readonly runtimeId?: string | undefined;
   readonly runtimeByExpert?: RuntimeByExpert | undefined;
   readonly context: RuntimeContextRecord;
   readonly controller: ExecutionController;
@@ -405,9 +405,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
   const invocationSignal = options.controller.signalForInvocation(options.invocationId);
   throwIfAborted(invocationSignal, options.invocationId);
 
-  const runtimeId =
-    options.runtimeId ?? options.context.runtimeId ?? options.context.snapshot?.runtimeId;
-  const runtime = options.runtimes.resolve(runtimeId);
+  const runtime = options.runtimes.resolve(options.context.runtimeId);
   validateDelegatedRuntimeRouting(options, delegation, runtime.descriptor.id);
   const runtimeIdentity = {
     contextId: options.context.contextId,
@@ -419,7 +417,6 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
   const persistRuntimeSnapshot = async (snapshot: RuntimeContextSnapshot): Promise<void> => {
     const next: RuntimeContextRecord = {
       ...options.context,
-      runtimeId: snapshot.runtimeId,
       snapshot,
       updatedAt: new Date().toISOString(),
     };
@@ -438,7 +435,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
               contextPatches: [
                 {
                   contextId: options.context.contextId,
-                  patch: { runtimeId: snapshot.runtimeId, snapshot },
+                  patch: { snapshot },
                 },
               ],
             }),
@@ -465,7 +462,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
           ? { ...options.owner, contextId: options.context.contextId }
           : {
               ...options.owner,
-              invocationId: options.context.createdByInvocationId,
+              invocationId: requireInvocationContextOrigin(options.context),
             },
       systemSessionId: options.context.snapshot?.systemSessionId,
       runtimeSession: options.context.snapshot?.runtimeSession,
@@ -474,8 +471,6 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
       onSessionInfo: async (info) => {
         if (info.runtimeSession.id === "") return;
         await persistRuntimeSnapshot({
-          expertId: nativeExpert.id,
-          runtimeId: runtime.descriptor.id,
           systemSessionId: info.systemSessionId,
           runtimeSession: info.runtimeSession,
         });
@@ -484,8 +479,6 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
     const info = opened.info();
     if (info.runtimeSession.id !== "") {
       await persistRuntimeSnapshot({
-        expertId: nativeExpert.id,
-        runtimeId: runtime.descriptor.id,
         systemSessionId: info.systemSessionId,
         runtimeSession: info.runtimeSession,
       });
@@ -514,12 +507,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
       });
       options.controller.addUsage(turn.usage);
       invocationUsage = mergeUsage(invocationUsage, turn.usage);
-      await persistSessionInfo(
-        session,
-        nativeExpert,
-        runtime.descriptor.id,
-        persistRuntimeSnapshot,
-      );
+      await persistSessionInfo(session, persistRuntimeSnapshot);
 
       if (
         orchestrator !== undefined &&
@@ -658,7 +646,6 @@ async function executeAgentJob(
     expert: job.expert,
     prompt: job.prompt,
     owner: parent.owner,
-    runtimeId: job.runtimeId ?? context.runtimeId,
     context,
     controller: parent.controller,
     store: parent.store,
@@ -866,14 +853,10 @@ async function appendUserMessage(
 
 async function persistSessionInfo(
   session: RuntimeAgentSession,
-  expert: Expert,
-  runtimeId: string,
   persist: (snapshot: RuntimeContextSnapshot) => Promise<void>,
 ): Promise<void> {
   const info = session.info();
   await persist({
-    expertId: expert.id,
-    runtimeId,
     systemSessionId: info.systemSessionId,
     runtimeSession: info.runtimeSession,
   });
@@ -885,9 +868,7 @@ function assertRuntimeIdentity(
 ): void {
   if (
     options.context.expert.id !== identity.expertId ||
-    (options.context.runtimeId !== undefined && options.context.runtimeId !== identity.runtimeId) ||
-    (options.context.snapshot !== undefined &&
-      options.context.snapshot.runtimeId !== identity.runtimeId)
+    options.context.runtimeId !== identity.runtimeId
   ) {
     throw new Error(
       `Runtime Context ${options.context.contextId} identity conflicts with ${identity.expertId}/${identity.runtimeId}.`,

--- a/packages/core/src/execution/expert-session-store.ts
+++ b/packages/core/src/execution/expert-session-store.ts
@@ -13,20 +13,17 @@ import {
   type ExpertSessionEvent,
   type Invocation,
   type PromptRequest,
-  type RuntimeContextRecord,
 } from "@pragma/shared";
 import { z } from "zod";
 
 import { withFileLock } from "../storage/file-lock.ts";
 import { PragmaPaths } from "../storage/pragma-paths.ts";
 import type { ExecutionStore } from "./execution-store.ts";
-import { mergeRuntimeContextRecord } from "./runtime-context-record.ts";
 
 export interface EnqueuePromptTransaction {
   readonly execution: ExecutionRecord;
   readonly rootInvocation: Invocation;
   readonly prompt: PromptRequest;
-  readonly context?: RuntimeContextRecord | undefined;
 }
 
 export interface ExpertSessionStore {
@@ -68,18 +65,33 @@ export function createFileExpertSessionStore(options: {
         if ((await readJson(paths.expertSessionState(record.sessionId))) !== undefined) {
           throw new Error(`ExpertSession already exists: ${record.sessionId}`);
         }
+        const parsedRecord = ExpertSessionRecordSchema.parse(record);
+        const rootContext = parsedRecord.contexts[parsedRecord.rootContextId]!;
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v2",
-          session: record,
+          schemaVersion: "pragma.expert-session-transaction/v3",
+          session: parsedRecord,
           prompts: [],
           events: [
             createSessionEvent(
-              record.sessionId,
+              parsedRecord.sessionId,
               1,
               "session-created",
               "session.created",
               {},
-              record.createdAt,
+              parsedRecord.createdAt,
+            ),
+            createSessionEvent(
+              parsedRecord.sessionId,
+              2,
+              `context-created:${parsedRecord.rootContextId}`,
+              "context.created",
+              {
+                contextId: parsedRecord.rootContextId,
+                source: { kind: "expert-session-root" },
+                expert: rootContext.expert,
+                runtimeId: rootContext.runtimeId,
+              },
+              parsedRecord.createdAt,
             ),
           ],
         });
@@ -117,21 +129,11 @@ export function createFileExpertSessionStore(options: {
           ...session,
           queuedRequestIds: [...session.queuedRequestIds, transaction.prompt.requestId],
           executionIds: [...session.executionIds, transaction.execution.executionId],
-          contexts:
-            transaction.context === undefined
-              ? session.contexts
-              : {
-                  ...session.contexts,
-                  [transaction.context.contextId]: mergeRuntimeContextRecord(
-                    session.contexts[transaction.context.contextId],
-                    transaction.context,
-                  ),
-                },
           updatedAt: transaction.prompt.createdAt,
         });
         const nextPrompts = PromptRequestSchema.array().parse([...prompts, transaction.prompt]);
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v2",
+          schemaVersion: "pragma.expert-session-transaction/v3",
           session: nextSession,
           prompts: nextPrompts,
           events: materializeSessionEvents(sessionId, events, [
@@ -179,7 +181,7 @@ export function createFileExpertSessionStore(options: {
         );
         const next = await action({ session: session.data, prompts });
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v2",
+          schemaVersion: "pragma.expert-session-transaction/v3",
           session: next.session,
           prompts: next.prompts,
           events: materializeSessionEvents(
@@ -252,7 +254,7 @@ const ExpertSessionLeaseSchema = z.object({
 
 const ExpertSessionTransactionJournalSchema = z
   .object({
-    schemaVersion: z.literal("pragma.expert-session-transaction/v2"),
+    schemaVersion: z.literal("pragma.expert-session-transaction/v3"),
     session: ExpertSessionRecordSchema,
     prompts: PromptRequestSchema.array(),
     events: ExpertSessionEventSchema.array(),
@@ -312,6 +314,16 @@ function deriveSessionEvents(
     }
   }
   if (current.status !== next.status && next.status === "closed") {
+    const currentRoot = current.contexts[current.rootContextId];
+    const nextRoot = next.contexts[next.rootContextId];
+    if (currentRoot?.lifecycle === "open" && nextRoot?.lifecycle === "closed") {
+      events.push({
+        eventId: `context-closed:${next.rootContextId}`,
+        type: "context.closed",
+        data: { contextId: next.rootContextId },
+        occurredAt: next.updatedAt,
+      });
+    }
     events.push({
       eventId: "session-closed",
       type: "session.closed",

--- a/packages/core/src/execution/expert-session.ts
+++ b/packages/core/src/execution/expert-session.ts
@@ -30,7 +30,7 @@ import {
   type ContextResolutionScopeSnapshot,
 } from "./context-resolution-service.ts";
 import type { ExpertSessionStore } from "./expert-session-store.ts";
-import { mergeRuntimeContextRecord } from "./runtime-context-record.ts";
+import { createRuntimeContextRecord, mergeRuntimeContextRecord } from "./runtime-context-record.ts";
 import {
   StoredExecutionView,
   type GetMessageHistoryOptions,
@@ -113,8 +113,17 @@ export class ExpertSessionManager {
     const now = new Date().toISOString();
     const rootExpert = isExpertTeam(expert) ? expert.coordinator : expert;
     const runtimeId = this.dependencies.runtimes.resolve(options.runtime).descriptor.id;
+    const rootContextId = randomUUID();
+    const rootContext = createRuntimeContextRecord({
+      contextId: rootContextId,
+      owner: { type: "expert-session", ownerId: sessionId },
+      origin: { type: "expert-session", sessionId },
+      expert: { id: rootExpert.id, version: rootExpert.version },
+      runtimeId,
+      now,
+    });
     await this.dependencies.sessions.create({
-      schemaVersion: "pragma.expert-session/v2",
+      schemaVersion: "pragma.expert-session/v3",
       sessionId,
       expertId: expert.id,
       expertVersion: expert.version,
@@ -122,9 +131,8 @@ export class ExpertSessionManager {
       status: "open",
       queuedRequestIds: [],
       executionIds: [],
-      runtimeId,
-      rootContextId: randomUUID(),
-      contexts: {},
+      rootContextId,
+      contexts: { [rootContextId]: rootContext },
       createdAt: now,
       updatedAt: now,
     });
@@ -136,7 +144,6 @@ export class ExpertSessionManager {
     }
     const session = this.createActiveSession(expert, sessionId, false, claimId);
     this.active.set(sessionId, session);
-    void rootExpert;
     return session;
   }
 
@@ -302,18 +309,6 @@ class ExpertSessionImpl implements ExpertSession {
     const executionId = await this.dependencies.sessions.enqueue({
       execution,
       prompt,
-      ...(session.contexts[rootContextId] === undefined
-        ? {
-            context: createRootRuntimeContext(
-              this.expert,
-              this.sessionId,
-              rootContextId,
-              id,
-              session.runtimeId,
-              now,
-            ),
-          }
-        : {}),
       rootInvocation: {
         invocationId: id,
         rootInvocationId: id,
@@ -527,11 +522,14 @@ class ExpertSessionImpl implements ExpertSession {
     const events = [
       ...(await this.dependencies.sessions.listEvents(this.sessionId)),
       ...executionEvents,
-    ].sort((left, right) =>
-      left.occurredAt === right.occurredAt
-        ? left.eventId.localeCompare(right.eventId)
-        : left.occurredAt.localeCompare(right.occurredAt),
-    );
+    ].sort((left, right) => {
+      const occurredAt = left.occurredAt.localeCompare(right.occurredAt);
+      if (occurredAt !== 0) return occurredAt;
+      if ("sessionId" in left.cursor && "sessionId" in right.cursor) {
+        return left.cursor.sequence - right.cursor.sequence;
+      }
+      return left.eventId.localeCompare(right.eventId);
+    });
     const offset = options.after?.offset ?? 0;
     const items = events.slice(offset, offset + limit);
     return {
@@ -733,7 +731,6 @@ class ExpertSessionImpl implements ExpertSession {
         expert: this.expert,
         prompt: prompt.content,
         owner: { type: "expert-session", ownerId: this.sessionId },
-        runtimeId: session.runtimeId,
         context: rootContext,
         controller,
         store: this.dependencies.executions,
@@ -831,9 +828,7 @@ class ExpertSessionImpl implements ExpertSession {
     );
     return {
       contexts: Object.values(session.contexts),
-      invocations: histories.flatMap(
-        (history): readonly Invocation[] => history.invocations,
-      ),
+      invocations: histories.flatMap((history): readonly Invocation[] => history.invocations),
       agents: histories.flatMap((history): readonly AgentInstance[] => history.agents),
     };
   }
@@ -866,32 +861,6 @@ class ExpertSessionImpl implements ExpertSession {
   private createExecutionView(executionId: string): StoredExecutionView {
     return new StoredExecutionView(executionId, this.dependencies.executions, this.sessionId);
   }
-}
-
-function createRootRuntimeContext(
-  definition: ExpertDefinition,
-  sessionId: string,
-  contextId: string,
-  invocationId: string,
-  runtimeId: string | undefined,
-  now: string,
-): RuntimeContextRecord {
-  const expert = rootExpert(definition);
-  return {
-    schemaVersion: "pragma.runtime-context/v1",
-    contextId,
-    owner: { type: "expert-session", ownerId: sessionId },
-    createdByInvocationId: invocationId,
-    expert: { id: expert.id, version: expert.version },
-    ...(runtimeId === undefined ? {} : { runtimeId }),
-    lifecycle: "open",
-    createdAt: now,
-    updatedAt: now,
-  };
-}
-
-function rootExpert(definition: ExpertDefinition) {
-  return isExpertTeam(definition) ? definition.coordinator : definition;
 }
 
 function closeSessionContexts(session: ExpertSessionRecord): ExpertSessionRecord {

--- a/packages/core/src/execution/runtime-context-record.ts
+++ b/packages/core/src/execution/runtime-context-record.ts
@@ -1,4 +1,34 @@
-import type { RuntimeContextRecord } from "@pragma/shared";
+import type {
+  RuntimeContextOrigin,
+  RuntimeContextOwner,
+  RuntimeContextRecord,
+} from "@pragma/shared";
+
+export interface CreateRuntimeContextRecordOptions {
+  readonly contextId: string;
+  readonly owner: RuntimeContextOwner;
+  readonly origin: RuntimeContextOrigin;
+  readonly expert: { readonly id: string; readonly version: string };
+  readonly runtimeId: string;
+  readonly now?: string | undefined;
+}
+
+export function createRuntimeContextRecord(
+  options: CreateRuntimeContextRecordOptions,
+): RuntimeContextRecord {
+  const now = options.now ?? new Date().toISOString();
+  return {
+    schemaVersion: "pragma.runtime-context/v2",
+    contextId: options.contextId,
+    owner: options.owner,
+    origin: options.origin,
+    expert: options.expert,
+    runtimeId: options.runtimeId,
+    lifecycle: "open",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
 
 export function mergeRuntimeContextRecord(
   current: RuntimeContextRecord | undefined,
@@ -11,21 +41,17 @@ export function mergeRuntimeContextRecord(
   const lifecycle =
     current.lifecycle === "closed" || incoming.lifecycle === "closed" ? "closed" : "open";
   const updatedAt =
-    incoming.updatedAt.localeCompare(current.updatedAt) > 0 ? incoming.updatedAt : current.updatedAt;
-  const runtimeId = incomingIsNewer
-    ? (incoming.runtimeId ?? current.runtimeId)
-    : (current.runtimeId ?? incoming.runtimeId);
+    incoming.updatedAt.localeCompare(current.updatedAt) > 0
+      ? incoming.updatedAt
+      : current.updatedAt;
   const snapshot = incomingIsNewer
     ? (incoming.snapshot ?? current.snapshot)
     : (current.snapshot ?? incoming.snapshot);
   const closedAt =
-    lifecycle === "closed"
-      ? (incoming.closedAt ?? current.closedAt ?? updatedAt)
-      : undefined;
+    lifecycle === "closed" ? (incoming.closedAt ?? current.closedAt ?? updatedAt) : undefined;
 
   return {
     ...current,
-    ...(runtimeId === undefined ? {} : { runtimeId }),
     ...(snapshot === undefined ? {} : { snapshot }),
     lifecycle,
     updatedAt,
@@ -40,7 +66,8 @@ function assertSameRuntimeContext(
   if (
     current.contextId !== incoming.contextId ||
     current.owner.type !== incoming.owner.type ||
-    current.owner.ownerId !== incoming.owner.ownerId
+    current.owner.ownerId !== incoming.owner.ownerId ||
+    !sameRuntimeContextOrigin(current.origin, incoming.origin)
   ) {
     throw new Error(`Runtime Context owner conflict: ${incoming.contextId}.`);
   }
@@ -50,11 +77,30 @@ function assertSameRuntimeContext(
   ) {
     throw new Error(`Runtime Context Expert identity conflict: ${incoming.contextId}.`);
   }
-  if (
-    current.runtimeId !== undefined &&
-    incoming.runtimeId !== undefined &&
-    current.runtimeId !== incoming.runtimeId
-  ) {
+  if (current.runtimeId !== incoming.runtimeId) {
     throw new Error(`Runtime Context Runtime identity conflict: ${incoming.contextId}.`);
+  }
+}
+
+export function requireInvocationContextOrigin(context: RuntimeContextRecord): string {
+  if (context.origin.type !== "invocation") {
+    throw new Error(`Runtime Context requires an Invocation origin: ${context.contextId}.`);
+  }
+  return context.origin.invocationId;
+}
+
+export function sameRuntimeContextOrigin(
+  current: RuntimeContextOrigin,
+  incoming: RuntimeContextOrigin,
+): boolean {
+  switch (current.type) {
+    case "expert-session":
+      return incoming.type === "expert-session" && current.sessionId === incoming.sessionId;
+    case "invocation":
+      return incoming.type === "invocation" && current.invocationId === incoming.invocationId;
+    default: {
+      const unsupported: never = current;
+      throw new Error(`Unsupported Runtime Context origin: ${String(unsupported)}`);
+    }
   }
 }

--- a/packages/core/src/flow/flow-execution.ts
+++ b/packages/core/src/flow/flow-execution.ts
@@ -444,7 +444,6 @@ async function runStep(
       return output;
     }
     const expert = step.definition as ExpertDefinition;
-    const nativeExpert = isExpertTeam(expert) ? expert.coordinator : expert;
     const context = await options.store.getContext(options.executionId, invocation.contextId);
     if (context === undefined) {
       throw new Error(`Runtime Context not found: ${invocation.contextId}.`);
@@ -456,7 +455,6 @@ async function runStep(
       expert,
       prompt: typeof input === "string" ? input : JSON.stringify(input),
       owner: { type: "flow-execution", ownerId: options.executionId },
-      runtimeId: resolveFlowStepRuntimeId(step, nativeExpert.id, options.runtime),
       ...(readFlowStepRuntimeByExpert(step) === undefined
         ? {}
         : { runtimeByExpert: readFlowStepRuntimeByExpert(step) }),
@@ -666,7 +664,7 @@ async function createStepInvocation(
       },
       owner: { type: "flow-execution", ownerId: options.executionId },
       expert: { id: nativeExpert.id, version: nativeExpert.version },
-      requestedRuntimeId: options.runtimes.resolve(
+      runtimeId: options.runtimes.resolve(
         resolveFlowStepRuntimeId(step, nativeExpert.id, options.runtime),
       ).descriptor.id,
       resolver:

--- a/packages/core/test/context-resolution.test.ts
+++ b/packages/core/test/context-resolution.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { Invocation, RuntimeContextRecord } from "@pragma/shared";
+import {
+  RuntimeContextRecordSchema,
+  type Invocation,
+  type RuntimeContextRecord,
+} from "@pragma/shared";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -17,11 +21,13 @@ describe("ContextResolutionService", () => {
   it("selects any earlier compatible Context in stable history order", async () => {
     const fixture = await createFixture();
     let candidates: readonly string[] = [];
+    let selectedRuntimeId: string | undefined;
     const resolver = defineContextIdResolver({
       id: "test.select-first",
       version: "1.0.0",
-      resolve: ({ previousContexts, freshContextId }) => {
+      resolve: ({ previousContexts, freshContextId, target }) => {
         candidates = previousContexts.map((context) => context.contextId);
+        selectedRuntimeId = target.runtimeId;
         return previousContexts[0]?.contextId ?? freshContextId;
       },
     });
@@ -35,12 +41,13 @@ describe("ContextResolutionService", () => {
       source: { kind: "flow", flowId: "flow", stepId: "review", visit: 3 },
       owner: fixture.owner,
       expert: fixture.expert,
-      requestedRuntimeId: "runtime",
+      runtimeId: "runtime",
       resolver,
       freshContextId: "fresh-third",
     });
 
     expect(candidates).toEqual(["context-1", "context-2"]);
+    expect(selectedRuntimeId).toBe("runtime");
     expect(resolution).toMatchObject({
       disposition: "reused",
       context: { contextId: "context-1" },
@@ -104,7 +111,7 @@ describe("ContextResolutionService", () => {
         source: { kind: "flow", flowId: "flow", stepId: "review", visit: 3 },
         owner: fixture.owner,
         expert: fixture.expert,
-        requestedRuntimeId: "runtime",
+        runtimeId: "runtime",
         resolver: fixed("context-1"),
       }),
     ).rejects.toThrow("closed");
@@ -118,7 +125,7 @@ describe("ContextResolutionService", () => {
         source: { kind: "flow", flowId: "flow", stepId: "other", visit: 1 },
         owner: fixture.owner,
         expert: { id: "other-expert", version: "1.0.0" },
-        requestedRuntimeId: "runtime",
+        runtimeId: "runtime",
         resolver: fixed("context-2"),
       }),
     ).rejects.toThrow("Expert identity conflict");
@@ -132,7 +139,7 @@ describe("ContextResolutionService", () => {
         source: { kind: "flow", flowId: "flow", stepId: "review", visit: 3 },
         owner: fixture.owner,
         expert: fixture.expert,
-        requestedRuntimeId: "other-runtime",
+        runtimeId: "other-runtime",
         resolver: fixed("context-2"),
       }),
     ).rejects.toThrow("Runtime identity conflict");
@@ -146,10 +153,56 @@ describe("ContextResolutionService", () => {
         source: { kind: "flow", flowId: "flow", stepId: "review", visit: 3 },
         owner: { type: "flow-execution", ownerId: "other-execution" },
         expert: fixture.expert,
-        requestedRuntimeId: "runtime",
+        runtimeId: "runtime",
         resolver: fixed("context-2"),
       }),
     ).rejects.toThrow("owner conflict");
+  });
+
+  it("requires immutable Runtime identity and valid Session provenance", () => {
+    const now = new Date().toISOString();
+    const base = {
+      schemaVersion: "pragma.runtime-context/v2",
+      contextId: "root",
+      owner: { type: "expert-session", ownerId: "session" },
+      origin: { type: "expert-session", sessionId: "session" },
+      expert: { id: "expert", version: "1.0.0" },
+      runtimeId: "runtime",
+      lifecycle: "open",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    expect(RuntimeContextRecordSchema.safeParse(base).success).toBe(true);
+    expect(
+      RuntimeContextRecordSchema.safeParse({
+        ...base,
+        origin: { type: "expert-session", sessionId: "other-session" },
+      }).success,
+    ).toBe(false);
+    expect(RuntimeContextRecordSchema.safeParse({ ...base, runtimeId: undefined }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects Runtime Context identity mutation patches instead of ignoring them", async () => {
+    const fixture = await createFixture();
+
+    await expect(
+      fixture.store.commit({
+        commitId: "mutate-context-origin",
+        executionId: "execution",
+        contextPatches: [
+          {
+            contextId: "context-2",
+            patch: { origin: { type: "invocation", invocationId: "replacement" } },
+          },
+        ],
+      }),
+    ).rejects.toThrow("Runtime Context identity cannot change");
+    await expect(fixture.store.getContext("execution", "context-2")).resolves.toMatchObject({
+      origin: { type: "invocation", invocationId: "second" },
+    });
   });
 });
 
@@ -226,10 +279,10 @@ function contextRecord(
   closed: boolean,
 ): RuntimeContextRecord {
   return {
-    schemaVersion: "pragma.runtime-context/v1",
+    schemaVersion: "pragma.runtime-context/v2",
     contextId,
     owner,
-    createdByInvocationId: invocationId,
+    origin: { type: "invocation", invocationId },
     expert,
     runtimeId: "runtime",
     lifecycle: closed ? "closed" : "open",
@@ -244,7 +297,7 @@ function resolutionContext() {
     source: { kind: "flow" as const, flowId: "flow", stepId: "step", visit: 1 },
     executionId: "execution",
     owner: { type: "flow-execution" as const, ownerId: "execution" },
-    target: { expertId: "expert", expertVersion: "1.0.0" },
+    target: { expertId: "expert", expertVersion: "1.0.0", runtimeId: "runtime" },
     invocation: { input: null },
     state: {},
     previousContexts: [],

--- a/packages/core/test/execution-event-log.test.ts
+++ b/packages/core/test/execution-event-log.test.ts
@@ -255,7 +255,7 @@ describe("Execution canonical event log", () => {
     await writeFile(
       paths.executionTransaction("execution"),
       `${JSON.stringify({
-        schemaVersion: "pragma.execution-transaction/v5",
+        schemaVersion: "pragma.execution-transaction/v6",
         commitId: "recovered-commit",
         signature: "a".repeat(64),
         execution: {

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -397,6 +397,44 @@ async function trackedFixture(options: Omit<FakeRuntimeOptions, "stats"> = {}) {
 }
 
 describe("ExpertSession", () => {
+  it("creates one durable root Context before the first prompt", async () => {
+    const { app, expert } = await fixture();
+    const first = await app.experts.createSession(expert);
+    const firstState = await first.getState();
+    const firstRoot = firstState.contexts[firstState.rootContextId];
+
+    expect("runtimeId" in firstState).toBe(false);
+    expect(firstRoot).toMatchObject({
+      owner: { type: "expert-session", ownerId: first.sessionId },
+      origin: { type: "expert-session", sessionId: first.sessionId },
+      expert: { id: expert.id, version: expert.version },
+      runtimeId: "fake",
+      lifecycle: "open",
+    });
+    expect((await first.listEvents()).items.map((event) => event.type)).toEqual([
+      "session.created",
+      "context.created",
+    ]);
+
+    const turn = await first.prompt("hello", { requestId: "root-binding" });
+    await turn.result;
+    expect((await turn.getTree()).invocation).toMatchObject({
+      contextId: firstState.rootContextId,
+    });
+    expect((await turn.getTree()).invocation.contextResolution).toBeUndefined();
+
+    const second = await app.experts.createSession(expert);
+    expect((await second.getState()).rootContextId).not.toBe(firstState.rootContextId);
+    await first.close();
+    expect((await first.getState()).contexts[firstState.rootContextId]).toMatchObject({
+      lifecycle: "closed",
+    });
+    expect((await first.listEvents()).items.map((event) => event.type)).toEqual(
+      expect.arrayContaining(["context.closed", "session.closed"]),
+    );
+    await second.close();
+  });
+
   it("streams only future events until terminal and exposes durable message history", async () => {
     const { app, expert } = await fixture(100);
     const session = await app.experts.createSession(expert);
@@ -477,7 +515,7 @@ describe("ExpertSession", () => {
     ).rejects.toThrow("is closed");
   });
 
-  it("atomically preserves the first creator of the root Context under concurrent prompts", async () => {
+  it("keeps the Session-created root Context immutable under concurrent prompts", async () => {
     const { app, expert } = await trackedFixture({ delayMs: 25 });
     const session = await app.experts.createSession(expert);
     const [first, second] = await Promise.all([
@@ -486,11 +524,15 @@ describe("ExpertSession", () => {
     ]);
     const state = await session.getState();
     expect(Object.keys(state.contexts)).toEqual([state.rootContextId]);
-    expect(state.contexts[state.rootContextId]?.createdByInvocationId).toBe(state.executionIds[0]);
+    expect(state.contexts[state.rootContextId]?.origin).toEqual({
+      type: "expert-session",
+      sessionId: session.sessionId,
+    });
     await Promise.all([first.result, second.result]);
-    expect((await session.getState()).contexts[state.rootContextId]?.createdByInvocationId).toBe(
-      state.executionIds[0],
-    );
+    expect((await session.getState()).contexts[state.rootContextId]?.origin).toEqual({
+      type: "expert-session",
+      sessionId: session.sessionId,
+    });
     await session.close();
   });
 
@@ -566,8 +608,9 @@ describe("ExpertSession", () => {
     expect(memberContexts).toHaveLength(1);
     expect(memberContexts[0]).toMatchObject({
       contextId: firstMember?.contextId,
-      createdByInvocationId: firstMember?.invocationId,
-      snapshot: { expertId: member.id, runtimeId: "fake" },
+      origin: { type: "invocation", invocationId: firstMember?.invocationId },
+      runtimeId: "fake",
+      snapshot: { systemSessionId: expect.any(String) },
     });
     expect(stats.createSessionCalls).toBe(2);
     expect(recoveredStats.createSessionCalls).toBe(0);
@@ -636,7 +679,7 @@ describe("ExpertSession", () => {
     const sessions = createFileExpertSessionStore({ executions, pragmaHome: home });
     const now = new Date().toISOString();
     await sessions.create({
-      schemaVersion: "pragma.expert-session/v2",
+      schemaVersion: "pragma.expert-session/v3",
       sessionId: "leased-session",
       expertId: "expert",
       expertVersion: "1.0.0",
@@ -645,7 +688,9 @@ describe("ExpertSession", () => {
       queuedRequestIds: [],
       executionIds: [],
       rootContextId: "root",
-      contexts: {},
+      contexts: {
+        root: sessionRootContext("leased-session", "root", "expert", "1.0.0", "fake", now),
+      },
       createdAt: now,
       updatedAt: now,
     });
@@ -703,7 +748,7 @@ describe("ExpertSession", () => {
     const original = team("1.0.0");
     const now = new Date().toISOString();
     await sessions.create({
-      schemaVersion: "pragma.expert-session/v2",
+      schemaVersion: "pragma.expert-session/v3",
       sessionId: "fingerprint-session",
       expertId: original.id,
       expertVersion: original.version,
@@ -711,9 +756,10 @@ describe("ExpertSession", () => {
       status: "open",
       queuedRequestIds: [],
       executionIds: [],
-      runtimeId: "fake",
       rootContextId: "root",
-      contexts: {},
+      contexts: {
+        root: sessionRootContext("fingerprint-session", "root", lead.id, lead.version, "fake", now),
+      },
       createdAt: now,
       updatedAt: now,
     });
@@ -1230,16 +1276,14 @@ describe("ExpertSession", () => {
     });
     const session = await app.experts.createSession(expert, { sessionId: "journal-session" });
     const current = await session.getState();
-    const sessionCreated = (await session.listEvents()).items.find(
-      (event) => event.type === "session.created",
-    )!;
+    const sessionCreated = (await session.listEvents()).items;
     const now = new Date().toISOString();
     const executionId = "journal-execution";
     const definition = { id: expert.id, version: expert.version, kind: "expert" as const };
     await writeFile(
       new PragmaPaths({ pragmaHome: home }).expertSessionTransaction(session.sessionId),
       `${JSON.stringify({
-        schemaVersion: "pragma.expert-session-transaction/v2",
+        schemaVersion: "pragma.expert-session-transaction/v3",
         session: {
           ...current,
           queuedRequestIds: ["journal-request"],
@@ -1259,11 +1303,11 @@ describe("ExpertSession", () => {
           },
         ],
         events: [
-          sessionCreated,
+          ...sessionCreated,
           {
             schemaVersion: "pragma.expert-session-event/v1",
             eventId: "prompt-enqueued:journal-request",
-            cursor: { sessionId: session.sessionId, sequence: 2 },
+            cursor: { sessionId: session.sessionId, sequence: 3 },
             sessionId: session.sessionId,
             type: "prompt.enqueued",
             data: {
@@ -1293,7 +1337,7 @@ describe("ExpertSession", () => {
           rootInvocationId: executionId,
           definition,
           executorId: expert.id,
-          contextId: "journal-context",
+          contextId: current.rootContextId,
           status: "queued",
           input: "recover me",
           createdAt: now,
@@ -1320,7 +1364,7 @@ describe("ExpertSession", () => {
     const sessions = createFileExpertSessionStore({ executions, pragmaHome: home });
     const now = new Date().toISOString();
     await sessions.create({
-      schemaVersion: "pragma.expert-session/v2",
+      schemaVersion: "pragma.expert-session/v3",
       sessionId: "atomic-session",
       expertId: "expert",
       expertVersion: "1.0.0",
@@ -1329,28 +1373,54 @@ describe("ExpertSession", () => {
       queuedRequestIds: [],
       executionIds: [],
       rootContextId: "root-context",
-      contexts: {},
+      contexts: {
+        "root-context": sessionRootContext(
+          "atomic-session",
+          "root-context",
+          "expert",
+          "1.0.0",
+          "fake",
+          now,
+        ),
+      },
       createdAt: now,
       updatedAt: now,
     });
-    const created = (await sessions.listEvents("atomic-session"))[0]!;
+    const created = await sessions.listEvents("atomic-session");
     const closedAt = new Date(Date.now() + 1).toISOString();
+    const current = (await sessions.get("atomic-session"))!;
+    const closedRoot = {
+      ...current.contexts[current.rootContextId]!,
+      lifecycle: "closed" as const,
+      closedAt,
+      updatedAt: closedAt,
+    };
     await writeFile(
       new PragmaPaths({ pragmaHome: home }).expertSessionTransaction("atomic-session"),
       `${JSON.stringify({
-        schemaVersion: "pragma.expert-session-transaction/v2",
+        schemaVersion: "pragma.expert-session-transaction/v3",
         session: {
-          ...(await sessions.get("atomic-session")),
+          ...current,
           status: "closed",
+          contexts: { ...current.contexts, [current.rootContextId]: closedRoot },
           updatedAt: closedAt,
         },
         prompts: [],
         events: [
-          created,
+          ...created,
+          {
+            schemaVersion: "pragma.expert-session-event/v1",
+            eventId: "context-closed:root-context",
+            cursor: { sessionId: "atomic-session", sequence: 3 },
+            sessionId: "atomic-session",
+            type: "context.closed",
+            data: { contextId: "root-context" },
+            occurredAt: closedAt,
+          },
           {
             schemaVersion: "pragma.expert-session-event/v1",
             eventId: "session-closed",
-            cursor: { sessionId: "atomic-session", sequence: 2 },
+            cursor: { sessionId: "atomic-session", sequence: 4 },
             sessionId: "atomic-session",
             type: "session.closed",
             data: {},
@@ -1364,6 +1434,8 @@ describe("ExpertSession", () => {
     await expect(sessions.get("atomic-session")).resolves.toMatchObject({ status: "closed" });
     await expect(sessions.listEvents("atomic-session")).resolves.toMatchObject([
       { type: "session.created" },
+      { type: "context.created" },
+      { type: "context.closed" },
       { type: "session.closed" },
     ]);
   });
@@ -1433,7 +1505,7 @@ describe("FlowExecution", () => {
     expect((await execution.getTree()).children[0]?.invocation.contextResolution).toBeDefined();
     const store = createFileExecutionStore({ pragmaHome: home });
     expect(await store.listContexts(execution.executionId)).toMatchObject([
-      { lifecycle: "closed", snapshot: { runtimeId: "fake" } },
+      { lifecycle: "closed", runtimeId: "fake", snapshot: { systemSessionId: expect.any(String) } },
     ]);
     const eventTypes = (await streamed).map((event) => event.type);
     expect(eventTypes).toContain("context.closed");
@@ -2358,6 +2430,27 @@ async function waitUntil(predicate: () => Promise<boolean>): Promise<void> {
     if (Date.now() >= deadline) throw new Error("Timed out waiting for test condition.");
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
   }
+}
+
+function sessionRootContext(
+  sessionId: string,
+  contextId: string,
+  expertId: string,
+  expertVersion: string,
+  runtimeId: string,
+  now: string,
+) {
+  return {
+    schemaVersion: "pragma.runtime-context/v2" as const,
+    contextId,
+    owner: { type: "expert-session" as const, ownerId: sessionId },
+    origin: { type: "expert-session" as const, sessionId },
+    expert: { id: expertId, version: expertVersion },
+    runtimeId,
+    lifecycle: "open" as const,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 async function waitForHumanRequest(

--- a/packages/shared/src/execution/execution.schema.ts
+++ b/packages/shared/src/execution/execution.schema.ts
@@ -27,8 +27,6 @@ export const DefinitionReferenceSchema = z.object({
 });
 
 export const RuntimeContextSnapshotSchema = z.object({
-  expertId: z.string().min(1),
-  runtimeId: z.string().min(1),
   systemSessionId: z.string().min(1),
   runtimeSession: RuntimeSessionRefSchema,
 });
@@ -38,17 +36,28 @@ export const RuntimeContextOwnerSchema = z.object({
   ownerId: z.string().min(1),
 });
 
+export const RuntimeContextOriginSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("expert-session"),
+    sessionId: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("invocation"),
+    invocationId: z.string().min(1),
+  }),
+]);
+
 export const RuntimeContextRecordSchema = z
   .object({
-    schemaVersion: z.literal("pragma.runtime-context/v1"),
+    schemaVersion: z.literal("pragma.runtime-context/v2"),
     contextId: z.string().min(1),
     owner: RuntimeContextOwnerSchema,
-    createdByInvocationId: z.string().min(1),
+    origin: RuntimeContextOriginSchema,
     expert: z.object({
       id: z.string().min(1),
       version: z.string().min(1),
     }),
-    runtimeId: z.string().min(1).optional(),
+    runtimeId: z.string().min(1),
     snapshot: RuntimeContextSnapshotSchema.optional(),
     lifecycle: z.enum(["open", "closed"]),
     createdAt: z.string().datetime(),
@@ -56,6 +65,23 @@ export const RuntimeContextRecordSchema = z
     closedAt: z.string().datetime().optional(),
   })
   .superRefine((value, context) => {
+    if (
+      value.origin.type === "expert-session" &&
+      (value.owner.type !== "expert-session" || value.owner.ownerId !== value.origin.sessionId)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["origin"],
+        message: "ExpertSession Context origin must match its owner.",
+      });
+    }
+    if (value.owner.type === "flow-execution" && value.origin.type !== "invocation") {
+      context.addIssue({
+        code: "custom",
+        path: ["origin"],
+        message: "FlowExecution Context requires an Invocation origin.",
+      });
+    }
     if (value.lifecycle === "closed" && value.closedAt === undefined) {
       context.addIssue({ code: "custom", path: ["closedAt"], message: "closedAt is required." });
     }
@@ -65,22 +91,6 @@ export const RuntimeContextRecordSchema = z
         path: ["closedAt"],
         message: "Open Context cannot have closedAt.",
       });
-    }
-    if (value.snapshot !== undefined) {
-      if (value.snapshot.expertId !== value.expert.id) {
-        context.addIssue({
-          code: "custom",
-          path: ["snapshot", "expertId"],
-          message: "Snapshot Expert mismatch.",
-        });
-      }
-      if (value.runtimeId !== undefined && value.snapshot.runtimeId !== value.runtimeId) {
-        context.addIssue({
-          code: "custom",
-          path: ["snapshot", "runtimeId"],
-          message: "Snapshot Runtime mismatch.",
-        });
-      }
     }
   });
 
@@ -203,6 +213,7 @@ export type InvocationKind = z.infer<typeof InvocationKindSchema>;
 export type DefinitionReference = z.infer<typeof DefinitionReferenceSchema>;
 export type RuntimeContextSnapshot = z.infer<typeof RuntimeContextSnapshotSchema>;
 export type RuntimeContextOwner = z.infer<typeof RuntimeContextOwnerSchema>;
+export type RuntimeContextOrigin = z.infer<typeof RuntimeContextOriginSchema>;
 export type RuntimeContextRecord = z.infer<typeof RuntimeContextRecordSchema>;
 export type ContextResolutionRecord = z.infer<typeof ContextResolutionRecordSchema>;
 export type Invocation = z.infer<typeof InvocationSchema>;

--- a/packages/shared/src/execution/expert-session.schema.ts
+++ b/packages/shared/src/execution/expert-session.schema.ts
@@ -26,23 +26,72 @@ export const PromptRequestSchema = z.object({
   updatedAt: z.string().datetime(),
 });
 
-export const ExpertSessionRecordSchema = z.object({
-  schemaVersion: z.literal("pragma.expert-session/v2"),
-  sessionId: z.string().min(1),
-  expertId: z.string().min(1),
-  expertVersion: z.string().min(1),
-  definitionFingerprint: z.string().length(64),
-  status: z.enum(["open", "closed"]),
-  activeExecutionId: z.string().min(1).optional(),
-  queuedRequestIds: z.array(z.string().min(1)),
-  executionIds: z.array(z.string().min(1)),
-  runtimeId: z.string().min(1).optional(),
-  rootContextId: z.string().min(1),
-  contexts: z.record(z.string(), RuntimeContextRecordSchema),
-  lastStatus: ExecutionStatusSchema.optional(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-});
+export const ExpertSessionRecordSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.expert-session/v3"),
+    sessionId: z.string().min(1),
+    expertId: z.string().min(1),
+    expertVersion: z.string().min(1),
+    definitionFingerprint: z.string().length(64),
+    status: z.enum(["open", "closed"]),
+    activeExecutionId: z.string().min(1).optional(),
+    queuedRequestIds: z.array(z.string().min(1)),
+    executionIds: z.array(z.string().min(1)),
+    rootContextId: z.string().min(1),
+    contexts: z.record(z.string(), RuntimeContextRecordSchema),
+    lastStatus: ExecutionStatusSchema.optional(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .superRefine((value, context) => {
+    for (const [contextId, runtimeContext] of Object.entries(value.contexts)) {
+      if (runtimeContext.contextId !== contextId) {
+        context.addIssue({
+          code: "custom",
+          path: ["contexts", contextId],
+          message: "ExpertSession Context key must match contextId.",
+        });
+      }
+      if (
+        runtimeContext.owner.type !== "expert-session" ||
+        runtimeContext.owner.ownerId !== value.sessionId
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["contexts", contextId, "owner"],
+          message: "ExpertSession Context owner must match the Session.",
+        });
+      }
+      if (contextId !== value.rootContextId && runtimeContext.origin.type !== "invocation") {
+        context.addIssue({
+          code: "custom",
+          path: ["contexts", contextId, "origin"],
+          message: "Delegated ExpertSession Context requires an Invocation origin.",
+        });
+      }
+    }
+    const root = value.contexts[value.rootContextId];
+    if (root === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["rootContextId"],
+        message: "ExpertSession root Context is missing.",
+      });
+      return;
+    }
+    if (
+      root.owner.type !== "expert-session" ||
+      root.owner.ownerId !== value.sessionId ||
+      root.origin.type !== "expert-session" ||
+      root.origin.sessionId !== value.sessionId
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["rootContextId"],
+        message: "ExpertSession root Context identity is invalid.",
+      });
+    }
+  });
 
 export const ExpertSessionEventCursorSchema = z.object({
   sessionId: z.string().min(1),


### PR DESCRIPTION
## What changed

- create and persist one immutable root Runtime Context atomically with every ExpertSession
- make Runtime Context the single source of Expert and Runtime identity
- distinguish ExpertSession root origins from Flow and delegation Invocation origins
- keep ContextIdResolver scoped to Flow and delegated Context creation/reuse
- remove duplicated runtime identity from ExpertSession, Invocation execution options, and Runtime snapshots
- persist root context lifecycle events and enforce immutable Context identity patches
- update schemas, transaction versions, architecture documentation, and behavioral coverage

## Why

ExpertSession, Runtime Context, and native Runtime Session previously had overlapping identity and routing fields. Root Context creation was deferred until the first prompt, which allowed incomplete Session state and made the first Invocation appear to own the root conversation.

This change establishes the invariant that one ExpertSession always owns one continuous root Runtime Context. A fresh root conversation requires a new ExpertSession. Runtime routing is resolved before Context creation and execution subsequently reads only RuntimeContextRecord.runtimeId.

## Impact

This is an intentional persisted-state breaking change:

- RuntimeContextRecord v1 → v2
- ExpertSessionRecord v2 → v3
- Execution transaction v5 → v6
- ExpertSession transaction v2 → v3

No legacy migration or compatibility path is retained.

## Validation

- pnpm check
- pnpm build
- @pragma/core: 82 tests passed
- Claude Code review completed; verified findings were addressed