### PR TITLE
refactor(examples): share interactive TUI support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,11 +3,11 @@
 示例按功能目录组织，每个文件聚焦验证一个能力。建议从 `experts/getting-started`
 开始，再逐步阅读会话、团队和 Flow 示例。
 
-## 1. Expert 入门：控制台聊天
+## 1. Expert 入门：TUI 聊天
 
 这个示例会创建一个最小 Expert 和一个 `ExpertSession`，然后在同一个 Session 中持续
-接收控制台输入，因此 Expert 可以使用之前轮次的对话内容。控制台会像 Codex CLI 一样
-区分并流式展示 `Thinking`、工具调用、工具结果和最终 `Expert` 回答。
+接收控制台输入，因此 Expert 可以使用之前轮次的对话内容。全屏 TUI 会区分并流式展示
+`Thinking`、工具调用、工具结果和最终回答；发生 `askUserQuestion` 时，底部输入区会切换成答题模式。
 
 准备模型配置：
 
@@ -27,7 +27,7 @@ pnpm --filter @pragma/examples example:expert-chat
 pnpm --filter @pragma/examples dev src/experts/getting-started/console-chat.ts
 ```
 
-输入 `/exit` 或按 `Ctrl+C` 结束聊天。
+输入 `/exit` 或按 `Ctrl+C` 结束聊天，使用 `PgUp` / `PgDn` 滚动历史输出。
 
 ### 如何验证
 
@@ -45,27 +45,23 @@ pnpm --filter @pragma/examples dev src/experts/getting-started/console-chat.ts
 3. 两轮输入属于控制台打印出的同一个 `ExpertSession`；
 4. Runtime 保留并使用了同一会话的上下文。
 
-再输入“现在几点？”，Expert 应调用 `get_current_time`，控制台会展示：
+再输入“现在几点？”，Expert 应调用 `get_current_time`，TUI 会依次展示工具调用参数、流式工具输出
+和完成状态。输入下面的提示可验证 Human-in-the-loop：
 
 ```text
-• Running get_current_time
-  ↳ {}
-  ↳ 2026-07-12T10:00:00.000Z
-  ✓ get_current_time completed
-• Expert
-...
+你 > 请先用 askUserQuestion 问我想聊哪个主题，再根据回答继续。
 ```
 
-`Thinking` 只会在模型和提供商实际返回 reasoning delta 时出现；renderer 不会伪造思考内容。
+TUI 应显示结构化问题；单选题可输入编号或选项名，多选题使用逗号分隔，文本题直接输入内容。
+回答会通过 `respondToHumanInteraction()` 交还正在等待的 Turn。
+
+`Thinking` 只会在模型和提供商实际返回 reasoning delta 时出现；TUI 不会伪造思考内容。
 
 实时输出只监听订阅后的未来增量，并在 Execution 结束后自动关闭：
 
 ```ts
-const output = await turn.subscribeOutput({ scope: { kind: "all" } });
-for await (const item of output) renderer.renderOutput(item);
-
-const result = await turn.result;
-const turnUsage = await turn.usage;
+activeTurn = await session.prompt(prompt);
+await ui.followTurn(activeTurn);
 ```
 
 需要读取既有对话时使用 Session 的 message history，而不是重放执行事件：
@@ -77,12 +73,12 @@ const sessionUsage = await session.getUsage();
 ```
 
 Usage 随 Execution 持久化。`turn.usage` 读取单轮汇总，`session.getUsage()` 汇总 Session
-内所有已完成 Turn；三个控制台聊天示例会在输入 `/exit` 时打印 Session 总 Usage。
+内所有已完成 Turn；TUI 底部会显示最近完成 Turn 的 token Usage。
 
 模型输出并非确定性结果；这个检查验证的是调用链与多轮上下文，不代表对任意事实问题的
 答案都准确。业务准确性应为具体 Expert 准备固定输入、期望标准和自动化评测。
 
-## 2. 本地 Runtime：Codex 与 Claude Code 控制台聊天
+## 2. 本地 Runtime：Codex 与 Claude Code TUI 聊天
 
 两个示例分别验证已安装并已登录的 Codex CLI 和 Claude Code CLI。启动后会依次：
 
@@ -90,7 +86,7 @@ Usage 随 Execution 持久化。`turn.usage` 读取单轮汇总，`session.getUs
 2. 通过 `listModels()` 探测当前环境支持的模型；
 3. 让你输入编号选择模型，或直接回车沿用 CLI 默认模型；
 4. 根据所选模型展示支持的思考深度，选择编号或回车沿用 CLI 默认深度；
-5. 创建带测试用 In-memory Context Store 的 ExpertSession 并进入流式聊天。
+5. 创建带测试用 In-memory Context Store 的 ExpertSession 并进入全屏流式 TUI。
 
 ```bash
 pnpm --filter @pragma/examples example:runtime-codex
@@ -109,6 +105,9 @@ Context Store 同时准备了 `always_on`、`model_decision`、`manual` 三类�
 回答应分别包含 `AO-2048`、`MD-4096`、`7319` 和 `Aurora Finch`。`always_on` 内容会自动
 预加载；后两类验证中，流式输出应出现 `list_expert_context` 或 `read_expert_context` 等
 上下文工具调用。测试上下文只存在于当前 example 进程的内存中，不会写入 workspace。
+
+两个 Runtime TUI 与 Getting Started 共用同一套交互层，也支持 `Thinking`、工具调用与工具输出增量、
+`askUserQuestion`、`/exit`、`Ctrl+C` 和滚动历史。模型与思考深度仍在进入全屏 TUI 前选择。
 
 ## 3. Context、MCP、Skills、Plugin 与 Tool 审批
 

--- a/examples/src/README.md
+++ b/examples/src/README.md
@@ -5,7 +5,8 @@ Flow 的公共 API。
 
 ## Expert、Subagent 与团队
 
-- `experts/getting-started/console-chat.ts`：最小控制台聊天、多轮消息与 Usage。
+- `experts/getting-started/console-chat.ts`：单 Expert 全屏 TUI、多轮消息、流式 Thinking/Tool、
+  `askUserQuestion` 与 Usage。
 - `experts/conversations/single-multi.ts`：单 Expert 的单轮和多轮执行。
 - `experts/conversations/resume.ts`：恢复 `ExpertSession` 后继续提交 prompt。
 - `experts/conversations/queue-steer.ts`：持久化 prompt queue 与 steer。
@@ -17,8 +18,9 @@ Flow 的公共 API。
   每个 Agent 独立的思考、工具和回答流。
 - `experts/teams/invocation-tree.ts`：读取团队 InvocationTree。
 
-两个 delegation 入口共用多 Agent TUI：顶部成员栏展示各 Agent 状态，`Tab` / `Shift+Tab` 或
-`F1` - `F4` 切换成员，`Esc` 返回 Main Agent / Lead，`PgUp` / `PgDn` 滚动当前日志。两个控制台
+Getting Started 与两个 delegation 入口共用 Expert TUI 的事件和 Human-in-the-loop 处理。
+多 Agent 模式在顶部成员栏展示各 Agent 状态，`Tab` / `Shift+Tab` 或
+`F1` - `F4` 切换成员，`Esc` 返回 Main Agent / Lead，`PgUp` / `PgDn` 滚动当前日志。所有 TUI
 都会按 Agent 隔离并解析思考、工具调用、工具输出、进度和回答；`askUserQuestion` 触发的
 `human.requested` 会进入 TUI 答题模式，并通过 `respondToHumanInteraction()` 将答案交还当前 Turn。
 
@@ -38,9 +40,9 @@ Flow 的公共 API。
 
 ## Runtime
 
-- `runtimes/codex/console-chat.ts`：Codex CLI Runtime。
-- `runtimes/claude-code/console-chat.ts`：Claude Code CLI Runtime。
-- `runtimes/shared/console-runtime-chat.ts`：两个本地 Runtime 共用的控制台流程。
+- `runtimes/codex/console-chat.ts`：Codex CLI Runtime 的单 Expert 全屏 TUI。
+- `runtimes/claude-code/console-chat.ts`：Claude Code CLI Runtime 的单 Expert 全屏 TUI。
+- `runtimes/shared/console-runtime-chat.ts`：两个本地 Runtime 共用的探测、模型选择与 TUI 流程。
 
 ## Flow
 
@@ -56,5 +58,11 @@ Flow 的公共 API。
 ## 示例支撑
 
 - `support/example-kit.ts`：示例共用的 Expert、Runtime Registry 和 Pragma App 装配。
+- `console/execution-output-accumulator.ts`：统一把 Runtime 输出解析成 Answer、Thinking、Tool、
+  Tool output 和 Progress 活动，处理完成消息回退、结构化 Tool delta 与累积快照去重。
+- `console/human-interaction-parser.ts`：统一校验 `human.requested`，解析单选、多选、文本和审批输入，
+  并构造类型安全的 Human response。
+- `console/human-interaction-controller.ts`：管理多问题、多个等待交互、选项状态和已完成响应。
+- `console/expert-console-tui.ts`：单 Expert 与多 Expert 共用的状态、Turn 生命周期和全屏 TUI。
 - `console/flow-console-tui.ts`：可复用的 Flow 节点图、详情面板、Team 子树和 Human-in-the-loop
-  全屏控制台。
+  全屏控制台；与 Expert TUI 共用上述输出和人工交互协议层。

--- a/examples/src/console/console-turn-renderer.ts
+++ b/examples/src/console/console-turn-renderer.ts
@@ -1,5 +1,11 @@
 import type { ExecutionOutputItem, ExpertTurn } from "@pragma/core";
 
