### PR TITLE
Format console log output

### DIFF
--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -104,7 +104,7 @@ export function createLoggerProvider(options: CreateLoggerProviderOptions): Prag
 export function createConsoleLogHandler(): PragmaLogHandler {
   return {
     write(record) {
-      const payload = JSON.stringify(record);
+      const payload = formatConsoleLogRecord(record);
       switch (record.level) {
         case "debug":
           console.debug(payload);
@@ -122,6 +122,39 @@ export function createConsoleLogHandler(): PragmaLogHandler {
       }
     },
   };
+}
+
+function formatConsoleLogRecord(record: PragmaLogRecord): string {
+  const lines = [
+    `[${record.occurredAt}] ${record.level.toUpperCase()} ${record.component}/${record.event} - ${record.message}`,
+    `  stream: ${record.stream}`,
+    `  sequence: ${record.sequence}`,
+    `  host: ${formatKeyValues(record.host)}`,
+  ];
+  if (Object.keys(record.scope).length > 0) {
+    lines.push(`  scope: ${formatKeyValues(record.scope)}`);
+  }
+  if (record.attributes !== undefined) {
+    lines.push(`  attributes:\n${indentBlock(JSON.stringify(record.attributes, null, 2))}`);
+  }
+  if (record.stream === "failure") {
+    lines.push(`  diagnosticId: ${record.diagnosticId}`);
+    lines.push(`  error:\n${indentBlock(JSON.stringify(record.error, null, 2))}`);
+  }
+  return lines.join("\n");
+}
+
+function formatKeyValues(values: Record<string, unknown>): string {
+  return Object.entries(values)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(" ");
+}
+
+function indentBlock(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n");
 }
 
 export function createConsoleLoggerProvider(

--- a/packages/core/test/logger.test.ts
+++ b/packages/core/test/logger.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createCompositeLogHandler,
+  createConsoleLogHandler,
   createLoggerProvider,
   type PragmaLogRecord,
 } from "../src/index.ts";
@@ -60,6 +61,36 @@ describe("Pragma logger", () => {
     logger.info("test.info", "Info");
 
     expect(records.map((record) => record.level)).toEqual(["info"]);
+  });
+
+  it("formats console log records for human reading", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const logger = createLoggerProvider({
+      handler: createConsoleLogHandler(),
+      host: {
+        kind: "test",
+        bootId: "00000000-0000-4000-8000-000000000001",
+      },
+    }).createLogger({ component: "core.test", scope: { executionId: "execution-1" } });
+
+    logger.info("test.info", "Info", { count: 1 });
+    logger.error("test.failed", "Failed", new Error("boom"));
+
+    const infoPayload = info.mock.calls[0]?.[0];
+    const errorPayload = error.mock.calls[0]?.[0];
+    expect(typeof infoPayload).toBe("string");
+    expect(typeof errorPayload).toBe("string");
+    expect(() => JSON.parse(infoPayload as string)).toThrow();
+    expect(infoPayload).toContain("INFO core.test/test.info - Info");
+    expect(infoPayload).toContain("scope: executionId=execution-1");
+    expect(infoPayload).toContain('attributes:\n    {\n      "count": 1\n    }');
+    expect(errorPayload).toContain("ERROR core.test/test.failed - Failed");
+    expect(errorPayload).toContain("diagnosticId:");
+    expect(errorPayload).toContain('"message": "boom"');
+
+    info.mockRestore();
+    error.mockRestore();
   });
 
   it("bounds each serialized record", () => {


### PR DESCRIPTION
## What changed

- Format console logger output as a human-readable multi-line message instead of a raw single-line JSON string.
- Preserve structured details by rendering scope, attributes, diagnostic IDs, and errors in readable sections.
- Add logger test coverage for the console formatter behavior.

## Why

Console logs were technically structured but hard to scan during local development and runtime debugging because they printed as compact JSON strings.

## Validation

- `pnpm --filter @pragma/core test -- logger.test.ts`
- `pnpm --filter @pragma/core typecheck`
- `pnpm --filter @pragma/core lint`