### PR TITLE
Fix knowledge editor full-height layout

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -4546,8 +4546,17 @@ p {
   overflow: hidden;
 }
 
+.knowledge-editor-toolbar {
+  grid-row: 1;
+}
+
+.knowledge-conflict {
+  grid-row: 2;
+}
+
 .knowledge-editor-empty {
-  min-height: 500px;
+  grid-row: 1 / -1;
+  min-height: 0;
   padding: 30px;
 }
 
@@ -4599,6 +4608,7 @@ p {
 }
 
 .knowledge-markdown-editor {
+  grid-row: 3;
   width: 100%;
   height: 100%;
   min-height: 0;
@@ -4620,6 +4630,7 @@ p {
 }
 
 .knowledge-markdown-preview {
+  grid-row: 3;
   min-height: 0;
   padding: 24px 28px;
   overflow-y: auto;


### PR DESCRIPTION
## What changed

- Assign the knowledge editor toolbar and optional conflict banner to explicit grid rows.
- Place the Markdown editor and preview in the remaining flexible row.
- Let the empty state span the full editor panel without imposing a fixed minimum height.

## Why

The conflict banner is optional. Without explicit grid placement, the Markdown content was auto-positioned into an `auto` row while the flexible row remained empty, leaving a large blank area below the editor.

## Impact

The knowledge-base Markdown editor and preview now fill the available content height consistently.

## Validation

- `pnpm --filter @pragma/desktop exec vitest run src/renderer/src/pages/studio/ContextStoreFragment.test.tsx`
- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop typecheck`
- `git diff --check`

Visual verification was intentionally skipped at the request of the reporter.