### PR TITLE
Fix mission session upgrade recovery

### DIFF
--- a/apps/desktop/src/main/automation-store.ts
+++ b/apps/desktop/src/main/automation-store.ts
@@ -4,7 +4,6 @@ import { dirname, join, relative, sep } from "node:path";
 
 import {
   applyAtomicStateMigration,
-  derivePragmaResourceId,
   PragmaPaths,
   recoverAtomicStateMigration,
   withFileLock,
@@ -17,6 +16,7 @@ import {
   type AutomationBinding,
   type AutomationRunRecord,
 } from "../shared/desktop-api.ts";
+import { migrateLegacyPragmaResourceRef } from "@pragma/interpreter";
 
 const QueuedAutomationEventSchema = z
   .object({
@@ -229,9 +229,7 @@ async function migrateAutomationStorageV1(paths: PragmaPaths, projectId: string)
 }
 
 function migrateAutomationRef(ref: string, projectId: string): string {
-  const match = /^automation:([^@]+)@[^@]+$/.exec(ref);
-  if (match === null) return ref;
-  return `automation:${derivePragmaResourceId(`${projectId}\0Automation\0${match[1]}`)}`;
+  return migrateLegacyPragmaResourceRef(ref, projectId);
 }
 
 function validateAutomationMigrationDocuments(

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -66,6 +66,7 @@ import { createAutomationService } from "./automation-service.ts";
 import { createAutomationStore } from "./automation-store.ts";
 import { createDesktopLogHandler } from "./desktop-log-handler.ts";
 import { DesktopRendererLogSchema } from "../shared/desktop-api.ts";
+import { runPersistentStateUpgradeCoordinator } from "./persistent-state-upgrade-coordinator.ts";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const applicationId = "dev.pragma.desktop";
@@ -294,6 +295,11 @@ const desktopStartup = app.whenReady().then(async () => {
   });
   const missionStore = createMissionStore({
     missionsPath,
+  });
+  await runPersistentStateUpgradeCoordinator({
+    project: pragmaProjectStore,
+    missions: missionStore,
+    logger: mainLogger,
   });
   const modelProviderStore = createModelProviderStore({
     configPath: modelProvidersPath,

--- a/apps/desktop/src/main/mission-runner.test.ts
+++ b/apps/desktop/src/main/mission-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -79,9 +79,7 @@ const removeTemporaryPath = async (path: string): Promise<void> => {
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(
-    temporaryPaths.splice(0).map(async (path) => await removeTemporaryPath(path)),
-  );
+  await Promise.all(temporaryPaths.splice(0).map(async (path) => await removeTemporaryPath(path)));
 });
 
 describe("MissionRunner", { timeout: 15_000 }, () => {
@@ -1538,6 +1536,397 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     ).items;
     expect(events.filter((event) => event.type === "human.requested")).toHaveLength(1);
     expect(events.filter((event) => event.type === "human.responded")).toHaveLength(1);
+  });
+
+  it("continues a Mission whose persisted ExpertSession uses a legacy Expert id", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-legacy-expert-session-"));
+    temporaryPaths.push(root);
+    const pragmaHome = join(root, "state");
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const expertResource = snapshot.resources.find((resource) => resource.kind === "Expert")!;
+    await writeFile(
+      join(root, "projects", snapshot.projectId, "identity-migrations.json"),
+      `${JSON.stringify(
+        {
+          schemaVersion: "pragma.desktop-project-identity-migrations/v1",
+          projectId: snapshot.projectId,
+          migrations: [
+            {
+              kind: "Expert",
+              sourceId: "issue_reporter",
+              targetId: expertResource.metadata.id,
+            },
+          ],
+        },
+        undefined,
+        2,
+      )}\n`,
+    );
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Created before DSL identity migration",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(expertResource),
+    });
+    const runtime = defineRuntimeDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      restoreSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      startTurn: (_session, turn) => ({
+        outputText: `writer:${turn.rawQuery}`,
+        runtimeSessionId: "runtime",
+      }),
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const runtimes = createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" });
+    const executions = createFileExecutionStore({ pragmaHome });
+    const expertSessions = createFileExpertSessionStore({ executions, pragmaHome });
+    const sessionId = "10000000-0000-4000-8000-000000000024";
+    const executionId = "20000000-0000-4000-8000-000000000024";
+    const contextId = "30000000-0000-4000-8000-000000000024";
+    const now = new Date().toISOString();
+    const runtimeBinding = (await runtimes.bind({ runtimeId: "fake" })).binding;
+    await expertSessions.create({
+      schemaVersion: "pragma.expert-session/v5",
+      sessionId,
+      expertId: "issue_reporter",
+      definitionFingerprint: "c".repeat(64),
+      status: "open",
+      queuedRequestIds: [],
+      executionIds: [],
+      rootContextId: contextId,
+      contexts: {
+        [contextId]: {
+          schemaVersion: "pragma.runtime-context/v5",
+          contextId,
+          owner: { type: "expert-session", ownerId: sessionId },
+          origin: { type: "expert-session", sessionId },
+          expert: { id: "issue_reporter" },
+          runtime: runtimeBinding,
+          lifecycle: "open",
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+    await missions.updateExecution(mission.id, {
+      id: executionId,
+      inputMessageId: mission.initialMessageId,
+      sessionId,
+      status: "succeeded",
+      startedAt: now,
+      finishedAt: now,
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome,
+      runtimes,
+    });
+
+    await runner.sendMessage({
+      id: mission.id,
+      content: "Continue after upgrade",
+      requestId: "00000000-0000-4000-8000-000000000024",
+    });
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+
+    const migrated = await expertSessions.get(sessionId);
+    expect(migrated?.expertId).toBe(expertResource.metadata.id);
+    expect(migrated?.contexts[migrated.rootContextId]?.expert.id).toBe(expertResource.metadata.id);
+    const chat = await runner.getChat({ id: mission.id, limit: 50 });
+    expect(chat.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "assistant", content: "writer:Continue after upgrade" }),
+      ]),
+    );
+  });
+
+  it("creates a successor ExpertSession when an existing Mission definition is incompatible", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-successor-session-"));
+    temporaryPaths.push(root);
+    const pragmaHome = join(root, "state");
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const expertResource = snapshot.resources.find((resource) => resource.kind === "Expert")!;
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Keep working after incompatible upgrade",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(expertResource),
+    });
+    const runtime = defineRuntimeDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      restoreSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      startTurn: (_session, turn) => ({
+        outputText: `successor:${turn.rawQuery}`,
+        runtimeSessionId: "runtime",
+      }),
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const runtimes = createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" });
+    const executions = createFileExecutionStore({ pragmaHome });
+    const expertSessions = createFileExpertSessionStore({ executions, pragmaHome });
+    const sessionId = "10000000-0000-4000-8000-000000000025";
+    const executionId = "20000000-0000-4000-8000-000000000025";
+    const contextId = "30000000-0000-4000-8000-000000000025";
+    const now = new Date().toISOString();
+    const runtimeBinding = (await runtimes.bind({ runtimeId: "fake" })).binding;
+    const definition = { id: expertResource.metadata.id, kind: "expert" as const };
+    await expertSessions.create({
+      schemaVersion: "pragma.expert-session/v5",
+      sessionId,
+      expertId: expertResource.metadata.id,
+      definitionFingerprint: "b".repeat(64),
+      status: "open",
+      activeExecutionId: executionId,
+      queuedRequestIds: [],
+      executionIds: [executionId],
+      rootContextId: contextId,
+      contexts: {
+        [contextId]: {
+          schemaVersion: "pragma.runtime-context/v5",
+          contextId,
+          owner: { type: "expert-session", ownerId: sessionId },
+          origin: { type: "expert-session", sessionId },
+          expert: { id: expertResource.metadata.id },
+          runtime: runtimeBinding,
+          lifecycle: "open",
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+    await executions.create(
+      {
+        schemaVersion: "pragma.execution/v7",
+        executionId,
+        version: 0,
+        kind: "expert-turn",
+        definition,
+        rootInvocationId: executionId,
+        status: "running",
+        input: mission.goal,
+        state: {},
+        lastAppliedSequence: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        invocationId: executionId,
+        rootInvocationId: executionId,
+        definition,
+        executorId: expertResource.metadata.id,
+        contextId,
+        status: "running",
+        input: mission.goal,
+        createdAt: now,
+        updatedAt: now,
+      },
+    );
+    await missions.updateExecution(mission.id, {
+      id: executionId,
+      inputMessageId: mission.initialMessageId,
+      sessionId,
+      status: "running",
+      startedAt: now,
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome,
+      runtimes,
+    });
+
+    await runner.sendMessage({
+      id: mission.id,
+      content: "Continue on a successor",
+      requestId: "00000000-0000-4000-8000-000000000025",
+    });
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+
+    const updatedMission = await missions.get(mission.id);
+    expect(updatedMission.execution?.sessionId).not.toBe(sessionId);
+    const oldSession = await expertSessions.get(sessionId);
+    expect(oldSession).toMatchObject({
+      sessionId,
+      definitionFingerprint: "b".repeat(64),
+      lastStatus: "interrupted",
+    });
+    expect(oldSession?.activeExecutionId).toBeUndefined();
+    await expect(executions.get(executionId)).resolves.toMatchObject({ status: "interrupted" });
+    await expect(executions.getInvocation(executionId, executionId)).resolves.toMatchObject({
+      status: "interrupted",
+    });
+    const successorId = updatedMission.execution!.sessionId!;
+    expect(await expertSessions.get(successorId)).toMatchObject({
+      sessionId: successorId,
+      expertId: expertResource.metadata.id,
+    });
+    await expect(runner.getChat({ id: mission.id, limit: 50 })).resolves.toMatchObject({
+      entries: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "assistant",
+          content: "successor:Continue on a successor",
+        }),
+      ]),
+    });
+  });
+
+  it("keeps the old ExpertSession active when successor creation fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-successor-create-fails-"));
+    temporaryPaths.push(root);
+    const pragmaHome = join(root, "state");
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const expertResource = snapshot.resources.find((resource) => resource.kind === "Expert")!;
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Do not damage the old session",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(expertResource),
+    });
+    const runtime = defineRuntimeDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      restoreSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      startTurn: () => ({ outputText: "unreachable", runtimeSessionId: "runtime" }),
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const availableRuntimes = createStaticRuntimeResolver({
+      runtimes: [runtime],
+      defaultRuntimeId: "fake",
+    });
+    const executions = createFileExecutionStore({ pragmaHome });
+    const expertSessions = createFileExpertSessionStore({ executions, pragmaHome });
+    const sessionId = "10000000-0000-4000-8000-000000000026";
+    const executionId = "20000000-0000-4000-8000-000000000026";
+    const contextId = "30000000-0000-4000-8000-000000000026";
+    const now = new Date().toISOString();
+    const runtimeBinding = (await availableRuntimes.bind({ runtimeId: "fake" })).binding;
+    await expertSessions.create({
+      schemaVersion: "pragma.expert-session/v5",
+      sessionId,
+      expertId: expertResource.metadata.id,
+      definitionFingerprint: "c".repeat(64),
+      status: "open",
+      activeExecutionId: executionId,
+      queuedRequestIds: [mission.initialMessageId],
+      executionIds: [executionId],
+      rootContextId: contextId,
+      contexts: {
+        [contextId]: {
+          schemaVersion: "pragma.runtime-context/v5",
+          contextId,
+          owner: { type: "expert-session", ownerId: sessionId },
+          origin: { type: "expert-session", sessionId },
+          expert: { id: expertResource.metadata.id },
+          runtime: runtimeBinding,
+          lifecycle: "open",
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+    await expertSessions.transact(sessionId, ({ session }) => ({
+      result: undefined,
+      session,
+      prompts: [
+        {
+          requestId: mission.initialMessageId,
+          sessionId,
+          content: mission.goal,
+          mode: "enqueue" as const,
+          executionId,
+          status: "queued" as const,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+    }));
+    await missions.updateExecution(mission.id, {
+      id: executionId,
+      inputMessageId: mission.initialMessageId,
+      sessionId,
+      status: "running",
+      startedAt: now,
+    });
+    const failingSuccessorRuntimes: RuntimeResolver = {
+      getDefaultRuntimeId: async () => await availableRuntimes.getDefaultRuntimeId(),
+      bind: async () => {
+        throw new Error("Successor Runtime bind failed.");
+      },
+      resolve: async (request) => await availableRuntimes.resolve(request),
+    };
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome,
+      runtimes: failingSuccessorRuntimes,
+    });
+
+    await expect(
+      runner.sendMessage({
+        id: mission.id,
+        content: "Try to continue",
+        requestId: "00000000-0000-4000-8000-000000000026",
+      }),
+    ).rejects.toThrow("Successor Runtime bind failed.");
+
+    await expect(expertSessions.get(sessionId)).resolves.toMatchObject({
+      sessionId,
+      activeExecutionId: executionId,
+      queuedRequestIds: [mission.initialMessageId],
+    });
+    expect((await expertSessions.get(sessionId))?.lastStatus).toBeUndefined();
+    await expect(missions.get(mission.id)).resolves.toMatchObject({
+      execution: {
+        id: executionId,
+        sessionId,
+        status: "running",
+      },
+    });
   });
 
   it("projects oversized replies as Handoff references without copying full text", async () => {

--- a/apps/desktop/src/main/mission-runner.ts
+++ b/apps/desktop/src/main/mission-runner.ts
@@ -33,6 +33,7 @@ import type {
   PragmaAdapterHost,
   PragmaBindingRecord,
 } from "@pragma/interpreter";
+import { createPragmaResourceIdentityMigrationIndex } from "@pragma/interpreter";
 import type {
   HumanInteractionRequest,
   HumanInteractionResponse,
@@ -40,7 +41,7 @@ import type {
   RuntimeContextRecord,
   RuntimeEnvironmentBinding,
 } from "@pragma/shared";
-import { ExpertAgentStreamEventSchema } from "@pragma/shared";
+import { ExpertAgentStreamEventSchema, isFinalExecutionStatus } from "@pragma/shared";
 
 import type {
   Mission,
@@ -69,6 +70,10 @@ import {
   parseDesktopContextBindingRef,
 } from "./desktop-binding-ref.ts";
 import { MissionOperationError } from "./mission-operation-error.ts";
+import {
+  createMissionResumeOptions,
+  shouldCreateSuccessorExpertSession,
+} from "./mission-session-upgrade.ts";
 import type { MissionStore, MissionTimelineTurn } from "./mission-store.ts";
 import type { PragmaProjectStore } from "./pragma-project-store.ts";
 import type { PluginStore } from "./plugin-store.ts";
@@ -375,6 +380,128 @@ export function createMissionRunner(options: {
     return record?.contexts[record.rootContextId];
   };
 
+  const createMissionExpertSession = async (
+    compiled: CompiledResource<InvocableResource>,
+    app: ReturnType<typeof createPragma>,
+    input: {
+      readonly modelSelection?: RuntimeModelSelection | undefined;
+    } = {},
+  ): Promise<ExpertSession> => {
+    if ("kind" in compiled.value && compiled.value.kind === "flow") {
+      throw new Error("Flow missions do not use ExpertSession.");
+    }
+    return await app.experts.createSession(compiled.value, {
+      runtime: compiled.rootRuntimeId,
+      ...(input.modelSelection === undefined ? {} : { modelSelection: input.modelSelection }),
+    });
+  };
+
+  const resumeMissionSession = async (
+    mission: Mission,
+    compiled: CompiledResource<InvocableResource>,
+    app: ReturnType<typeof createPragma>,
+    sessionId: string,
+  ): Promise<ExpertSession> => {
+    if ("kind" in compiled.value && compiled.value.kind === "flow") {
+      throw new Error("Flow missions do not use ExpertSession.");
+    }
+    const record = await expertSessionStore.get(sessionId);
+    const identityIndex = createPragmaResourceIdentityMigrationIndex({
+      projectId: mission.project.id,
+      migrations: await options.project.readIdentityMigrations(),
+    });
+    const request = createMissionResumeOptions({
+      mission,
+      compiled,
+      sessionId,
+      record,
+      identityIndex,
+    });
+    return await app.experts.resumeSession(compiled.value, request);
+  };
+
+  const interruptSupersededMissionSession = async (mission: Mission): Promise<void> => {
+    if (
+      mission.execution?.sessionId === undefined ||
+      !["queued", "running", "waiting"].includes(mission.execution.status)
+    ) {
+      return;
+    }
+    const now = new Date().toISOString();
+    const execution = await executionStore.get(mission.execution.id);
+    if (execution !== undefined && !isFinalExecutionStatus(execution.status)) {
+      const invocations = await executionStore.listInvocations(execution.executionId);
+      await executionStore.commit({
+        commitId: randomUUID(),
+        executionId: execution.executionId,
+        executionPatch: { status: "interrupted" },
+        invocationPatches: invocations
+          .filter((invocation) => !isFinalExecutionStatus(invocation.status))
+          .map((invocation) => ({
+            invocationId: invocation.invocationId,
+            patch: { status: "interrupted", updatedAt: now },
+          })),
+      });
+    }
+    await expertSessionStore.transact(mission.execution.sessionId, ({ session, prompts }) => ({
+      result: undefined,
+      session: {
+        ...session,
+        activeExecutionId:
+          session.activeExecutionId === mission.execution!.id
+            ? undefined
+            : session.activeExecutionId,
+        lastStatus: "interrupted",
+        queuedRequestIds: session.queuedRequestIds.filter(
+          (requestId) =>
+            !prompts.some(
+              (prompt) =>
+                prompt.requestId === requestId && prompt.executionId === mission.execution!.id,
+            ),
+        ),
+        updatedAt: now,
+      },
+      prompts: prompts.map((prompt) =>
+        prompt.executionId === mission.execution!.id &&
+        (prompt.status === "queued" || prompt.status === "running")
+          ? { ...prompt, status: "interrupted" as const, updatedAt: now }
+          : prompt,
+      ),
+    }));
+  };
+
+  const openMissionExpertSession = async (input: {
+    readonly mission: Mission;
+    readonly compiled: CompiledResource<InvocableResource>;
+    readonly app: ReturnType<typeof createPragma>;
+    readonly sessionId?: string | undefined;
+    readonly modelSelection?: RuntimeModelSelection | undefined;
+    readonly createSuccessorOnMismatch: boolean;
+  }): Promise<ExpertSession> => {
+    if (input.sessionId === undefined) {
+      return await createMissionExpertSession(input.compiled, input.app, {
+        modelSelection: input.modelSelection,
+      });
+    }
+    try {
+      return await resumeMissionSession(input.mission, input.compiled, input.app, input.sessionId);
+    } catch (error) {
+      if (!input.createSuccessorOnMismatch || !shouldCreateSuccessorExpertSession(error)) {
+        throw error;
+      }
+      const successor = await createMissionExpertSession(input.compiled, input.app, {
+        modelSelection: input.modelSelection,
+      });
+      await interruptSupersededMissionSession(input.mission);
+      logger.warn(
+        "mission.session_successor_created",
+        `Created a successor ExpertSession for Mission ${input.mission.id} after an incompatible definition upgrade.`,
+        { error, sessionId: successor.sessionId },
+      );
+      return successor;
+    }
+  };
+
   const trackExecution = (input: {
     readonly missionId: string;
     readonly handle: MutableExecution & { readonly result: Promise<unknown> };
@@ -523,14 +650,14 @@ export function createMissionRunner(options: {
       ["queued", "running", "waiting"].includes(mission.execution.status);
     const session =
       sessions.get(mission.id) ??
-      (recoverable
-        ? await app.experts.resumeSession(compiled.value, {
-            sessionId: mission.execution!.sessionId!,
-          })
-        : await app.experts.createSession(compiled.value, {
-            runtime: compiled.rootRuntimeId,
-            ...(modelSelection === undefined ? {} : { modelSelection }),
-          }));
+      (await openMissionExpertSession({
+        mission,
+        compiled,
+        app,
+        sessionId: recoverable ? mission.execution!.sessionId : undefined,
+        modelSelection,
+        createSuccessorOnMismatch: true,
+      }));
     sessions.set(mission.id, session);
     const recoveredPrompt = recoverable
       ? (await session.getPromptQueue()).find(
@@ -636,14 +763,14 @@ export function createMissionRunner(options: {
       : desiredModelSelection;
     const session =
       sessions.get(mission.id) ??
-      (mission.execution?.sessionId === undefined
-        ? await app.experts.createSession(compiled.value, {
-            runtime: compiled.rootRuntimeId,
-            ...(modelSelection === undefined ? {} : { modelSelection }),
-          })
-        : await app.experts.resumeSession(compiled.value, {
-            sessionId: mission.execution.sessionId,
-          }));
+      (await openMissionExpertSession({
+        mission,
+        compiled,
+        app,
+        sessionId: mission.execution?.sessionId,
+        modelSelection,
+        createSuccessorOnMismatch: true,
+      }));
     sessions.set(mission.id, session);
     await options.missions.appendUserMessage(mission.id, {
       id: input.requestId,
@@ -848,10 +975,7 @@ export function createMissionRunner(options: {
       throw new Error("Flow missions do not expose a chat context to compact.");
     }
     const session =
-      sessions.get(id) ??
-      (await app.experts.resumeSession(compiled.value, {
-        sessionId,
-      }));
+      sessions.get(id) ?? (await resumeMissionSession(mission, compiled, app, sessionId));
     sessions.set(id, session);
     const usage = await session.compactRootContext();
     invalidateChat(id);

--- a/apps/desktop/src/main/mission-session-upgrade.ts
+++ b/apps/desktop/src/main/mission-session-upgrade.ts
@@ -1,0 +1,61 @@
+import {
+  isExpertDefinitionMismatchError,
+  isExpertTeam,
+  type ResumeExpertSessionOptions,
+} from "@pragma/core";
+import type { PragmaResourceIdentityMigrationIndex } from "@pragma/interpreter";
+import type { ExpertSessionRecord } from "@pragma/shared";
+import type { CompiledResource, InvocableResource } from "@pragma/interpreter";
+
+import type { Mission } from "../shared/desktop-api.ts";
+
+export function createMissionResumeOptions(input: {
+  readonly mission: Mission;
+  readonly compiled: CompiledResource<InvocableResource>;
+  readonly sessionId: string;
+  readonly record?: ExpertSessionRecord | undefined;
+  readonly identityIndex: PragmaResourceIdentityMigrationIndex;
+}): ResumeExpertSessionOptions {
+  if ("kind" in input.compiled.value && input.compiled.value.kind === "flow") {
+    throw new Error("Flow missions do not use ExpertSession.");
+  }
+  const rootContext =
+    input.record === undefined ? undefined : input.record.contexts[input.record.rootContextId];
+  const rootExpert = isExpertTeam(input.compiled.value)
+    ? input.compiled.value.coordinator
+    : input.compiled.value;
+  const expectedRef = isExpertTeam(input.compiled.value)
+    ? `team:${input.compiled.value.id}`
+    : `expert:${input.compiled.value.id}`;
+  const sessionKind = isExpertTeam(input.compiled.value) ? "ExpertTeam" : "Expert";
+  if (
+    input.record === undefined ||
+    rootContext === undefined ||
+    input.mission.executor.ref !== expectedRef ||
+    (input.record.expertId === input.compiled.value.id &&
+      rootContext.expert.id === rootExpert.id) ||
+    !input.identityIndex.hasMigration(
+      sessionKind,
+      input.record.expertId,
+      input.compiled.value.id,
+    ) ||
+    !input.identityIndex.hasMigration("Expert", rootContext.expert.id, rootExpert.id)
+  ) {
+    return { sessionId: input.sessionId };
+  }
+  return {
+    sessionId: input.sessionId,
+    definitionMigration: {
+      previousExpertId: input.record.expertId,
+      previousRootExpertId: rootContext.expert.id,
+      reason: [
+        `Desktop Mission ${input.mission.id} is resuming executor ${input.mission.executor.ref}`,
+        `from project ${input.mission.project.id}@${input.mission.project.revision}.`,
+      ].join(" "),
+    },
+  };
+}
+
+export function shouldCreateSuccessorExpertSession(error: unknown): boolean {
+  return isExpertDefinitionMismatchError(error);
+}

--- a/apps/desktop/src/main/mission-store.ts
+++ b/apps/desktop/src/main/mission-store.ts
@@ -12,8 +12,12 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { derivePragmaResourceId, withFileLock } from "@pragma/core";
-import { formatPragmaYaml, parsePragmaYaml } from "@pragma/interpreter";
+import { withFileLock } from "@pragma/core";
+import {
+  formatPragmaYaml,
+  migrateLegacyPragmaResourceRef,
+  parsePragmaYaml,
+} from "@pragma/interpreter";
 import { z } from "zod";
 
 import {
@@ -204,7 +208,7 @@ export function createMissionStore(options: { readonly missionsPath: string }): 
         void _version;
         const migratedExecutor = {
           ...executor,
-          ref: migrateMissionExecutorRef(executor.ref, legacy.project.id),
+          ref: migrateLegacyPragmaResourceRef(executor.ref, legacy.project.id),
         };
         const migrated = MissionSchema.parse({
           ...legacy,
@@ -550,14 +554,6 @@ export function createMissionStore(options: { readonly missionsPath: string }): 
       });
     },
   };
-}
-
-function migrateMissionExecutorRef(ref: string, projectId: string): string {
-  const match = /^(expert|team|flow):([^@]+)@[^@]+$/.exec(ref);
-  if (match === null) return ref;
-  if (match[1] === "expert" && match[2] === "pragma") return "expert:0000000000pragma";
-  const kind = match[1] === "expert" ? "Expert" : match[1] === "team" ? "ExpertTeam" : "Flow";
-  return `${match[1]}:${derivePragmaResourceId(`${projectId}\0${kind}\0${match[2]}`)}`;
 }
 
 function toMissionSummary(mission: Mission): MissionSummary {

--- a/apps/desktop/src/main/persistent-state-upgrade-coordinator.test.ts
+++ b/apps/desktop/src/main/persistent-state-upgrade-coordinator.test.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLoggerProvider } from "@pragma/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createMissionStore } from "./mission-store.ts";
+import { runPersistentStateUpgradeCoordinator } from "./persistent-state-upgrade-coordinator.ts";
+import { createPragmaProjectStore } from "./pragma-project-store.ts";
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryPaths.splice(0).map(async (path) => await rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("persistent state upgrade coordinator", () => {
+  it("checks project and Mission state through Host store boundaries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-upgrade-coordinator-"));
+    temporaryPaths.push(root);
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const logger = createLoggerProvider({
+      handler: { write: () => undefined },
+      minimumLevel: "silent",
+    }).createLogger({ component: "test" });
+
+    await expect(
+      runPersistentStateUpgradeCoordinator({ project, missions, logger }),
+    ).resolves.toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/persistent-state-upgrade-coordinator.ts
+++ b/apps/desktop/src/main/persistent-state-upgrade-coordinator.ts
@@ -1,0 +1,81 @@
+import type { PragmaLogger } from "@pragma/core";
+
+import type { MissionStore } from "./mission-store.ts";
+import type { PragmaProjectStore } from "./pragma-project-store.ts";
+
+export interface PersistentStateUpgradeDiagnostic {
+  readonly ownerKind: "project" | "mission";
+  readonly ownerId: string;
+  readonly code: "upgrade_failed";
+  readonly message: string;
+}
+
+export async function runPersistentStateUpgradeCoordinator(input: {
+  readonly project: PragmaProjectStore;
+  readonly missions: MissionStore;
+  readonly logger: PragmaLogger;
+}): Promise<readonly PersistentStateUpgradeDiagnostic[]> {
+  const diagnostics: PersistentStateUpgradeDiagnostic[] = [];
+  try {
+    await input.project.get();
+    await input.project.readIdentityMigrations();
+  } catch (error) {
+    diagnostics.push({
+      ownerKind: "project",
+      ownerId: input.project.projectId,
+      code: "upgrade_failed",
+      message: errorMessage(error),
+    });
+    input.logger.warn("desktop.project_upgrade_failed", "Project state upgrade failed.", {
+      projectId: input.project.projectId,
+      error,
+    });
+  }
+
+  const missionIds = await input.missions
+    .list()
+    .then((missions) => missions.map((mission) => mission.id))
+    .catch((error: unknown) => {
+      diagnostics.push({
+        ownerKind: "mission",
+        ownerId: "*",
+        code: "upgrade_failed",
+        message: errorMessage(error),
+      });
+      input.logger.warn("desktop.mission_list_upgrade_failed", "Mission state listing failed.", {
+        error,
+      });
+      return undefined;
+    });
+  if (missionIds === undefined) {
+    return diagnostics;
+  }
+
+  for (const missionId of missionIds) {
+    try {
+      await input.missions.get(missionId);
+    } catch (error) {
+      diagnostics.push({
+        ownerKind: "mission",
+        ownerId: missionId,
+        code: "upgrade_failed",
+        message: errorMessage(error),
+      });
+      input.logger.warn("desktop.mission_upgrade_failed", "Mission state upgrade failed.", {
+        missionId,
+        error,
+      });
+    }
+  }
+  if (diagnostics.length === 0) {
+    input.logger.info(
+      "desktop.persistent_state_upgrade_checked",
+      "Persistent state upgrade checks completed.",
+    );
+  }
+  return diagnostics;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/src/main/pragma-project-store.test.ts
+++ b/apps/desktop/src/main/pragma-project-store.test.ts
@@ -108,6 +108,9 @@ describe("PragmaProjectStore", () => {
         }),
       ],
     });
+    await expect(project.readIdentityMigrations()).resolves.toEqual([
+      { kind: "Flow", sourceId: "release", targetId: expectedId },
+    ]);
     expect(await readFile(join(directory, "studio", "project.json"), "utf8")).toContain(
       "pragma.desktop-project/v4",
     );

--- a/apps/desktop/src/main/pragma-project-store.ts
+++ b/apps/desktop/src/main/pragma-project-store.ts
@@ -26,6 +26,7 @@ import {
   type PragmaProjectRevisionLocation,
   type PragmaProjectSourceRepository,
   type PragmaProjectChangeSetInput,
+  type PragmaResourceIdentityMigration,
 } from "@pragma/interpreter";
 import type { PragmaLoggerProvider } from "@pragma/core";
 import {
@@ -73,6 +74,30 @@ const ProjectRevisionManifestSchema = z
   })
   .strict();
 
+const ProjectIdentityMigrationManifestSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.desktop-project-identity-migrations/v1"),
+    projectId: z.string().min(1),
+    migrations: z.array(
+      z
+        .object({
+          kind: z.enum([
+            "Expert",
+            "ExpertTeam",
+            "Flow",
+            "Automation",
+            "Capability",
+            "ContextStore",
+            "RuntimeProfile",
+          ]),
+          sourceId: z.string().min(1),
+          targetId: z.string().min(1),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
 export interface PragmaProjectStore {
   get(): Promise<PragmaProjectSnapshot>;
   ensurePublished(): Promise<PragmaProjectSnapshot>;
@@ -102,6 +127,7 @@ export interface PragmaProjectStore {
     input: Parameters<PragmaProjectService["compile"]>[0],
   ): Promise<CompiledResource<T>>;
   openRevision(revision: number): Promise<PragmaProject>;
+  readIdentityMigrations(): Promise<readonly PragmaResourceIdentityMigration[]>;
   readonly projectId: string;
 }
 
@@ -170,6 +196,27 @@ export function createPragmaProjectStore(options: {
   const get = async (): Promise<PragmaProjectSnapshot> => {
     await ensureMigrated();
     return PragmaProjectSnapshotSchema.parse(await service.get(projectId));
+  };
+
+  const readIdentityMigrations = async (): Promise<readonly PragmaResourceIdentityMigration[]> => {
+    await ensureMigrated();
+    try {
+      const manifest = ProjectIdentityMigrationManifestSchema.parse(
+        JSON.parse(
+          await readFile(join(options.projectsPath, projectId, "identity-migrations.json"), "utf8"),
+        ) as unknown,
+      );
+      if (manifest.projectId !== projectId) {
+        throw new PragmaProjectStoreError(
+          "project_invalid",
+          `Project identity migration index belongs to ${manifest.projectId}, expected ${projectId}.`,
+        );
+      }
+      return manifest.migrations;
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") return [];
+      throw error;
+    }
   };
 
   const normalizeError = (error: unknown): never => {
@@ -388,6 +435,7 @@ export function createPragmaProjectStore(options: {
         requireLock: true,
       });
     },
+    readIdentityMigrations,
   };
 }
 
@@ -826,6 +874,11 @@ async function migrateDesktopProjectStorageV3ToV4(input: {
         const migrated = revisions[revision]!;
         await input.publish(revision, migrated.resources, migrated.artifacts);
       }
+      await writeLegacyProjectIdentityMigrationIndex(
+        projectPath,
+        input.projectId,
+        revisions.flatMap((revision) => revision.identityMigrations),
+      );
       await migrateLegacyFlowLayouts(
         legacyLayouts,
         projectPath,
@@ -839,6 +892,34 @@ async function migrateDesktopProjectStorageV3ToV4(input: {
       throw error;
     }
   });
+}
+
+async function writeLegacyProjectIdentityMigrationIndex(
+  projectPath: string,
+  projectId: string,
+  identities: readonly {
+    readonly kind: PragmaResource["kind"];
+    readonly sourceId: string;
+    readonly targetId: string;
+  }[],
+): Promise<void> {
+  const unique = new Map<string, (typeof identities)[number]>();
+  for (const identity of identities) {
+    unique.set(`${identity.kind}:${identity.sourceId}:${identity.targetId}`, identity);
+  }
+  if (unique.size === 0) return;
+  await writeAtomically(
+    join(projectPath, "identity-migrations.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: "pragma.desktop-project-identity-migrations/v1",
+        projectId,
+        migrations: [...unique.values()],
+      },
+      undefined,
+      2,
+    )}\n`,
+  );
 }
 
 async function readProjectMigrationJournal(
@@ -950,7 +1031,8 @@ async function createProjectViewLease(directory: string): Promise<string> {
       );
       return lease;
     } catch (error) {
-      if (errorCode(error) !== "ENOENT") throw error;
+      const code = errorCode(error);
+      if (code !== "ENOENT" && code !== "EINVAL") throw error;
     }
   }
 }

--- a/apps/desktop/src/shared/desktop-api.ts
+++ b/apps/desktop/src/shared/desktop-api.ts
@@ -5,8 +5,11 @@ import {
   ModelApiSchema as SharedModelApiSchema,
   ModelCompatibilityProfileIdSchema,
   ModelThinkingLevelSchema,
+  MissionExecutorRefSchema,
+  MissionExecutorSchema,
   ProviderModelDefinitionSchema,
   ToolPermissionModeSchema,
+  type MissionExecutor,
 } from "@pragma/shared";
 import {
   canonicalPragmaResourceRef,
@@ -18,7 +21,6 @@ import {
   PragmaScheduleTriggerSchema,
   PragmaExpertIdSchema,
   PragmaExpertRefSchema,
-  PragmaInvocableResourceRefSchema,
   PragmaLockSchema,
   PragmaResourceRefSchema,
   PragmaResourceSchema,
@@ -1077,18 +1079,9 @@ export const MissionWorkspaceSchema = z.object({
   basename: z.string().trim().min(1).max(255),
 });
 
-const MissionExecutorBaseSchema = z.object({
-  ref: PragmaInvocableResourceRefSchema,
+const MissionExecutorOptionBaseSchema = z.object({
+  ref: MissionExecutorRefSchema,
   name: z.string().trim().min(1).max(120),
-});
-
-export const MissionExecutorSchema = z.discriminatedUnion("kind", [
-  MissionExecutorBaseSchema.extend({ kind: z.literal("expert") }),
-  MissionExecutorBaseSchema.extend({ kind: z.literal("team") }),
-  MissionExecutorBaseSchema.extend({ kind: z.literal("flow") }),
-]);
-
-const MissionExecutorOptionBaseSchema = MissionExecutorBaseSchema.extend({
   description: z.string().trim().max(2_000),
   origin: z.enum(["project", "built-in"]),
   readOnly: z.boolean(),
@@ -1206,7 +1199,7 @@ export const AutomationAdapterOptionSchema = z
   .strict();
 
 export const MissionModelOptionsRequestSchema = z.object({
-  executorRef: PragmaInvocableResourceRefSchema,
+  executorRef: MissionExecutorRefSchema,
   missionId: MissionIdSchema.optional(),
 });
 
@@ -1383,7 +1376,7 @@ export const MissionSummarySchema = z.object({
 export const CreateMissionSchema = z.object({
   workspace: z.string().trim().min(1).max(2_000),
   executor: z.object({
-    ref: PragmaInvocableResourceRefSchema,
+    ref: MissionExecutorRefSchema,
   }),
   input: z.discriminatedUnion("kind", [
     z.object({ kind: z.literal("prompt"), value: z.string().trim().min(1).max(100_000) }).strict(),
@@ -1663,7 +1656,8 @@ export type GetWorkflowLayout = z.infer<typeof GetWorkflowLayoutSchema>;
 export type DeleteWorkflowLayout = z.infer<typeof DeleteWorkflowLayoutSchema>;
 export type Mission = z.infer<typeof MissionSchema>;
 export type MissionSummary = z.infer<typeof MissionSummarySchema>;
-export type MissionExecutor = z.infer<typeof MissionExecutorSchema>;
+export { MissionExecutorRefSchema, MissionExecutorSchema };
+export type { MissionExecutor };
 export type MissionExecutorOption = z.infer<typeof MissionExecutorOptionSchema>;
 export type MissionCreationDefaults = z.infer<typeof MissionCreationDefaultsSchema>;
 export type MissionModelOverride = z.infer<typeof MissionModelOverrideSchema>;

--- a/docs/adr/020-host-coordinated-persistent-state-upgrades.md
+++ b/docs/adr/020-host-coordinated-persistent-state-upgrades.md
@@ -1,0 +1,40 @@
+# ADR 020: Host-Coordinated Persistent State Upgrades
+
+## Status
+
+Accepted
+
+## Context
+
+Desktop upgrades have repeatedly failed in different places: application startup, built-in Expert
+initialization, and Mission session recovery. The common problem is not one strict check, but mixed
+ownership of identity, compatibility, DSL migration, and durable runtime state.
+
+## Decision
+
+Persistent upgrade responsibilities are split by layer.
+
+- `@pragma/core` owns Core recoverable state only: `ExpertSession`, `Execution`,
+  `RuntimeContext`, `RuntimeSession`, ownership claims, and Core storage migration APIs. It exposes
+  structured compatibility failures such as `ExpertDefinitionMismatchError`; it does not know DSL,
+  Mission, Project, Desktop, or Server policy.
+- `@pragma/interpreter` owns portable DSL migration and Pragma resource identity resolution. It keeps
+  the static adjacent DSL migration chain, emits resource `identityMigrations` as facts, and exposes
+  a pure identity migration index for Hosts. It does not mutate Host storage.
+- Host applications own cross-aggregate orchestration. Desktop currently coordinates Project,
+  Mission, Automation, ExpertSession, and RuntimeSession recovery. Server must use the same
+  boundary when it gains durable Missions.
+
+When an old Mission points at the same logical executor but persisted session state uses a previous
+resource identity, the Host may pass an explicit `definitionMigration` to Core. If Core reports a
+definition mismatch that is not safely migratable, the Host creates a successor `ExpertSession` and
+binds the next Mission execution to it. The old session remains historical state.
+
+## Consequences
+
+- Core remains fail-closed and no longer needs relaxed fingerprint checks.
+- DSL `apiVersion`, Host `schemaVersion`, and Project `revision` stay separate.
+- Project resource identity migration resolution is centralized in `@pragma/interpreter` and shared
+  by Host Mission and Automation migrations.
+- Startup performs Host upgrade checks through store boundaries and records diagnostics instead of
+  letting one stale aggregate make the application unusable.

--- a/packages/core/src/execution/expert-session.ts
+++ b/packages/core/src/execution/expert-session.ts
@@ -29,6 +29,7 @@ import type {
 import { openRuntimeSession } from "../runtime/session-factory.ts";
 import {
   readRuntimeSessionContextWindowUsage,
+  rebindRuntimeSessionExpertId,
   readRuntimeSessionRecord,
 } from "../runtime/session-record.ts";
 import { mergeUsages } from "../runtime/usage.ts";
@@ -60,6 +61,30 @@ export interface CreateExpertSessionOptions {
   readonly sessionId?: string | undefined;
   readonly runtime?: string | undefined;
   readonly modelSelection?: RuntimeModelSelection | undefined;
+}
+
+export interface ResumeExpertSessionOptions {
+  readonly sessionId: string;
+  readonly definitionMigration?:
+    | {
+        readonly previousExpertId: string;
+        readonly previousRootExpertId?: string | undefined;
+        readonly reason: string;
+      }
+    | undefined;
+}
+
+export class ExpertDefinitionMismatchError extends Error {
+  constructor(readonly sessionId: string) {
+    super(`Expert definition mismatch for Session ${sessionId}.`);
+    this.name = "ExpertDefinitionMismatchError";
+  }
+}
+
+export function isExpertDefinitionMismatchError(
+  error: unknown,
+): error is ExpertDefinitionMismatchError {
+  return error instanceof ExpertDefinitionMismatchError;
 }
 
 export interface PromptOptions {
@@ -125,8 +150,43 @@ type SteerClaim =
       readonly contextId: string;
     };
 
+interface ValidDefinitionMigration {
+  readonly previousExpertId: string;
+  readonly previousRootExpertId: string;
+  readonly reason: string;
+}
+
 const EXPERT_SESSION_LEASE_MS = 30_000;
 const EXPERT_SESSION_LEASE_RENEWAL_MS = 10_000;
+
+function validateDefinitionMigration(
+  record: ExpertSessionRecord,
+  expert: ExpertDefinition,
+  currentFingerprint: string,
+  request: ResumeExpertSessionOptions,
+): ValidDefinitionMigration | undefined {
+  const migration = request.definitionMigration;
+  if (migration === undefined) return undefined;
+  if (migration.reason.trim() === "") return undefined;
+  if (record.expertId !== migration.previousExpertId) return undefined;
+  const rootContext = record.contexts[record.rootContextId];
+  if (rootContext === undefined) return undefined;
+  const rootExpert = isExpertTeam(expert) ? expert.coordinator : expert;
+  const previousRootExpertId = migration.previousRootExpertId ?? migration.previousExpertId;
+  if (rootContext.expert.id !== previousRootExpertId) return undefined;
+  if (
+    record.expertId === expert.id &&
+    rootContext.expert.id === rootExpert.id &&
+    record.definitionFingerprint !== currentFingerprint
+  ) {
+    return undefined;
+  }
+  return {
+    previousExpertId: migration.previousExpertId,
+    previousRootExpertId,
+    reason: migration.reason,
+  };
+}
 
 export class ExpertSessionManager {
   private readonly active = new Map<string, ExpertSessionImpl>();
@@ -182,19 +242,23 @@ export class ExpertSessionManager {
 
   async resumeSession(
     expert: ExpertDefinition,
-    request: { readonly sessionId: string },
+    request: ResumeExpertSessionOptions,
   ): Promise<ExpertSession> {
     const existing = this.active.get(request.sessionId);
     if (existing !== undefined) return existing;
-    const record = await this.dependencies.sessions.get(request.sessionId);
+    let record = await this.dependencies.sessions.get(request.sessionId);
     if (record === undefined) throw new Error(`ExpertSession not found: ${request.sessionId}`);
     if (record.status === "closed")
       throw new Error(`ExpertSession is closed: ${request.sessionId}`);
-    if (
-      record.expertId !== expert.id ||
-      record.definitionFingerprint !== fingerprintExpertExecutionDefinition(expert)
-    ) {
-      throw new Error(`Expert definition mismatch for Session ${request.sessionId}.`);
+    const currentFingerprint = fingerprintExpertExecutionDefinition(expert);
+    const definitionMatches =
+      record.expertId === expert.id && record.definitionFingerprint === currentFingerprint;
+    const rootExpert = isExpertTeam(expert) ? expert.coordinator : expert;
+    const migration = definitionMatches
+      ? undefined
+      : validateDefinitionMigration(record, expert, currentFingerprint, request);
+    if (!definitionMatches && migration === undefined) {
+      throw new ExpertDefinitionMismatchError(request.sessionId);
     }
     const claimId = randomUUID();
     if (
@@ -207,6 +271,17 @@ export class ExpertSessionManager {
       throw new Error(`ExpertSession is active in another process: ${request.sessionId}`);
     }
     try {
+      if (migration !== undefined) {
+        record = await this.migrateSessionDefinition({
+          sessionId: request.sessionId,
+          expertId: expert.id,
+          rootExpertId: rootExpert.id,
+          definitionFingerprint: currentFingerprint,
+          previousExpertId: migration.previousExpertId,
+          previousRootExpertId: migration.previousRootExpertId,
+          reason: migration.reason,
+        });
+      }
       let recoveredExecutionId: string | undefined;
       let recoveredHumanInteractionIds: readonly string[] = [];
       if (record.activeExecutionId !== undefined) {
@@ -261,6 +336,7 @@ export class ExpertSessionManager {
             ),
           }));
         } else {
+          const activeExecutionId = record.activeExecutionId;
           if (execution !== undefined && !isFinal(execution.status)) {
             await this.dependencies.executions.update(execution.executionId, {
               status: "interrupted",
@@ -286,7 +362,7 @@ export class ExpertSessionManager {
               updatedAt: new Date().toISOString(),
             },
             prompts: prompts.map((prompt) =>
-              prompt.executionId === record.activeExecutionId && prompt.status === "running"
+              prompt.executionId === activeExecutionId && prompt.status === "running"
                 ? {
                     ...prompt,
                     status: "interrupted" as const,
@@ -311,6 +387,64 @@ export class ExpertSessionManager {
       await this.dependencies.sessions.releaseLease(request.sessionId, claimId);
       throw error;
     }
+  }
+
+  private async migrateSessionDefinition(options: {
+    readonly sessionId: string;
+    readonly expertId: string;
+    readonly rootExpertId: string;
+    readonly definitionFingerprint: string;
+    readonly previousExpertId: string;
+    readonly previousRootExpertId: string;
+    readonly reason: string;
+  }): Promise<ExpertSessionRecord> {
+    return await this.dependencies.sessions.transact(
+      options.sessionId,
+      async ({ session, prompts }) => {
+        const rootContext = session.contexts[session.rootContextId];
+        if (rootContext === undefined) throw new Error("ExpertSession root Context is missing.");
+        if (
+          session.expertId !== options.previousExpertId ||
+          rootContext.expert.id !== options.previousRootExpertId
+        ) {
+          throw new ExpertDefinitionMismatchError(options.sessionId);
+        }
+        const now = new Date().toISOString();
+        if (rootContext.snapshot !== undefined) {
+          const paths = new PragmaPaths(
+            this.dependencies.pragmaHome === undefined
+              ? {}
+              : { pragmaHome: this.dependencies.pragmaHome },
+          );
+          await rebindRuntimeSessionExpertId({
+            paths,
+            ownerId: options.sessionId,
+            systemSessionId: rootContext.snapshot.systemSessionId,
+            fromExpertId: options.previousRootExpertId,
+            toExpertId: options.rootExpertId,
+          });
+        }
+        const migrated: ExpertSessionRecord = {
+          ...session,
+          expertId: options.expertId,
+          definitionFingerprint: options.definitionFingerprint,
+          contexts: {
+            ...session.contexts,
+            [session.rootContextId]: {
+              ...rootContext,
+              expert: { id: options.rootExpertId },
+              updatedAt: now,
+            },
+          },
+          updatedAt: now,
+        };
+        return {
+          result: migrated,
+          session: migrated,
+          prompts,
+        };
+      },
+    );
   }
 
   private createActiveSession(

--- a/packages/core/src/pragma-app.ts
+++ b/packages/core/src/pragma-app.ts
@@ -3,6 +3,7 @@ import {
   ExpertSessionManager,
   type CreateExpertSessionOptions,
   type ExpertSession,
+  type ResumeExpertSessionOptions,
 } from "./execution/expert-session.ts";
 import {
   createFileExpertSessionStore,
@@ -39,7 +40,7 @@ export interface PragmaApp {
     ): Promise<ExpertSession>;
     resumeSession(
       expert: ExpertDefinition,
-      request: { readonly sessionId: string },
+      request: ResumeExpertSessionOptions,
     ): Promise<ExpertSession>;
   };
   readonly flows: {

--- a/packages/core/src/runtime/session-record.ts
+++ b/packages/core/src/runtime/session-record.ts
@@ -88,6 +88,27 @@ export async function restoreRuntimeSessionRecord(options: {
   return updated;
 }
 
+export async function rebindRuntimeSessionExpertId(options: {
+  readonly paths: PragmaPaths;
+  readonly ownerId: string;
+  readonly systemSessionId: string;
+  readonly fromExpertId: string;
+  readonly toExpertId: string;
+}): Promise<void> {
+  if (options.fromExpertId === options.toExpertId) return;
+  const record = await readRuntimeSessionRecord(
+    options.paths,
+    options.ownerId,
+    options.systemSessionId,
+  );
+  assertEqual(record.expertId, options.fromExpertId, "Expert");
+  await writeRuntimeSessionRecord(options.paths, {
+    ...record,
+    expertId: options.toExpertId,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
 export async function updateRuntimeSessionRecord(
   paths: PragmaPaths,
   record: RuntimeSessionRecord,

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -15,6 +15,7 @@ import {
   createPragma,
   createFileExecutionStore,
   createFileExpertSessionStore,
+  createRuntimeSessionRecord,
   createStaticRuntimeResolver,
   ContextSystem,
   defineExpert,
@@ -24,6 +25,7 @@ import {
   defineRuntimeDriver,
   fingerprintExpertExecutionDefinition,
   PragmaPaths,
+  readRuntimeSessionRecord,
   StaticContextStore,
   type AgentMessageUsage,
   type ExecutionEvent,
@@ -945,6 +947,82 @@ describe("ExpertSession", () => {
     expect((await sessions.get("fingerprint-session"))?.definitionFingerprint).toBe(
       fingerprintExpertExecutionDefinition(original),
     );
+  });
+
+  it("migrates an explicitly aliased persisted Expert definition on resume", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-definition-migration-"));
+    const runtime = createFakeRuntime();
+    const executions = createFileExecutionStore({ pragmaHome: home });
+    const sessions = createFileExpertSessionStore({ executions, pragmaHome: home });
+    const app = createPragma({
+      pragmaHome: home,
+      executionStore: executions,
+      expertSessionStore: sessions,
+      runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
+    });
+    const expert = await defineExpert({
+      id: "canonical-expert",
+      name: "Canonical Expert",
+      description: "Canonical Expert",
+      tags: [],
+      scope: "test",
+      workspace: home,
+    });
+    const sessionId = "definition-migration-session";
+    const contextId = "definition-migration-root";
+    const systemSessionId = "definition-migration-runtime";
+    const now = new Date().toISOString();
+    await createRuntimeSessionRecord({
+      paths: new PragmaPaths({ pragmaHome: home }),
+      owner: { type: "expert-session", ownerId: sessionId, contextId },
+      systemSessionId,
+      agentId: "legacy-expert",
+      runtime: { id: "fake", kind: "fake", displayName: "Fake" },
+      workspace: home,
+    });
+    const rootContext = {
+      ...sessionRootContext(sessionId, contextId, "legacy-expert", "fake", now),
+      snapshot: {
+        systemSessionId,
+        runtimeSession: { type: "fake", id: "native-definition-migration-runtime" },
+      },
+    };
+    await sessions.create({
+      schemaVersion: "pragma.expert-session/v5",
+      sessionId,
+      expertId: "legacy-expert",
+      definitionFingerprint: "b".repeat(64),
+      status: "open",
+      queuedRequestIds: [],
+      executionIds: [],
+      rootContextId: contextId,
+      contexts: { [contextId]: rootContext },
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const resumed = await app.experts.resumeSession(expert, {
+      sessionId,
+      definitionMigration: {
+        previousExpertId: "legacy-expert",
+        reason: "test canonical Expert id migration",
+      },
+    });
+
+    const migrated = await resumed.getState();
+    expect(migrated.expertId).toBe(expert.id);
+    expect(migrated.definitionFingerprint).toBe(fingerprintExpertExecutionDefinition(expert));
+    expect(migrated.contexts[migrated.rootContextId]?.expert.id).toBe(expert.id);
+    expect(
+      (
+        await readRuntimeSessionRecord(
+          new PragmaPaths({ pragmaHome: home }),
+          sessionId,
+          systemSessionId,
+        )
+      ).expertId,
+    ).toBe(expert.id);
+    await resumed.close();
   });
 
   it("reuses the Runtime Session after a failed prompt", async () => {

--- a/packages/interpreter/src/migrations/index.ts
+++ b/packages/interpreter/src/migrations/index.ts
@@ -21,6 +21,13 @@ export {
   type PragmaDslProjectMigrationResult,
   type PragmaResourceIdentityMigration,
 } from "./types.ts";
+export {
+  createPragmaResourceIdentityMigrationIndex,
+  migrateLegacyPragmaResourceRef,
+  type PragmaProjectResourceKind,
+  type PragmaProjectResourceNamespace,
+  type PragmaResourceIdentityMigrationIndex,
+} from "./resource-identity-index.ts";
 
 const migrationSteps = [pragmaDslV2ToV3Step] as const satisfies readonly PragmaDslMigrationStep[];
 const migrationStepsBySource = indexMigrationSteps(migrationSteps);

--- a/packages/interpreter/src/migrations/resource-identity-index.ts
+++ b/packages/interpreter/src/migrations/resource-identity-index.ts
@@ -1,0 +1,105 @@
+import { derivePragmaResourceId } from "@pragma/core";
+
+import type { PragmaResource } from "../ast/pragma-dsl.schema.ts";
+import type { PragmaResourceIdentityMigration } from "./types.ts";
+
+export type PragmaProjectResourceKind = PragmaResource["kind"];
+export type PragmaProjectResourceNamespace =
+  | "expert"
+  | "team"
+  | "flow"
+  | "automation"
+  | "capability"
+  | "context-store"
+  | "runtime-profile";
+
+const namespaceByKind = {
+  Expert: "expert",
+  ExpertTeam: "team",
+  Flow: "flow",
+  Automation: "automation",
+  Capability: "capability",
+  ContextStore: "context-store",
+  RuntimeProfile: "runtime-profile",
+} as const satisfies Readonly<Record<PragmaProjectResourceKind, PragmaProjectResourceNamespace>>;
+
+export interface PragmaResourceIdentityMigrationIndex {
+  readonly projectId: string;
+  resolveRef(ref: string): string;
+  resolveId(kind: PragmaProjectResourceKind, id: string): string;
+  hasMigration(kind: PragmaProjectResourceKind, sourceId: string, targetId: string): boolean;
+}
+
+export function createPragmaResourceIdentityMigrationIndex(input: {
+  readonly projectId: string;
+  readonly migrations?: readonly PragmaResourceIdentityMigration[] | undefined;
+}): PragmaResourceIdentityMigrationIndex {
+  const explicitRefTargets = new Map<string, string>();
+  const explicitIdTargets = new Map<string, string>();
+  for (const migration of input.migrations ?? []) {
+    const namespace = namespaceByKind[migration.kind];
+    explicitIdTargets.set(identityKey(migration.kind, migration.sourceId), migration.targetId);
+    explicitRefTargets.set(
+      `${namespace}:${migration.sourceId}`,
+      `${namespace}:${migration.targetId}`,
+    );
+  }
+  return {
+    projectId: input.projectId,
+    resolveRef(ref) {
+      return (
+        explicitRefTargets.get(stripRefVersion(ref)) ??
+        migrateLegacyPragmaResourceRef(ref, input.projectId)
+      );
+    },
+    resolveId(kind, id) {
+      return explicitIdTargets.get(identityKey(kind, id)) ?? id;
+    },
+    hasMigration(kind, sourceId, targetId) {
+      if (sourceId === targetId) return true;
+      return explicitIdTargets.get(identityKey(kind, sourceId)) === targetId;
+    },
+  };
+}
+
+export function migrateLegacyPragmaResourceRef(ref: string, projectId: string): string {
+  const match =
+    /^(expert|team|flow|automation|capability|context-store|runtime-profile):([^@]+)@[^@]+$/.exec(
+      ref,
+    );
+  if (match === null) return ref;
+  const namespace = match[1] as PragmaProjectResourceNamespace;
+  const sourceId = match[2]!;
+  if (namespace === "expert" && sourceId === "pragma") return "expert:0000000000pragma";
+  return `${namespace}:${derivePragmaResourceId(
+    `${projectId}\0${kindByNamespace(namespace)}\0${sourceId}`,
+  )}`;
+}
+
+function stripRefVersion(ref: string): string {
+  const match = /^([^:]+:[^@]+)@[^@]+$/.exec(ref);
+  return match?.[1] ?? ref;
+}
+
+function kindByNamespace(namespace: PragmaProjectResourceNamespace): PragmaProjectResourceKind {
+  switch (namespace) {
+    case "expert":
+      return "Expert";
+    case "team":
+      return "ExpertTeam";
+    case "flow":
+      return "Flow";
+    case "automation":
+      return "Automation";
+    case "capability":
+      return "Capability";
+    case "context-store":
+      return "ContextStore";
+    case "runtime-profile":
+      return "RuntimeProfile";
+  }
+}
+
+function identityKey(kind: PragmaProjectResourceKind, id: string): string {
+  return `${kind}:${id}`;
+}

--- a/packages/interpreter/test/resource-identity-index.test.ts
+++ b/packages/interpreter/test/resource-identity-index.test.ts
@@ -1,0 +1,34 @@
+import { derivePragmaResourceId } from "@pragma/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  createPragmaResourceIdentityMigrationIndex,
+  migrateLegacyPragmaResourceRef,
+} from "../src/migrations/index.ts";
+
+describe("Pragma resource identity migration index", () => {
+  it("migrates legacy versioned refs through the interpreter resolver", () => {
+    expect(migrateLegacyPragmaResourceRef("expert:pragma@1.0.0", "studio")).toBe(
+      "expert:0000000000pragma",
+    );
+    expect(migrateLegacyPragmaResourceRef("flow:release@1.0.0", "studio")).toBe(
+      `flow:${derivePragmaResourceId("studio\0Flow\0release")}`,
+    );
+    expect(migrateLegacyPragmaResourceRef("automation:daily@1.0.0", "studio")).toBe(
+      `automation:${derivePragmaResourceId("studio\0Automation\0daily")}`,
+    );
+    expect(migrateLegacyPragmaResourceRef("expert:current", "studio")).toBe("expert:current");
+  });
+
+  it("prefers explicit DSL identity migrations and exposes proof checks", () => {
+    const index = createPragmaResourceIdentityMigrationIndex({
+      projectId: "studio",
+      migrations: [{ kind: "Expert", sourceId: "writer", targetId: "stable_writer" }],
+    });
+
+    expect(index.resolveRef("expert:writer@1.0.0")).toBe("expert:stable_writer");
+    expect(index.resolveId("Expert", "writer")).toBe("stable_writer");
+    expect(index.hasMigration("Expert", "writer", "stable_writer")).toBe(true);
+    expect(index.hasMigration("Expert", "reviewer", "stable_writer")).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./context/context-metadata.schema.ts";
 export * from "./health.schema.ts";
 export * from "./logging/log.schema.ts";
 export * from "./model-provider.schema.ts";
+export * from "./mission/mission-executor.schema.ts";
 export * from "./result.ts";
 export {
   RunStatus as ExecutionRunStatus,

--- a/packages/shared/src/mission/mission-executor.schema.ts
+++ b/packages/shared/src/mission/mission-executor.schema.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const MISSION_EXECUTOR_REF_ID = "[0-9a-hjkmnp-tv-z]{16}";
+
+export const MissionExecutorKindSchema = z.enum(["expert", "team", "flow"]);
+
+export const MissionExecutorRefSchema = z
+  .string()
+  .trim()
+  .regex(
+    new RegExp(`^(expert|team|flow):${MISSION_EXECUTOR_REF_ID}$`, "i"),
+    "Expected a Mission executor reference such as expert:7k2m9q4v8np6r3dt.",
+  );
+
+const MissionExecutorBaseSchema = z.object({
+  ref: MissionExecutorRefSchema,
+  name: z.string().trim().min(1).max(120),
+});
+
+export const MissionExecutorSchema = z.discriminatedUnion("kind", [
+  MissionExecutorBaseSchema.extend({ kind: z.literal("expert") }),
+  MissionExecutorBaseSchema.extend({ kind: z.literal("team") }),
+  MissionExecutorBaseSchema.extend({ kind: z.literal("flow") }),
+]);
+
+export type MissionExecutorKind = z.infer<typeof MissionExecutorKindSchema>;
+export type MissionExecutorRef = z.infer<typeof MissionExecutorRefSchema>;
+export type MissionExecutor = z.infer<typeof MissionExecutorSchema>;

--- a/packages/shared/test/mission-executor.test.ts
+++ b/packages/shared/test/mission-executor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { MissionExecutorSchema } from "../src/mission/mission-executor.schema.ts";
+
+describe("MissionExecutorSchema", () => {
+  it("accepts current Host-neutral Mission executor refs", () => {
+    expect(
+      MissionExecutorSchema.parse({
+        kind: "expert",
+        ref: "expert:7k2m9q4v8np6r3dt",
+        name: "Writer",
+      }),
+    ).toMatchObject({ kind: "expert" });
+  });
+
+  it("rejects legacy versioned executor refs", () => {
+    expect(
+      MissionExecutorSchema.safeParse({
+        kind: "expert",
+        ref: "expert:writer@1.0.0",
+        name: "Writer",
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes Mission resume after DSL/resource identity upgrades by separating current Mission executor refs from legacy versioned refs and moving legacy identity resolution into the Interpreter boundary.
- Adds explicit Core ExpertSession definition migration support so host code can resume only when a persisted identity mapping proves the old and new definitions are the same logical resource.
- Adds Desktop host coordination for startup state upgrades, Mission/Automation ref migration, and incompatible-session successor creation.
- Hardens successor handling so old sessions/executions are only interrupted after the new session is created, and marks old execution + invocations atomically.
- Retries macOS project checkout lease creation on the observed concurrent `EINVAL` race.

## Root Cause

Mission state mixed legacy versioned DSL refs, current semantic executor refs, Core session fingerprints, and host storage migration responsibilities. After resource identity or Expert definition upgrades, Core correctly rejected stale persisted definitions, but Desktop did not have a governed path to prove identity migration or create a safe successor session.

## Validation

- `pnpm check`
- `pnpm build`

Closes #24