### PR TITLE
Pause Flow timeout during HumanTask waits

### DIFF
--- a/docs/architecture/pragma-yaml-dsl.md
+++ b/docs/architecture/pragma-yaml-dsl.md
@@ -183,10 +183,10 @@ Ordinary and repeat edges remain distinct multigraph edges, and `onLimit` must l
 Internal control state lives in a reserved namespace that DSL `save` paths cannot address; state
 reducers, deadlines, loop counters, and transition decisions use versioned CAS commits so
 concurrent nested Flows cannot overwrite one another.
-Flow `limits.timeoutMs` is compiled into Core and persisted as an absolute wall-clock deadline on
-first entry. Recovery reuses that deadline, so process downtime and HumanTask waits count toward
-the same timeout. Timeout is a `failed` terminal state; explicit user cancellation remains
-`cancelled`.
+Flow `limits.timeoutMs` is compiled into Core and persisted as an absolute runtime deadline on
+first entry. HumanTask waits pause that deadline, including across process restart recovery, so a
+Flow waiting for user input does not fail only because the app was closed or upgraded. Timeout is a
+`failed` terminal state; explicit user cancellation remains `cancelled`.
 
 Context reuse policies are versioned extension references such as
 `context-policy:pragma.fresh@v1`; runtime overrides are exact RuntimeProfile references. Runtime