+import {
+  asConsoleRecord as asRecord,
+  formatConsoleValue,
+  readConsoleString as readString,
+} from "./execution-output-accumulator.ts";
+
 interface ConsoleOutput {
   readonly isTTY?: boolean | undefined;
   write(text: string): unknown;
@@ -211,15 +217,6 @@ export async function renderExpertTurn(
   }
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
-
-function readString(record: Record<string, unknown>, key: string): string {
-  const value = record[key];
-  return typeof value === "string" ? value : "";
-}
-
 function hasMeaningfulPreview(value: unknown): boolean {
   if (value === undefined || value === null || value === "") {
     return false;
@@ -234,7 +231,5 @@ function hasMeaningfulPreview(value: unknown): boolean {
 }
 
 function formatValue(value: unknown, maxLength: number): string {
-  const text =
-    typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? String(value));
-  return text.length <= maxLength ? text : `${text.slice(0, Math.max(0, maxLength - 1))}…`;
+  return formatConsoleValue(value, maxLength) ?? String(value);
 }

--- a/examples/src/console/execution-output-accumulator.ts
+++ b/examples/src/console/execution-output-accumulator.ts
@@ -1,0 +1,238 @@
+import type { ExecutionOutputItem } from "@pragma/core";
+
+export type ConsoleExecutionActivityKind =
+  | "answer"
+  | "progress"
+  | "thinking"
+  | "tool"
+  | "tool-output";
+
+export interface ConsoleExecutionActivity {
+  readonly kind: ConsoleExecutionActivityKind;
+  readonly text: string;
+  readonly append: boolean;
+}
+
+export interface ExecutionOutputAccumulatorOptions {
+  readonly includeRoutineProgress?: boolean | undefined;
+  readonly maxPreviewLength?: number | undefined;
+}
+
+export class ExecutionOutputAccumulator {
+  private readonly includeRoutineProgress: boolean;
+  private readonly maxPreviewLength: number;
+  private readonly invocationsWithAnswers = new Set<string>();
+  private readonly activeToolKeys = new Map<string, string>();
+  private readonly toolOutputSnapshots = new Map<string, string>();
+  private readonly toolsWithOutputDeltas = new Set<string>();
+
+  constructor(options: ExecutionOutputAccumulatorOptions = {}) {
+    this.includeRoutineProgress = options.includeRoutineProgress ?? true;
+    this.maxPreviewLength = options.maxPreviewLength ?? 800;
+  }
+
+  consume(item: ExecutionOutputItem): readonly ConsoleExecutionActivity[] {
+    switch (item.channel) {
+      case "thought": {
+        const text = item.delta ?? formatConsoleValue(item.value);
+        return text === undefined ? [] : [{ kind: "thinking", text, append: true }];
+      }
+      case "message":
+        return this.consumeMessage(item);
+      case "tool":
+        return this.consumeTool(item);
+      case "progress": {
+        const payload = asConsoleRecord(item.value);
+        const stage = readConsoleString(payload, "stage");
+        if (!this.includeRoutineProgress && isRoutineProgress(stage)) return [];
+        const text = formatConsoleProgress(item.value);
+        return text === undefined ? [] : [{ kind: "progress", text, append: false }];
+      }
+      case "result": {
+        if (this.invocationsWithAnswers.has(item.invocationId)) return [];
+        const text = formatConsoleValue(item.value);
+        return text === undefined ? [] : [{ kind: "answer", text, append: false }];
+      }
+    }
+  }
+
+  reset(): void {
+    this.invocationsWithAnswers.clear();
+    this.activeToolKeys.clear();
+    this.toolOutputSnapshots.clear();
+    this.toolsWithOutputDeltas.clear();
+  }
+
+  private consumeMessage(item: ExecutionOutputItem): readonly ConsoleExecutionActivity[] {
+    if (item.delta !== undefined) {
+      if (item.delta === "") return [];
+      this.invocationsWithAnswers.add(item.invocationId);
+      return [{ kind: "answer", text: item.delta, append: true }];
+    }
+    if (this.invocationsWithAnswers.has(item.invocationId)) return [];
+    const text = readCompletedMessageText(item.value);
+    if (text === undefined) return [];
+    this.invocationsWithAnswers.add(item.invocationId);
+    return [{ kind: "answer", text, append: false }];
+  }
+
+  private consumeTool(item: ExecutionOutputItem): readonly ConsoleExecutionActivity[] {
+    if (item.delta !== undefined) {
+      const toolKey = this.activeToolKeys.get(item.invocationId) ?? item.invocationId;
+      const normalized = normalizeToolOutputDelta(item.delta, this.maxPreviewLength);
+      const increment =
+        normalized === undefined
+          ? undefined
+          : readToolOutputIncrement(this.toolOutputSnapshots, toolKey, normalized);
+      if (increment === undefined || increment === "") return [];
+      this.toolsWithOutputDeltas.add(toolKey);
+      return [{ kind: "tool-output", text: increment, append: true }];
+    }
+
+    const payload = asConsoleRecord(item.value);
+    const toolName = readConsoleString(payload, "toolName") || "tool";
+    const toolCallId = readConsoleString(payload, "toolCallId") || item.invocationId;
+    const toolKey = `${item.invocationId}:${toolCallId}`;
+    const started =
+      payload["message"] === undefined &&
+      payload["approvalId"] === undefined &&
+      payload["outputPreview"] === undefined;
+
+    if (started) {
+      this.activeToolKeys.set(item.invocationId, toolKey);
+      this.toolOutputSnapshots.delete(toolKey);
+      this.toolsWithOutputDeltas.delete(toolKey);
+      const preview = formatConsolePreview(payload["inputPreview"], this.maxPreviewLength);
+      return [
+        {
+          kind: "tool",
+          text: `→ ${toolName}${preview === undefined ? "" : `\n${preview}`}`,
+          append: false,
+        },
+      ];
+    }
+
+    const activeToolKey = this.activeToolKeys.get(item.invocationId) ?? item.invocationId;
+    let activities: readonly ConsoleExecutionActivity[];
+    if (payload["message"] !== undefined) {
+      activities = [
+        {
+          kind: "tool",
+          text: `× ${toolName}: ${readConsoleString(payload, "message")}`,
+          append: false,
+        },
+      ];
+    } else if (payload["approvalId"] !== undefined) {
+      activities = [{ kind: "tool", text: `! ${toolName} requires approval`, append: false }];
+    } else {
+      const preview = formatConsolePreview(payload["outputPreview"], this.maxPreviewLength);
+      activities = [
+        { kind: "tool", text: `✓ ${toolName} completed`, append: false },
+        ...(preview === undefined || this.toolsWithOutputDeltas.has(activeToolKey)
+          ? []
+          : [{ kind: "tool-output" as const, text: preview, append: false }]),
+      ];
+    }
+
+    if (payload["approvalId"] === undefined) {
+      this.activeToolKeys.delete(item.invocationId);
+      this.toolOutputSnapshots.delete(activeToolKey);
+      this.toolsWithOutputDeltas.delete(activeToolKey);
+    }
+    return activities;
+  }
+}
+
+export function asConsoleRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+export function readConsoleString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value : "";
+}
+
+export function formatConsoleValue(value: unknown, maxLength?: number): string | undefined {
+  if (value === undefined) return undefined;
+  const text =
+    typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? String(value));
+  if (maxLength === undefined || text.length <= maxLength) return text;
+  return `${text.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+export function formatConsolePreview(value: unknown, maxLength = 800): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (Array.isArray(value) && value.length === 0) return undefined;
+  if (
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(asConsoleRecord(value)).length === 0
+  ) {
+    return undefined;
+  }
+  return formatConsoleValue(value, maxLength);
+}
+
+export function formatConsoleProgress(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  const record = asConsoleRecord(value);
+  const stage = readConsoleString(record, "stage");
+  const message = readConsoleString(record, "message");
+  if (stage !== "" || message !== "") {
+    return `${stage}${stage !== "" && message !== "" ? " — " : ""}${message}`;
+  }
+  return formatConsoleValue(value);
+}
+
+function readCompletedMessageText(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  const content = asConsoleRecord(value)["content"];
+  if (!Array.isArray(content)) return undefined;
+  const text = content
+    .map((item) => {
+      const record = asConsoleRecord(item);
+      return record["type"] === "text" ? readConsoleString(record, "text") : "";
+    })
+    .join("");
+  return text === "" ? undefined : text;
+}
+
+function normalizeToolOutputDelta(delta: string, maxLength: number): string | undefined {
+  try {
+    const parsed = JSON.parse(delta) as unknown;
+    const content = asConsoleRecord(parsed)["content"];
+    if (Array.isArray(content)) {
+      const text = content
+        .map((item) => readConsoleString(asConsoleRecord(item), "text"))
+        .join("\n");
+      return text === "" ? undefined : text;
+    }
+    return formatConsolePreview(parsed, maxLength);
+  } catch {
+    return delta;
+  }
+}
+
+function readToolOutputIncrement(
+  snapshots: Map<string, string>,
+  key: string,
+  next: string,
+): string | undefined {
+  const previous = snapshots.get(key);
+  if (previous === undefined) {
+    snapshots.set(key, next);
+    return next;
+  }
+  if (next === previous) return undefined;
+  if (next.startsWith(previous)) {
+    snapshots.set(key, next);
+    return next.slice(previous.length) || undefined;
+  }
+  snapshots.set(key, `${previous}${next}`);
+  return next;
+}
+
+function isRoutineProgress(stage: string): boolean {
+  return stage === "" || stage === "turn.start" || stage === "turn.end" || stage === "queue.update";
+}

--- a/examples/src/console/expert-console-tui.ts
+++ b/examples/src/console/expert-console-tui.ts
@@ -1,5 +1,4 @@
 import {
-  ExpertAgentHumanRequestSchema,
   type AgentMessageUsage,
   type ExecutionEvent,
   type ExecutionEventSubscription,
@@ -22,7 +21,17 @@ import {
   visibleWidth,
 } from "@earendil-works/pi-tui";
 
-export type DelegationAgentStatus =
+import { ExecutionOutputAccumulator } from "./execution-output-accumulator.ts";
+import {
+  consoleQuestionInstruction,
+  createToolApprovalResponse,
+  createUserQuestionResponse,
+  parseConsoleApprovalAnswer,
+  parseConsoleQuestionAnswer,
+  parseHumanInteractionEvent,
+} from "./human-interaction-parser.ts";
+
+export type ExpertConsoleAgentStatus =
   | "idle"
   | "queued"
   | "working"
@@ -31,7 +40,7 @@ export type DelegationAgentStatus =
   | "failed"
   | "cancelled";
 
-export interface DelegationConsoleAgent {
+export interface ExpertConsoleAgent {
   readonly id: string;
   readonly name: string;
   readonly shortName: string;
@@ -44,9 +53,9 @@ interface AgentLogSection {
 }
 
 interface AgentPane {
-  readonly definition: DelegationConsoleAgent;
+  readonly definition: ExpertConsoleAgent;
   readonly sections: AgentLogSection[];
-  status: DelegationAgentStatus;
+  status: ExpertConsoleAgentStatus;
 }
 
 interface ConsoleInteractionPresentation {
@@ -65,10 +74,6 @@ interface PendingConsoleInput {
   readonly reject: (error: unknown) => void;
 }
 
-export type DelegationQuestionAnswerResult =
-  | { readonly ok: true; readonly answer: string }
-  | { readonly ok: false; readonly message: string };
-
 type InvocationTree = Awaited<ReturnType<ExpertTurn["getTree"]>>;
 
 const ANSI = {
@@ -85,27 +90,28 @@ const ANSI = {
 
 const MAX_LOG_CHARACTERS = 200_000;
 
-export class DelegationConsoleModel {
+export class ExpertConsoleModel {
   readonly panes: readonly AgentPane[];
   private readonly awaitingInput = new Set<string>();
-  private readonly invocationsWithAnswerDeltas = new Set<string>();
-  private readonly toolOutputSnapshots = new Map<string, string>();
+  private readonly outputAccumulator = new ExecutionOutputAccumulator({
+    includeRoutineProgress: false,
+  });
   private selectedIndex = 0;
   private scrollOffset = 0;
   private usage: AgentMessageUsage | undefined;
 
-  constructor(agents: readonly DelegationConsoleAgent[]) {
-    if (agents.length < 2) {
-      throw new Error("Delegation console requires a primary Agent and at least one subagent.");
+  constructor(agents: readonly ExpertConsoleAgent[]) {
+    if (agents.length === 0) {
+      throw new Error("Expert console requires at least one Agent.");
     }
     if (new Set(agents.map((agent) => agent.id)).size !== agents.length) {
-      throw new Error("Delegation console Agent ids must be unique.");
+      throw new Error("Expert console Agent ids must be unique.");
     }
     const primaryIndexes = agents.flatMap((agent, index) =>
       agent.primary === true ? [index] : [],
     );
     if (primaryIndexes.length !== 1) {
-      throw new Error("Delegation console requires exactly one primary Agent.");
+      throw new Error("Expert console requires exactly one primary Agent.");
     }
     this.panes = agents.map((definition) => ({ definition, sections: [], status: "idle" }));
     this.selectedIndex = primaryIndexes[0]!;
@@ -129,8 +135,7 @@ export class DelegationConsoleModel {
 
   beginTurn(prompt: string): void {
     this.awaitingInput.clear();
-    this.invocationsWithAnswerDeltas.clear();
-    this.toolOutputSnapshots.clear();
+    this.outputAccumulator.reset();
     for (const pane of this.panes) pane.status = "idle";
     const primary = this.panes.find((pane) => pane.definition.primary === true)!;
     primary.status = "working";
@@ -144,41 +149,13 @@ export class DelegationConsoleModel {
     if (pane === undefined) return;
     if (pane.status === "idle" || pane.status === "queued") pane.status = "working";
 
-    switch (item.channel) {
-      case "thought": {
-        const text = item.delta ?? formatValue(item.value);
-        if (text !== undefined) appendSection(pane, "thinking", text, item.delta !== undefined);
-        break;
-      }
-      case "message": {
-        if (item.delta !== undefined) {
-          this.invocationsWithAnswerDeltas.add(item.invocationId);
-          appendSection(pane, "answer", item.delta, true);
-        } else if (!this.invocationsWithAnswerDeltas.has(item.invocationId)) {
-          const text = readCompletedMessageText(item.value);
-          if (text !== undefined) appendSection(pane, "answer", text);
-        }
-        break;
-      }
-      case "tool":
-        consumeToolOutput(pane, item, this.toolOutputSnapshots);
-        break;
-      case "progress": {
-        const payload = asRecord(item.value);
-        const stage = readString(payload, "stage");
-        if (!isRoutineProgress(stage)) {
-          const message = readString(payload, "message");
-          appendSection(pane, "system", `${stage}${message === "" ? "" : ` — ${message}`}`);
-        }
-        break;
-      }
-      case "result": {
-        const text = formatValue(item.value);
-        if (text !== undefined && !this.invocationsWithAnswerDeltas.has(item.invocationId)) {
-          appendSection(pane, "answer", text);
-        }
-        break;
-      }
+    for (const activity of this.outputAccumulator.consume(item)) {
+      appendSection(
+        pane,
+        activity.kind === "progress" ? "system" : activity.kind,
+        activity.text,
+        activity.append,
+      );
     }
 
     trimPane(pane);
@@ -186,7 +163,7 @@ export class DelegationConsoleModel {
   }
 
   syncTree(tree: InvocationTree): void {
-    const statuses = new Map<string, DelegationAgentStatus[]>();
+    const statuses = new Map<string, ExpertConsoleAgentStatus[]>();
     visitTree(tree, (executorId, status) => {
       const values = statuses.get(executorId) ?? [];
       values.push(mapInvocationStatus(status));
@@ -242,34 +219,34 @@ export class DelegationConsoleModel {
   }
 }
 
-export interface DelegationConsoleTuiOptions {
-  readonly agents: readonly DelegationConsoleAgent[];
+export interface ExpertConsoleTuiOptions {
+  readonly agents: readonly ExpertConsoleAgent[];
   readonly sessionId: string;
   readonly title: string;
   readonly examplePrompt: string;
-  readonly onPrompt: (prompt: string, ui: DelegationConsoleTui) => Promise<void>;
+  readonly onPrompt: (prompt: string, ui: ExpertConsoleTui) => Promise<void>;
   readonly onExit: () => Promise<void>;
   readonly terminal?: Terminal | undefined;
 }
 
-export class DelegationConsoleTui {
-  readonly model: DelegationConsoleModel;
+export class ExpertConsoleTui {
+  readonly model: ExpertConsoleModel;
   private readonly terminal: Terminal;
   private readonly tui: TUI;
-  private readonly view: DelegationConsoleView;
-  private readonly options: DelegationConsoleTuiOptions;
+  private readonly view: ExpertConsoleView;
+  private readonly options: ExpertConsoleTuiOptions;
   private promptTask: Promise<void> | undefined;
   private pendingInput: PendingConsoleInput | undefined;
   private exitPromise: Promise<void>;
   private resolveExit!: () => void;
   private exiting = false;
 
-  constructor(options: DelegationConsoleTuiOptions) {
+  constructor(options: ExpertConsoleTuiOptions) {
     this.options = options;
-    this.model = new DelegationConsoleModel(options.agents);
+    this.model = new ExpertConsoleModel(options.agents);
     this.terminal = options.terminal ?? new ProcessTerminal();
     this.tui = new TUI(this.terminal, true);
-    this.view = new DelegationConsoleView({
+    this.view = new ExpertConsoleView({
       model: this.model,
       terminal: this.terminal,
       sessionId: options.sessionId,
@@ -324,7 +301,7 @@ export class DelegationConsoleTui {
     } catch (error) {
       this.rejectPendingInput(error);
       await interactionTask.catch(() => undefined);
-      await turn.cancel("Delegation console interaction failed.").catch(() => undefined);
+      await turn.cancel("Expert console interaction failed.").catch(() => undefined);
       this.model.completeTurn(await turn.usage.catch(() => undefined), error);
       this.tui.requestRender();
       throw error;
@@ -392,7 +369,7 @@ export class DelegationConsoleTui {
     const handled = new Set<string>();
     const handle = async (event: ExecutionEvent): Promise<void> => {
       if (event.type !== "human.requested") return;
-      const interaction = readHumanInteraction(event);
+      const interaction = parseHumanInteractionEvent(event);
       if (handled.has(interaction.interactionId)) return;
       handled.add(interaction.interactionId);
       await this.respondToHumanInteraction(turn, event, interaction);
@@ -449,17 +426,17 @@ export class DelegationConsoleTui {
           header: question.header,
           question: question.question,
           options: question.options,
-          instruction: questionInstruction(question),
+          instruction: consoleQuestionInstruction(question),
         },
         (input) => {
-          const result = parseDelegationQuestionAnswer(question, input);
+          const result = parseConsoleQuestionAnswer(question, input);
           return result.ok
             ? { ok: true, value: result.answer }
             : { ok: false, message: result.message };
         },
       );
     }
-    return { kind: "user_question", answered: true, answers };
+    return createUserQuestionResponse(answers);
   }
 
   private async answerToolApproval(
@@ -483,13 +460,17 @@ export class DelegationConsoleTui {
         ],
         instruction: "输入 y/yes 或 n/no 后回车。",
       },
-      parseApprovalAnswer,
+      (input) => {
+        const result = parseConsoleApprovalAnswer(input);
+        return result.ok
+          ? { ok: true, value: result.approved }
+          : { ok: false, message: result.message };
+      },
     );
-    return {
-      kind: "tool_approval",
-      approved,
-      reason: approved ? "用户批准。" : "用户拒绝。",
-    };
+    return createToolApprovalResponse(approved, {
+      approvedReason: "用户批准。",
+      rejectedReason: "用户拒绝。",
+    });
   }
 
   private requestInput<T>(
@@ -529,8 +510,8 @@ export class DelegationConsoleTui {
   }
 }
 
-class DelegationConsoleView implements Component, Focusable {
-  readonly model: DelegationConsoleModel;
+class ExpertConsoleView implements Component, Focusable {
+  readonly model: ExpertConsoleModel;
   readonly terminal: Terminal;
   readonly sessionId: string;
   readonly title: string;
@@ -545,7 +526,7 @@ class DelegationConsoleView implements Component, Focusable {
   private _focused = false;
 
   constructor(options: {
-    readonly model: DelegationConsoleModel;
+    readonly model: ExpertConsoleModel;
     readonly terminal: Terminal;
     readonly sessionId: string;
     readonly title: string;
@@ -654,16 +635,24 @@ class DelegationConsoleView implements Component, Focusable {
       this.interaction !== undefined
         ? `回答 ${this.input.render(Math.max(1, safeWidth - 5))[0] ?? ""}`
         : this.busy
-          ? paint("● Agents 正在工作；Tab 切换 Agent 查看实时过程", ANSI.yellow, color)
+          ? paint(
+              this.model.panes.length === 1
+                ? "● Agent 正在工作；Thinking、Tool 与回答将实时更新"
+                : "● Agents 正在工作；Tab 切换 Agent 查看实时过程",
+              ANSI.yellow,
+              color,
+            )
           : `你 ${this.input.render(Math.max(1, safeWidth - 3))[0] ?? ""}`;
     const usage = formatUsage(this.model.latestUsage);
     const directKeyHint = `F1-F${Math.min(4, this.model.panes.length)} 直达`;
+    const navigationHint =
+      this.model.panes.length === 1
+        ? "PgUp/PgDn 滚动 · Ctrl+C 退出"
+        : `Tab/Shift+Tab 切换 · ${directKeyHint} · Esc 回主 Agent · PgUp/PgDn 滚动 · Ctrl+C 退出`;
     const hint =
       this.notice ??
       this.interaction?.instruction ??
-      (this.model.selected.sections.length === 0
-        ? `示例：${this.examplePrompt}`
-        : `Tab/Shift+Tab 切换 · ${directKeyHint} · Esc 回主 Agent · PgUp/PgDn 滚动 · Ctrl+C 退出`);
+      (this.model.selected.sections.length === 0 ? `示例：${this.examplePrompt}` : navigationHint);
 
     return [
       header,
@@ -683,7 +672,7 @@ class DelegationConsoleView implements Component, Focusable {
   }
 }
 
-function renderAgentTabs(model: DelegationConsoleModel, width: number, color: boolean): string[] {
+function renderAgentTabs(model: ExpertConsoleModel, width: number, color: boolean): string[] {
   const tabs = model.panes.map((pane, index) => {
     const icon = statusIcon(pane.status);
     const text = `${index + 1}:${icon} ${pane.definition.shortName}`;
@@ -706,7 +695,15 @@ function renderAgentTabs(model: DelegationConsoleModel, width: number, color: bo
 
 function renderLog(pane: AgentPane, width: number, color: boolean): string[] {
   if (pane.sections.length === 0) {
-    return [paint("尚未参与当前对话。主 Agent 会在任务需要该能力时自动委派。", ANSI.dim, color)];
+    return [
+      paint(
+        pane.definition.primary === true
+          ? "尚无对话内容。输入问题开始聊天。"
+          : "尚未参与当前对话。主 Agent 会在任务需要该能力时自动委派。",
+        ANSI.dim,
+        color,
+      ),
+    ];
   }
   return pane.sections.flatMap((section) => {
     const label = sectionLabel(section.kind, pane.definition, color);
@@ -734,59 +731,6 @@ function renderInteraction(
       ),
     );
   return [truncateToWidth(heading, width), ...question, ...options];
-}
-
-function consumeToolOutput(
-  pane: AgentPane,
-  item: ExecutionOutputItem,
-  snapshots: Map<string, string>,
-): void {
-  if (item.delta !== undefined) {
-    const normalized = normalizeToolDelta(item.delta);
-    const text =
-      normalized === undefined
-        ? undefined
-        : readToolOutputIncrement(item.invocationId, normalized, snapshots);
-    if (text !== undefined) appendSection(pane, "tool-output", text, true);
-    return;
-  }
-  const payload = asRecord(item.value);
-  const name = readString(payload, "toolName") || "tool";
-  const started =
-    payload["message"] === undefined &&
-    payload["approvalId"] === undefined &&
-    payload["outputPreview"] === undefined;
-  if (started) snapshots.delete(item.invocationId);
-  if (payload["message"] !== undefined) {
-    appendSection(pane, "tool", `× ${name}: ${readString(payload, "message")}`);
-  } else if (payload["approvalId"] !== undefined) {
-    appendSection(pane, "tool", `! ${name} requires approval`);
-  } else if (payload["outputPreview"] !== undefined) {
-    appendSection(pane, "tool", `✓ ${name} completed`);
-  } else if (payload["toolName"] !== undefined) {
-    const preview = formatPreview(payload["inputPreview"]);
-    appendSection(pane, "tool", `→ ${name}${preview === undefined ? "" : `\n${preview}`}`);
-  }
-  if (!started) snapshots.delete(item.invocationId);
-}
-
-function readToolOutputIncrement(
-  invocationId: string,
-  next: string,
-  snapshots: Map<string, string>,
-): string | undefined {
-  const previous = snapshots.get(invocationId);
-  if (previous === undefined) {
-    snapshots.set(invocationId, next);
-    return next;
-  }
-  if (next === previous) return undefined;
-  if (next.startsWith(previous)) {
-    snapshots.set(invocationId, next);
-    return next.slice(previous.length) || undefined;
-  }
-  snapshots.set(invocationId, `${previous}${next}`);
-  return next;
 }
 
 function appendSection(
@@ -820,7 +764,7 @@ function visitTree(
 
 function mapInvocationStatus(
   status: InvocationTree["invocation"]["status"],
-): DelegationAgentStatus {
+): ExpertConsoleAgentStatus {
   switch (status) {
     case "queued":
       return "queued";
@@ -837,8 +781,10 @@ function mapInvocationStatus(
   }
 }
 
-function aggregateStatuses(statuses: readonly DelegationAgentStatus[]): DelegationAgentStatus {
-  const priority: readonly DelegationAgentStatus[] = [
+function aggregateStatuses(
+  statuses: readonly ExpertConsoleAgentStatus[],
+): ExpertConsoleAgentStatus {
+  const priority: readonly ExpertConsoleAgentStatus[] = [
     "failed",
     "input",
     "working",
@@ -850,7 +796,7 @@ function aggregateStatuses(statuses: readonly DelegationAgentStatus[]): Delegati
   return priority.find((status) => statuses.includes(status)) ?? "idle";
 }
 
-function statusIcon(status: DelegationAgentStatus): string {
+function statusIcon(status: ExpertConsoleAgentStatus): string {
   switch (status) {
     case "idle":
       return "○";
@@ -869,8 +815,8 @@ function statusIcon(status: DelegationAgentStatus): string {
   }
 }
 
-function statusLabel(status: DelegationAgentStatus, color: boolean): string {
-  const labels: Record<DelegationAgentStatus, string> = {
+function statusLabel(status: ExpertConsoleAgentStatus, color: boolean): string {
+  const labels: Record<ExpertConsoleAgentStatus, string> = {
     idle: "idle",
     queued: "queued",
     working: "working",
@@ -882,7 +828,7 @@ function statusLabel(status: DelegationAgentStatus, color: boolean): string {
   return statusColor(`${statusIcon(status)} ${labels[status]}`, status, color);
 }
 
-function statusColor(text: string, status: DelegationAgentStatus, color: boolean): string {
+function statusColor(text: string, status: ExpertConsoleAgentStatus, color: boolean): string {
   if (status === "input") return paint(text, ANSI.cyan, color);
   if (status === "working" || status === "queued") return paint(text, ANSI.yellow, color);
   if (status === "done") return paint(text, ANSI.green, color);
@@ -892,7 +838,7 @@ function statusColor(text: string, status: DelegationAgentStatus, color: boolean
 
 function sectionLabel(
   kind: AgentLogSection["kind"],
-  agent: DelegationConsoleAgent,
+  agent: ExpertConsoleAgent,
   color: boolean,
 ): string {
   switch (kind) {
@@ -931,147 +877,4 @@ function formatUsage(usage: AgentMessageUsage | undefined): string {
   if (usage === undefined) return "";
   const total = usage.totalTokens ?? usage.input + usage.output;
   return `tokens ${total.toLocaleString("en-US")}`;
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
-
-function readString(record: Record<string, unknown>, key: string): string {
-  const value = record[key];
-  return typeof value === "string" ? value : "";
-}
-
-function readHumanInteraction(event: ExecutionEvent): {
-  readonly interactionId: string;
-  readonly request: ExpertAgentHumanRequest;
-} {
-  const payload = asRecord(event.data);
-  const interactionId = readString(payload, "interactionId");
-  if (interactionId === "") throw new Error("human.requested event is missing interactionId.");
-  return {
-    interactionId,
-    request: ExpertAgentHumanRequestSchema.parse(payload["request"]),
-  };
-}
-
-export function parseDelegationQuestionAnswer(
-  question: ExpertAgentUserQuestion,
-  input: string,
-): DelegationQuestionAnswerResult {
-  const normalized = input.trim();
-  if (normalized === "") return { ok: false, message: "请输入回答后再按回车。" };
-  if (question.kind === "text") return { ok: true, answer: normalized };
-
-  const tokens =
-    question.kind === "multiple_choice"
-      ? normalized
-          .split(/[,，]/u)
-          .map((token) => token.trim())
-          .filter((token) => token !== "")
-      : [normalized];
-  const selected: string[] = [];
-  for (const token of tokens) {
-    const option = readSelectedOption(question.options, token);
-    if (option === undefined) {
-      return {
-        ok: false,
-        message: `无法识别选项“${token}”；请输入编号或完整选项名称。`,
-      };
-    }
-    if (!selected.includes(option.label)) selected.push(option.label);
-  }
-  if (question.kind === "single_choice" && selected.length !== 1) {
-    return { ok: false, message: "单选题只能选择一个选项。" };
-  }
-  return { ok: true, answer: selected.join(", ") };
-}
-
-function readSelectedOption(
-  options: ExpertAgentUserQuestion["options"],
-  token: string,
-): ExpertAgentUserQuestion["options"][number] | undefined {
-  const numeric = Number(token);
-  if (Number.isInteger(numeric) && numeric >= 1 && numeric <= options.length) {
-    return options[numeric - 1];
-  }
-  const normalized = token.toLocaleLowerCase();
-  return options.find((option) => option.label.toLocaleLowerCase() === normalized);
-}
-
-function questionInstruction(question: ExpertAgentUserQuestion): string {
-  switch (question.kind) {
-    case "text":
-      return "输入回答后回车；Ctrl+C 可取消整个 Turn。";
-    case "single_choice":
-      return "输入一个选项编号或名称后回车；Ctrl+C 可取消整个 Turn。";
-    case "multiple_choice":
-      return "输入多个编号或名称并用逗号分隔；Ctrl+C 可取消整个 Turn。";
-  }
-}
-
-function parseApprovalAnswer(
-  input: string,
-):
-  | { readonly ok: true; readonly value: boolean }
-  | { readonly ok: false; readonly message: string } {
-  const normalized = input.trim().toLocaleLowerCase();
-  if (normalized === "y" || normalized === "yes" || normalized === "1") {
-    return { ok: true, value: true };
-  }
-  if (normalized === "n" || normalized === "no" || normalized === "2") {
-    return { ok: true, value: false };
-  }
-  return { ok: false, message: "请输入 y/yes 或 n/no。" };
-}
-
-function readCompletedMessageText(value: unknown): string | undefined {
-  if (typeof value === "string") return value;
-  const content = asRecord(value)["content"];
-  if (!Array.isArray(content)) return undefined;
-  const text = content
-    .map((item) => {
-      const record = asRecord(item);
-      return record["type"] === "text" ? readString(record, "text") : "";
-    })
-    .join("");
-  return text === "" ? undefined : text;
-}
-
-function formatValue(value: unknown): string | undefined {
-  if (value === undefined) return undefined;
-  return typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? String(value));
-}
-
-function formatPreview(value: unknown): string | undefined {
-  if (value === undefined || value === null || value === "") return undefined;
-  if (Array.isArray(value) && value.length === 0) return undefined;
-  if (
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    Object.keys(asRecord(value)).length === 0
-  ) {
-    return undefined;
-  }
-  const text = formatValue(value);
-  if (text === undefined) return undefined;
-  return text.length <= 800 ? text : `${text.slice(0, 799)}…`;
-}
-
-function normalizeToolDelta(delta: string): string | undefined {
-  try {
-    const parsed = JSON.parse(delta) as unknown;
-    const content = asRecord(parsed)["content"];
-    if (Array.isArray(content)) {
-      const text = content.map((item) => readString(asRecord(item), "text")).join("\n");
-      return text === "" ? undefined : text;
-    }
-    return formatPreview(parsed);
-  } catch {
-    return delta;
-  }
-}
-
-function isRoutineProgress(stage: string): boolean {
-  return stage === "" || stage === "turn.start" || stage === "turn.end" || stage === "queue.update";
 }

--- a/examples/src/console/flow-console-tui.ts
+++ b/examples/src/console/flow-console-tui.ts
@@ -1,11 +1,8 @@
 import {
-  ExpertAgentHumanRequestSchema,
   type AgentMessageUsage,
   type ExecutionEvent,
   type ExecutionEventSubscription,
   type ExecutionOutputItem,
-  type ExpertAgentHumanRequest,
-  type ExpertAgentUserQuestion,
   type Flow,
   type FlowExecution,
   type FlowSpec,
@@ -24,6 +21,20 @@ import {
   visibleWidth,
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+
+import {
+  asConsoleRecord as asRecord,
+  ExecutionOutputAccumulator,
+  formatConsolePreview as formatPreview,
+  formatConsoleProgress as formatProgress,
+  formatConsoleValue as formatValue,
+  readConsoleString as readString,
+} from "./execution-output-accumulator.ts";
+import { HumanInteractionQueue } from "./human-interaction-controller.ts";
+import {
+  findPendingHumanRequestEvents,
+  parseHumanInteractionEvent,
+} from "./human-interaction-parser.ts";
 
 type InvocationTree = Awaited<ReturnType<FlowExecution["getTree"]>>;
 type Invocation = InvocationTree["invocation"];
@@ -117,8 +128,9 @@ export class FlowConsoleModel {
   private selectedKey: string;
   private readonly invocationKeys = new Map<string, Set<string>>();
   private readonly invocationVisitByNode = new Map<string, Map<string, string>>();
-  private readonly toolSnapshots = new Map<string, string>();
-  private readonly invocationsWithAnswerDeltas = new Set<string>();
+  private readonly outputAccumulator = new ExecutionOutputAccumulator({
+    maxPreviewLength: 500,
+  });
 
   constructor(definition: FlowSpec | Flow) {
     this.flow = "compile" in definition ? definition.compile() : definition;
@@ -183,78 +195,19 @@ export class FlowConsoleModel {
   consumeOutput(item: ExecutionOutputItem): void {
     const keys = this.invocationKeys.get(item.invocationId);
     if (keys === undefined) return;
+    const activities = this.outputAccumulator.consume(item);
     for (const key of keys) {
       const node = this.nodes.get(key);
       if (node === undefined) continue;
-      switch (item.channel) {
-        case "thought": {
-          const text = item.delta ?? formatValue(item.value);
-          if (text !== undefined)
-            this.append(
-              node,
-              "thinking",
-              text,
-              true,
-              item.executorId,
-              this.visitId(item.invocationId, key),
-            );
-          break;
-        }
-        case "message": {
-          if (item.delta !== undefined) {
-            this.invocationsWithAnswerDeltas.add(item.invocationId);
-            this.append(
-              node,
-              "answer",
-              item.delta,
-              true,
-              item.executorId,
-              this.visitId(item.invocationId, key),
-            );
-          } else if (!this.invocationsWithAnswerDeltas.has(item.invocationId)) {
-            const text = readCompletedMessageText(item.value);
-            if (text !== undefined)
-              this.append(
-                node,
-                "answer",
-                text,
-                false,
-                item.executorId,
-                this.visitId(item.invocationId, key),
-              );
-          }
-          break;
-        }
-        case "tool":
-          this.consumeTool(node, item, item.executorId, this.visitId(item.invocationId, key));
-          break;
-        case "progress": {
-          const text = formatProgress(item.value);
-          if (text !== undefined)
-            this.append(
-              node,
-              "progress",
-              text,
-              false,
-              item.executorId,
-              this.visitId(item.invocationId, key),
-            );
-          break;
-        }
-        case "result": {
-          const text = formatValue(item.value);
-          if (text !== undefined && !this.invocationsWithAnswerDeltas.has(item.invocationId)) {
-            this.append(
-              node,
-              "answer",
-              text,
-              false,
-              item.executorId,
-              this.visitId(item.invocationId, key),
-            );
-          }
-          break;
-        }
+      for (const activity of activities) {
+        this.append(
+          node,
+          activity.kind,
+          activity.text,
+          activity.append,
+          item.executorId,
+          this.visitId(item.invocationId, key),
+        );
       }
     }
     this.scrollOffset = 0;
@@ -513,50 +466,6 @@ export class FlowConsoleModel {
     }
   }
 
-  private consumeTool(
-    node: FlowConsoleNode,
-    item: ExecutionOutputItem,
-    source: string | undefined,
-    visitId: string,
-  ): void {
-    const payload = asRecord(item.value);
-    const toolName = readString(payload, "toolName") || "tool";
-    const toolCallId = readString(payload, "toolCallId") || item.invocationId;
-    const snapshotKey = `${node.key}:${toolCallId}`;
-    if (item.delta !== undefined) {
-      const increment = readToolIncrement(this.toolSnapshots, snapshotKey, item.delta);
-      if (increment !== undefined)
-        this.append(node, "tool-output", increment, true, source, visitId);
-      return;
-    }
-    if (payload["message"] !== undefined) {
-      this.append(
-        node,
-        "tool",
-        `× ${toolName}: ${readString(payload, "message")}`,
-        false,
-        source,
-        visitId,
-      );
-    } else if (payload["approvalId"] !== undefined) {
-      this.append(node, "tool", `! ${toolName} requires approval`, false, source, visitId);
-    } else if (payload["outputPreview"] !== undefined) {
-      this.append(node, "tool", `✓ ${toolName} completed`, false, source, visitId);
-      const preview = formatPreview(payload["outputPreview"]);
-      if (preview !== undefined) this.append(node, "tool-output", preview, false, source, visitId);
-    } else {
-      const preview = formatPreview(payload["inputPreview"]);
-      this.append(
-        node,
-        "tool",
-        `→ ${toolName}${preview === undefined ? "" : `\n${preview}`}`,
-        false,
-        source,
-        visitId,
-      );
-    }
-  }
-
   private markSkippedRoutes(): void {
     for (const [nodeId, transition] of this.flow.transitions) {
       if (transition.type !== "route") continue;
@@ -582,139 +491,6 @@ export class FlowConsoleModel {
   }
 }
 
-interface QueuedInteraction {
-  readonly interactionId: string;
-  readonly invocationId: string;
-  readonly request: ExpertAgentHumanRequest;
-  readonly questions: readonly ExpertAgentUserQuestion[];
-  readonly answers: Record<string, string>;
-  questionIndex: number;
-  optionIndex: number;
-  selectedOptions: Set<number>;
-  completion?: CompletedInteraction | undefined;
-}
-
-interface CompletedInteraction {
-  readonly interactionId: string;
-  readonly invocationId: string;
-  readonly response: unknown;
-}
-
-export class FlowInteractionQueue {
-  private readonly items: QueuedInteraction[] = [];
-
-  get active(): QueuedInteraction | undefined {
-    return this.items[0];
-  }
-
-  get size(): number {
-    return this.items.length;
-  }
-
-  enqueue(input: {
-    readonly interactionId: string;
-    readonly invocationId: string;
-    readonly request: ExpertAgentHumanRequest;
-  }): void {
-    if (this.items.some((item) => item.interactionId === input.interactionId)) return;
-    const questions =
-      input.request.kind === "user_question"
-        ? input.request.questions
-        : [
-            {
-              header: "Tool approval",
-              question: `${input.request.toolName}: ${input.request.reason ?? "Allow this tool?"}`,
-              kind: "single_choice" as const,
-              options: [
-                { label: "Yes", description: "Allow execution" },
-                { label: "No", description: "Reject execution" },
-              ],
-            },
-          ];
-    this.items.push({
-      ...input,
-      questions,
-      answers: {},
-      questionIndex: 0,
-      optionIndex: 0,
-      selectedOptions: new Set(),
-    });
-  }
-
-  remove(interactionId: string): string | undefined {
-    const index = this.items.findIndex((item) => item.interactionId === interactionId);
-    if (index < 0) return undefined;
-    return this.items.splice(index, 1)[0]?.invocationId;
-  }
-
-  moveOption(direction: 1 | -1): void {
-    const active = this.active;
-    const question = active?.questions[active.questionIndex];
-    if (active === undefined || question === undefined || question.options.length === 0) return;
-    active.optionIndex =
-      (active.optionIndex + direction + question.options.length) % question.options.length;
-  }
-
-  selectNumber(number: number): void {
-    const active = this.active;
-    const question = active?.questions[active.questionIndex];
-    if (
-      active === undefined ||
-      question === undefined ||
-      number < 1 ||
-      number > question.options.length
-    )
-      return;
-    active.optionIndex = number - 1;
-  }
-
-  toggleOption(): void {
-    const active = this.active;
-    const question = active?.questions[active.questionIndex];
-    if (active === undefined || question?.kind !== "multiple_choice") return;
-    if (active.selectedOptions.has(active.optionIndex))
-      active.selectedOptions.delete(active.optionIndex);
-    else active.selectedOptions.add(active.optionIndex);
-  }
-
-  submit(text = ""): CompletedInteraction | string | undefined {
-    const active = this.active;
-    if (active?.completion !== undefined) return active.completion;
-    const question = active?.questions[active.questionIndex];
-    if (active === undefined || question === undefined) return undefined;
-    let answer: string;
-    if (question.kind === "text") {
-      answer = text.trim();
-      if (answer === "") return "请输入回答后再提交。";
-    } else if (question.kind === "multiple_choice") {
-      const indexes = [...active.selectedOptions].sort((left, right) => left - right);
-      if (indexes.length === 0) return "请至少选择一个选项。";
-      answer = indexes.map((index) => question.options[index]!.label).join(", ");
-    } else {
-      answer = question.options[active.optionIndex]?.label ?? "";
-      if (answer === "") return "请选择一个选项。";
-    }
-    active.answers[question.question] = answer;
-    active.questionIndex += 1;
-    active.optionIndex = 0;
-    active.selectedOptions.clear();
-    if (active.questionIndex < active.questions.length) return undefined;
-    active.completion = {
-      interactionId: active.interactionId,
-      invocationId: active.invocationId,
-      response:
-        active.request.kind === "tool_approval"
-          ? {
-              kind: "tool_approval",
-              approved: answer.toLocaleLowerCase() === "yes",
-              reason: answer.toLocaleLowerCase() === "yes" ? "User approved." : "User rejected.",
-            }
-          : { kind: "user_question", answered: true, answers: active.answers },
-    };
-    return active.completion;
-  }
-}
-
 export interface FlowConsoleTuiOptions {
   readonly definition: FlowSpec | Flow;
   readonly title: string;
@@ -724,7 +500,7 @@ export interface FlowConsoleTuiOptions {
 
 export class FlowConsoleTui {
   readonly model: FlowConsoleModel;
-  readonly interactions = new FlowInteractionQueue();
+  readonly interactions = new HumanInteractionQueue();
   private readonly options: FlowConsoleTuiOptions;
   private readonly terminal: Terminal;
   private readonly tui: TUI;
@@ -864,15 +640,11 @@ export class FlowConsoleTui {
   }
 
   private async enqueueInteraction(event: ExecutionEvent): Promise<void> {
-    const payload = asRecord(event.data);
-    const interactionId = readString(payload, "interactionId");
+    const interaction = parseHumanInteractionEvent(event);
+    const { interactionId } = interaction;
     if (interactionId === "" || this.handledInteractions.has(interactionId)) return;
     this.handledInteractions.add(interactionId);
-    this.interactions.enqueue({
-      interactionId,
-      invocationId: event.invocationId,
-      request: ExpertAgentHumanRequestSchema.parse(payload["request"]),
-    });
+    this.interactions.enqueue(interaction);
     this.model.focusInvocation(event.invocationId);
   }
 
@@ -971,22 +743,6 @@ export class FlowConsoleTui {
   }
 }
 
-export function findPendingHumanRequestEvents(
-  events: readonly ExecutionEvent[],
-): readonly ExecutionEvent[] {
-  const responded = new Set(
-    events
-      .filter((event) => event.type === "human.responded")
-      .map((event) => readString(asRecord(event.data), "interactionId"))
-      .filter((interactionId) => interactionId !== ""),
-  );
-  return events.filter(
-    (event) =>
-      event.type === "human.requested" &&
-      !responded.has(readString(asRecord(event.data), "interactionId")),
-  );
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -998,7 +754,7 @@ class FlowConsoleView implements Component, Focusable {
   constructor(
     private readonly options: {
       readonly model: FlowConsoleModel;
-      readonly interactions: FlowInteractionQueue;
+      readonly interactions: HumanInteractionQueue;
       readonly terminal: Terminal;
       readonly title: string;
       readonly requestRender: () => void;
@@ -1038,7 +794,7 @@ class FlowConsoleView implements Component, Focusable {
 
 export function renderFlowConsole(options: {
   readonly model: FlowConsoleModel;
-  readonly interactions: FlowInteractionQueue;
+  readonly interactions: HumanInteractionQueue;
   readonly input?: Input | undefined;
   readonly title: string;
   readonly width: number;
@@ -1331,7 +1087,7 @@ function appendActivity(
 }
 
 function renderHumanInteraction(
-  interactions: FlowInteractionQueue,
+  interactions: HumanInteractionQueue,
   input: Input | undefined,
   width: number,
   color: boolean,
@@ -1485,70 +1241,8 @@ function formatUsage(usage: AgentMessageUsage | undefined): string {
   return `tokens ${(usage.totalTokens ?? usage.input + usage.output).toLocaleString("en-US")}`;
 }
 
-function formatProgress(value: unknown): string | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value === "string") return value;
-  const record = asRecord(value);
-  const stage = readString(record, "stage");
-  const message = readString(record, "message");
-  if (stage !== "" || message !== "")
-    return `${stage}${stage !== "" && message !== "" ? " — " : ""}${message}`;
-  return formatValue(value);
-}
-
-function readCompletedMessageText(value: unknown): string | undefined {
-  if (typeof value === "string") return value;
-  const content = asRecord(value)["content"];
-  if (!Array.isArray(content)) return undefined;
-  const text = content
-    .map((item) => {
-      const record = asRecord(item);
-      return record["type"] === "text" ? readString(record, "text") : "";
-    })
-    .join("");
-  return text === "" ? undefined : text;
-}
-
-function readToolIncrement(
-  snapshots: Map<string, string>,
-  key: string,
-  next: string,
-): string | undefined {
-  const previous = snapshots.get(key);
-  if (previous === undefined) {
-    snapshots.set(key, next);
-    return next;
-  }
-  if (next === previous) return undefined;
-  if (next.startsWith(previous)) {
-    snapshots.set(key, next);
-    return next.slice(previous.length);
-  }
-  snapshots.set(key, `${previous}${next}`);
-  return next;
-}
-
 function agentPrefix(executorId: string | undefined): string {
   return executorId === undefined ? "" : `[${executorId}] `;
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
-
-function readString(record: Record<string, unknown>, key: string): string {
-  return typeof record[key] === "string" ? record[key] : "";
-}
-
-function formatValue(value: unknown): string | undefined {
-  if (value === undefined) return undefined;
-  return typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? String(value));
-}
-
-function formatPreview(value: unknown): string | undefined {
-  const text = formatValue(value);
-  if (text === undefined) return undefined;
-  return text.length <= 500 ? text : `${text.slice(0, 499)}…`;
 }
 
 function shortId(value: string): string {

--- a/examples/src/console/human-interaction-controller.ts
+++ b/examples/src/console/human-interaction-controller.ts
@@ -1,0 +1,136 @@
+import type {
+  ExpertAgentHumanRequest,
+  ExpertAgentHumanResponse,
+  ExpertAgentUserQuestion,
+} from "@pragma/core";
+
+import {
+  createHumanInteractionResponse,
+  questionsForHumanRequest,
+} from "./human-interaction-parser.ts";
+
+export interface QueuedConsoleInteraction {
+  readonly interactionId: string;
+  readonly invocationId: string;
+  readonly request: ExpertAgentHumanRequest;
+  readonly questions: readonly ExpertAgentUserQuestion[];
+  readonly answers: Record<string, string>;
+  questionIndex: number;
+  optionIndex: number;
+  selectedOptions: Set<number>;
+  completion?: CompletedConsoleInteraction | undefined;
+}
+
+export interface CompletedConsoleInteraction {
+  readonly interactionId: string;
+  readonly invocationId: string;
+  readonly response: ExpertAgentHumanResponse;
+}
+
+export class HumanInteractionQueue {
+  private readonly items: QueuedConsoleInteraction[] = [];
+
+  get active(): QueuedConsoleInteraction | undefined {
+    return this.items[0];
+  }
+
+  get size(): number {
+    return this.items.length;
+  }
+
+  enqueue(input: {
+    readonly interactionId: string;
+    readonly invocationId: string;
+    readonly request: ExpertAgentHumanRequest;
+  }): void {
+    if (this.items.some((item) => item.interactionId === input.interactionId)) return;
+    this.items.push({
+      ...input,
+      questions: questionsForHumanRequest(input.request),
+      answers: {},
+      questionIndex: 0,
+      optionIndex: 0,
+      selectedOptions: new Set(),
+    });
+  }
+
+  remove(interactionId: string): string | undefined {
+    const index = this.items.findIndex((item) => item.interactionId === interactionId);
+    if (index < 0) return undefined;
+    return this.items.splice(index, 1)[0]?.invocationId;
+  }
+
+  moveOption(direction: 1 | -1): void {
+    const active = this.active;
+    const question = active?.questions[active.questionIndex];
+    if (active === undefined || question === undefined || question.options.length === 0) return;
+    active.optionIndex =
+      (active.optionIndex + direction + question.options.length) % question.options.length;
+  }
+
+  selectNumber(number: number): void {
+    const active = this.active;
+    const question = active?.questions[active.questionIndex];
+    if (
+      active === undefined ||
+      question === undefined ||
+      number < 1 ||
+      number > question.options.length
+    ) {
+      return;
+    }
+    active.optionIndex = number - 1;
+  }
+
+  toggleOption(): void {
+    const active = this.active;
+    const question = active?.questions[active.questionIndex];
+    if (active === undefined || question?.kind !== "multiple_choice") return;
+    if (active.selectedOptions.has(active.optionIndex)) {
+      active.selectedOptions.delete(active.optionIndex);
+    } else {
+      active.selectedOptions.add(active.optionIndex);
+    }
+  }
+
+  submit(text = ""): CompletedConsoleInteraction | string | undefined {
+    const active = this.active;
+    if (active?.completion !== undefined) return active.completion;
+    const question = active?.questions[active.questionIndex];
+    if (active === undefined || question === undefined) return undefined;
+
+    const answer = readInteractionAnswer(active, question, text);
+    if (typeof answer !== "string") return answer.message;
+    active.answers[question.question] = answer;
+    active.questionIndex += 1;
+    active.optionIndex = 0;
+    active.selectedOptions.clear();
+    if (active.questionIndex < active.questions.length) return undefined;
+
+    active.completion = {
+      interactionId: active.interactionId,
+      invocationId: active.invocationId,
+      response: createHumanInteractionResponse(active.request, active.answers),
+    };
+    return active.completion;
+  }
+}
+
+function readInteractionAnswer(
+  interaction: QueuedConsoleInteraction,
+  question: ExpertAgentUserQuestion,
+  text: string,
+): string | { readonly message: string } {
+  if (question.kind === "text") {
+    const answer = text.trim();
+    return answer === "" ? { message: "请输入回答后再提交。" } : answer;
+  }
+  if (question.kind === "multiple_choice") {
+    const indexes = [...interaction.selectedOptions].sort((left, right) => left - right);
+    return indexes.length === 0
+      ? { message: "请至少选择一个选项。" }
+      : indexes.map((index) => question.options[index]!.label).join(", ");
+  }
+  const answer = question.options[interaction.optionIndex]?.label;
+  return answer === undefined || answer === "" ? { message: "请选择一个选项。" } : answer;
+}

--- a/examples/src/console/human-interaction-parser.ts
+++ b/examples/src/console/human-interaction-parser.ts
@@ -1,0 +1,186 @@
+import {
+  ExpertAgentHumanRequestSchema,
+  type ExecutionEvent,
+  type ExpertAgentHumanRequest,
+  type ExpertAgentHumanResponse,
+  type ExpertAgentUserQuestion,
+} from "@pragma/core";
+
+import { asConsoleRecord, readConsoleString } from "./execution-output-accumulator.ts";
+
+export interface ParsedHumanInteraction {
+  readonly interactionId: string;
+  readonly invocationId: string;
+  readonly request: ExpertAgentHumanRequest;
+}
+
+export type ConsoleQuestionAnswerResult =
+  | { readonly ok: true; readonly answer: string }
+  | { readonly ok: false; readonly message: string };
+
+export type ConsoleApprovalAnswerResult =
+  | { readonly ok: true; readonly approved: boolean }
+  | { readonly ok: false; readonly message: string };
+
+export interface AnsweredUserQuestionResponse {
+  readonly kind: "user_question";
+  readonly answered: true;
+  readonly answers: Readonly<Record<string, string>>;
+}
+
+export interface ConsoleToolApprovalResponse {
+  readonly kind: "tool_approval";
+  readonly approved: boolean;
+  readonly reason: string;
+}
+
+export function parseHumanInteractionEvent(event: ExecutionEvent): ParsedHumanInteraction {
+  if (event.type !== "human.requested") {
+    throw new Error(`Expected human.requested event, received ${event.type}.`);
+  }
+  const payload = asConsoleRecord(event.data);
+  const interactionId = readConsoleString(payload, "interactionId");
+  if (interactionId === "") throw new Error("human.requested event is missing interactionId.");
+  return {
+    interactionId,
+    invocationId: event.invocationId,
+    request: ExpertAgentHumanRequestSchema.parse(payload["request"]),
+  };
+}
+
+export function findPendingHumanRequestEvents(
+  events: readonly ExecutionEvent[],
+): readonly ExecutionEvent[] {
+  const responded = new Set(
+    events
+      .filter((event) => event.type === "human.responded")
+      .map((event) => readConsoleString(asConsoleRecord(event.data), "interactionId"))
+      .filter((interactionId) => interactionId !== ""),
+  );
+  return events.filter(
+    (event) =>
+      event.type === "human.requested" &&
+      !responded.has(readConsoleString(asConsoleRecord(event.data), "interactionId")),
+  );
+}
+
+export function parseConsoleQuestionAnswer(
+  question: ExpertAgentUserQuestion,
+  input: string,
+): ConsoleQuestionAnswerResult {
+  const normalized = input.trim();
+  if (normalized === "") return { ok: false, message: "请输入回答后再按回车。" };
+  if (question.kind === "text") return { ok: true, answer: normalized };
+
+  const tokens =
+    question.kind === "multiple_choice"
+      ? normalized
+          .split(/[,，]/u)
+          .map((token) => token.trim())
+          .filter((token) => token !== "")
+      : [normalized];
+  const selected: string[] = [];
+  for (const token of tokens) {
+    const option = readSelectedOption(question.options, token);
+    if (option === undefined) {
+      return {
+        ok: false,
+        message: `无法识别选项“${token}”；请输入编号或完整选项名称。`,
+      };
+    }
+    if (!selected.includes(option.label)) selected.push(option.label);
+  }
+  if (question.kind === "single_choice" && selected.length !== 1) {
+    return { ok: false, message: "单选题只能选择一个选项。" };
+  }
+  return { ok: true, answer: selected.join(", ") };
+}
+
+export function parseConsoleApprovalAnswer(input: string): ConsoleApprovalAnswerResult {
+  const normalized = input.trim().toLocaleLowerCase();
+  if (normalized === "y" || normalized === "yes" || normalized === "1") {
+    return { ok: true, approved: true };
+  }
+  if (normalized === "n" || normalized === "no" || normalized === "2") {
+    return { ok: true, approved: false };
+  }
+  return { ok: false, message: "请输入 y/yes 或 n/no。" };
+}
+
+export function consoleQuestionInstruction(question: ExpertAgentUserQuestion): string {
+  switch (question.kind) {
+    case "text":
+      return "输入回答后回车；Ctrl+C 可取消整个 Turn。";
+    case "single_choice":
+      return "输入一个选项编号或名称后回车；Ctrl+C 可取消整个 Turn。";
+    case "multiple_choice":
+      return "输入多个编号或名称并用逗号分隔；Ctrl+C 可取消整个 Turn。";
+  }
+}
+
+export function questionsForHumanRequest(
+  request: ExpertAgentHumanRequest,
+): readonly ExpertAgentUserQuestion[] {
+  if (request.kind === "user_question") return request.questions;
+  return [
+    {
+      header: "Tool approval",
+      question: `${request.toolName}: ${request.reason ?? "Allow this tool?"}`,
+      kind: "single_choice",
+      options: [
+        { label: "Yes", description: "Allow execution" },
+        { label: "No", description: "Reject execution" },
+      ],
+    },
+  ];
+}
+
+export function createHumanInteractionResponse(
+  request: ExpertAgentHumanRequest,
+  answers: Readonly<Record<string, string>>,
+  options: {
+    readonly approvedReason?: string | undefined;
+    readonly rejectedReason?: string | undefined;
+  } = {},
+): ExpertAgentHumanResponse {
+  if (request.kind === "user_question") {
+    return createUserQuestionResponse(answers);
+  }
+  const question = questionsForHumanRequest(request)[0]!;
+  const approved = answers[question.question]?.toLocaleLowerCase() === "yes";
+  return createToolApprovalResponse(approved, options);
+}
+
+export function createUserQuestionResponse(
+  answers: Readonly<Record<string, string>>,
+): AnsweredUserQuestionResponse {
+  return { kind: "user_question", answered: true, answers };
+}
+
+export function createToolApprovalResponse(
+  approved: boolean,
+  options: {
+    readonly approvedReason?: string | undefined;
+    readonly rejectedReason?: string | undefined;
+  } = {},
+): ConsoleToolApprovalResponse {
+  return {
+    kind: "tool_approval",
+    approved,
+    reason: approved
+      ? (options.approvedReason ?? "User approved.")
+      : (options.rejectedReason ?? "User rejected."),
+  };
+}
+
+function readSelectedOption(
+  options: ExpertAgentUserQuestion["options"],
+  token: string,
+): ExpertAgentUserQuestion["options"][number] | undefined {
+  const numeric = Number(token);
+  if (Number.isInteger(numeric) && numeric >= 1 && numeric <= options.length) {
+    return options[numeric - 1];
+  }
+  const normalized = token.toLocaleLowerCase();
+  return options.find((option) => option.label.toLocaleLowerCase() === normalized);
+}

--- a/examples/src/experts/getting-started/console-chat.ts
+++ b/examples/src/experts/getting-started/console-chat.ts
@@ -1,12 +1,12 @@
-import { createInterface } from "node:readline/promises";
-import { stdin, stdout } from "node:process";
+import type { ExpertAgentManagedTool, ExpertAgentToolCallResult, ExpertTurn } from "@pragma/core";
 
-import type { ExpertAgentManagedTool, ExpertAgentToolCallResult } from "@pragma/core";
-
-import { renderExpertTurn } from "../../console/console-turn-renderer.ts";
-import { formatConsoleUsage } from "../../console/console-usage.ts";
+import { ExpertConsoleTui } from "../../console/expert-console-tui.ts";
 import { createExampleApp, createExampleExpert } from "../../support/example-kit.ts";
 import { readCurrentLocalTime } from "../../support/current-time.ts";
+
+if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) {
+  throw new Error("The Getting Started chat example requires an interactive TTY terminal.");
+}
 
 const currentTimeTool: ExpertAgentManagedTool<"get_current_time", ExpertAgentToolCallResult> = {
   name: "get_current_time",
@@ -25,39 +25,32 @@ const expert = await createExampleExpert(
     "Use earlier messages in this session when they are relevant.",
     "When the user asks for the current time, call get_current_time instead of guessing.",
     "Report the tool's timestamp as local time and preserve its UTC offset and time zone.",
+    "When a useful answer requires a preference or missing detail from the user, call askUserQuestion instead of guessing.",
   ].join("\n"),
   { tools: [currentTimeTool] },
 );
 const session = await createExampleApp().experts.createSession(expert);
-const terminal = createInterface({ input: stdin, output: stdout });
-
-console.log("Pragma Expert 已就绪。输入问题开始聊天，输入 /exit 退出。");
-console.log(`Session: ${session.sessionId}`);
-
-terminal.setPrompt("你 > ");
-terminal.prompt();
+let activeTurn: ExpertTurn | undefined;
+const consoleUi = new ExpertConsoleTui({
+  title: "Pragma Getting Started",
+  sessionId: session.sessionId,
+  examplePrompt: "请先用 askUserQuestion 问我想聊哪个主题，再根据回答继续。",
+  agents: [{ id: expert.id, name: expert.name, shortName: "Expert", primary: true }],
+  async onPrompt(prompt, ui) {
+    activeTurn = await session.prompt(prompt);
+    try {
+      await ui.followTurn(activeTurn);
+    } finally {
+      activeTurn = undefined;
+    }
+  },
+  async onExit() {
+    if (activeTurn !== undefined) await activeTurn.cancel("Getting Started console closed.");
+  },
+});
 
 try {
-  for await (const line of terminal) {
-    const prompt = line.trim();
-    if (prompt === "/exit") {
-      console.log(formatConsoleUsage(await session.getUsage()));
-      break;
-    }
-    if (prompt === "") {
-      terminal.prompt();
-      continue;
-    }
-
-    try {
-      const turn = await session.prompt(prompt);
-      await renderExpertTurn(turn);
-    } catch {
-      // renderExpertTurn already displayed the failure with the streamed turn output.
-    }
-    terminal.prompt();
-  }
+  await consoleUi.run();
 } finally {
-  terminal.close();
-  await session.close("Console chat ended.");
+  await session.close("Getting Started console chat ended.");
 }

--- a/examples/src/experts/subagents/delegation.ts
+++ b/examples/src/experts/subagents/delegation.ts
@@ -1,6 +1,6 @@
 import { createAgentLauncher, type ExpertTurn } from "@pragma/core";
 
-import { DelegationConsoleTui } from "../../console/delegation-console-tui.ts";
+import { ExpertConsoleTui } from "../../console/expert-console-tui.ts";
 import { createExampleApp, createExampleExpert } from "../../support/example-kit.ts";
 
 if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) {
@@ -48,7 +48,7 @@ const mainAgent = await createExampleExpert(
 
 const session = await createExampleApp().experts.createSession(mainAgent);
 let activeTurn: ExpertTurn | undefined;
-const consoleUi = new DelegationConsoleTui({
+const consoleUi = new ExpertConsoleTui({
   title: "Pragma Main + Research Agent",
   sessionId: session.sessionId,
   examplePrompt: "请查看 Pragma 的实现原理，并说明一次 Expert 调用是如何执行的。",

--- a/examples/src/experts/teams/delegation.ts
+++ b/examples/src/experts/teams/delegation.ts
@@ -1,6 +1,6 @@
 import { defineExpertTeam, type ExpertTurn } from "@pragma/core";
 
-import { DelegationConsoleTui } from "../../console/delegation-console-tui.ts";
+import { ExpertConsoleTui } from "../../console/expert-console-tui.ts";
 import { createExampleApp, createExampleExpert } from "../../support/example-kit.ts";
 
 if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) {
@@ -94,7 +94,7 @@ const team = defineExpertTeam({
 
 const session = await createExampleApp().experts.createSession(team);
 let activeTurn: ExpertTurn | undefined;
-const consoleUi = new DelegationConsoleTui({
+const consoleUi = new ExpertConsoleTui({
   title: "Pragma Engineering Review Team",
   sessionId: session.sessionId,
   examplePrompt: "请评审 Pragma 的 delegation 实现，说明调用链、架构风险和测试缺口，并给出优先级。",

--- a/examples/src/runtimes/shared/console-runtime-chat.ts
+++ b/examples/src/runtimes/shared/console-runtime-chat.ts
@@ -9,13 +9,13 @@ import {
   createRuntimeRegistry,
   defineExpert,
   type ExpertSession,
+  type ExpertTurn,
   type RuntimeAdapter,
   type RuntimeModel,
   type RuntimeThinkingLevel,
 } from "@pragma/core";
 
-import { renderExpertTurn } from "../../console/console-turn-renderer.ts";
-import { formatConsoleUsage } from "../../console/console-usage.ts";
+import { ExpertConsoleTui } from "../../console/expert-console-tui.ts";
 
 export interface RuntimeConsoleChatOptions {
   readonly runtimeName: string;
@@ -29,8 +29,14 @@ export interface RuntimeConsoleDefaults {
 }
 
 export async function runRuntimeConsoleChat(options: RuntimeConsoleChatOptions): Promise<void> {
+  if (stdin.isTTY !== true || stdout.isTTY !== true) {
+    throw new Error(`${options.runtimeName} chat example requires an interactive TTY terminal.`);
+  }
+
   const terminal = createInterface({ input: stdin, output: stdout });
+  let terminalOpen = true;
   let session: ExpertSession | undefined;
+  let activeTurn: ExpertTurn | undefined;
 
   try {
     const probeRuntime = options.createRuntime();
@@ -62,6 +68,7 @@ export async function runRuntimeConsoleChat(options: RuntimeConsoleChatOptions):
         "Use earlier messages in this session when they are relevant.",
         "When the user asks about test reference material, use the Pragma context tools.",
         "Read the requested context instead of guessing from its description.",
+        "When a useful answer requires a preference or missing detail from the user, call askUserQuestion instead of guessing.",
       ].join("\n"),
       tags: ["example", "runtime", "context"],
       version: "1.0.0",
@@ -78,42 +85,41 @@ export async function runRuntimeConsoleChat(options: RuntimeConsoleChatOptions):
         defaultRuntime: runtime.descriptor.id,
       }),
     });
-    session = await app.experts.createSession(expert, { runtime: runtime.descriptor.id });
+    const expertSession = await app.experts.createSession(expert, {
+      runtime: runtime.descriptor.id,
+    });
+    session = expertSession;
+    terminal.close();
+    terminalOpen = false;
 
-    console.log(`\n${options.runtimeName} Expert 已就绪。输入问题开始聊天，输入 /exit 退出。`);
-    console.log("可测试：分别询问 always-on、model-decision 和 manual 测试上下文。");
-    console.log(`模型: ${selectedModel?.displayName ?? "CLI 默认模型"}`);
-    console.log(`思考深度: ${selectedThinkingLevel?.label ?? "CLI 默认深度"}`);
-    console.log(`Session: ${session.sessionId}`);
-
-    terminal.setPrompt("你 > ");
-    terminal.prompt();
-
-    for await (const line of terminal) {
-      const prompt = line.trim();
-      if (prompt === "/exit") {
-        console.log(formatConsoleUsage(await session.getUsage()));
-        break;
-      }
-      if (prompt === "") {
-        terminal.prompt();
-        continue;
-      }
-
-      try {
-        const turn = await session.prompt(prompt);
-        await renderExpertTurn(turn);
-      } catch {
-        // renderExpertTurn already displayed the failure with the streamed turn output.
-      }
-      terminal.prompt();
-    }
+    const modelLabel = selectedModel?.displayName ?? "CLI 默认模型";
+    const thinkingLabel = selectedThinkingLevel?.label ?? "CLI 默认深度";
+    const consoleUi = new ExpertConsoleTui({
+      title: `${options.runtimeName} · ${modelLabel} · ${thinkingLabel}`,
+      sessionId: expertSession.sessionId,
+      examplePrompt: "请列出测试上下文，再读取验证码和发布代号，并说明信息来源。",
+      agents: [{ id: expert.id, name: expert.name, shortName: "Expert", primary: true }],
+      async onPrompt(prompt, ui) {
+        activeTurn = await expertSession.prompt(prompt);
+        try {
+          await ui.followTurn(activeTurn);
+        } finally {
+          activeTurn = undefined;
+        }
+      },
+      async onExit() {
+        if (activeTurn !== undefined) {
+          await activeTurn.cancel(`${options.runtimeName} console closed.`);
+        }
+      },
+    });
+    await consoleUi.run();
   } catch (error) {
     console.error(`× ${error instanceof Error ? error.message : String(error)}`);
     process.exitCode = 1;
   } finally {
-    terminal.close();
-    await session?.close("Console chat ended.");
+    if (terminalOpen) terminal.close();
+    await session?.close(`${options.runtimeName} console chat ended.`);
   }
 }
 

--- a/examples/test/execution-output-accumulator.test.ts
+++ b/examples/test/execution-output-accumulator.test.ts
@@ -1,0 +1,134 @@
+import type { ExecutionOutputItem } from "@pragma/core";
+import { describe, expect, it } from "vitest";
+
+import { ExecutionOutputAccumulator } from "../src/console/execution-output-accumulator.ts";
+
+describe("ExecutionOutputAccumulator", () => {
+  it("normalizes answer, thinking, progress, and completed-message fallback", () => {
+    const accumulator = new ExecutionOutputAccumulator({ includeRoutineProgress: false });
+
+    expect(accumulator.consume(output("thought", "Considering "))).toEqual([
+      { kind: "thinking", text: "Considering ", append: true },
+    ]);
+    expect(accumulator.consume(output("message", "the answer"))).toEqual([
+      { kind: "answer", text: "the answer", append: true },
+    ]);
+    expect(
+      accumulator.consume(
+        outputValue("message", { content: [{ type: "text", text: "duplicate" }] }),
+      ),
+    ).toEqual([]);
+    expect(
+      accumulator.consume(outputValue("progress", { stage: "turn.start", message: "Starting" })),
+    ).toEqual([]);
+    expect(
+      accumulator.consume(outputValue("progress", { stage: "context.load", message: "Ready" })),
+    ).toEqual([{ kind: "progress", text: "context.load — Ready", append: false }]);
+
+    const completedOnly = new ExecutionOutputAccumulator();
+    expect(completedOnly.consume(outputValue("message", "completed answer"))).toEqual([
+      { kind: "answer", text: "completed answer", append: false },
+    ]);
+    expect(completedOnly.consume(outputValue("result", "completed answer"))).toEqual([]);
+  });
+
+  it("does not let an empty message delta suppress the completed-message fallback", () => {
+    const accumulator = new ExecutionOutputAccumulator();
+
+    expect(accumulator.consume(output("message", ""))).toEqual([]);
+    expect(accumulator.consume(outputValue("message", "completed answer"))).toEqual([
+      { kind: "answer", text: "completed answer", append: false },
+    ]);
+  });
+
+  it("deduplicates cumulative tool output and unwraps structured Runtime deltas", () => {
+    const accumulator = new ExecutionOutputAccumulator();
+    expect(
+      accumulator.consume(
+        outputValue("tool", {
+          toolCallId: "call-1",
+          toolName: "search",
+          inputPreview: { query: "Pragma" },
+        }),
+      ),
+    ).toEqual([
+      {
+        kind: "tool",
+        text: '→ search\n{\n  "query": "Pragma"\n}',
+        append: false,
+      },
+    ]);
+    expect(accumulator.consume(output("tool", "first"))).toEqual([
+      { kind: "tool-output", text: "first", append: true },
+    ]);
+    expect(accumulator.consume(output("tool", "first result"))).toEqual([
+      { kind: "tool-output", text: " result", append: true },
+    ]);
+    expect(
+      accumulator.consume(
+        output("tool", JSON.stringify({ content: [{ type: "text", text: "structured output" }] })),
+      ),
+    ).toEqual([{ kind: "tool-output", text: "structured output", append: true }]);
+    expect(
+      accumulator.consume(
+        outputValue("tool", {
+          toolCallId: "call-1",
+          toolName: "search",
+          outputPreview: "first result",
+        }),
+      ),
+    ).toEqual([{ kind: "tool", text: "✓ search completed", append: false }]);
+  });
+
+  it("uses the completion preview when a tool produced no output deltas", () => {
+    const accumulator = new ExecutionOutputAccumulator();
+    accumulator.consume(outputValue("tool", { toolCallId: "call-2", toolName: "clock" }));
+
+    expect(
+      accumulator.consume(
+        outputValue("tool", {
+          toolCallId: "call-2",
+          toolName: "clock",
+          outputPreview: "10:30 +08:00",
+        }),
+      ),
+    ).toEqual([
+      { kind: "tool", text: "✓ clock completed", append: false },
+      { kind: "tool-output", text: "10:30 +08:00", append: false },
+    ]);
+  });
+
+  it("does not repeat the completion preview when tool output arrives before its start event", () => {
+    const accumulator = new ExecutionOutputAccumulator();
+
+    expect(accumulator.consume(output("tool", "streamed output"))).toEqual([
+      { kind: "tool-output", text: "streamed output", append: true },
+    ]);
+    expect(
+      accumulator.consume(
+        outputValue("tool", {
+          toolCallId: "call-3",
+          toolName: "search",
+          outputPreview: "streamed output",
+        }),
+      ),
+    ).toEqual([{ kind: "tool", text: "✓ search completed", append: false }]);
+  });
+});
+
+function output(channel: ExecutionOutputItem["channel"], delta: string): ExecutionOutputItem {
+  return {
+    sourceEventId: `${channel}-${delta}`,
+    executionId: "execution",
+    invocationId: "invocation",
+    executorId: "expert",
+    contextId: "context",
+    channel,
+    delta,
+    occurredAt: new Date().toISOString(),
+  };
+}
+
+function outputValue(channel: ExecutionOutputItem["channel"], value: unknown): ExecutionOutputItem {
+  return { ...output(channel, ""), delta: undefined, value };
+}

--- a/examples/test/expert-console-tui.test.ts
+++ b/examples/test/expert-console-tui.test.ts
@@ -1,10 +1,7 @@
 import type { ExecutionOutputItem } from "@pragma/core";
 import { describe, expect, it } from "vitest";
 
-import {
-  DelegationConsoleModel,
-  parseDelegationQuestionAnswer,
-} from "../src/console/delegation-console-tui.ts";
+import { ExpertConsoleModel } from "../src/console/expert-console-tui.ts";
 
 const agents = [
   { id: "lead", name: "Lead", shortName: "Lead", primary: true },
@@ -12,9 +9,27 @@ const agents = [
   { id: "tests", name: "Tests", shortName: "Tests" },
 ] as const;
 
-describe("DelegationConsoleModel", () => {
+describe("ExpertConsoleModel", () => {
+  it("supports a single primary Expert", () => {
+    const model = new ExpertConsoleModel([
+      { id: "expert", name: "Expert", shortName: "Expert", primary: true },
+    ]);
+
+    model.beginTurn("Hello");
+    model.consume(output("expert", "thought", "Considering the request."));
+    model.consume(output("expert", "message", "Hello!"));
+
+    expect(model.selected.definition.id).toBe("expert");
+    expect(model.selected.status).toBe("working");
+    expect(model.selected.sections).toMatchObject([
+      { kind: "user", text: "Hello" },
+      { kind: "thinking", text: "Considering the request." },
+      { kind: "answer", text: "Hello!" },
+    ]);
+  });
+
   it("tracks the lead conversation and member activity independently", () => {
-    const model = new DelegationConsoleModel(agents);
+    const model = new ExpertConsoleModel(agents);
 
     model.beginTurn("Review delegation.");
     model.consume(output("research", "thought", "Inspecting "));
@@ -38,7 +53,7 @@ describe("DelegationConsoleModel", () => {
   });
 
   it("syncs Invocation status and supports focus switching without mixing logs", () => {
-    const model = new DelegationConsoleModel(agents);
+    const model = new ExpertConsoleModel(agents);
     model.beginTurn("Review delegation.");
     model.syncTree(
       tree("lead", "running", [tree("research", "succeeded"), tree("tests", "running")]),
@@ -66,21 +81,21 @@ describe("DelegationConsoleModel", () => {
   it("requires a unique lead and unique member ids", () => {
     expect(
       () =>
-        new DelegationConsoleModel([
+        new ExpertConsoleModel([
           { id: "one", name: "One", shortName: "One" },
           { id: "two", name: "Two", shortName: "Two" },
         ]),
     ).toThrow("primary Agent");
     expect(
       () =>
-        new DelegationConsoleModel([
+        new ExpertConsoleModel([
           { id: "one", name: "One", shortName: "One", primary: true },
           { id: "two", name: "Two", shortName: "Two", primary: true },
         ]),
     ).toThrow("exactly one primary Agent");
     expect(
       () =>
-        new DelegationConsoleModel([
+        new ExpertConsoleModel([
           { id: "same", name: "Lead", shortName: "Lead", primary: true },
           { id: "same", name: "Member", shortName: "Member" },
         ]),
@@ -88,7 +103,7 @@ describe("DelegationConsoleModel", () => {
   });
 
   it("keeps completed-only answers from later turns", () => {
-    const model = new DelegationConsoleModel(agents);
+    const model = new ExpertConsoleModel(agents);
 
     model.beginTurn("First");
     model.consume(outputValue("lead", "message", "First answer"));
@@ -105,7 +120,7 @@ describe("DelegationConsoleModel", () => {
   });
 
   it("deduplicates cumulative tool snapshots while preserving true deltas", () => {
-    const model = new DelegationConsoleModel(agents);
+    const model = new ExpertConsoleModel(agents);
     model.beginTurn("Inspect the repository.");
     model.consume(
       outputValue("research", "tool", {
@@ -121,50 +136,6 @@ describe("DelegationConsoleModel", () => {
     expect(model.panes[1]?.sections.find((section) => section.kind === "tool-output")?.text).toBe(
       "createAgentLauncher\npackages/core/src/agent-launcher.ts\n",
     );
-  });
-});
-
-describe("parseDelegationQuestionAnswer", () => {
-  const options = [
-    { label: "Fast", description: "Prefer speed" },
-    { label: "Safe", description: "Prefer safety" },
-    { label: "Balanced", description: "Balance both" },
-  ] as const;
-
-  it("accepts numbered and named single-choice answers", () => {
-    const question = {
-      question: "Which mode?",
-      header: "Mode",
-      kind: "single_choice" as const,
-      options,
-    };
-
-    expect(parseDelegationQuestionAnswer(question, "2")).toEqual({ ok: true, answer: "Safe" });
-    expect(parseDelegationQuestionAnswer(question, "balanced")).toEqual({
-      ok: true,
-      answer: "Balanced",
-    });
-    expect(parseDelegationQuestionAnswer(question, "unknown")).toMatchObject({ ok: false });
-  });
-
-  it("accepts comma-separated multiple choices and direct text", () => {
-    expect(
-      parseDelegationQuestionAnswer(
-        {
-          question: "Which modes?",
-          header: "Modes",
-          kind: "multiple_choice",
-          options,
-        },
-        "1，Safe",
-      ),
-    ).toEqual({ ok: true, answer: "Fast, Safe" });
-    expect(
-      parseDelegationQuestionAnswer(
-        { question: "Why?", header: "Reason", kind: "text", options: [] },
-        "  Need evidence.  ",
-      ),
-    ).toEqual({ ok: true, answer: "Need evidence." });
   });
 });
 
@@ -208,5 +179,5 @@ function tree(executorId: string, status: string, children: unknown[] = []) {
       updatedAt: now,
     },
     children,
-  } as Parameters<DelegationConsoleModel["syncTree"]>[0];
+  } as Parameters<ExpertConsoleModel["syncTree"]>[0];
 }

--- a/examples/test/flow-console-tui.test.ts
+++ b/examples/test/flow-console-tui.test.ts
@@ -1,18 +1,8 @@
-import {
-  defineExpert,
-  defineExpertTeam,
-  defineFlow,
-  type ExecutionEvent,
-  type ExecutionOutputItem,
-} from "@pragma/core";
+import { defineExpert, defineExpertTeam, defineFlow, type ExecutionOutputItem } from "@pragma/core";
 import { describe, expect, it } from "vitest";
 
-import {
-  FlowConsoleModel,
-  FlowInteractionQueue,
-  findPendingHumanRequestEvents,
-  renderFlowConsole,
-} from "../src/console/flow-console-tui.ts";
+import { FlowConsoleModel, renderFlowConsole } from "../src/console/flow-console-tui.ts";
+import { HumanInteractionQueue } from "../src/console/human-interaction-controller.ts";
 
 describe("FlowConsoleModel", () => {
   it("tracks route decisions and marks unselected branches as skipped", () => {
@@ -60,7 +50,7 @@ describe("FlowConsoleModel", () => {
     expect(model.selected.nodeId).toBe("approve");
     const skippedDetails = renderFlowConsole({
       model,
-      interactions: new FlowInteractionQueue(),
+      interactions: new HumanInteractionQueue(),
       title: "Review",
       width: 120,
       height: 24,
@@ -274,7 +264,7 @@ describe("FlowConsoleModel", () => {
     );
     const rendered = renderFlowConsole({
       model,
-      interactions: new FlowInteractionQueue(),
+      interactions: new HumanInteractionQueue(),
       title: "Review",
       width: 240,
       height: 40,
@@ -335,7 +325,7 @@ describe("FlowConsoleModel", () => {
     const task = flow.task({ id: "prepare", version: "1.0.0", handler: () => "done" });
     flow.compose(({ start, end }) => start(task).next(end()));
     const model = new FlowConsoleModel(flow);
-    const queue = new FlowInteractionQueue();
+    const queue = new HumanInteractionQueue();
     const wide = renderFlowConsole({
       model,
       interactions: queue,
@@ -363,83 +353,6 @@ describe("FlowConsoleModel", () => {
     });
     expect(tooSmall.join(" ")).toContain("Terminal too small");
     expect(tooSmall.every((line) => line.length <= 40)).toBe(true);
-  });
-});
-
-describe("FlowInteractionQueue", () => {
-  it("restores only Human requests that have no durable response", () => {
-    const requested = executionEvent("requested", "human.requested", {
-      interactionId: "completed",
-    });
-    const pending = executionEvent("pending", "human.requested", {
-      interactionId: "pending",
-    });
-    const responded = executionEvent("responded", "human.responded", {
-      interactionId: "completed",
-    });
-
-    expect(findPendingHumanRequestEvents([requested, pending, responded])).toEqual([pending]);
-  });
-
-  it("collects multiple questions and queues tool approval behind them", () => {
-    const queue = new FlowInteractionQueue();
-    queue.enqueue({
-      interactionId: "review",
-      invocationId: "review-invocation",
-      request: {
-        kind: "user_question",
-        toolName: "askUserQuestion",
-        questions: [
-          {
-            header: "Decision",
-            question: "Decision?",
-            kind: "single_choice",
-            options: [
-              { label: "approve", description: "Approve" },
-              { label: "revise", description: "Revise" },
-            ],
-          },
-          { header: "Notes", question: "Notes?", kind: "text", options: [] },
-        ],
-      },
-    });
-    queue.enqueue({
-      interactionId: "approval",
-      invocationId: "expert-invocation",
-      request: {
-        kind: "tool_approval",
-        toolName: "publish",
-        input: {},
-        reason: "External side effect",
-      },
-    });
-    expect(queue.size).toBe(2);
-    queue.moveOption(1);
-    expect(queue.submit()).toBeUndefined();
-    const reviewResponse = queue.submit("Tighten scope.");
-    expect(reviewResponse).toEqual({
-      interactionId: "review",
-      invocationId: "review-invocation",
-      response: {
-        kind: "user_question",
-        answered: true,
-        answers: { "Decision?": "revise", "Notes?": "Tighten scope." },
-      },
-    });
-    expect(queue.submit()).toEqual(reviewResponse);
-    expect(queue.size).toBe(2);
-    expect(queue.remove("review")).toBe("review-invocation");
-    expect(queue.size).toBe(1);
-    expect(queue.remove("missing")).toBeUndefined();
-    const approvalResponse = queue.submit();
-    expect(approvalResponse).toEqual({
-      interactionId: "approval",
-      invocationId: "expert-invocation",
-      response: { kind: "tool_approval", approved: true, reason: "User approved." },
-    });
-    expect(queue.size).toBe(1);
-    expect(queue.remove("approval")).toBe("expert-invocation");
-    expect(queue.size).toBe(0);
   });
 });
 
@@ -505,17 +418,4 @@ function outputValue(
   value: unknown,
 ): ExecutionOutputItem {
   return { ...output(invocationId, executorId, channel, ""), delta: undefined, value };
-}
-
-function executionEvent(eventId: string, type: string, data: unknown): ExecutionEvent {
-  return {
-    schemaVersion: "pragma.execution-event/v5",
-    eventId,
-    cursor: { executionId: "execution", sequence: 1 },
-    executionId: "execution",
-    invocationId: "invocation",
-    type,
-    data,
-    occurredAt: new Date().toISOString(),
-  };
 }

--- a/examples/test/human-interaction-controller.test.ts
+++ b/examples/test/human-interaction-controller.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { HumanInteractionQueue } from "../src/console/human-interaction-controller.ts";
+
+describe("HumanInteractionQueue", () => {
+  it("collects multiple questions and queues tool approval behind them", () => {
+    const queue = new HumanInteractionQueue();
+    queue.enqueue({
+      interactionId: "review",
+      invocationId: "review-invocation",
+      request: {
+        kind: "user_question",
+        toolName: "askUserQuestion",
+        questions: [
+          {
+            header: "Decision",
+            question: "Decision?",
+            kind: "single_choice",
+            options: [
+              { label: "approve", description: "Approve" },
+              { label: "revise", description: "Revise" },
+            ],
+          },
+          { header: "Notes", question: "Notes?", kind: "text", options: [] },
+        ],
+      },
+    });
+    queue.enqueue({
+      interactionId: "approval",
+      invocationId: "expert-invocation",
+      request: {
+        kind: "tool_approval",
+        toolName: "publish",
+        input: {},
+        reason: "External side effect",
+      },
+    });
+    expect(queue.size).toBe(2);
+    queue.moveOption(1);
+    expect(queue.submit()).toBeUndefined();
+    const reviewResponse = queue.submit("Tighten scope.");
+    expect(reviewResponse).toEqual({
+      interactionId: "review",
+      invocationId: "review-invocation",
+      response: {
+        kind: "user_question",
+        answered: true,
+        answers: { "Decision?": "revise", "Notes?": "Tighten scope." },
+      },
+    });
+    expect(queue.submit()).toEqual(reviewResponse);
+    expect(queue.size).toBe(2);
+    expect(queue.remove("review")).toBe("review-invocation");
+    expect(queue.size).toBe(1);
+    expect(queue.remove("missing")).toBeUndefined();
+    const approvalResponse = queue.submit();
+    expect(approvalResponse).toEqual({
+      interactionId: "approval",
+      invocationId: "expert-invocation",
+      response: { kind: "tool_approval", approved: true, reason: "User approved." },
+    });
+    expect(queue.size).toBe(1);
+    expect(queue.remove("approval")).toBe("expert-invocation");
+    expect(queue.size).toBe(0);
+  });
+});

--- a/examples/test/human-interaction-parser.test.ts
+++ b/examples/test/human-interaction-parser.test.ts
@@ -1,0 +1,103 @@
+import type { ExecutionEvent } from "@pragma/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  createHumanInteractionResponse,
+  findPendingHumanRequestEvents,
+  parseConsoleApprovalAnswer,
+  parseConsoleQuestionAnswer,
+  parseHumanInteractionEvent,
+} from "../src/console/human-interaction-parser.ts";
+
+const options = [
+  { label: "Fast", description: "Prefer speed" },
+  { label: "Safe", description: "Prefer safety" },
+  { label: "Balanced", description: "Balance both" },
+] as const;
+
+describe("human interaction parser", () => {
+  it("parses and validates durable Human request events", () => {
+    const event = executionEvent("requested", "human.requested", {
+      interactionId: "interaction",
+      request: {
+        kind: "user_question",
+        toolName: "askUserQuestion",
+        questions: [{ question: "Why?", header: "Reason", kind: "text", options: [] }],
+      },
+    });
+
+    expect(parseHumanInteractionEvent(event)).toMatchObject({
+      interactionId: "interaction",
+      invocationId: "invocation",
+      request: { kind: "user_question" },
+    });
+  });
+
+  it("accepts numbered, named, multiple-choice, and text answers", () => {
+    expect(
+      parseConsoleQuestionAnswer(
+        { question: "Which mode?", header: "Mode", kind: "single_choice", options },
+        "2",
+      ),
+    ).toEqual({ ok: true, answer: "Safe" });
+    expect(
+      parseConsoleQuestionAnswer(
+        { question: "Which mode?", header: "Mode", kind: "single_choice", options },
+        "balanced",
+      ),
+    ).toEqual({ ok: true, answer: "Balanced" });
+    expect(
+      parseConsoleQuestionAnswer(
+        { question: "Which modes?", header: "Modes", kind: "multiple_choice", options },
+        "1，Safe",
+      ),
+    ).toEqual({ ok: true, answer: "Fast, Safe" });
+    expect(
+      parseConsoleQuestionAnswer(
+        { question: "Why?", header: "Reason", kind: "text", options: [] },
+        "  Need evidence.  ",
+      ),
+    ).toEqual({ ok: true, answer: "Need evidence." });
+  });
+
+  it("parses approvals and builds typed responses", () => {
+    expect(parseConsoleApprovalAnswer("yes")).toEqual({ ok: true, approved: true });
+    expect(parseConsoleApprovalAnswer("2")).toEqual({ ok: true, approved: false });
+    expect(parseConsoleApprovalAnswer("later")).toMatchObject({ ok: false });
+    expect(
+      createHumanInteractionResponse(
+        { kind: "tool_approval", toolName: "publish", input: {}, reason: "Side effect" },
+        { "publish: Side effect": "Yes" },
+      ),
+    ).toEqual({ kind: "tool_approval", approved: true, reason: "User approved." });
+  });
+
+  it("finds requests without a durable response", () => {
+    const completed = executionEvent("completed", "human.requested", {
+      interactionId: "completed",
+    });
+    const pending = executionEvent("pending", "human.requested", { interactionId: "pending" });
+    const response = executionEvent("response", "human.responded", {
+      interactionId: "completed",
+    });
+
+    expect(findPendingHumanRequestEvents([completed, pending, response])).toEqual([pending]);
+  });
+});
+
+function executionEvent(
+  eventId: string,
+  type: ExecutionEvent["type"],
+  data: unknown,
+): ExecutionEvent {
+  return {
+    schemaVersion: "pragma.execution-event/v5",
+    eventId,
+    cursor: { executionId: "execution", sequence: 1 },
+    executionId: "execution",
+    invocationId: "invocation",
+    type,
+    data,
+    occurredAt: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

- convert the Getting Started, Codex runtime, and Claude Code runtime chats to the shared full-screen Expert TUI
- extract reusable execution-output accumulation and human-interaction parsing/controller utilities under `examples/src/console`
- reuse the shared behavior across Expert, delegation/team, and Flow TUIs
- stream thinking, answers, tool calls, and tool output while supporting `askUserQuestion`, approvals, usage display, and scrollable history
- update the Examples documentation and expand focused test coverage

## Why

Several examples implemented their own streaming and human-in-the-loop handling. That duplicated message/tool parsing, question validation, answer construction, and pending-interaction state, making behavior inconsistent and harder to evolve.

This refactor establishes one examples-layer implementation for those concerns while retaining separate Expert and Flow presentation models.

## Fixes included

- keep completed-message fallback available after an empty message delta
- avoid repeating a tool completion preview when streamed tool output arrives after a missed `tool.started` event

## Impact

The Getting Started and local Runtime examples now provide the same interactive TUI capabilities as the delegation examples. Future examples can reuse the shared output and human-interaction utilities instead of reimplementing protocol parsing.

## Validation

- `pnpm --filter @pragma/examples lint`
- `pnpm --filter @pragma/examples typecheck`
- `pnpm --filter @pragma/examples test` — 12 files, 41 tests
- `pnpm --filter @pragma/examples build`
- `git diff --check`
