### PR TITLE
Fix expert editor action layout

### DIFF
--- a/apps/desktop/src/renderer/src/pages/studio/ExpertEditorFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/ExpertEditorFragment.tsx
@@ -256,356 +256,364 @@ export function ExpertEditorFragment(props: {
             advance();
           }}
         >
-          {step === "identity" ? (
-            <>
-              <div className="creator-preview">
-                <span className="studio-asset-icon">
-                  <User size={24} />
-                </span>
-                <div>
-                  <strong>{draft.name || t("expertName", { ns: "studio" })}</strong>
-                  <p>{draft.description || t("conciseDescription", { ns: "studio" })}</p>
+          <div className="creator-form-content">
+            {step === "identity" ? (
+              <>
+                <div className="creator-preview">
+                  <span className="studio-asset-icon">
+                    <User size={24} />
+                  </span>
+                  <div>
+                    <strong>{draft.name || t("expertName", { ns: "studio" })}</strong>
+                    <p>{draft.description || t("conciseDescription", { ns: "studio" })}</p>
+                  </div>
                 </div>
-              </div>
-              <label>
-                {t("name", { ns: "studio" })}
-                <input
-                  value={draft.name}
-                  onChange={(event) =>
-                    setDraft({
-                      ...draft,
-                      name: event.target.value.slice(0, EXPERT_NAME_MAX_LENGTH),
-                    })
-                  }
-                  placeholder={t("expertName", { ns: "studio" })}
-                  maxLength={EXPERT_NAME_MAX_LENGTH}
-                  autoFocus
-                />
-                <small className="field-hint">
-                  <span>{t("chooseName", { ns: "studio" })}</span>
-                  <span>
-                    {draft.name.length}/{EXPERT_NAME_MAX_LENGTH}
-                  </span>
-                </small>
-              </label>
-              <label>
-                {t("description", { ns: "studio" })}
-                <textarea
-                  value={draft.description}
-                  onChange={(event) =>
-                    setDraft({
-                      ...draft,
-                      description: event.target.value.slice(0, EXPERT_DESCRIPTION_MAX_LENGTH),
-                    })
-                  }
-                  placeholder={t("expertPurpose", { ns: "studio" })}
-                  maxLength={EXPERT_DESCRIPTION_MAX_LENGTH}
-                />
-                <small className="field-hint">
-                  <span>{t("descriptionHint", { ns: "studio" })}</span>
-                  <span>
-                    {draft.description.length}/{EXPERT_DESCRIPTION_MAX_LENGTH}
-                  </span>
-                </small>
-              </label>
-              <label>
-                {t("tags", { ns: "studio" })}
-                <input
-                  value={draft.tagInput}
-                  onChange={(event) =>
-                    setDraft({
-                      ...draft,
-                      tagInput: event.target.value.slice(0, EXPERT_TAG_MAX_LENGTH),
-                    })
-                  }
-                  maxLength={EXPERT_TAG_MAX_LENGTH}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      addTag();
-                    }
-                  }}
-                  placeholder={t("addTag", { ns: "studio" })}
-                />
-                <small className="field-hint">
-                  <span>{t("tagLimit", { ns: "studio", count: EXPERT_TAG_MAX_LENGTH })}</span>
-                  <span>
-                    {draft.tagInput.length}/{EXPERT_TAG_MAX_LENGTH}
-                  </span>
-                </small>
-                <span className="draft-tags">
-                  {draft.tags.map((tag) => (
-                    <button
-                      type="button"
-                      key={tag}
-                      onClick={() =>
-                        setDraft({ ...draft, tags: draft.tags.filter((item) => item !== tag) })
-                      }
-                    >
-                      {tag} ×
-                    </button>
-                  ))}
-                </span>
-              </label>
-              <label>
-                {t("scope", { ns: "studio" })}
-                <textarea
-                  value={draft.scope}
-                  onChange={(event) =>
-                    setDraft({
-                      ...draft,
-                      scope: truncateUnicode(event.target.value, EXPERT_SCOPE_MAX_LENGTH),
-                    })
-                  }
-                  placeholder={t("scopePrompt", { ns: "studio" })}
-                  maxLength={EXPERT_SCOPE_MAX_LENGTH * 2}
-                  readOnly={isBuiltIn}
-                />
-                <small className="field-hint">
-                  <span>{t(isBuiltIn ? "builtInScopeLocked" : "scopeHint", { ns: "studio" })}</span>
-                  <span>
-                    {unicodeLength(draft.scope)}/{EXPERT_SCOPE_MAX_LENGTH}
-                  </span>
-                </small>
-              </label>
-            </>
-          ) : null}
-          {step === "instructions" ? (
-            <div className="instructions-editor">
-              {isBuiltIn ? (
                 <label>
-                  {t("builtInFoundationInstructions", { ns: "studio" })}
-                  <textarea className="instructions-input" value={draft.instructions} readOnly />
+                  {t("name", { ns: "studio" })}
+                  <input
+                    value={draft.name}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        name: event.target.value.slice(0, EXPERT_NAME_MAX_LENGTH),
+                      })
+                    }
+                    placeholder={t("expertName", { ns: "studio" })}
+                    maxLength={EXPERT_NAME_MAX_LENGTH}
+                    autoFocus
+                  />
                   <small className="field-hint">
-                    <span>{t("builtInFoundationLocked", { ns: "studio" })}</span>
+                    <span>{t("chooseName", { ns: "studio" })}</span>
+                    <span>
+                      {draft.name.length}/{EXPERT_NAME_MAX_LENGTH}
+                    </span>
                   </small>
                 </label>
-              ) : null}
-              <label>
-                {t(isBuiltIn ? "additionalInstructions" : "instructions", { ns: "studio" })}
-                <textarea
-                  className="instructions-input"
-                  value={isBuiltIn ? draft.additionalInstructions : draft.instructions}
-                  onChange={(event) =>
-                    setDraft({
-                      ...draft,
-                      ...(isBuiltIn
-                        ? {
-                            additionalInstructions: truncateUnicode(
-                              event.target.value,
-                              EXPERT_INSTRUCTIONS_MAX_LENGTH,
-                            ),
-                          }
-                        : {
-                            instructions: truncateUnicode(
-                              event.target.value,
-                              EXPERT_INSTRUCTIONS_MAX_LENGTH,
-                            ),
-                          }),
-                    })
-                  }
-                  placeholder={t(
-                    isBuiltIn ? "additionalInstructionsPrompt" : "instructionsPrompt",
-                    { ns: "studio" },
-                  )}
-                  maxLength={EXPERT_INSTRUCTIONS_MAX_LENGTH * 2}
-                  autoFocus
-                />
-                <small className="field-hint">
-                  <span>
-                    {t(isBuiltIn ? "additionalInstructionsHint" : "instructionsHint", {
-                      ns: "studio",
-                    })}
-                  </span>
-                  <span>
-                    {unicodeLength(isBuiltIn ? draft.additionalInstructions : draft.instructions)}/
-                    {EXPERT_INSTRUCTIONS_MAX_LENGTH}
-                  </span>
-                </small>
-              </label>
-            </div>
-          ) : null}
-          {step === "capabilities" ? (
-            <div className="capability-editor">
-              <h2>{t("addCapabilities", { ns: "studio" })}</h2>
-              <p>{t("modelSelectionHint", { ns: "studio" })}</p>
-              <label>
-                {t("runtime", { ns: "studio" })}
-                <select
-                  value={selectedRuntime}
-                  onChange={(event) => {
-                    setSelectedRuntime(event.target.value);
-                    setDraft({ ...draft, model: null });
-                  }}
-                >
-                  <option value="">
-                    {t(isBuiltIn ? "systemDefault" : "notConfigured", { ns: "studio" })}
-                  </option>
-                  {props.runtimes.map((runtime) => (
-                    <option
-                      key={runtime.id}
-                      value={runtime.id}
-                      disabled={runtime.status !== "available"}
-                    >
-                      {runtime.displayName}
-                      {runtime.status === "available"
-                        ? ""
-                        : ` (${t("unavailable", { ns: "studio" })})`}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              {selectedRuntime ? (
                 <label>
-                  {t("model", { ns: "studio" })}
-                  <select
-                    value={selectedModel === undefined ? "" : runtimeModelKey(selectedModel)}
-                    onChange={(event) => {
-                      const model = modelOptions.find(
-                        (candidate) => runtimeModelKey(candidate) === event.target.value,
-                      );
+                  {t("description", { ns: "studio" })}
+                  <textarea
+                    value={draft.description}
+                    onChange={(event) =>
                       setDraft({
                         ...draft,
-                        model:
-                          model === undefined
-                            ? null
-                            : {
-                                runtimeId: selectedRuntime,
-                                providerId: model.provider.id,
-                                modelId: model.id,
-                              },
-                      });
-                    }}
-                  >
-                    <option value="">
-                      {draft.model === null
-                        ? t("selectModel", { ns: "studio" })
-                        : t("unavailableModel", {
-                            ns: "studio",
-                            model: draft.model.modelId,
-                          })}
-                    </option>
-                    {modelOptions.map((model) => {
-                      return (
-                        <option key={runtimeModelKey(model)} value={runtimeModelKey(model)}>
-                          {model.provider.kind === "registered"
-                            ? `${model.provider.displayName} / ${model.displayName}`
-                            : model.displayName}
-                        </option>
-                      );
-                    })}
-                  </select>
-                  {selectedRuntimeInfo?.modelDiscoveryError ? (
-                    <small className="form-error">{selectedRuntimeInfo.modelDiscoveryError}</small>
-                  ) : null}
+                        description: event.target.value.slice(0, EXPERT_DESCRIPTION_MAX_LENGTH),
+                      })
+                    }
+                    placeholder={t("expertPurpose", { ns: "studio" })}
+                    maxLength={EXPERT_DESCRIPTION_MAX_LENGTH}
+                  />
+                  <small className="field-hint">
+                    <span>{t("descriptionHint", { ns: "studio" })}</span>
+                    <span>
+                      {draft.description.length}/{EXPERT_DESCRIPTION_MAX_LENGTH}
+                    </span>
+                  </small>
                 </label>
-              ) : null}
-              {selectedModel?.thinking !== undefined ? (
                 <label>
-                  {t("thinkingLevel", { ns: "studio" })}
-                  <select
-                    value={draft.model?.thinkingLevel ?? ""}
-                    onChange={(event) => {
-                      if (draft.model === null) return;
-                      const thinkingLevel = event.target.value;
-                      const model = { ...draft.model };
-                      delete model.thinkingLevel;
+                  {t("tags", { ns: "studio" })}
+                  <input
+                    value={draft.tagInput}
+                    onChange={(event) =>
                       setDraft({
                         ...draft,
-                        model: {
-                          ...model,
-                          ...(thinkingLevel === "" ? {} : { thinkingLevel }),
-                        },
-                      });
+                        tagInput: event.target.value.slice(0, EXPERT_TAG_MAX_LENGTH),
+                      })
+                    }
+                    maxLength={EXPERT_TAG_MAX_LENGTH}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        addTag();
+                      }
+                    }}
+                    placeholder={t("addTag", { ns: "studio" })}
+                  />
+                  <small className="field-hint">
+                    <span>{t("tagLimit", { ns: "studio", count: EXPERT_TAG_MAX_LENGTH })}</span>
+                    <span>
+                      {draft.tagInput.length}/{EXPERT_TAG_MAX_LENGTH}
+                    </span>
+                  </small>
+                  <span className="draft-tags">
+                    {draft.tags.map((tag) => (
+                      <button
+                        type="button"
+                        key={tag}
+                        onClick={() =>
+                          setDraft({ ...draft, tags: draft.tags.filter((item) => item !== tag) })
+                        }
+                      >
+                        {tag} ×
+                      </button>
+                    ))}
+                  </span>
+                </label>
+                <label>
+                  {t("scope", { ns: "studio" })}
+                  <textarea
+                    value={draft.scope}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        scope: truncateUnicode(event.target.value, EXPERT_SCOPE_MAX_LENGTH),
+                      })
+                    }
+                    placeholder={t("scopePrompt", { ns: "studio" })}
+                    maxLength={EXPERT_SCOPE_MAX_LENGTH * 2}
+                    readOnly={isBuiltIn}
+                  />
+                  <small className="field-hint">
+                    <span>
+                      {t(isBuiltIn ? "builtInScopeLocked" : "scopeHint", { ns: "studio" })}
+                    </span>
+                    <span>
+                      {unicodeLength(draft.scope)}/{EXPERT_SCOPE_MAX_LENGTH}
+                    </span>
+                  </small>
+                </label>
+              </>
+            ) : null}
+            {step === "instructions" ? (
+              <div className="instructions-editor">
+                {isBuiltIn ? (
+                  <label>
+                    {t("builtInFoundationInstructions", { ns: "studio" })}
+                    <textarea className="instructions-input" value={draft.instructions} readOnly />
+                    <small className="field-hint">
+                      <span>{t("builtInFoundationLocked", { ns: "studio" })}</span>
+                    </small>
+                  </label>
+                ) : null}
+                <label>
+                  {t(isBuiltIn ? "additionalInstructions" : "instructions", { ns: "studio" })}
+                  <textarea
+                    className="instructions-input"
+                    value={isBuiltIn ? draft.additionalInstructions : draft.instructions}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        ...(isBuiltIn
+                          ? {
+                              additionalInstructions: truncateUnicode(
+                                event.target.value,
+                                EXPERT_INSTRUCTIONS_MAX_LENGTH,
+                              ),
+                            }
+                          : {
+                              instructions: truncateUnicode(
+                                event.target.value,
+                                EXPERT_INSTRUCTIONS_MAX_LENGTH,
+                              ),
+                            }),
+                      })
+                    }
+                    placeholder={t(
+                      isBuiltIn ? "additionalInstructionsPrompt" : "instructionsPrompt",
+                      { ns: "studio" },
+                    )}
+                    maxLength={EXPERT_INSTRUCTIONS_MAX_LENGTH * 2}
+                    autoFocus
+                  />
+                  <small className="field-hint">
+                    <span>
+                      {t(isBuiltIn ? "additionalInstructionsHint" : "instructionsHint", {
+                        ns: "studio",
+                      })}
+                    </span>
+                    <span>
+                      {unicodeLength(isBuiltIn ? draft.additionalInstructions : draft.instructions)}
+                      /{EXPERT_INSTRUCTIONS_MAX_LENGTH}
+                    </span>
+                  </small>
+                </label>
+              </div>
+            ) : null}
+            {step === "capabilities" ? (
+              <div className="capability-editor">
+                <h2>{t("addCapabilities", { ns: "studio" })}</h2>
+                <p>{t("modelSelectionHint", { ns: "studio" })}</p>
+                <label>
+                  {t("runtime", { ns: "studio" })}
+                  <select
+                    value={selectedRuntime}
+                    onChange={(event) => {
+                      setSelectedRuntime(event.target.value);
+                      setDraft({ ...draft, model: null });
                     }}
                   >
                     <option value="">
-                      {t("runtimeDefault", { ns: "studio" })}
-                      {selectedModel.thinking.defaultLevel === undefined
-                        ? ""
-                        : ` (${selectedModel.thinking.defaultLevel})`}
+                      {t(isBuiltIn ? "systemDefault" : "notConfigured", { ns: "studio" })}
                     </option>
-                    {selectedModel.thinking.supportedLevels.map((level) => (
-                      <option key={level.value} value={level.value}>
-                        {level.label}
+                    {props.runtimes.map((runtime) => (
+                      <option
+                        key={runtime.id}
+                        value={runtime.id}
+                        disabled={runtime.status !== "available"}
+                      >
+                        {runtime.displayName}
+                        {runtime.status === "available"
+                          ? ""
+                          : ` (${t("unavailable", { ns: "studio" })})`}
                       </option>
                     ))}
                   </select>
                 </label>
-              ) : null}
-              <ExpertCapabilityPicker
-                currentExpertId={draft.id}
-                resources={props.resources}
-                contextStores={props.contextStores}
-                capabilities={props.capabilities}
-                resourceTools={draft.resourceTools}
-                contextStoreMounts={draft.contextStoreMounts}
-                capabilityReferences={draft.capabilities}
-                toolApprovals={draft.toolApprovals}
-                allowResourceTools={!isBuiltIn}
-                onResourceToolsChange={(resourceTools) => setDraft({ ...draft, resourceTools })}
-                onContextStoreMountsChange={(contextStoreMounts) =>
-                  setDraft({ ...draft, contextStoreMounts })
-                }
-                onCapabilityReferencesChange={setCapabilityReferences}
-                onToolApprovalsChange={(toolApprovals) => setDraft({ ...draft, toolApprovals })}
-              />
-              <ExpertPluginPicker
-                plugins={props.plugins}
-                references={draft.plugins}
-                secretMutations={draft.pluginSecretMutations}
-                onReferencesChange={(plugins) => setDraft({ ...draft, plugins: [...plugins] })}
-                onSecretMutationsChange={(pluginSecretMutations) =>
-                  setDraft({ ...draft, pluginSecretMutations })
-                }
-              />
-            </div>
-          ) : null}
-          {step === "review" ? (
-            <div className="review-summary">
-              <h2>
-                {isEditing ? t("readySave", { ns: "studio" }) : t("readyCreate", { ns: "studio" })}
-              </h2>
-              <p>
-                {isEditing
-                  ? t("reviewSave", { ns: "studio" })
-                  : t("reviewCreate", { ns: "studio" })}
+                {selectedRuntime ? (
+                  <label>
+                    {t("model", { ns: "studio" })}
+                    <select
+                      value={selectedModel === undefined ? "" : runtimeModelKey(selectedModel)}
+                      onChange={(event) => {
+                        const model = modelOptions.find(
+                          (candidate) => runtimeModelKey(candidate) === event.target.value,
+                        );
+                        setDraft({
+                          ...draft,
+                          model:
+                            model === undefined
+                              ? null
+                              : {
+                                  runtimeId: selectedRuntime,
+                                  providerId: model.provider.id,
+                                  modelId: model.id,
+                                },
+                        });
+                      }}
+                    >
+                      <option value="">
+                        {draft.model === null
+                          ? t("selectModel", { ns: "studio" })
+                          : t("unavailableModel", {
+                              ns: "studio",
+                              model: draft.model.modelId,
+                            })}
+                      </option>
+                      {modelOptions.map((model) => {
+                        return (
+                          <option key={runtimeModelKey(model)} value={runtimeModelKey(model)}>
+                            {model.provider.kind === "registered"
+                              ? `${model.provider.displayName} / ${model.displayName}`
+                              : model.displayName}
+                          </option>
+                        );
+                      })}
+                    </select>
+                    {selectedRuntimeInfo?.modelDiscoveryError ? (
+                      <small className="form-error">
+                        {selectedRuntimeInfo.modelDiscoveryError}
+                      </small>
+                    ) : null}
+                  </label>
+                ) : null}
+                {selectedModel?.thinking !== undefined ? (
+                  <label>
+                    {t("thinkingLevel", { ns: "studio" })}
+                    <select
+                      value={draft.model?.thinkingLevel ?? ""}
+                      onChange={(event) => {
+                        if (draft.model === null) return;
+                        const thinkingLevel = event.target.value;
+                        const model = { ...draft.model };
+                        delete model.thinkingLevel;
+                        setDraft({
+                          ...draft,
+                          model: {
+                            ...model,
+                            ...(thinkingLevel === "" ? {} : { thinkingLevel }),
+                          },
+                        });
+                      }}
+                    >
+                      <option value="">
+                        {t("runtimeDefault", { ns: "studio" })}
+                        {selectedModel.thinking.defaultLevel === undefined
+                          ? ""
+                          : ` (${selectedModel.thinking.defaultLevel})`}
+                      </option>
+                      {selectedModel.thinking.supportedLevels.map((level) => (
+                        <option key={level.value} value={level.value}>
+                          {level.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                <ExpertCapabilityPicker
+                  currentExpertId={draft.id}
+                  resources={props.resources}
+                  contextStores={props.contextStores}
+                  capabilities={props.capabilities}
+                  resourceTools={draft.resourceTools}
+                  contextStoreMounts={draft.contextStoreMounts}
+                  capabilityReferences={draft.capabilities}
+                  toolApprovals={draft.toolApprovals}
+                  allowResourceTools={!isBuiltIn}
+                  onResourceToolsChange={(resourceTools) => setDraft({ ...draft, resourceTools })}
+                  onContextStoreMountsChange={(contextStoreMounts) =>
+                    setDraft({ ...draft, contextStoreMounts })
+                  }
+                  onCapabilityReferencesChange={setCapabilityReferences}
+                  onToolApprovalsChange={(toolApprovals) => setDraft({ ...draft, toolApprovals })}
+                />
+                <ExpertPluginPicker
+                  plugins={props.plugins}
+                  references={draft.plugins}
+                  secretMutations={draft.pluginSecretMutations}
+                  onReferencesChange={(plugins) => setDraft({ ...draft, plugins: [...plugins] })}
+                  onSecretMutationsChange={(pluginSecretMutations) =>
+                    setDraft({ ...draft, pluginSecretMutations })
+                  }
+                />
+              </div>
+            ) : null}
+            {step === "review" ? (
+              <div className="review-summary">
+                <h2>
+                  {isEditing
+                    ? t("readySave", { ns: "studio" })
+                    : t("readyCreate", { ns: "studio" })}
+                </h2>
+                <p>
+                  {isEditing
+                    ? t("reviewSave", { ns: "studio" })
+                    : t("reviewCreate", { ns: "studio" })}
+                </p>
+                <dl>
+                  <div>
+                    <dt>{t("name", { ns: "studio" })}</dt>
+                    <dd>{draft.name || t("untitledExpert", { ns: "studio" })}</dd>
+                  </div>
+                  <div>
+                    <dt>{t("id", { ns: "studio" })}</dt>
+                    <dd>{draft.id || t("generatedName", { ns: "studio" })}</dd>
+                  </div>
+                  <div>
+                    <dt>{t("scope", { ns: "studio" })}</dt>
+                    <dd>{draft.scope}</dd>
+                  </div>
+                  <div>
+                    <dt>{t("capabilities", { ns: "studio" })}</dt>
+                    <dd>
+                      {draft.model === null
+                        ? t(isBuiltIn ? "systemDefault" : "notConfigured", { ns: "studio" })
+                        : `${draft.model.runtimeId} / ${draft.model.modelId}`}{" "}
+                      · {draft.contextStoreMounts.length} knowledge bases · {draft.skills} skills ·{" "}
+                      {draft.tools} tools · {draft.mcpServers} MCP server · {draft.plugins.length}{" "}
+                      plugins
+                      {isBuiltIn
+                        ? ` · ${t("requiredSystemCapabilitiesLocked", { ns: "studio" })}`
+                        : ""}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            ) : null}
+            {error ? (
+              <p className="form-error" role="alert">
+                {error}
               </p>
-              <dl>
-                <div>
-                  <dt>{t("name", { ns: "studio" })}</dt>
-                  <dd>{draft.name || t("untitledExpert", { ns: "studio" })}</dd>
-                </div>
-                <div>
-                  <dt>{t("id", { ns: "studio" })}</dt>
-                  <dd>{draft.id || t("generatedName", { ns: "studio" })}</dd>
-                </div>
-                <div>
-                  <dt>{t("scope", { ns: "studio" })}</dt>
-                  <dd>{draft.scope}</dd>
-                </div>
-                <div>
-                  <dt>{t("capabilities", { ns: "studio" })}</dt>
-                  <dd>
-                    {draft.model === null
-                      ? t(isBuiltIn ? "systemDefault" : "notConfigured", { ns: "studio" })
-                      : `${draft.model.runtimeId} / ${draft.model.modelId}`}{" "}
-                    · {draft.contextStoreMounts.length} knowledge bases · {draft.skills} skills ·{" "}
-                    {draft.tools} tools · {draft.mcpServers} MCP server · {draft.plugins.length}{" "}
-                    plugins
-                    {isBuiltIn
-                      ? ` · ${t("requiredSystemCapabilitiesLocked", { ns: "studio" })}`
-                      : ""}
-                  </dd>
-                </div>
-              </dl>
-            </div>
-          ) : null}
-          {error ? (
-            <p className="form-error" role="alert">
-              {error}
-            </p>
-          ) : null}
+            ) : null}
+          </div>
           <footer className="creator-actions">
             <button className="secondary-button" type="button" onClick={retreat} disabled={saving}>
               {index === 0 ? t("cancel", { ns: "studio" }) : t("back", { ns: "studio" })}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -5110,16 +5110,25 @@ p {
   height: 100%;
   min-height: 0;
   gap: 0;
-  margin-top: 28px;
+  padding: 28px 0 24px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.expert-creator .studio-screen-body {
+  display: grid;
+  min-height: 0;
   overflow: hidden;
 }
 
 .creator-steps {
   display: grid;
+  min-height: 0;
   align-content: start;
   gap: 13px;
   margin: 0;
   padding: 0 18px 0 0;
+  overflow-y: auto;
   border-right: 1px solid #e0e5e1;
   list-style: none;
 }
@@ -5178,22 +5187,27 @@ p {
 }
 
 .creator-form {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-content: start;
-  min-width: 0;
-  min-height: 0;
-  gap: 17px;
+  display: flex;
   width: 100%;
   height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  min-width: 0;
+  min-height: 0;
+  max-height: 100%;
+  flex-direction: column;
   padding-left: 48px;
   padding-right: 18px;
 }
 
-.expert-creator .studio-screen-body {
-  overflow: hidden;
+.creator-form-content {
+  display: grid;
+  min-height: 0;
+  flex: 0 1 auto;
+  gap: 17px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 12px;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .creator-preview {
@@ -5238,7 +5252,7 @@ p {
   -webkit-line-clamp: 2;
 }
 
-.creator-form > label,
+.creator-form-content > label,
 .creator-field-row label,
 .capability-editor > label {
   display: grid;
@@ -5310,11 +5324,7 @@ p {
 .review-summary {
   display: grid;
   gap: 13px;
-  min-height: 356px;
-  padding: 25px;
-  border: 1px solid #dbe1dc;
-  border-radius: 10px;
-  background: #fcfdfb;
+  min-height: 0;
 }
 
 .capability-toggles {
@@ -5367,11 +5377,27 @@ p {
 
 .creator-actions {
   display: flex;
+  flex: 0 0 auto;
   justify-content: space-between;
   gap: 16px;
   margin-top: 15px;
+  margin-right: 12px;
   padding-top: 22px;
   border-top: 1px solid var(--border);
+}
+
+.expert-creator .creator-form-content,
+.expert-creator .capability-editor,
+.expert-creator .review-summary {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.expert-creator .capability-editor,
+.expert-creator .review-summary {
+  padding: 0;
 }
 
 @media (max-width: 1360px) {


### PR DESCRIPTION
## Summary

- separate the expert editor's scrollable step content from the action footer
- keep Back/Continue directly after short content while pinning the footer at the bottom when content overflows
- make overflowing step content independently scrollable
- remove the white panel background, border, and shadow from the capability and review step content areas
- preserve the latest `main` behavior that allows edit-mode step navigation

## Root cause

The expert editor form was the scroll container and the action footer participated in the same content flow. Fixed minimum heights and white panel styling on step content made the footer appear in the middle of the page and created an oversized white region.

## Impact

Expert editing now uses the available viewport predictably: short steps remain compact, long steps scroll without moving the actions out of reach, and step backgrounds match the surrounding Studio surface.

## Validation

- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop typecheck`
- `pnpm --filter @pragma/desktop test` (68 files, 407 tests)
- `pnpm --filter @pragma/desktop build`

Visual verification was intentionally left to the requester.