### PR TITLE
Restore HumanTask prompts after restart

### DIFF
--- a/apps/desktop/src/main/mission-runner.test.ts
+++ b/apps/desktop/src/main/mission-runner.test.ts
@@ -11,6 +11,7 @@ import {
   fingerprintExpertExecutionDefinition,
   PragmaPaths,
   readRuntimeSessionRecord,
+  StoredExecutionView,
   type RuntimeDriverSessionContext,
   type RuntimeModelSelection,
   type RuntimeResolver,
@@ -1505,15 +1506,15 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       pragmaHome: join(root, "state"),
       runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
     });
-    await restartingRunner.run(mission.id);
-    await expect(restartingRunner.getWork(mission.id)).resolves.toEqual(
-      expect.objectContaining({
-        records: expect.arrayContaining([
-          expect.objectContaining({ kind: "flow" }),
-          expect.objectContaining({ kind: "human-task", status: "waiting" }),
-        ]),
-      }),
-    );
+
+    const chat = await restartingRunner.getChat({ id: mission.id, limit: 50 });
+    expect(chat.execution).toMatchObject({
+      id: waitingMission.execution!.id,
+      status: "waiting",
+      interruptible: false,
+    });
+    expect(chat.pendingInteractions).toHaveLength(1);
+    expect(chat.pendingInteractions[0]?.request.kind).toBe("question");
     const interactions = await restartingRunner.listHumanInteractions(mission.id);
     expect(interactions).toHaveLength(1);
     expect(interactions[0]?.request.kind).toBe("question");
@@ -1529,6 +1530,14 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
       { timeout: settlementTimeoutMs },
     );