--- a/packages/core/src/flow/flow-execution.ts
+++ b/packages/core/src/flow/flow-execution.ts
@@ -632,7 +632,6 @@ async function runHumanTask(
   outputSchema: z.ZodType | undefined,
   deadlineState: FlowDeadlineState,
 ): Promise<unknown> {
-  await putStatus(options.store, options.executionId, invocation, "waiting");
   const context: FlowTaskContext = {
     input,
     state,
@@ -656,6 +655,10 @@ async function runHumanTask(
       ? await definition.request(context)
       : definition.request;
   const resumeDeadline = await pauseFlowDeadlineForHumanWait(options, deadlineState);
+  if (context.signal.aborted) {
+    throw context.signal.reason ?? new FlowTimeoutError(`Flow ${options.flow.id} timed out.`);
+  }
+  await putStatus(options.store, options.executionId, invocation, "waiting");
   const response = await options.controller
     .requestHumanInteraction(
       invocation.invocationId,

--- a/packages/core/src/flow/flow-execution.ts
+++ b/packages/core/src/flow/flow-execution.ts
@@ -21,7 +21,11 @@ import type {
   ExpertAgentHumanResponse,
   ExpertAgentUserQuestion,
 } from "../tools/managed-tool.ts";
-import { ExecutionController, runExpertInvocation } from "../execution/expert-runner.ts";
+import {
+  ExecutionController,
+  listPendingHumanInteractionIds,
+  runExpertInvocation,
+} from "../execution/expert-runner.ts";
 import { HandoffService, unwrapInvocationHandoff } from "../execution/handoff/handoff-service.ts";
 import {
   ContextResolutionService,
@@ -177,6 +181,10 @@ export class FlowExecutionManager {
     if (!(await this.executions.claimRecovery(request.executionId, claimId, 30_000))) {
       throw new Error(`FlowExecution recovery is already claimed: ${request.executionId}`);
     }
+    const pendingHumanInteractionIds = await listPendingHumanInteractionIds(
+      this.executions,
+      request.executionId,
+    );
     for (const invocation of await this.executions.listInvocations(request.executionId)) {
       if (!isFinal(invocation.status) && invocation.status !== "waiting") {
         await this.executions.putInvocation(request.executionId, {
@@ -207,7 +215,7 @@ export class FlowExecutionManager {
         },
       ],
     });
-    return this.activate(flow, request.executionId, runtimeId, claimId);
+    return this.activate(flow, request.executionId, runtimeId, claimId, pendingHumanInteractionIds);
   }
 
   private activate(
@@ -215,9 +223,11 @@ export class FlowExecutionManager {
     executionId: string,
     runtime: string | undefined,
     claimId: string,
+    recoverHumanInteractionIds: readonly string[] = [],
   ): FlowExecution {
     const controller = new ExecutionController(executionId, this.executions, undefined, {
       closeContextsOnCancel: true,
+      ...(recoverHumanInteractionIds.length === 0 ? {} : { recoverHumanInteractionIds }),
       automaticHumanInteractionHandler: this.automaticHumanInteractionHandler,
     });
     const handle = this.createHandle(executionId, controller);
@@ -378,23 +388,16 @@ async function runFlow(options: {
   readonly handoffs: HandoffService;
   readonly loggerProvider?: PragmaLoggerProvider | undefined;
 }): Promise<unknown> {
-  const deadline = await ensureFlowDeadline(options);
+  let deadline = await ensureFlowDeadline(options);
+  deadline = await extendExpiredDeadlineForPendingHumanInteraction(options, deadline);
+  const deadlineState: FlowDeadlineState = { deadline, timeout: undefined };
   const timeoutReason = `Flow ${options.flow.id} timed out.`;
   const timeoutError = new FlowTimeoutError(timeoutReason);
   if (deadline !== undefined && deadline <= Date.now()) {
     await options.controller.abortInvocationTree(options.flowInvocationId, timeoutError);
     throw timeoutError;
   }
-  const timeout =
-    deadline === undefined
-      ? undefined
-      : setTimeout(
-          () => {
-            void options.controller.abortInvocationTree(options.flowInvocationId, timeoutError);
-          },
-          Math.max(1, deadline - Date.now()),
-        );
-  timeout?.unref();
+  armFlowDeadline(options, deadlineState);
   let stepId: string | undefined = options.flow.startStepId;
   let terminal:
     | {
@@ -446,7 +449,7 @@ async function runFlow(options: {
       if (invocation.status === "succeeded") {
         output = readStepInvocationOutput(step, invocation);
       } else {
-        output = await runStep(options, step, invocation, input);
+        output = await runStep(options, step, invocation, input, deadlineState);
       }
       await applyReductionOnce(options, step, invocation.invocationId, output);
       const transition = options.flow.transitions.get(stepId);
@@ -471,7 +474,7 @@ async function runFlow(options: {
       terminal.output;
     return options.flow.output?.parse(output) ?? output;
   } finally {
-    if (timeout !== undefined) clearTimeout(timeout);
+    if (deadlineState.timeout !== undefined) clearTimeout(deadlineState.timeout);
   }
 }
 
@@ -499,6 +502,7 @@ async function runStep(
   step: CompiledFlowStep,
   invocation: Invocation,
   input: unknown,
+  deadlineState: FlowDeadlineState,
 ): Promise<unknown> {
   try {
     const record = (await options.store.get(options.executionId))!;
@@ -542,6 +546,7 @@ async function runStep(
         input,
         readUserFlowState(record.state),
         step.options.output,
+        deadlineState,
       );
     }
     if ("kind" in step.definition && step.definition.kind === "flow") {
@@ -625,6 +630,7 @@ async function runHumanTask(
   input: unknown,
   state: FlowState,
   outputSchema: z.ZodType | undefined,
+  deadlineState: FlowDeadlineState,
 ): Promise<unknown> {
   await putStatus(options.store, options.executionId, invocation, "waiting");
   const context: FlowTaskContext = {
@@ -649,11 +655,14 @@ async function runHumanTask(
     typeof definition.request === "function"
       ? await definition.request(context)
       : definition.request;
-  const response = await options.controller.requestHumanInteraction(
-    invocation.invocationId,
-    toExpertHumanRequest(request),
-    `human:${invocation.invocationId}`,
-  );
+  const resumeDeadline = await pauseFlowDeadlineForHumanWait(options, deadlineState);
+  const response = await options.controller
+    .requestHumanInteraction(
+      invocation.invocationId,
+      toExpertHumanRequest(request),
+      `human:${invocation.invocationId}`,
+    )
+    .finally(async () => await resumeDeadline());
   const humanResponse = fromExpertHumanResponse(request, response);
   const output = outputSchema?.parse(humanResponse) ?? humanResponse;
   await putStatus(options.store, options.executionId, invocation, "succeeded", output);
@@ -1010,6 +1019,11 @@ class FlowTimeoutError extends Error {
   }
 }
 
+interface FlowDeadlineState {
+  deadline: number | undefined;
+  timeout: ReturnType<typeof setTimeout> | undefined;
+}
+
 async function ensureFlowDeadline(
   options: Parameters<typeof runFlow>[0],
 ): Promise<number | undefined> {
@@ -1028,6 +1042,93 @@ async function ensureFlowDeadline(
       state: { ...readUserFlowState(record.state), [FLOW_INTERNAL_STATE_KEY]: internal },
     };
   });
+}
+
+async function writeFlowDeadline(
+  options: Pick<Parameters<typeof runFlow>[0], "executionId" | "flowInvocationId" | "store">,
+  deadline: number,
+): Promise<void> {
+  await mutateFlowState(options, (record) => {
+    const internal = readFlowInternalState(record.state);
+    internal.deadlines[options.flowInvocationId] = deadline;
+    return {
+      changed: true,
+      value: undefined,
+      state: { ...readUserFlowState(record.state), [FLOW_INTERNAL_STATE_KEY]: internal },
+    };
+  });
+}
+
+async function extendExpiredDeadlineForPendingHumanInteraction(
+  options: Parameters<typeof runFlow>[0],
+  deadline: number | undefined,
+): Promise<number | undefined> {
+  if (deadline === undefined || deadline > Date.now()) return deadline;
+  if (!(await hasPendingHumanInteractionWait(options))) return deadline;
+  const extended = Date.now() + options.flow.timeoutMs!;
+  await writeFlowDeadline(options, extended);
+  return extended;
+}
+
+async function hasPendingHumanInteractionWait(
+  options: Pick<Parameters<typeof runFlow>[0], "executionId" | "flowInvocationId" | "store">,
+): Promise<boolean> {
+  if ((await listPendingHumanInteractionIds(options.store, options.executionId)).length > 0) {
+    return true;
+  }
+  const invocations = await options.store.listInvocations(options.executionId);
+  const descendants = new Set([options.flowInvocationId]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const invocation of invocations) {
+      if (
+        invocation.parentInvocationId !== undefined &&
+        descendants.has(invocation.parentInvocationId) &&
+        !descendants.has(invocation.invocationId)
+      ) {
+        descendants.add(invocation.invocationId);
+        changed = true;
+      }
+    }
+  }
+  return invocations.some(
+    (invocation) =>
+      invocation.definition.kind === "human-task" &&
+      invocation.status === "waiting" &&
+      descendants.has(invocation.invocationId),
+  );
+}
+
+async function pauseFlowDeadlineForHumanWait(
+  options: Parameters<typeof runFlow>[0],
+  state: FlowDeadlineState,
+): Promise<() => Promise<void>> {
+  if (state.deadline === undefined) return async () => undefined;
+  if (state.timeout !== undefined) {
+    clearTimeout(state.timeout);
+    state.timeout = undefined;
+  }
+  const remainingMs = Math.max(1, state.deadline - Date.now());
+  return async () => {
+    state.deadline = Date.now() + remainingMs;
+    await writeFlowDeadline(options, state.deadline);
+    armFlowDeadline(options, state);
+  };
+}
+
+function armFlowDeadline(options: Parameters<typeof runFlow>[0], state: FlowDeadlineState): void {
+  if (state.deadline === undefined) return;
+  if (state.timeout !== undefined) clearTimeout(state.timeout);
+  const timeoutReason = `Flow ${options.flow.id} timed out.`;
+  const timeoutError = new FlowTimeoutError(timeoutReason);
+  state.timeout = setTimeout(
+    () => {
+      void options.controller.abortInvocationTree(options.flowInvocationId, timeoutError);
+    },
+    Math.max(1, state.deadline - Date.now()),
+  );
+  state.timeout.unref();
 }
 
 async function raceWithSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -1807,18 +1807,42 @@ describe("FlowExecution", () => {
     expect((await execution.getTree()).children[0]?.invocation.status).toBe("failed");
   });
 
-  it("times out a pending HumanTask as failed instead of cancelled", async () => {
+  it("pauses Flow timeout while a HumanTask is waiting", async () => {
     const { app } = await fixture();
     const flow = defineFlow({ id: "human-timeout-flow", timeoutMs: 40 });
     const gate = flow.humanTask({
       id: "approval",
-      request: { kind: "approval", prompt: "Wait forever?" },
+      request: {
+        kind: "approval",
+        prompt: "Wait forever?",
+        options: [
+          { label: "Reject", description: "Stop." },
+          { label: "Approve", description: "Continue." },
+        ],
+        approveOption: "Approve",
+      },
     });
     flow.compose(({ start, end }) => start(gate).next(end()));
 
     const execution = await app.flows.start(flow, { input: null });
-    await expect(execution.result).rejects.toThrow("timed out");
-    expect((await execution.getState()).status).toBe("failed");
+    await waitUntil(
+      async () => (await execution.getTree()).children[0]?.invocation.status === "waiting",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect((await execution.getState()).status).toBe("running");
+    const requested = (
+      await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 })
+    ).items.find((event) => event.type === "human.requested")!;
+    await execution.respondToHumanInteraction(
+      (requested.data as { interactionId: string }).interactionId,
+      { kind: "user_question", answered: true, answers: { "Wait forever?": "Approve" } },
+      { requestId: "human-timeout-response" },
+    );
+    await expect(execution.result).resolves.toMatchObject({
+      approved: true,
+      decision: "Approve",
+    });
+    expect((await execution.getState()).status).toBe("succeeded");
   });
 
   it("rejects Flow runtime routes hidden by ExpertTeam delegation", async () => {
@@ -2593,7 +2617,7 @@ describe("FlowExecution", () => {
   it("recovers a waiting HumanTask in a new app without rerunning completed steps", async () => {
     const { home, app } = await fixture();
     let prepareCalls = 0;
-    const flow = defineFlow({ id: "human-recovery-flow" });
+    const flow = defineFlow({ id: "human-recovery-flow", timeoutMs: 5_000 });
     const prepare = flow.task({
       id: "prepare",
       handler: () => {
@@ -2633,12 +2657,21 @@ describe("FlowExecution", () => {
         (await execution.getTree()).children.find((child) => child.invocation.nodeId === "approval")
           ?.invocation.status === "waiting",
     );
+    expect((await execution.getState()).status).toBe("running");
 
     const store = createFileExecutionStore({ pragmaHome: home });
     const stored = (await store.get(execution.executionId))!;
+    const internal = stored.state["__pragma"] as { readonly deadlines?: Record<string, unknown> };
     await store.update(execution.executionId, {
       state: {
         ...stored.state,
+        __pragma: {
+          ...internal,
+          deadlines: {
+            ...(internal.deadlines ?? {}),
+            [execution.executionId]: Date.now() - 1_000,
+          },
+        },
         __recoveryClaim: {
           claimId: "exited-process",
           processId: 2_147_483_647,

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -1809,7 +1809,7 @@ describe("FlowExecution", () => {
 
   it("pauses Flow timeout while a HumanTask is waiting", async () => {
     const { app } = await fixture();
-    const flow = defineFlow({ id: "human-timeout-flow", timeoutMs: 40 });
+    const flow = defineFlow({ id: "human-timeout-flow", timeoutMs: 250 });
     const gate = flow.humanTask({
       id: "approval",
       request: {
@@ -1825,10 +1825,12 @@ describe("FlowExecution", () => {
     flow.compose(({ start, end }) => start(gate).next(end()));
 
     const execution = await app.flows.start(flow, { input: null });
+    const result = execution.result;
+    void result.catch(() => undefined);
     await waitUntil(
       async () => (await execution.getTree()).children[0]?.invocation.status === "waiting",
     );
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    await new Promise((resolve) => setTimeout(resolve, 500));
     expect((await execution.getState()).status).toBe("running");
     const requested = (
       await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 })
@@ -1838,7 +1840,7 @@ describe("FlowExecution", () => {
       { kind: "user_question", answered: true, answers: { "Wait forever?": "Approve" } },
       { requestId: "human-timeout-response" },
     );
-    await expect(execution.result).resolves.toMatchObject({
+    await expect(result).resolves.toMatchObject({
       approved: true,
       decision: "Approve",
     });


### PR DESCRIPTION
## Summary
- pause Flow timeout while a HumanTask is waiting for user input
- make HumanTask `waiting` observable only after the Flow deadline is paused, avoiding timeout races on slower CI runners
- recover pending Flow HumanTask interactions through ExecutionController using persisted human.requested events
- tolerate the restart window where a HumanTask invocation is already waiting but the human.requested event has not been written yet
- update Flow timeout documentation and regression coverage

## Root Cause
Issue #27 latest comment reported that reopening a Flow after app upgrade changed the waiting task into failed with `Flow ... timed out.` Core persisted Flow timeout as an absolute wall-clock deadline and checked it before restoring the pending HumanTask. If the app was closed or upgraded while waiting for input, that stale deadline could expire and recovery would fail the Flow immediately.

The CI failure on this branch exposed a second race: the regression test could observe the HumanTask invocation as `waiting` before the in-memory Flow deadline timer had actually been paused, allowing the original deadline to fail the Flow.

## Validation
- `pnpm --filter @pragma/core test -- execution-system.test.ts -t "pauses Flow timeout while a HumanTask is waiting"`
- `pnpm --filter @pragma/core typecheck`
- `pnpm --filter @pragma/core lint`

Fixes #27