### PR TITLE
feat(desktop): polish application UI

### DIFF
--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -43,9 +43,9 @@ export function Sidebar(props: {
           onClick={props.onToggle}
         >
           {props.collapsed ? (
-            <CaretDoubleRight size={18} weight="bold" aria-hidden="true" />
+            <CaretDoubleRight size={18} aria-hidden="true" />
           ) : (
-            <CaretDoubleLeft size={18} weight="bold" aria-hidden="true" />
+            <CaretDoubleLeft size={18} aria-hidden="true" />
           )}
         </button>
       </div>
@@ -75,7 +75,7 @@ export function Sidebar(props: {
               disabled={!isAvailable}
               onClick={() => targetView !== null && props.onNavigate(targetView)}
             >
-              <NavigationIcon size={24} weight={isActive ? "fill" : "regular"} />
+              <NavigationIcon size={22} aria-hidden="true" />
               <span>{item.label}</span>
             </button>
           );

--- a/apps/desktop/src/renderer/src/lib/mission-time.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mission-time.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMissionDateTime, formatMissionTime } from "./mission-time.ts";
+
+describe("mission time formatting", () => {
+  const now = Date.parse("2026-07-15T12:00:00.000Z");
+
+  it("uses compact relative labels for recent mission activity", () => {
+    expect(formatMissionTime("2026-07-15T11:59:30.000Z", now)).toBe("Now");
+    expect(formatMissionTime("2026-07-15T11:42:00.000Z", now)).toBe("18m");
+    expect(formatMissionTime("2026-07-15T08:00:00.000Z", now)).toBe("4h");
+    expect(formatMissionTime("2026-07-13T12:00:00.000Z", now)).toBe("2d");
+  });
+
+  it("handles invalid timestamps without leaking invalid date copy", () => {
+    expect(formatMissionTime("invalid", now)).toBe("");
+    expect(formatMissionDateTime("invalid")).toBe("");
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/mission-time.ts
+++ b/apps/desktop/src/renderer/src/lib/mission-time.ts
@@ -1,0 +1,29 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function formatMissionTime(isoTimestamp: string, now = Date.now()): string {
+  const timestamp = Date.parse(isoTimestamp);
+  if (!Number.isFinite(timestamp)) return "";
+
+  const elapsed = Math.max(0, now - timestamp);
+  if (elapsed < MINUTE_MS) return "Now";
+  if (elapsed < HOUR_MS) return `${Math.floor(elapsed / MINUTE_MS)}m`;
+  if (elapsed < DAY_MS) return `${Math.floor(elapsed / HOUR_MS)}h`;
+  if (elapsed < 7 * DAY_MS) return `${Math.floor(elapsed / DAY_MS)}d`;
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(timestamp);
+}
+
+export function formatMissionDateTime(isoTimestamp: string): string {
+  const timestamp = Date.parse(isoTimestamp);
+  if (!Number.isFinite(timestamp)) return "";
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(timestamp);
+}

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -2,7 +2,21 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import type { Mission } from "../../../../shared/desktop-api.ts";
-import { MissionDetailFragment } from "./MissionsPage.tsx";
+import { MissionDetailFragment, MissionsPage } from "./MissionsPage.tsx";
+
+describe("MissionsPage", () => {
+  it("presents mission creation as an AI prompt card with scoped capability entries", () => {
+    const html = renderToStaticMarkup(<MissionsPage />);
+
+    expect(html).toContain("Start a mission");
+    expect(html).toContain('aria-label="Mission context and tools"');
+    expect(html).toContain(">Context<");
+    expect(html).toContain(">Files<");
+    expect(html).toContain(">Knowledge<");
+    expect(html).toContain(">Tools<");
+    expect(html.match(/aria-disabled="true"/g)?.length).toBe(3);
+  });
+});
 
 describe("MissionDetailFragment", () => {
   it("uses the full detail width for a single expert", () => {

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -2,13 +2,17 @@ import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from
 
 import {
   ArrowCounterClockwise,
+  Books,
   CheckCircle,
+  Files,
   Folder,
   GitBranch,
   MagnifyingGlass,
   Paperclip,
   Plus,
   Play,
+  Stack,
+  Toolbox,
   User,
   UsersThree,
 } from "@phosphor-icons/react";
@@ -21,6 +25,7 @@ import type {
   PragmaDesktopAPI,
 } from "../../../../shared/desktop-api.ts";
 import { errorMessage } from "../../lib/errors.ts";
+import { formatMissionDateTime, formatMissionTime } from "../../lib/mission-time.ts";
 
 type MissionScreen = "create" | "detail";
 
@@ -31,6 +36,12 @@ export function MissionsPage() {
   const [selectedMissionId, setSelectedMissionId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     const api = desktopApi();
@@ -88,6 +99,7 @@ export function MissionsPage() {
       <MissionRail
         missions={visibleMissions}
         search={search}
+        now={now}
         selectedMissionId={screen === "detail" ? selectedMissionId : null}
         onSearch={setSearch}
         onCreate={() => {
@@ -159,6 +171,7 @@ export function MissionsPage() {
 function MissionRail(props: {
   readonly missions: readonly Mission[];
   readonly search: string;
+  readonly now: number;
   readonly selectedMissionId: string | null;
   readonly onSearch: (value: string) => void;
   readonly onCreate: () => void;
@@ -170,7 +183,7 @@ function MissionRail(props: {
     <aside className="mission-rail">
       <h1>Missions</h1>
       <button className="mission-new-button" type="button" onClick={props.onCreate}>
-        <Plus size={18} weight="bold" aria-hidden="true" />
+        <Plus size={18} aria-hidden="true" />
         New mission
       </button>
       <label className="mission-search">
@@ -185,12 +198,14 @@ function MissionRail(props: {
       <MissionRailGroup
         label="Active"
         missions={active}
+        now={props.now}
         selectedMissionId={props.selectedMissionId}
         onOpen={props.onOpen}
       />
       <MissionRailGroup
         label="Completed"
         missions={completed}
+        now={props.now}
         selectedMissionId={props.selectedMissionId}
         onOpen={props.onOpen}
       />
@@ -201,6 +216,7 @@ function MissionRail(props: {
 function MissionRailGroup(props: {
   readonly label: string;
   readonly missions: readonly Mission[];
+  readonly now: number;
   readonly selectedMissionId: string | null;
   readonly onOpen: (mission: Mission) => void;
 }) {
@@ -229,7 +245,15 @@ function MissionRailGroup(props: {
             />
             <span>
               <strong>{mission.title}</strong>
-              <small>{mission.lifecycleStatus === "active" ? "Ready" : "Completed"}</small>
+              <small>
+                <span>{mission.lifecycleStatus === "active" ? "Ready" : "Completed"}</span>
+                <time
+                  dateTime={mission.updatedAt}
+                  title={formatMissionDateTime(mission.updatedAt)}
+                >
+                  {formatMissionTime(mission.updatedAt, props.now)}
+                </time>
+              </small>
             </span>
           </button>
         ))
@@ -337,10 +361,53 @@ function CreateMissionFragment(props: {
           autoFocus
         />
         <footer>
-          <span className="mission-context-disabled" title="Files are accessed from the workspace">
-            <Paperclip size={19} aria-hidden="true" />
-            Workspace context
-          </span>
+          <div className="mission-prompt-tools" aria-label="Mission context and tools">
+            <button
+              type="button"
+              aria-disabled="true"
+              title={
+                executorRef === ""
+                  ? "Choose an executor to inherit its context"
+                  : "Context is inherited from the selected executor"
+              }
+            >
+              <Stack size={18} aria-hidden="true" />
+              Context
+            </button>
+            <button
+              className={workspace === null ? "" : "is-active"}
+              type="button"
+              onClick={() => void pickWorkspace()}
+              title={workspace?.path ?? "Choose files through a mission workspace"}
+            >
+              <Files size={18} aria-hidden="true" />
+              Files
+            </button>
+            <button
+              type="button"
+              aria-disabled="true"
+              title={
+                executorRef === ""
+                  ? "Choose an executor to inherit its knowledge"
+                  : "Knowledge is managed by the selected executor"
+              }
+            >
+              <Books size={18} aria-hidden="true" />
+              Knowledge
+            </button>
+            <button
+              type="button"
+              aria-disabled="true"
+              title={
+                executorRef === ""
+                  ? "Choose an executor to inherit its tools"
+                  : "Tools are managed by the selected executor"
+              }
+            >
+              <Toolbox size={18} aria-hidden="true" />
+              Tools
+            </button>
+          </div>
           <button
             className="primary-button"
             type="button"

--- a/apps/desktop/src/renderer/src/pages/settings/ModelProvidersFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/ModelProvidersFragment.tsx
@@ -205,7 +205,7 @@ function ProviderCard(props: {
     <article className="provider-card is-expanded">
       <header className="card-header">
         <span className="card-icon" aria-hidden="true">
-          <Robot size={24} weight="duotone" />
+          <Robot size={24} />
         </span>
         <div className="card-title-group">
           <h3>{props.provider.name}</h3>

--- a/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.tsx
@@ -37,7 +37,7 @@ function RuntimeCard(props: { readonly runtime: DesktopRuntimeAvailability }) {
     <article className="runtime-card">
       <header className="card-header runtime-card-header">
         <span className="card-icon runtime-icon" aria-hidden="true">
-          <TerminalWindow size={24} weight="duotone" />
+          <TerminalWindow size={24} />
         </span>
         <div className="card-title-group">
           <h3>{details.name}</h3>

--- a/apps/desktop/src/renderer/src/pages/studio/StudioPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/StudioPage.tsx
@@ -230,7 +230,7 @@ export function StudioPage() {
                 setContextDrawerOpen(false);
               }}
             >
-              <SectionIcon size={20} weight={isActive ? "fill" : "regular"} aria-hidden="true" />
+              <SectionIcon size={20} aria-hidden="true" />
               <span>{section.label}</span>
               {count !== undefined ? <em>{count}</em> : null}
             </button>

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.tsx
@@ -664,7 +664,7 @@ function StepNode(props: NodeProps<StepCanvasNode>) {
       <span className="flow-step-kind">{props.data.kind}</span>
       <div className="flow-step-main">
         <span className="flow-step-icon">
-          <Icon size={18} weight="duotone" />
+          <Icon size={18} />
         </span>
         <div>
           <strong>{props.data.label}</strong>
@@ -712,7 +712,7 @@ function TerminalNode(props: NodeProps<TerminalCanvasNode>) {
 }
 
 function PlayIcon() {
-  return <GitBranch size={18} weight="duotone" />;
+  return <GitBranch size={18} />;
 }
 
 const nodeTypes = { step: StepNode, terminal: TerminalNode };

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1,6 +1,6 @@
 :root {
-  color: #20231f;
-  background: #f7f8f5;
+  color: #1d211f;
+  background: #f8f9fb;
   font-family:
     Inter,
     "SF Pro Text",
@@ -11,19 +11,28 @@
     sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --background: #fbfcf9;
-  --sidebar: #f9faf7;
-  --surface: #fcfdfb;
-  --surface-muted: #eef1ed;
-  --surface-soft: #f4f7f3;
-  --border: #d0d7d1;
-  --border-strong: #c5cdc7;
-  --text: #20231f;
-  --muted: #626b64;
-  --faint: #888f89;
-  --green: #5e806f;
-  --green-dark: #4d6f5e;
-  --lime: #b8e23e;
+  color-scheme: light;
+  --background: #f8f9fb;
+  --sidebar: #f1f3f2;
+  --surface: #ffffff;
+  --surface-muted: #edf1ee;
+  --surface-soft: #f5f7f6;
+  --border: #e4e8e5;
+  --border-strong: #d8ded9;
+  --text: #1d211f;
+  --muted: #67706a;
+  --faint: #919994;
+  --green: #587968;
+  --green-dark: #456454;
+  --lime: #97bd57;
+  --green-soft: #e9f0ec;
+  --focus-ring: rgb(88 121 104 / 20%);
+  --shadow-soft: 0 1px 2px rgb(20 31 25 / 4%), 0 8px 24px rgb(20 31 25 / 5%);
+  --shadow-hover: 0 2px 5px rgb(20 31 25 / 6%), 0 12px 30px rgb(20 31 25 / 8%);
+  --shadow-panel: 0 18px 50px rgb(20 31 25 / 12%);
+  --radius-control: 10px;
+  --radius-card: 14px;
+  --radius-large: 16px;
 }
 
 * {
@@ -2340,6 +2349,12 @@ p {
   background: var(--green);
 }
 
+.studio-nav-item > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .mount-trigger-summary {
   margin: 7px 0 4px 55px;
   color: var(--muted);
@@ -4243,5 +4258,1017 @@ p {
 
   .flow-validation-panel {
     right: 62px;
+  }
+}
+
+/* Enterprise AI-native polish layer */
+
+::selection {
+  background: rgb(88 121 104 / 18%);
+}
+
+button,
+input,
+select,
+textarea {
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    transform 150ms ease;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
+.desktop-shell {
+  background: var(--background);
+}
+
+.sidebar {
+  padding: 30px 18px 26px;
+  border-right: 0;
+  background: var(--sidebar);
+}
+
+.brand {
+  gap: 12px;
+  padding: 0 10px;
+}
+
+.brand-mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--green);
+  box-shadow: 0 5px 14px rgb(69 100 84 / 18%);
+  font-size: 24px;
+}
+
+.brand-name {
+  font-size: 25px;
+  font-weight: 720;
+  letter-spacing: -0.04em;
+}
+
+.sidebar-collapse-toggle {
+  border-radius: var(--radius-control);
+}
+
+.sidebar-collapse-toggle:hover {
+  background: rgb(255 255 255 / 72%);
+  color: var(--green-dark);
+}
+
+.navigation {
+  gap: 6px;
+  margin-top: 48px;
+}
+
+.navigation-item {
+  height: 44px;
+  gap: 14px;
+  padding: 0 15px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  cursor: pointer;
+  font-weight: 560;
+}
+
+.navigation-item:hover:not(:disabled) {
+  background: rgb(255 255 255 / 60%);
+  color: var(--text);
+}
+
+.navigation-item.is-active {
+  border-color: rgb(88 121 104 / 8%);
+  background: #fff;
+  color: var(--green-dark);
+  box-shadow: 0 1px 3px rgb(20 31 25 / 5%);
+}
+
+.navigation-item.is-active::before {
+  top: 11px;
+  bottom: 11px;
+  width: 3px;
+  background: var(--green);
+}
+
+.navigation-item:disabled {
+  opacity: 0.45;
+}
+
+.primary-button,
+.secondary-button,
+.danger-button,
+.text-button,
+.studio-primary-action,
+.mission-new-button {
+  border-radius: var(--radius-control);
+}
+
+.primary-button,
+.studio-primary-action,
+.mission-new-button {
+  border-color: transparent;
+  background: var(--green);
+  box-shadow: 0 1px 2px rgb(36 65 50 / 12%);
+}
+
+.primary-button:hover:not(:disabled),
+.studio-primary-action:hover:not(:disabled),
+.mission-new-button:hover:not(:disabled) {
+  background: var(--green-dark);
+  box-shadow: 0 4px 12px rgb(36 65 50 / 16%);
+  transform: translateY(-1px);
+}
+
+.secondary-button {
+  border-color: var(--border);
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(20 31 25 / 3%);
+}
+
+.secondary-button:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--surface-soft);
+}
+
+.primary-button:focus-visible,
+.secondary-button:focus-visible,
+.danger-button:focus-visible,
+.text-button:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.settings-page {
+  padding: 48px 60px 72px;
+  background: var(--background);
+}
+
+.settings-page > h1,
+.studio-heading h1,
+.mission-create > header h1,
+.mission-detail-header h1,
+.mission-empty-detail h1 {
+  color: var(--text);
+  font-weight: 720;
+  letter-spacing: -0.04em;
+}
+
+.settings-page > h1 {
+  font-size: 32px;
+}
+
+.settings-layout {
+  gap: 48px;
+  margin-top: 40px;
+}
+
+.settings-navigation {
+  gap: 6px;
+}
+
+.settings-nav-item {
+  min-height: 43px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+}
+
+.settings-nav-item:hover {
+  background: rgb(255 255 255 / 66%);
+}
+
+.settings-nav-item.is-active {
+  border-color: rgb(88 121 104 / 8%);
+  background: #fff;
+  color: var(--green-dark);
+  box-shadow: 0 1px 3px rgb(20 31 25 / 5%);
+}
+
+.panel-heading h2 {
+  font-size: 24px;
+  font-weight: 680;
+}
+
+.provider-list,
+.runtime-list {
+  gap: 14px;
+}
+
+.provider-card,
+.runtime-card {
+  border-color: transparent;
+  border-radius: var(--radius-card);
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.provider-card:hover,
+.runtime-card:hover {
+  border-color: rgb(88 121 104 / 15%);
+  box-shadow: var(--shadow-hover);
+}
+
+.card-icon,
+.device-icon,
+.runtime-icon {
+  border-radius: 11px;
+  background: var(--green-soft);
+  color: var(--green-dark);
+}
+
+.provider-fields,
+.provider-danger-zone,
+.advanced-section,
+.runtime-defaults {
+  border-color: var(--border);
+}
+
+.static-field input,
+.key-input-wrap,
+.configured-value,
+.input-shell,
+.runtime-command {
+  border-color: transparent;
+  border-radius: var(--radius-control);
+  background: var(--surface-soft);
+}
+
+.static-field input:hover,
+.key-input-wrap:hover,
+.input-shell:hover {
+  background: #f1f4f2;
+}
+
+.static-field input:focus,
+.key-input-wrap:focus-within {
+  border-color: var(--green);
+  background: #fff;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.configured-model-list {
+  gap: 3px;
+  padding: 3px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--surface-soft);
+}
+
+.configured-model {
+  border-radius: 9px;
+  background: #fff;
+}
+
+.configured-model + .configured-model {
+  border-top: 0;
+}
+
+.empty-state {
+  border: 0;
+  border-radius: var(--radius-card);
+  background: var(--surface-soft);
+}
+
+.setting-row {
+  min-height: 86px;
+  border-bottom: 0;
+}
+
+.setting-row + .setting-row {
+  border-top: 1px solid var(--border);
+}
+
+.device-summary {
+  border-color: transparent;
+  border-radius: var(--radius-card);
+  background: var(--green-soft);
+}
+
+.runtime-command {
+  padding: 14px 16px;
+}
+
+.studio-page {
+  background: var(--background);
+}
+
+.studio-navigation {
+  gap: 6px;
+  border-right: 0;
+}
+
+.studio-nav-item {
+  min-height: 44px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+}
+
+.studio-nav-item:hover {
+  background: rgb(255 255 255 / 62%);
+}
+
+.studio-nav-item.is-active {
+  border-color: rgb(88 121 104 / 8%);
+  background: #fff;
+  color: var(--green-dark);
+  box-shadow: 0 1px 3px rgb(20 31 25 / 5%);
+}
+
+.studio-nav-item.is-active::before {
+  top: 10px;
+  bottom: 10px;
+  width: 3px;
+  background: var(--green);
+}
+
+.studio-content {
+  padding-top: 10px;
+}
+
+.studio-heading {
+  min-height: 102px;
+  padding-bottom: 30px;
+  border-bottom: 0;
+}
+
+.studio-heading h1 {
+  font-size: 32px;
+}
+
+.studio-create-menu {
+  padding: 6px;
+  border-color: var(--border);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: var(--shadow-panel);
+}
+
+.studio-create-menu button {
+  border-radius: 8px;
+}
+
+.studio-asset-rows {
+  gap: 9px;
+}
+
+.studio-asset-row {
+  min-height: 92px;
+  padding: 15px 16px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(20 31 25 / 3%);
+}
+
+.studio-asset-row:hover {
+  border-color: rgb(88 121 104 / 20%);
+  box-shadow: var(--shadow-hover);
+  transform: translateY(-1px);
+}
+
+.studio-asset-icon,
+.store-icon,
+.expert-avatar,
+.mission-user-message > span {
+  border-radius: 11px;
+  background: var(--green-soft);
+  color: var(--green-dark);
+}
+
+.pragma-resource-editor > header,
+.pragma-resource-editor > footer {
+  border-color: var(--border);
+}
+
+.pragma-resource-form input,
+.pragma-resource-form select,
+.pragma-resource-form textarea,
+.capability-form input,
+.capability-form select,
+.capability-form textarea,
+.store-config-form input,
+.store-config-form textarea,
+.store-config-form select,
+.creator-form input,
+.creator-form textarea,
+.creator-form select {
+  border-color: var(--border);
+  border-radius: var(--radius-control);
+  background: #fff;
+}
+
+.pragma-resource-form input:focus,
+.pragma-resource-form select:focus,
+.pragma-resource-form textarea:focus,
+.capability-form input:focus,
+.capability-form select:focus,
+.capability-form textarea:focus,
+.store-config-form input:focus,
+.store-config-form textarea:focus,
+.store-config-form select:focus,
+.creator-form input:focus,
+.creator-form textarea:focus,
+.creator-form select:focus {
+  border-color: var(--green);
+  outline: 0;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.pragma-flow-node,
+.mission-human-loop,
+.creator-form,
+.creator-preview,
+.capability-editor,
+.review-summary,
+.instructions-preview,
+.expert-scope,
+.expert-context-section {
+  border-color: transparent;
+  border-radius: var(--radius-card);
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.capability-table,
+.store-table,
+.expert-table {
+  display: grid;
+  gap: 7px;
+  border: 0;
+}
+
+.capability-table-heading,
+.store-table-heading,
+.expert-table-heading {
+  padding: 0 14px;
+}
+
+.capability-row,
+.store-list-row,
+.expert-list-row {
+  padding-right: 14px;
+  padding-left: 14px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(20 31 25 / 3%);
+}
+
+.capability-row:hover,
+.store-list-row:hover,
+.expert-list-row:hover {
+  border-color: rgb(88 121 104 / 18%);
+  background: #fff;
+  box-shadow: var(--shadow-hover);
+}
+
+.store-list-row.is-selected {
+  border-color: rgb(88 121 104 / 28%);
+  background: var(--green-soft);
+}
+
+.store-filter-tabs,
+.capability-filters {
+  border-radius: 10px;
+  background: var(--surface-muted);
+}
+
+.store-filter-tabs button,
+.capability-filters button {
+  border-radius: 8px;
+}
+
+.store-filter-tabs button.is-active,
+.capability-filters button.is-active {
+  background: #fff;
+  color: var(--green-dark);
+  box-shadow: 0 1px 3px rgb(20 31 25 / 6%);
+}
+
+.directory-search,
+.mission-search,
+.mount-search {
+  border-color: transparent;
+  border-radius: var(--radius-control);
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(20 31 25 / 4%);
+}
+
+.directory-search:focus-within,
+.mission-search:focus-within,
+.mount-search:focus-within {
+  border-color: var(--green);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.expert-detail-header {
+  padding-bottom: 28px;
+  border-bottom: 0;
+}
+
+.expert-scope,
+.instructions-preview,
+.expert-context-section,
+.capability-editor,
+.review-summary {
+  padding: 22px 24px;
+}
+
+.expert-capabilities > div,
+.review-summary dl div,
+.store-detail dl div,
+.store-review-list div,
+.expert-context-list > div {
+  border-color: var(--border);
+}
+
+.creator-steps li,
+.drawer-steps li {
+  border-radius: var(--radius-control);
+}
+
+.creator-steps li.is-active,
+.drawer-steps li.is-active {
+  background: var(--green-soft);
+  color: var(--green-dark);
+}
+
+.capability-drawer-backdrop,
+.drawer-scrim {
+  background: rgb(26 34 29 / 28%);
+}
+
+.capability-drawer,
+.store-creator-drawer,
+.context-mount-drawer {
+  background: #fff;
+  box-shadow: var(--shadow-panel);
+}
+
+.store-type-options > button,
+.trigger-options > label,
+.mount-store-row,
+.create-inline-store,
+.capability-upload {
+  border-color: var(--border);
+  border-radius: 12px;
+  background: var(--surface-soft);
+}
+
+.store-type-options > button:hover,
+.trigger-options > label:hover,
+.mount-store-row:hover,
+.create-inline-store:hover {
+  border-color: rgb(88 121 104 / 24%);
+  background: #fff;
+}
+
+.store-type-options > button.is-selected,
+.trigger-options > label.is-selected,
+.mount-store-row.is-selected {
+  border-color: var(--green);
+  background: var(--green-soft);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.missions-page {
+  background: var(--background);
+}
+
+.mission-rail {
+  padding: 42px 20px 34px;
+  border-right: 0;
+  background: #f4f6f5;
+}
+
+.mission-rail > h1 {
+  font-size: 19px;
+  letter-spacing: -0.02em;
+}
+
+.mission-new-button {
+  height: 40px;
+  border: 0;
+}
+
+.mission-search {
+  height: 40px;
+}
+
+.mission-rail-group {
+  margin-top: 28px;
+}
+
+.mission-rail-group h2 {
+  padding: 0 8px 8px;
+  border-bottom: 0;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mission-row {
+  grid-template-columns: 8px minmax(0, 1fr);
+  margin-top: 3px;
+  padding: 11px 10px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+}
+
+.mission-row:hover {
+  border-color: rgb(88 121 104 / 12%);
+  background: #fff;
+  box-shadow: 0 4px 14px rgb(20 31 25 / 5%);
+  transform: translateY(-1px);
+}
+
+.mission-row.is-active {
+  border-color: rgb(88 121 104 / 28%);
+  background: #fff;
+  box-shadow: 0 5px 16px rgb(20 31 25 / 6%);
+}
+
+.mission-row small {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.mission-row small > span {
+  color: var(--green-dark);
+}
+
+.mission-row time {
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.mission-status-dot.is-active,
+.mission-ready-dot,
+.online-dot,
+.status-copy.is-active .status-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 3px rgb(88 121 104 / 12%);
+}
+
+.mission-main {
+  background: var(--background);
+}
+
+.mission-create {
+  padding: 64px 58px 58px;
+}
+
+.mission-create > header h1,
+.mission-detail-header h1,
+.mission-empty-detail h1 {
+  font-size: 30px;
+}
+
+.mission-create-selectors {
+  gap: 10px;
+  margin-top: 38px;
+  border: 0;
+}
+
+.mission-selector {
+  padding: 13px 14px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: rgb(255 255 255 / 64%);
+}
+
+.mission-selector + .mission-selector {
+  border-left: 1px solid transparent;
+}
+
+.mission-selector:hover,
+.mission-selector:focus-within {
+  border-color: rgb(88 121 104 / 18%);
+  background: #fff;
+  box-shadow: 0 4px 16px rgb(20 31 25 / 5%);
+}
+
+.mission-selector-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: var(--green-soft);
+  color: var(--green-dark);
+}
+
+.mission-selector small {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.mission-selector em {
+  color: var(--faint);
+  font-size: 11px;
+}
+
+.mission-goal-composer {
+  min-height: 360px;
+  margin-top: 22px;
+  border-color: var(--border);
+  border-radius: var(--radius-large);
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.mission-goal-composer:hover {
+  border-color: rgb(88 121 104 / 20%);
+}
+
+.mission-goal-composer:focus-within {
+  border-color: var(--green);
+  box-shadow: 0 0 0 3px var(--focus-ring), var(--shadow-hover);
+}
+
+.mission-goal-composer > label {
+  padding: 20px 22px 0;
+  color: var(--green-dark);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+.mission-goal-composer textarea {
+  min-height: 226px;
+  padding: 15px 22px;
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.mission-goal-composer textarea::placeholder {
+  color: #9da49f;
+}
+
+.mission-goal-composer textarea:focus-visible,
+.mission-selector select:focus-visible {
+  outline: 0;
+}
+
+.mission-goal-composer footer {
+  gap: 14px;
+  padding: 11px 12px 11px 14px;
+  border-top-color: var(--border);
+}
+
+.mission-prompt-tools {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 2px;
+}
+
+.mission-prompt-tools button {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--faint);
+  cursor: pointer;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.mission-prompt-tools button:hover {
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+.mission-prompt-tools button.is-active {
+  color: var(--green-dark);
+  background: var(--green-soft);
+}
+
+.mission-prompt-tools button[aria-disabled="true"] {
+  cursor: help;
+}
+
+.mission-form-note {
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.mission-page-error,
+.flow-editor-error {
+  border-color: #efd5d1;
+  border-radius: 12px;
+  background: #fff8f7;
+  box-shadow: var(--shadow-hover);
+}
+
+.mission-detail-header {
+  padding-top: 54px;
+}
+
+.mission-detail-tabs {
+  border-bottom-color: var(--border);
+}
+
+.mission-detail-tabs button {
+  color: var(--muted);
+}
+
+.mission-detail-tabs button.is-active {
+  border-bottom-color: var(--green);
+  color: var(--green-dark);
+}
+
+.mission-user-message > span {
+  border-radius: 12px;
+}
+
+.mission-execution-notice {
+  border-left: 0;
+  border-radius: 12px;
+  background: var(--green-soft);
+  box-shadow: inset 3px 0 var(--green);
+}
+
+.mission-human-loop {
+  padding: 18px;
+}
+
+.mission-disabled-composer {
+  border-color: var(--border);
+  border-radius: var(--radius-card);
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.mission-team-inspector {
+  border-left: 0;
+  background: #f4f6f5;
+  box-shadow: inset 1px 0 var(--border);
+}
+
+.flow-editor-shell {
+  border: 0;
+  background: var(--background);
+}
+
+.flow-editor-toolbar {
+  border-bottom: 0;
+  background: #fff;
+  box-shadow: 0 1px 0 var(--border), 0 4px 16px rgb(20 31 25 / 4%);
+}
+
+.flow-editor-title > button,
+.flow-editor-toolbar-actions > button,
+.flow-panel-toggle,
+.flow-validation-panel header button {
+  border-radius: 9px;
+}
+
+.flow-node-palette,
+.flow-inspector {
+  border-color: transparent;
+  background: #f3f5f4;
+}
+
+.flow-palette-item {
+  border-color: transparent;
+  border-radius: 11px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(20 31 25 / 3%);
+}
+
+.flow-palette-item:hover {
+  border-color: rgb(88 121 104 / 20%);
+  box-shadow: 0 6px 18px rgb(20 31 25 / 7%);
+  transform: translateY(-1px);
+}
+
+.flow-canvas {
+  background: #fafbfc;
+}
+
+.flow-step-node,
+.flow-terminal-node {
+  border-color: transparent;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.flow-step-node:hover,
+.flow-step-node.is-selected {
+  border-color: var(--green);
+  box-shadow: 0 0 0 3px var(--focus-ring), var(--shadow-hover);
+  transform: translateY(-1px);
+}
+
+.flow-step-node.is-invalid {
+  border-color: #c96b5f;
+  box-shadow: 0 0 0 3px rgb(201 107 95 / 12%);
+}
+
+.flow-step-icon,
+.flow-inspector-icon,
+.flow-palette-item > span,
+.flow-terminal-node > span {
+  border-radius: 9px;
+  background: var(--green-soft);
+  color: var(--green-dark);
+}
+
+.flow-inspector-field input,
+.flow-inspector-field select,
+.flow-inspector-field textarea {
+  border-color: var(--border);
+  border-radius: 9px;
+  background: #fff;
+}
+
+.flow-inspector-field input:focus,
+.flow-inspector-field select:focus,
+.flow-inspector-field textarea:focus {
+  border-color: var(--green);
+  outline: 0;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.flow-validation-panel {
+  border-color: var(--border);
+  border-radius: var(--radius-card);
+  background: #fff;
+  box-shadow: var(--shadow-panel);
+}
+
+.flow-minimap,
+.flow-canvas-hint {
+  border-color: var(--border);
+  border-radius: 10px;
+  background: rgb(255 255 255 / 94%);
+  box-shadow: var(--shadow-soft);
+}
+
+@media (max-width: 1220px) {
+  .mission-rail {
+    padding-right: 17px;
+    padding-left: 17px;
+  }
+
+  .mission-create {
+    padding-right: 34px;
+    padding-left: 34px;
+  }
+
+  .mission-prompt-tools button {
+    padding-right: 6px;
+    padding-left: 6px;
+  }
+}
+
+@media (max-width: 1180px) {
+  .settings-page {
+    padding-right: 38px;
+    padding-left: 38px;
+  }
+
+  .settings-layout {
+    gap: 30px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button,
+  input,
+  select,
+  textarea,
+  .studio-asset-row,
+  .mission-row,
+  .flow-palette-item,
+  .flow-step-node {
+    transition: none;
+  }
+
+  .primary-button:hover:not(:disabled),
+  .studio-primary-action:hover:not(:disabled),
+  .mission-new-button:hover:not(:disabled),
+  .studio-asset-row:hover,
+  .mission-row:hover,
+  .flow-palette-item:hover,
+  .flow-step-node:hover {
+    transform: none;
   }
 }


### PR DESCRIPTION
## Summary

- establish a cohesive light visual system for the Desktop app with refined typography, spacing, surfaces, radii, shadows, and interaction states
- polish Missions, Studio, Settings, and the Flow Editor without changing their existing information architecture
- upgrade mission creation to an AI prompt card with contextual capability affordances and live relative activity timestamps
- standardize Phosphor icons on the regular style and preserve reduced-motion and compact-window behavior

## Impact

This is a renderer-focused UI update. It does not change public schemas, Desktop IPC contracts, persistence formats, or execution behavior.

The PR is stacked on #4 so its review contains only the Desktop UI polish commit.

## Validation

- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop typecheck`
- `pnpm --filter @pragma/desktop test` — 58 tests passed
- `pnpm --filter @pragma/desktop build`
- visual checks at 1440×900, 1280×800, and 1080×700