+    const events = (
+      await new StoredExecutionView(waitingMission.execution!.id, executionStore).listEvents({
+        scope: { kind: "all" },
+        limit: 1_000,
+      })
+    ).items;
+    expect(events.filter((event) => event.type === "human.requested")).toHaveLength(1);
+    expect(events.filter((event) => event.type === "human.responded")).toHaveLength(1);
   });
 
   it("projects oversized replies as Handoff references without copying full text", async () => {

--- a/apps/desktop/src/main/mission-runner.ts
+++ b/apps/desktop/src/main/mission-runner.ts
@@ -501,10 +501,11 @@ export function createMissionRunner(options: {
           createdAt: executionStartedAt,
         });
       }
+      const recoveredWaiting = recoverable && (await hasPendingHumanInteraction(handle));
       const running = await options.missions.updateExecution(mission.id, {
         id: handle.executionId,
         inputMessageId,
-        status: "running",
+        status: recoveredWaiting ? "waiting" : "running",
         startedAt: executionStartedAt,
       });
       trackExecution({
@@ -877,8 +878,7 @@ export function createMissionRunner(options: {
 
     const names = await getExecutorNames(mission);
     const current = active.get(mission.id);
-    const pendingInteractions =
-      current === undefined ? [] : await listPendingHumanInteractions(current.handle);
+    const pendingInteractions = await listMissionPendingHumanInteractions(mission);
 
     // Keep using the projection captured before history was read. The execution may settle across
     // the awaits above; looking it up again would omit both durable history (which was skipped for
@@ -1158,15 +1158,10 @@ export function createMissionRunner(options: {
       liveWorkOutputs.delete(id);
     },
     async listHumanInteractions(id) {
-      const execution = active.get(id);
-      if (execution === undefined) return [];
-      return await listPendingHumanInteractions(execution.handle);
+      return await listMissionPendingHumanInteractions(await options.missions.get(id));
     },
     async respondToHumanInteraction(input) {
-      const execution = active.get(input.missionId);
-      if (execution === undefined) {
-        throw new Error("This human interaction is not active in the current Desktop process.");
-      }
+      const execution = await ensureActiveExecution(input.missionId, input.interactionId);
       const request = await findHumanRequest(execution.handle, input.interactionId);
       await execution.handle.respondToHumanInteraction(
         input.interactionId,
@@ -1178,6 +1173,53 @@ export function createMissionRunner(options: {
       invalidateChat(input.missionId);
     },
   };
+
+  async function listMissionPendingHumanInteractions(
+    mission: Mission,
+  ): Promise<MissionHumanInteraction[]> {
+    const execution = active.get(mission.id);
+    if (execution !== undefined) return await listPendingHumanInteractions(execution.handle);
+    if (
+      mission.execution === undefined ||
+      !["queued", "running", "waiting"].includes(mission.execution.status)
+    ) {
+      return [];
+    }
+    return await listPendingHumanInteractions(
+      new StoredExecutionView(mission.execution.id, executionStore),
+    ).catch(() => []);
+  }
+
+  async function ensureActiveExecution(
+    id: string,
+    interactionId: string,
+  ): Promise<ActiveMissionExecution> {
+    const existing = active.get(id);
+    if (existing !== undefined) return existing;
+    const pending = pendingOperations.get(id);
+    if (pending?.kind === "run") {
+      await pending.promise;
+    } else if (pending !== undefined) {
+      throw new MissionOperationError();
+    } else {
+      const mission = await options.missions.get(id);
+      if (
+        mission.execution === undefined ||
+        !["queued", "running", "waiting"].includes(mission.execution.status)
+      ) {
+        throw new Error("This human interaction is no longer waiting for a response.");
+      }
+      const restoring = runMission(id);
+      trackOperation(id, { kind: "run", promise: restoring });
+      await restoring;
+    }
+    const restored = active.get(id);
+    if (restored === undefined) {
+      throw new Error("This human interaction could not be restored in the current Desktop process.");
+    }
+    await waitForRestoredHumanInteraction(restored.handle, interactionId);
+    return restored;
+  }
 }
 
 function createRuntimeAgentOrdinals(
@@ -2101,7 +2143,7 @@ function readAgentActivityPhase(
 async function listPendingHumanInteractions(
   execution: Pick<MutableExecution, "listEvents">,
 ): Promise<MissionHumanInteraction[]> {
-  const events = (await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 })).items;
+  const events = await readAllExecutionEvents(execution);
   const responded = new Set(
     events
       .filter((event) => event.type === "human.responded")
@@ -2194,7 +2236,7 @@ function formatValue(value: unknown, maxLength: number): string {
 async function hasPendingHumanInteraction(execution: {
   readonly listEvents: MutableExecution["listEvents"];
 }): Promise<boolean> {
-  const events = (await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 })).items;
+  const events = await readAllExecutionEvents(execution);
   const responded = new Set(
     events
       .filter((event) => event.type === "human.responded")
@@ -2211,7 +2253,7 @@ async function findHumanRequest(
   execution: MutableExecution,
   interactionId: string,
 ): Promise<ExpertAgentHumanRequest> {
-  const events = (await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 })).items;
+  const events = await readAllExecutionEvents(execution);
   const event = events.find(
     (candidate) =>
       candidate.type === "human.requested" &&
@@ -2219,6 +2261,45 @@ async function findHumanRequest(
   );
   if (event === undefined) throw new Error(`Human interaction was not found: ${interactionId}`);
   return ExpertAgentHumanRequestSchema.parse((event.data as { request?: unknown }).request);
+}
+
+async function waitForRestoredHumanInteraction(
+  execution: MutableExecution,
+  interactionId: string,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const [state, pending] = await Promise.all([
+      execution.getState().catch(() => undefined),
+      listPendingHumanInteractions(execution).catch(() => []),
+    ]);
+    if (
+      state?.status === "waiting" &&
+      pending.some((interaction) => interaction.interactionId === interactionId)
+    ) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function readAllExecutionEvents(
+  execution: Pick<MutableExecution, "listEvents">,
+): Promise<Awaited<ReturnType<MutableExecution["listEvents"]>>["items"]> {
+  const events: Array<
+    Awaited<ReturnType<MutableExecution["listEvents"]>>["items"][number]
+  > = [];
+  let after: Awaited<ReturnType<MutableExecution["listEvents"]>>["nextCursor"] | undefined;
+  do {
+    const page = await execution.listEvents({
+      scope: { kind: "all" },
+      limit: 1_000,
+      ...(after === undefined ? {} : { after }),
+    });
+    events.push(...page.items);
+    after = page.nextCursor;
+  } while (after !== undefined);
+  return events;
 }
 
 function toDesktopHumanRequest(request: ExpertAgentHumanRequest): HumanInteractionRequest {

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -627,7 +627,7 @@ export interface LocalMissionContextOperation {
 export type MissionClientOperationState =
   | { readonly kind: "idle" }
   | {
-      readonly kind: "sending" | "saving_options" | "compacting";
+      readonly kind: "sending" | "saving_options" | "compacting" | "restoring";
       readonly token: string;
     };
 
@@ -726,6 +726,7 @@ export function MissionDetailFragment(props: {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const chatRef = useRef<MissionChatSnapshot | null>(null);
   const clientOperationRef = useRef<MissionClientOperationState>({ kind: "idle" });
+  const autoRestoreExecutionRef = useRef<string | null>(null);
   const followLatestRef = useRef(true);
   const prependScrollHeightRef = useRef<number | null>(null);
   const updateChat = useCallback((update: SetStateAction<MissionChatSnapshot | null>) => {
@@ -777,6 +778,7 @@ export function MissionDetailFragment(props: {
     setWorkRecords([]);
     setWorkConversation(null);
     setWorkError(null);
+    autoRestoreExecutionRef.current = null;
   }, [props.mission.id]);
 
   useEffect(() => {
@@ -1243,6 +1245,35 @@ export function MissionDetailFragment(props: {
     window.addEventListener("keydown", close);
     return () => window.removeEventListener("keydown", close);
   }, [selectedWorkRecord]);
+
+  useEffect(() => {
+    const executionId = props.mission.execution?.id;
+    if (
+      props.mission.lifecycleStatus !== "active" ||
+      executionId === undefined ||
+      !executionActive ||
+      interruptible ||
+      autoRestoreExecutionRef.current === executionId
+    ) {
+      return;
+    }
+    const operationToken = beginClientOperation("restoring");
+    if (operationToken === undefined) return;
+    autoRestoreExecutionRef.current = executionId;
+    void Promise.resolve(props.onRun?.())
+      .catch((restoreError: unknown) => {
+        console.error("Failed to auto-restore Mission execution.", restoreError);
+      })
+      .finally(() => finishClientOperation(operationToken));
+  }, [
+    beginClientOperation,
+    executionActive,
+    finishClientOperation,
+    interruptible,
+    props.mission.execution?.id,
+    props.mission.lifecycleStatus,
+    props.onRun,
+  ]);
 
   const loadEarlier = async (): Promise<void> => {
     const api = desktopApi();


### PR DESCRIPTION
## Summary

Fixes the Desktop recovery path for waiting HumanTask executions after an app restart.

- Rebuild pending HumanTask interactions from durable execution events when the current process has no active execution handle.
- Automatically restore active waiting/running Mission executions when the Mission detail view opens, so the user does not need to click Resume before the input card appears.
- Restore the original execution before accepting a HumanTask response and wait for the recovered interaction to be live before submitting the answer.
- Preserve waiting Mission projection when a recovered Flow is already waiting for human input.

## Root Cause

Desktop Mission state persisted the execution as waiting, but the renderer and main-process chat snapshot only looked at the in-memory active execution map for pending HumanTask prompts. After a restart that map is empty, so the input card disappeared even though the durable `human.requested` event was still present. Recovery also had timing windows where recoverable state could be shown as non-interruptible until a manual resume.

## Validation

- `pnpm --filter @pragma/desktop typecheck`
- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop test -- MissionsPage.test.tsx`
- `pnpm --filter @pragma/desktop test -- mission-runner.test.ts -t "round-trips a Flow human interaction"`