### PR TITLE
Compact mission list rows

### DIFF
--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -612,6 +612,7 @@ function MissionRailGroup(props: {
             ["queued", "running", "waiting"].includes(mission.execution.status);
           const isActiveMission = mission.lifecycleStatus === "active";
           const isPinned = isActiveMission && props.pinnedMissionIds.has(mission.id);
+          const showStatusDot = isActiveMission;
           return (
             <div
               className={[
@@ -624,18 +625,13 @@ function MissionRailGroup(props: {
               key={mission.id}
             >
               <button
-                className="mission-row-open"
+                className={showStatusDot ? "mission-row-open has-status-dot" : "mission-row-open"}
                 type="button"
                 onClick={() => props.onOpen(mission)}
               >
-                <span
-                  className={
-                    mission.lifecycleStatus === "active"
-                      ? "mission-status-dot is-active"
-                      : "mission-status-dot"
-                  }
-                  aria-hidden="true"
-                />
+                {showStatusDot ? (
+                  <span className="mission-status-dot is-active" aria-hidden="true" />
+                ) : null}
                 <span>
                   <strong>{mission.title}</strong>
                   <small>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -10013,17 +10013,23 @@ textarea:focus-visible,
 
 .mission-row-open {
   display: grid;
-  grid-template-columns: 8px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   width: 100%;
   align-items: start;
-  gap: 8px;
-  padding: 8px 58px 8px 8px;
+  gap: 0;
+  padding: 8px;
   border: 0;
   border-radius: inherit;
   background: transparent;
   color: var(--text);
   cursor: pointer;
   text-align: left;
+  transition: padding-right 140ms ease;
+}
+
+.mission-row-open.has-status-dot {
+  grid-template-columns: 8px minmax(0, 1fr);
+  gap: 8px;
 }
 
 .mission-row-open > span:last-child {
@@ -10061,6 +10067,13 @@ textarea:focus-visible,
 .mission-row.is-active .mission-row-actions,
 .mission-row.is-pinned .mission-row-actions {
   opacity: 1;
+}
+
+.mission-row:hover .mission-row-open,
+.mission-row:focus-within .mission-row-open,
+.mission-row.is-active .mission-row-open,
+.mission-row.is-pinned .mission-row-open {
+  padding-right: 58px;
 }
 
 .mission-row-icon-action[aria-pressed="true"] {
@@ -12811,6 +12824,7 @@ textarea:focus-visible,
   textarea,
   .studio-asset-row,
   .mission-row,
+  .mission-row-open,
   .mission-search-slot,
   .flow-palette-item,
   .flow-step-node,


### PR DESCRIPTION
## Summary

Tightens the Desktop mission list layout so rows no longer reserve empty horizontal space when the status marker is not shown.

## What changed

- Render the mission status dot only for active missions.
- Use a single-column mission row layout when no status dot is present.
- Stop reserving delete-action space until the row is hovered, focused, or selected.
- Include the new row padding transition in reduced-motion handling.

## Impact

Mission titles and metadata get more usable width in the sidebar, especially for completed or inactive rows where no leading marker is displayed.

## Validation

- `pnpm --filter @pragma/desktop typecheck:web`
- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop test -- src/renderer/src/pages/missions/MissionsPage.test.tsx`