### PR TITLE
Fix Flow data contract validation

### DIFF
--- a/apps/desktop/src/main/default-agent-project-adapter.test.ts
+++ b/apps/desktop/src/main/default-agent-project-adapter.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
-import { PRAGMA_AUTOMATION_PROMPT_MAX_LENGTH } from "@pragma/interpreter/ast";
+import {
+  PRAGMA_AUTOMATION_PROMPT_MAX_LENGTH,
+  PragmaFlowResourceSchema,
+} from "@pragma/interpreter/ast";
 
 import type { Capability } from "../shared/desktop-api.ts";
 import { createPragmaProjectStore } from "./pragma-project-store.ts";
@@ -224,6 +227,92 @@ describe("Desktop DefaultAgent DSL project adapter", () => {
           metadata: expect.objectContaining({
             id: prepared.changes[0]!.ref.slice("flow:".length),
           }),
+        }),
+      ]),
+    );
+  });
+
+  it("validates nested Flow input mappings against the draft base revision", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-default-agent-nested-flow-draft-"));
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const child = PragmaFlowResourceSchema.parse({
+      apiVersion: "pragma/v3",
+      kind: "Flow",
+      metadata: {
+        id: "7k2m9q4v8np6r3dt",
+        name: "Child",
+        description: "Accepts a typed goal.",
+        tags: [],
+      },
+      spec: {
+        input: {
+          schema: {
+            type: "object",
+            properties: { goal: { type: "string" } },
+            required: ["goal"],
+            additionalProperties: false,
+          },
+        },
+        graph: {
+          start: "finish",
+          steps: {
+            finish: {
+              human: {
+                selectionMode: "single",
+                prompt: { segments: [{ text: "Finish?" }] },
+                options: [
+                  { value: "yes", label: "Yes" },
+                  { value: "no", label: "No" },
+                ],
+              },
+            },
+          },
+          transitions: { finish: { end: true } },
+          loops: {},
+        },
+      },
+    });
+    await project.publish({ expectedRevision: 0, resources: [child] });
+    const adapter = createDesktopDefaultAgentProjectPort(
+      adapterOptions(project, join(root, "state")),
+    );
+    const created = await adapter.createFlowDraft({
+      expectedProjectRevision: 1,
+      metadata: {
+        name: "Parent",
+        description: "Passes its typed input to a child Flow.",
+        tags: [],
+      },
+      input: {
+        schema: {
+          type: "object",
+          properties: { goal: { type: "number" } },
+          required: ["goal"],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    const updated = await adapter.updateFlowDraft({
+      draftId: created.draftId,
+      expectedDraftRevision: 0,
+      operations: [
+        {
+          type: "upsert_step",
+          stepId: "child",
+          step: { flow: { ref: "flow:7k2m9q4v8np6r3dt" } },
+        },
+        { type: "set_start", stepId: "child" },
+        { type: "set_transition", stepId: "child", transition: { end: true } },
+      ],
+    });
+
+    expect(updated.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "error",
+          code: "flow.contract.type_mismatch",
+          path: ["spec", "graph", "steps", "child", "input"],
         }),
       ]),
     );

--- a/apps/desktop/src/main/default-agent-project-adapter.ts
+++ b/apps/desktop/src/main/default-agent-project-adapter.ts
@@ -11,6 +11,7 @@ import {
 import { formatPragmaYaml, parsePragmaYaml } from "@pragma/interpreter";
 import {
   analyzePragmaFlowGraph,
+  validatePragmaFlowDataContracts,
   PragmaCapabilityResourceSchema,
   PragmaFlowResourceSchema,
   PragmaResourceSchema,
@@ -219,30 +220,36 @@ export function createDesktopDefaultAgentProjectPort(options: {
       }
       const now = new Date().toISOString();
       const draftId = randomUUID();
-      const draft = withDraftDiagnostics({
-        draftId,
-        baseProjectRevision: snapshot.revision,
-        draftRevision: 0,
-        resource: {
-          apiVersion: "pragma/v3",
-          kind: "Flow",
-          metadata: { ...input.metadata, id: generatePragmaResourceId() },
-          spec: {
-            ...(input.input === undefined ? {} : { input: input.input }),
-            ...(input.output === undefined ? {} : { output: input.output }),
-            limits: input.limits ?? { maxNodeVisits: 1_000 },
-            graph: { steps: {}, transitions: {}, loops: {} },
+      const draft = withDraftDiagnostics(
+        {
+          draftId,
+          baseProjectRevision: snapshot.revision,
+          draftRevision: 0,
+          resource: {
+            apiVersion: "pragma/v3",
+            kind: "Flow",
+            metadata: { ...input.metadata, id: generatePragmaResourceId() },
+            spec: {
+              ...(input.input === undefined ? {} : { input: input.input }),
+              ...(input.output === undefined ? {} : { output: input.output }),
+              limits: input.limits ?? { maxNodeVisits: 1_000 },
+              graph: { steps: {}, transitions: {}, loops: {} },
+            },
           },
+          diagnostics: [],
+          createdAt: now,
+          updatedAt: now,
         },
-        diagnostics: [],
-        createdAt: now,
-        updatedAt: now,
-      });
+        snapshot.resources,
+      );
       await writeJson(draftPath(draftId), draft);
       return draft;
     },
     async getFlowDraft(draftId) {
-      return withDraftDiagnostics(await readFlowDraft(draftPath(draftId)));
+      return await withProjectDraftDiagnostics(
+        options.project,
+        await readFlowDraft(draftPath(draftId)),
+      );
     },
     async updateFlowDraft(input) {
       const path = draftPath(input.draftId);
@@ -266,7 +273,7 @@ export function createDesktopDefaultAgentProjectPort(options: {
             );
           }
         }
-        const updated = withDraftDiagnostics({
+        const updated = await withProjectDraftDiagnostics(options.project, {
           ...current,
           baseProjectRevision,
           draftRevision: current.draftRevision + 1,
@@ -278,10 +285,16 @@ export function createDesktopDefaultAgentProjectPort(options: {
       });
     },
     async validateFlowDraft(draftId) {
-      return withDraftDiagnostics(await readFlowDraft(draftPath(draftId)));
+      return await withProjectDraftDiagnostics(
+        options.project,
+        await readFlowDraft(draftPath(draftId)),
+      );
     },
     async prepareFlowDraft(input) {
-      const draft = withDraftDiagnostics(await readFlowDraft(draftPath(input.draftId)));
+      const draft = await withProjectDraftDiagnostics(
+        options.project,
+        await readFlowDraft(draftPath(input.draftId)),
+      );
       if (draft.draftRevision !== input.expectedDraftRevision) {
         return invalidPrepare(
           "flow.draft.revision_conflict",
@@ -616,7 +629,21 @@ function materializeDraft(draft: DefaultAgentFlowDraft): PragmaFlowResource {
   } as PragmaFlowResource;
 }
 
-function withDraftDiagnostics(draft: DefaultAgentFlowDraft): DefaultAgentFlowDraft {
+async function withProjectDraftDiagnostics(
+  project: PragmaProjectStore,
+  draft: DefaultAgentFlowDraft,
+): Promise<DefaultAgentFlowDraft> {
+  const resources =
+    draft.baseProjectRevision === 0
+      ? []
+      : (await project.openRevision(draft.baseProjectRevision)).listResources();
+  return withDraftDiagnostics(draft, resources);
+}
+
+function withDraftDiagnostics(
+  draft: DefaultAgentFlowDraft,
+  resources: readonly PragmaResource[] = [],
+): DefaultAgentFlowDraft {
   const parsed = DefaultAgentFlowDraftSchema.parse(draft);
   const resource = materializeDraft(parsed);
   const diagnostics: DefaultAgentFlowDraftDiagnostic[] = [];
@@ -670,6 +697,21 @@ function withDraftDiagnostics(draft: DefaultAgentFlowDraft): DefaultAgentFlowDra
         path: [...issue.path],
       });
     }
+  }
+  if (schema.success) {
+    const resourcesByRef = new Map(
+      resources.map((candidate) => [canonicalPragmaResourceRef(candidate), candidate]),
+    );
+    diagnostics.push(
+      ...validatePragmaFlowDataContracts(resource, {
+        resolveResource: (ref) => resourcesByRef.get(ref),
+      }).map((issue) => ({
+        severity: "error" as const,
+        code: issue.code,
+        message: issue.message,
+        path: [...issue.path],
+      })),
+    );
   }
   const unique = diagnostics.filter(
     (diagnostic, index) =>

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.test.ts
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.test.ts
@@ -37,7 +37,6 @@ import {
   RuntimeBindingEditor,
   START_NODE_ID,
   validateFlowRuntimeSelections,
-  validateLogicRoutes,
 } from "./FlowEditor.tsx";
 
 describe("Flow editor canvas", () => {
@@ -176,6 +175,25 @@ describe("Flow editor canvas", () => {
     expect(inspectorNodeId(start)).toBe(START_NODE_ID);
     expect(inspectorNodeId(end)).toBe(END_NODE_ID);
     expect(inspectorNodeId(undefined)).toBeNull();
+  });
+
+  it("keeps End selected when result-source edits rebuild the canvas nodes", () => {
+    const flow = createEmptyFlow();
+    flow.spec.output = {
+      schema: {
+        type: "object",
+        properties: { result: { type: "string" } },
+        required: ["result"],
+        additionalProperties: false,
+      },
+    };
+
+    const terminalResultNodes = buildCanvasNodes(flow, {}, new Set(), END_NODE_ID);
+    flow.spec.output.value = { result: "$node.output.result" };
+    const mappedResultNodes = buildCanvasNodes(flow, {}, new Set(), END_NODE_ID);
+
+    expect(terminalResultNodes.find((node) => node.id === END_NODE_ID)?.selected).toBe(true);
+    expect(mappedResultNodes.find((node) => node.id === END_NODE_ID)?.selected).toBe(true);
   });
 
   it("allows every Human option to be removed while keeping new values unique", () => {
@@ -462,43 +480,6 @@ describe("Flow editor canvas", () => {
         .find((node) => node.type === "logic")
         ?.data.outputs.map((output) => output.id),
     ).toEqual(["branch:branch_1", "branch:branch_2", "fallback"]);
-  });
-
-  it("requires complete type-aware branches while preserving unresolved legacy route fields", () => {
-    const flow = flowFixture();
-    flow.spec.graph.steps.review!.output = {
-      schema: {
-        type: "object",
-        properties: { has_issue: { type: "boolean" }, outcome: { type: "string" } },
-        required: ["has_issue", "outcome"],
-        additionalProperties: false,
-      },
-    };
-    flow.spec.graph.transitions.review = {
-      route: "has_issue",
-      cases: { true: { end: true } },
-    };
-
-    expect(validateLogicRoutes(flow)).toEqual([
-      expect.objectContaining({
-        stepId: "review",
-        message: expect.stringContaining("true and false"),
-      }),
-    ]);
-
-    flow.spec.graph.transitions.review = {
-      route: "outcome",
-      cases: { success: { end: true } },
-    };
-    expect(validateLogicRoutes(flow)).toEqual([
-      expect.objectContaining({ message: expect.stringContaining("otherwise") }),
-    ]);
-
-    flow.spec.graph.transitions.review = {
-      route: "legacy_field",
-      cases: { success: { end: true } },
-    };
-    expect(validateLogicRoutes(flow)).toEqual([]);
   });
 
   it("turns a cycle-producing canvas connection into a bounded repeat edge", () => {

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.tsx
@@ -260,8 +260,7 @@ function FlowEditorCanvas(props: {
   );
   const localIssues = useMemo(
     () => [
-      ...validateFlowDraft(flow),
-      ...validateLogicRoutes(flow),
+      ...validateFlowDraft(flow, editorResources),
       ...validateFlowRuntimeSelections(flow, editorResources),
       ...logicDraftIds.map(
         (): FlowValidationIssue => ({
@@ -447,18 +446,15 @@ function FlowEditorCanvas(props: {
 
   useEffect(() => {
     setNodes((current) => {
-      const selectedStep = current.find((node) => node.type === "step" && node.selected);
       return buildCanvasNodes(
         flow,
         canvasPositions(current),
         invalidStepIds,
-        selectedStep?.id ??
-          current.find((node) => node.type === "logic" && node.selected)?.id ??
-          null,
+        selectedNodeId,
         logicDraftIds,
       );
     });
-  }, [flow, invalidStepIds, logicDraftIds, setNodes]);
+  }, [flow, invalidStepIds, logicDraftIds, selectedNodeId, setNodes]);
 
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {
@@ -2678,50 +2674,6 @@ export function validateFlowRuntimeSelections(
   return issues;
 }
 
-export function validateLogicRoutes(flow: PragmaFlowResource): readonly FlowValidationIssue[] {
-  const issues: FlowValidationIssue[] = [];
-  for (const [sourceId, transition] of Object.entries(flow.spec.graph.transitions)) {
-    if (!isRouteTransition(transition)) continue;
-    const field = routeFieldOptions(flow, sourceId).find(
-      (candidate) => candidate.name === transition.route,
-    );
-    const add = (message: string) =>
-      issues.push({
-        path: ["spec", "graph", "transitions", sourceId],
-        message,
-        stepId: sourceId,
-      });
-    if (isArrayRouteTransition(transition)) {
-      if (field?.type !== "string-array") {
-        add(`Logic ${sourceId}.result.${transition.route} must be a string array.`);
-      }
-      if (transition.branches.length === 0) {
-        add(`Logic ${sourceId}.result.${transition.route} requires at least one branch.`);
-      }
-      if (transition.fallback === undefined) {
-        add(`Logic ${sourceId}.result.${transition.route} requires an otherwise branch.`);
-      }
-      continue;
-    }
-    if (Object.keys(transition.cases).some((key) => key.trim() === "")) {
-      add("Logic branch values cannot be empty.");
-    }
-    if (field?.type === "boolean") {
-      if (transition.cases["true"] === undefined || transition.cases["false"] === undefined) {
-        add(`Boolean logic ${sourceId}.result.${field.name} requires true and false branches.`);
-      }
-      continue;
-    }
-    if (field !== undefined && Object.keys(transition.cases).length === 0) {
-      add(`Logic ${sourceId}.result.${field.name} requires at least one case.`);
-    }
-    if (field !== undefined && transition.fallback === undefined) {
-      add(`Logic ${sourceId}.result.${field.name} requires an otherwise branch.`);
-    }
-  }
-  return issues;
-}
-
 function runtimeModelKey(model: DesktopRuntimeModel): string {
   return `${model.provider.id}\u0000${model.id}`;
 }
@@ -4344,6 +4296,7 @@ export function buildCanvasNodes(
       position: suppliedPositions[START_NODE_ID] ?? defaultStartPosition,
       draggable: true,
       deletable: false,
+      selected: START_NODE_ID === selectedNodeId,
       data: { label: "Start", tone: "start" },
     },
     ...semantic,
@@ -4355,6 +4308,7 @@ export function buildCanvasNodes(
       position: suppliedPositions[END_NODE_ID] ?? defaultEndPosition,
       draggable: true,
       deletable: false,
+      selected: END_NODE_ID === selectedNodeId,
       data: { label: "End", tone: "end" },
     },
   ];
@@ -4365,6 +4319,7 @@ export function buildCanvasNodes(
       position: suppliedPositions[FAIL_NODE_ID] ?? defaultFailPosition,
       draggable: true,
       deletable: false,
+      selected: FAIL_NODE_ID === selectedNodeId,
       data: { label: "Fail", tone: "fail" },
     });
   }

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-model.test.ts
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-model.test.ts
@@ -25,7 +25,7 @@ describe("Flow editor model", () => {
       review_loop: { entry: "review", maxIterations: 3, onLimit: { fail: "Review timed out" } },
     };
     flow.spec.graph.transitions["review"] = {
-      route: "decision",
+      route: "selection",
       cases: {
         approved: { goto: "finish" },
         rejected: { fail: "Rejected" },

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-model.ts
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-model.ts
@@ -1,9 +1,12 @@
 import {
   analyzePragmaFlowGraph,
+  canonicalPragmaResourceRef,
   PragmaFlowResourceSchema,
+  validatePragmaFlowDataContracts,
   type PragmaFlowDestination,
   type PragmaFlowResource,
   type PragmaFlowTransition,
+  type PragmaResource,
 } from "@pragma/interpreter/ast";
 
 export type FlowStep = PragmaFlowResource["spec"]["graph"]["steps"][string];
@@ -219,7 +222,10 @@ function removeMappedNode(value: unknown, nodeId: string): unknown {
   return value;
 }
 
-export function validateFlowDraft(flow: PragmaFlowResource): readonly FlowValidationIssue[] {
+export function validateFlowDraft(
+  flow: PragmaFlowResource,
+  resources: readonly PragmaResource[] = [],
+): readonly FlowValidationIssue[] {
   const stepIds = new Set(Object.keys(flow.spec.graph.steps));
   const emptyGraph = stepIds.size === 0;
   const parsed = PragmaFlowResourceSchema.safeParse(flow);
@@ -263,6 +269,18 @@ export function validateFlowDraft(flow: PragmaFlowResource): readonly FlowValida
       });
     }
   }
+  const resourcesByRef = new Map(
+    resources.map((resource) => [canonicalPragmaResourceRef(resource), resource]),
+  );
+  issues.push(
+    ...validatePragmaFlowDataContracts(flow, {
+      resolveResource: (ref) => resourcesByRef.get(ref),
+    }).map((issue) => ({
+      path: issue.path,
+      message: issue.message,
+      ...(issue.stepId === undefined ? {} : { stepId: issue.stepId }),
+    })),
+  );
   return issues;
 }
 

--- a/packages/interpreter/src/ast/flow-data-contracts.ts
+++ b/packages/interpreter/src/ast/flow-data-contracts.ts
@@ -1,0 +1,645 @@
+import type { PragmaFlowPrompt, PragmaFlowResource, PragmaResource } from "./pragma-dsl.schema.ts";
+import type { PragmaJsonSchema } from "./tool-capability.schema.ts";
+import { analyzePragmaFlowNodeAvailability } from "./flow-graph.ts";
+
+export interface PragmaFlowDataContractIssue {
+  readonly code: string;
+  readonly message: string;
+  readonly path: readonly (string | number)[];
+  readonly stepId?: string | undefined;
+}
+
+export interface PragmaFlowDataContractOptions {
+  readonly resolveResource?: ((ref: string) => PragmaResource | undefined) | undefined;
+}
+
+interface ValueContext {
+  readonly flow: PragmaFlowResource;
+  readonly stageStepId?: string | undefined;
+  readonly terminalStepId?: string | undefined;
+  readonly add: (
+    code: string,
+    message: string,
+    path: readonly (string | number)[],
+    stepId?: string,
+  ) => void;
+  readonly resolveResource?: ((ref: string) => PragmaResource | undefined) | undefined;
+}
+
+interface ResolvedSource {
+  readonly label: string;
+  readonly schema?: PragmaJsonSchema | undefined;
+  readonly guaranteed: boolean;
+}
+
+interface TerminalPath {
+  readonly stepId: string;
+  readonly path: readonly (string | number)[];
+}
+
+export function validatePragmaFlowDataContracts(
+  flow: PragmaFlowResource,
+  options: PragmaFlowDataContractOptions = {},
+): readonly PragmaFlowDataContractIssue[] {
+  const issues: PragmaFlowDataContractIssue[] = [];
+  const seen = new Set<string>();
+  const add = (
+    code: string,
+    message: string,
+    path: readonly (string | number)[],
+    stepId?: string,
+  ): void => {
+    const key = JSON.stringify([code, message, path, stepId]);
+    if (seen.has(key)) return;
+    seen.add(key);
+    issues.push({ code, message, path, ...(stepId === undefined ? {} : { stepId }) });
+  };
+
+  for (const [stepId, step] of Object.entries(flow.spec.graph.steps)) {
+    validatePrompt(flow, stepId, step.prompt, ["spec", "graph", "steps", stepId, "prompt"], add);
+    validatePrompt(
+      flow,
+      stepId,
+      step.human?.prompt,
+      ["spec", "graph", "steps", stepId, "human", "prompt"],
+      add,
+    );
+    validateRoute(flow, stepId, options.resolveResource, add);
+
+    if (step.flow === undefined) continue;
+    const target = options.resolveResource?.(step.flow.ref);
+    if (target?.kind !== "Flow" || target.spec.input === undefined) continue;
+    validateMappedValue(
+      step.input ?? "$flow.input",
+      target.spec.input.schema,
+      ["spec", "graph", "steps", stepId, "input"],
+      {
+        flow,
+        stageStepId: stepId,
+        add,
+        resolveResource: options.resolveResource,
+      },
+    );
+  }
+
+  const output = flow.spec.output;
+  if (output === undefined) return issues;
+  const terminals = terminalPaths(flow);
+  if (output.value === undefined) {
+    for (const terminal of terminals) {
+      const source = stepOutputSchema(flow, terminal.stepId, options.resolveResource);
+      if (source === undefined) {
+        add(
+          "flow.output.terminal_unvalidated",
+          `Flow output cannot be verified for terminal node ${terminal.stepId}. Declare structured output for that node or configure an explicit Flow result mapping.`,
+          terminal.path,
+          terminal.stepId,
+        );
+        continue;
+      }
+      const incompatibility = schemaIncompatibility(source, output.schema);
+      if (incompatibility !== undefined) {
+        add(
+          "flow.output.terminal_incompatible",
+          `Terminal node ${terminal.stepId} cannot satisfy the Flow output contract: ${incompatibility}`,
+          terminal.path,
+          terminal.stepId,
+        );
+      }
+    }
+    return issues;
+  }
+
+  if (terminals.length === 0) {
+    validateMappedValue(output.value, output.schema, ["spec", "output", "value"], {
+      flow,
+      add,
+      resolveResource: options.resolveResource,
+    });
+    return issues;
+  }
+  for (const terminal of terminals) {
+    validateMappedValue(output.value, output.schema, ["spec", "output", "value"], {
+      flow,
+      terminalStepId: terminal.stepId,
+      add,
+      resolveResource: options.resolveResource,
+    });
+  }
+  return issues;
+}
+
+function validateRoute(
+  flow: PragmaFlowResource,
+  stepId: string,
+  resolveResource: ((ref: string) => PragmaResource | undefined) | undefined,
+  add: ValueContext["add"],
+): void {
+  const transition = flow.spec.graph.transitions[stepId];
+  if (typeof transition !== "object" || !("route" in transition)) return;
+  if (flow.spec.graph.steps[stepId]?.action !== undefined) return;
+  const path = ["spec", "graph", "transitions", stepId] as const;
+  const output = stepOutputSchema(flow, stepId, resolveResource);
+  const field = output?.type === "object" ? output.properties[transition.route] : undefined;
+  if ("branches" in transition) {
+    if (field?.type !== "array" || field.items.type !== "string") {
+      add(
+        "flow.route.field_invalid",
+        `Logic ${stepId}.result.${transition.route} must be a string array.`,
+        path,
+        stepId,
+      );
+    }
+    if (transition.branches.length === 0) {
+      add(
+        "flow.route.branches_missing",
+        `Logic ${stepId}.result.${transition.route} requires at least one branch.`,
+        path,
+        stepId,
+      );
+    }
+    if (transition.fallback === undefined) {
+      add(
+        "flow.route.fallback_missing",
+        `Logic ${stepId}.result.${transition.route} requires an otherwise branch.`,
+        path,
+        stepId,
+      );
+    }
+    return;
+  }
+  if (field === undefined || !["string", "number", "integer", "boolean"].includes(field.type)) {
+    add(
+      "flow.route.field_invalid",
+      `Node ${stepId} does not define routable output field ${transition.route}.`,
+      path,
+      stepId,
+    );
+  }
+  if (Object.keys(transition.cases).some((key) => key.trim() === "")) {
+    add("flow.route.case_invalid", "Logic branch values cannot be empty.", path, stepId);
+  }
+  if (field?.type === "boolean") {
+    if (transition.cases["true"] === undefined || transition.cases["false"] === undefined) {
+      add(
+        "flow.route.boolean_incomplete",
+        `Boolean logic ${stepId}.result.${transition.route} requires true and false branches.`,
+        path,
+        stepId,
+      );
+    }
+    return;
+  }
+  if (field !== undefined && Object.keys(transition.cases).length === 0) {
+    add(
+      "flow.route.cases_missing",
+      `Logic ${stepId}.result.${transition.route} requires at least one case.`,
+      path,
+      stepId,
+    );
+  }
+  if (field !== undefined && transition.fallback === undefined) {
+    add(
+      "flow.route.fallback_missing",
+      `Logic ${stepId}.result.${transition.route} requires an otherwise branch.`,
+      path,
+      stepId,
+    );
+  }
+}
+
+function validatePrompt(
+  flow: PragmaFlowResource,
+  stepId: string,
+  prompt: PragmaFlowPrompt | undefined,
+  path: readonly (string | number)[],
+  add: ValueContext["add"],
+): void {
+  if (prompt === undefined) return;
+  const availability = analyzePragmaFlowNodeAvailability(flow, stepId);
+  prompt.segments.forEach((segment, index) => {
+    if (!("variable" in segment)) return;
+    const variable = segment.variable;
+    const variablePath = [...path, "segments", index, "variable"];
+    if (variable.source === "flow-input") {
+      if (
+        variable.path.length > 0 &&
+        schemaAtPath(flow.spec.input?.schema, variable.path) === undefined
+      ) {
+        add(
+          "flow.prompt.variable_path_invalid",
+          `Flow input does not define structured field ${variable.path.join(".")}.`,
+          variablePath,
+          stepId,
+        );
+      }
+      return;
+    }
+    const source = flow.spec.graph.steps[variable.nodeId];
+    if (source === undefined) {
+      add(
+        "flow.prompt.variable_unknown",
+        `Prompt variable references an unknown node: ${variable.nodeId}.`,
+        variablePath,
+        stepId,
+      );
+      return;
+    }
+    if (!availability.upstream.has(variable.nodeId)) {
+      add(
+        "flow.prompt.variable_not_upstream",
+        `Prompt variable node cannot run before ${stepId}: ${variable.nodeId}.`,
+        variablePath,
+        stepId,
+      );
+    }
+    if (
+      variable.path.length > 0 &&
+      schemaAtPath(stepOutputSchema(flow, variable.nodeId), variable.path) === undefined
+    ) {
+      add(
+        "flow.prompt.variable_path_invalid",
+        `Node ${variable.nodeId} does not define structured output field ${variable.path.join(".")}.`,
+        variablePath,
+        stepId,
+      );
+    }
+  });
+}
+
+function validateMappedValue(
+  value: unknown,
+  expected: PragmaJsonSchema,
+  path: readonly (string | number)[],
+  context: ValueContext,
+  allowUndefined = false,
+): void {
+  if (typeof value === "string") {
+    const source = resolveExpression(value, context);
+    if (source !== undefined) {
+      if (!source.guaranteed && !allowUndefined) {
+        context.add(
+          "flow.contract.source_unavailable",
+          `${source.label} is not available on every path to this stage.`,
+          path,
+          context.stageStepId ?? context.terminalStepId,
+        );
+        return;
+      }
+      if (source.schema === undefined) {
+        context.add(
+          "flow.contract.source_unvalidated",
+          `${source.label} has no declared structured contract and cannot be assigned to a typed field.`,
+          path,
+          context.stageStepId ?? context.terminalStepId,
+        );
+        return;
+      }
+      const incompatibility = schemaIncompatibility(source.schema, expected);
+      if (incompatibility !== undefined) {
+        context.add(
+          "flow.contract.type_mismatch",
+          `${source.label} is incompatible with this field: ${incompatibility}`,
+          path,
+          context.stageStepId ?? context.terminalStepId,
+        );
+      }
+      return;
+    }
+    if (containsInterpolation(value)) {
+      validateInterpolations(value, path, context);
+      if (expected.type !== "string") {
+        addLiteralMismatch("interpolated string", expected, path, context);
+      }
+      return;
+    }
+    if (expected.type !== "string") addLiteralMismatch("string", expected, path, context);
+    return;
+  }
+
+  if (expected.type === "object") {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      addLiteralMismatch(valueKind(value), expected, path, context);
+      return;
+    }
+    const record = value as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      if (expected.properties[key] === undefined) {
+        context.add(
+          "flow.contract.property_unknown",
+          `Field ${key} is not declared by the target contract.`,
+          [...path, key],
+          context.stageStepId ?? context.terminalStepId,
+        );
+      }
+    }
+    for (const required of expected.required ?? []) {
+      if (!Object.hasOwn(record, required)) {
+        context.add(
+          "flow.contract.required_missing",
+          `Required field ${required} is not mapped.`,
+          [...path, required],
+          context.stageStepId ?? context.terminalStepId,
+        );
+      }
+    }
+    for (const [key, child] of Object.entries(expected.properties)) {
+      if (Object.hasOwn(record, key)) {
+        validateMappedValue(
+          record[key],
+          child,
+          [...path, key],
+          context,
+          !(expected.required ?? []).includes(key),
+        );
+      }
+    }
+    return;
+  }
+
+  if (expected.type === "array") {
+    if (!Array.isArray(value)) {
+      addLiteralMismatch(valueKind(value), expected, path, context);
+      return;
+    }
+    value.forEach((entry, index) =>
+      validateMappedValue(entry, expected.items, [...path, index], context),
+    );
+    return;
+  }
+
+  const compatible =
+    expected.type === "boolean"
+      ? typeof value === "boolean"
+      : expected.type === "number"
+        ? typeof value === "number" && Number.isFinite(value)
+        : expected.type === "integer"
+          ? typeof value === "number" && Number.isInteger(value)
+          : false;
+  if (!compatible) addLiteralMismatch(valueKind(value), expected, path, context);
+}
+
+function resolveExpression(value: string, context: ValueContext): ResolvedSource | undefined {
+  if (value === "$flow.input" || value.startsWith("$flow.input.")) {
+    const path = value === "$flow.input" ? [] : value.slice("$flow.input.".length).split(".");
+    const resolved = schemaAtPath(context.flow.spec.input?.schema, path);
+    return {
+      label: value,
+      schema: resolved?.schema,
+      guaranteed: path.length === 0 || resolved?.required === true,
+    };
+  }
+  if (value === "$node.output" || value.startsWith("$node.output.")) {
+    const terminalStepId = context.terminalStepId;
+    if (terminalStepId === undefined) {
+      return { label: value, guaranteed: false };
+    }
+    const path = value === "$node.output" ? [] : value.slice("$node.output.".length).split(".");
+    const resolved = schemaAtPath(
+      stepOutputSchema(context.flow, terminalStepId, context.resolveResource),
+      path,
+    );
+    return {
+      label: `${terminalStepId}.result${path.length === 0 ? "" : `.${path.join(".")}`}`,
+      schema: resolved?.schema,
+      guaranteed: path.length === 0 || resolved?.required === true,
+    };
+  }
+  const stateMatch = /^\$state\.nodes\.([^.]+)\.result(?:\.(.+))?$/.exec(value);
+  if (stateMatch === null) return undefined;
+  const nodeId = stateMatch[1]!;
+  const path = stateMatch[2]?.split(".") ?? [];
+  const resolved = schemaAtPath(
+    stepOutputSchema(context.flow, nodeId, context.resolveResource),
+    path,
+  );
+  return {
+    label: `${nodeId}.result${path.length === 0 ? "" : `.${path.join(".")}`}`,
+    schema: resolved?.schema,
+    guaranteed:
+      nodeAvailableAtStage(context.flow, nodeId, context.stageStepId, context.terminalStepId) &&
+      (path.length === 0 || resolved?.required === true),
+  };
+}
+
+function nodeAvailableAtStage(
+  flow: PragmaFlowResource,
+  nodeId: string,
+  stageStepId: string | undefined,
+  terminalStepId: string | undefined,
+): boolean {
+  const target = stageStepId ?? terminalStepId;
+  if (target === undefined || flow.spec.graph.steps[nodeId] === undefined) return false;
+  if (terminalStepId !== undefined && nodeId === terminalStepId) return true;
+  return analyzePragmaFlowNodeAvailability(flow, target).required.has(nodeId);
+}
+
+function validateInterpolations(
+  value: string,
+  path: readonly (string | number)[],
+  context: ValueContext,
+): void {
+  for (const match of value.matchAll(/\{\{\s*([^}|]+?)(?:\|\s*json)?\s*\}\}/g)) {
+    const expression = `$${match[1]!.trim().replace(/^\$/, "")}`;
+    const source = resolveExpression(expression, context);
+    if (source === undefined) continue;
+    if (!source.guaranteed) {
+      context.add(
+        "flow.contract.source_unavailable",
+        `${source.label} is not available on every path to this stage.`,
+        path,
+        context.stageStepId ?? context.terminalStepId,
+      );
+    } else if (source.schema === undefined) {
+      context.add(
+        "flow.contract.source_unvalidated",
+        `${source.label} does not refer to a declared field.`,
+        path,
+        context.stageStepId ?? context.terminalStepId,
+      );
+    }
+  }
+}
+
+function containsInterpolation(value: string): boolean {
+  return /\{\{\s*[^}]+\s*\}\}/.test(value);
+}
+
+function schemaAtPath(
+  schema: PragmaJsonSchema | undefined,
+  path: readonly string[],
+): { readonly schema: PragmaJsonSchema; readonly required: boolean } | undefined {
+  if (schema === undefined) return undefined;
+  let current = schema;
+  let required = true;
+  for (const segment of path) {
+    if (current.type !== "object") return undefined;
+    required &&= new Set(current.required ?? []).has(segment);
+    const next = current.properties[segment];
+    if (next === undefined) return undefined;
+    current = next;
+  }
+  return { schema: current, required };
+}
+
+function stepOutputSchema(
+  flow: PragmaFlowResource,
+  stepId: string,
+  resolveResource?: (ref: string) => PragmaResource | undefined,
+): PragmaJsonSchema | undefined {
+  const step = flow.spec.graph.steps[stepId];
+  if (step === undefined) return undefined;
+  if (step.human !== undefined) {
+    return {
+      type: "object",
+      properties: {
+        selection:
+          step.human.selectionMode === "multiple"
+            ? { type: "array", items: { type: "string" } }
+            : { type: "string" },
+      },
+      required: ["selection"],
+      additionalProperties: false,
+    };
+  }
+  if (step.output !== undefined) return step.output.schema;
+  if (step.flow !== undefined) {
+    const target = resolveResource?.(step.flow.ref);
+    if (target?.kind === "Flow") return target.spec.output?.schema;
+  }
+  return undefined;
+}
+
+function terminalPaths(flow: PragmaFlowResource): readonly TerminalPath[] {
+  const terminals: TerminalPath[] = [];
+  const addDestination = (
+    stepId: string,
+    destination: unknown,
+    path: readonly (string | number)[],
+  ): void => {
+    if (
+      typeof destination === "object" &&
+      destination !== null &&
+      "end" in destination &&
+      (destination as { readonly end?: unknown }).end === true
+    ) {
+      terminals.push({ stepId, path });
+    }
+  };
+  for (const [stepId, transition] of Object.entries(flow.spec.graph.transitions)) {
+    const base = ["spec", "graph", "transitions", stepId] as const;
+    if (typeof transition === "object" && "route" in transition) {
+      if ("branches" in transition) {
+        transition.branches.forEach((branch, index) =>
+          addDestination(stepId, branch.destination, [...base, "branches", index, "destination"]),
+        );
+      } else {
+        for (const [key, destination] of Object.entries(transition.cases)) {
+          addDestination(stepId, destination, [...base, "cases", key]);
+        }
+      }
+      if (transition.fallback !== undefined) {
+        addDestination(stepId, transition.fallback, [...base, "fallback"]);
+      }
+    } else {
+      addDestination(stepId, transition, base);
+    }
+  }
+  for (const [loopId, loop] of Object.entries(flow.spec.graph.loops)) {
+    if (loop.onLimit === undefined) continue;
+    const repeatSources = Object.entries(flow.spec.graph.transitions)
+      .filter(([, transition]) => transitionUsesLoop(transition, loopId))
+      .map(([stepId]) => stepId);
+    for (const stepId of repeatSources) {
+      addDestination(stepId, loop.onLimit, ["spec", "graph", "loops", loopId, "onLimit"]);
+    }
+  }
+  return terminals.filter(
+    (terminal, index) =>
+      terminals.findIndex(
+        (candidate) =>
+          candidate.stepId === terminal.stepId &&
+          JSON.stringify(candidate.path) === JSON.stringify(terminal.path),
+      ) === index,
+  );
+}
+
+function transitionUsesLoop(
+  transition: PragmaFlowResource["spec"]["graph"]["transitions"][string],
+  loopId: string,
+): boolean {
+  const destinations =
+    typeof transition === "object" && "route" in transition
+      ? [
+          ...("branches" in transition
+            ? transition.branches.map((branch) => branch.destination)
+            : Object.values(transition.cases)),
+          ...(transition.fallback === undefined ? [] : [transition.fallback]),
+        ]
+      : [transition];
+  return destinations.some(
+    (destination) =>
+      typeof destination === "object" &&
+      "repeat" in destination &&
+      destination.repeat.loop === loopId,
+  );
+}
+
+function schemaIncompatibility(
+  source: PragmaJsonSchema,
+  target: PragmaJsonSchema,
+  path = "result",
+): string | undefined {
+  if (source.type === "integer" && target.type === "number") return undefined;
+  if (source.type !== target.type) {
+    return `${path} is ${source.type}, but ${target.type} is required.`;
+  }
+  if (source.type === "array" && target.type === "array") {
+    return schemaIncompatibility(source.items, target.items, `${path}[]`);
+  }
+  if (source.type !== "object" || target.type !== "object") return undefined;
+  const sourceRequired = new Set(source.required ?? []);
+  for (const required of target.required ?? []) {
+    const child = source.properties[required];
+    if (child === undefined) return `required field ${path}.${required} is missing.`;
+    if (!sourceRequired.has(required)) {
+      return `required field ${path}.${required} is optional in the source.`;
+    }
+    const childIssue = schemaIncompatibility(
+      child,
+      target.properties[required]!,
+      `${path}.${required}`,
+    );
+    if (childIssue !== undefined) return childIssue;
+  }
+  for (const [name, child] of Object.entries(source.properties)) {
+    const targetChild = target.properties[name];
+    if (targetChild === undefined) {
+      return `${path}.${name} is not allowed by the target contract.`;
+    }
+    const childIssue = schemaIncompatibility(child, targetChild, `${path}.${name}`);
+    if (childIssue !== undefined) return childIssue;
+  }
+  return undefined;
+}
+
+function addLiteralMismatch(
+  actual: string,
+  expected: PragmaJsonSchema,
+  path: readonly (string | number)[],
+  context: ValueContext,
+): void {
+  context.add(
+    "flow.contract.type_mismatch",
+    `Expected ${expected.type}, but the mapped value is ${actual}.`,
+    path,
+    context.stageStepId ?? context.terminalStepId,
+  );
+}
+
+function valueKind(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "number" && Number.isInteger(value)) return "integer";
+  return typeof value;
+}

--- a/packages/interpreter/src/ast/index.ts
+++ b/packages/interpreter/src/ast/index.ts
@@ -1,3 +1,4 @@
+export * from "./flow-data-contracts.ts";
 export * from "./flow-graph.ts";
 export * from "./pragma-dsl.schema.ts";
 export * from "./resource-identity.ts";

--- a/packages/interpreter/src/compiler/pragma-project.ts
+++ b/packages/interpreter/src/compiler/pragma-project.ts
@@ -44,7 +44,8 @@ import {
   type PragmaResourceHealth,
   type PragmaSemanticResourceRef,
 } from "../ast/pragma-dsl.schema.ts";
-import { analyzePragmaFlowGraph, analyzePragmaFlowNodeAvailability } from "../ast/flow-graph.ts";
+import { validatePragmaFlowDataContracts } from "../ast/flow-data-contracts.ts";
+import { analyzePragmaFlowGraph } from "../ast/flow-graph.ts";
 import {
   canonicalPragmaResourceRef,
   normalizePragmaResourceName,
@@ -405,7 +406,9 @@ class PragmaProjectImpl implements PragmaProject {
     for (const indexed of this.resources.values()) {
       diagnostics.push(...this.validateReferences(indexed));
       diagnostics.push(...validatePortableSemantics(indexed, this.resources));
-      if (indexed.resource.kind === "Flow") diagnostics.push(...validateFlowGraph(indexed));
+      if (indexed.resource.kind === "Flow") {
+        diagnostics.push(...validateFlowGraph(indexed, this.resources));
+      }
       if (isDeclarativeResource(indexed.resource)) {
         diagnostics.push(
           ...adapters.validate(indexed.resource).map((diagnostic) => ({
@@ -1750,7 +1753,10 @@ function validateExtensionEnvironment(
   return diagnostics;
 }
 
-function validateFlowGraph(indexed: IndexedResource): PragmaDiagnostic[] {
+function validateFlowGraph(
+  indexed: IndexedResource,
+  resources: ReadonlyMap<string, IndexedResource>,
+): PragmaDiagnostic[] {
   const resource = indexed.resource as PragmaFlowResource;
   return [
     ...analyzePragmaFlowGraph(resource).issues.map((issue) => ({
@@ -1768,78 +1774,16 @@ function validateFlowGraph(indexed: IndexedResource): PragmaDiagnostic[] {
       source: indexed.source,
       path,
     })),
-    ...invalidFlowPromptVariables(resource).map((issue) => ({
+    ...validatePragmaFlowDataContracts(resource, {
+      resolveResource: (ref) => resources.get(ref)?.resource,
+    }).map((issue) => ({
       severity: "error" as const,
       code: issue.code,
       message: issue.message,
       source: indexed.source,
-      path: issue.path,
+      path: [...issue.path],
     })),
   ];
-}
-
-function invalidFlowPromptVariables(resource: PragmaFlowResource): {
-  readonly code: string;
-  readonly message: string;
-  readonly path: (string | number)[];
-}[] {
-  const issues: {
-    code: string;
-    message: string;
-    path: (string | number)[];
-  }[] = [];
-  for (const [stepId, step] of Object.entries(resource.spec.graph.steps)) {
-    if (step.prompt === undefined) continue;
-    const availability = analyzePragmaFlowNodeAvailability(resource, stepId);
-    step.prompt.segments.forEach((segment, index) => {
-      if (!("variable" in segment) || segment.variable.source !== "node-output") return;
-      const variable = segment.variable;
-      const path = ["spec", "graph", "steps", stepId, "prompt", "segments", index, "variable"];
-      const source = resource.spec.graph.steps[variable.nodeId];
-      if (source === undefined) {
-        issues.push({
-          code: "flow.prompt.variable_unknown",
-          message: `Prompt variable references an unknown node: ${variable.nodeId}.`,
-          path,
-        });
-        return;
-      }
-      if (!availability.upstream.has(variable.nodeId)) {
-        issues.push({
-          code: "flow.prompt.variable_not_upstream",
-          message: `Prompt variable node cannot run before ${stepId}: ${variable.nodeId}.`,
-          path,
-        });
-      }
-      if (variable.path.length === 0) return;
-      if (source.output === undefined || !jsonSchemaHasPath(source.output.schema, variable.path)) {
-        issues.push({
-          code: "flow.prompt.variable_path_invalid",
-          message: `Node ${variable.nodeId} does not define structured output field ${variable.path.join(
-            ".",
-          )}.`,
-          path,
-        });
-      }
-    });
-  }
-  return issues;
-}
-
-function jsonSchemaHasPath(schema: unknown, path: readonly string[]): boolean {
-  let current: unknown = schema;
-  for (const segment of path) {
-    if (typeof current !== "object" || current === null || Array.isArray(current)) return false;
-    const record = current as Record<string, unknown>;
-    if (record["type"] !== "object") return false;
-    const properties = record["properties"];
-    if (typeof properties !== "object" || properties === null || Array.isArray(properties)) {
-      return false;
-    }
-    current = (properties as Record<string, unknown>)[segment];
-    if (current === undefined) return false;
-  }
-  return true;
 }
 
 function invalidFlowExpressions(

--- a/packages/interpreter/test/flow-data-contracts.test.ts
+++ b/packages/interpreter/test/flow-data-contracts.test.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { formatPragmaYaml, loadPragmaProject } from "../src/index.ts";
+import {
+  PragmaFlowResourceSchema,
+  canonicalPragmaResourceRef,
+  validatePragmaFlowDataContracts,
+  type PragmaFlowResource,
+  type PragmaResource,
+} from "../src/ast/index.ts";
+
+const ISSUE_OUTPUT = {
+  type: "object" as const,
+  properties: {
+    issue_number: { type: "integer" as const },
+    issue_url: { type: "string" as const },
+  },
+  required: ["issue_number", "issue_url"],
+  additionalProperties: false as const,
+};
+
+function issueFlow(outputValue?: unknown): PragmaFlowResource {
+  return PragmaFlowResourceSchema.parse({
+    apiVersion: "pragma/v3",
+    kind: "Flow",
+    metadata: {
+      id: "spmnna7k705rhjnj",
+      name: "Issue report",
+      description: "Create and confirm an issue.",
+      tags: [],
+    },
+    spec: {
+      output: {
+        schema: ISSUE_OUTPUT,
+        ...(outputValue === undefined ? {} : { value: outputValue }),
+      },
+      graph: {
+        start: "create_issue",
+        steps: {
+          create_issue: {
+            expert: { ref: "expert:1xddvess309a6gme" },
+            prompt: { segments: [{ text: "Create the issue" }] },
+            output: { schema: ISSUE_OUTPUT },
+          },
+          check: {
+            human: {
+              selectionMode: "single",
+              prompt: { segments: [{ text: "Was it resolved?" }] },
+              options: [
+                { value: "resolved", label: "Resolved" },
+                { value: "unresolved", label: "Unresolved" },
+              ],
+            },
+          },
+        },
+        loops: {},
+        transitions: {
+          create_issue: "check",
+          check: { end: true },
+        },
+      },
+    },
+  });
+}
+
+describe("Flow data contracts", () => {
+  it("rejects a Human terminal result that cannot satisfy the Flow output contract", () => {
+    expect(validatePragmaFlowDataContracts(issueFlow())).toEqual([
+      expect.objectContaining({
+        code: "flow.output.terminal_incompatible",
+        stepId: "check",
+        path: ["spec", "graph", "transitions", "check"],
+      }),
+    ]);
+  });
+
+  it("accepts an explicit result mapping from a required upstream structured output", () => {
+    const flow = issueFlow({
+      issue_number: "$state.nodes.create_issue.result.issue_number",
+      issue_url: "$state.nodes.create_issue.result.issue_url",
+    });
+
+    expect(validatePragmaFlowDataContracts(flow)).toEqual([]);
+  });
+
+  it("checks every possible terminal path instead of validating only one End edge", () => {
+    const flow = issueFlow();
+    flow.spec.graph.transitions.create_issue = {
+      route: "issue_url",
+      cases: { immediate: { end: true } },
+      fallback: "check",
+    };
+
+    expect(validatePragmaFlowDataContracts(flow)).toEqual([
+      expect.objectContaining({
+        code: "flow.output.terminal_incompatible",
+        stepId: "check",
+      }),
+    ]);
+  });
+
+  it("validates Flow input fields in Human prompts", () => {
+    const flow = issueFlow({
+      issue_number: "$state.nodes.create_issue.result.issue_number",
+      issue_url: "$state.nodes.create_issue.result.issue_url",
+    });
+    flow.spec.input = {
+      schema: {
+        type: "object",
+        properties: { title: { type: "string" } },
+        required: ["title"],
+        additionalProperties: false,
+      },
+    };
+    flow.spec.graph.steps.check!.human!.prompt = {
+      segments: [
+        {
+          variable: {
+            source: "flow-input",
+            path: ["missing"],
+          },
+        },
+      ],
+    };
+
+    expect(validatePragmaFlowDataContracts(flow)).toEqual([
+      expect.objectContaining({
+        code: "flow.prompt.variable_path_invalid",
+        stepId: "check",
+        path: ["spec", "graph", "steps", "check", "human", "prompt", "segments", 0, "variable"],
+      }),
+    ]);
+  });
+
+  it("validates each routing stage against its node output fields", () => {
+    const flow = issueFlow({
+      issue_number: "$state.nodes.create_issue.result.issue_number",
+      issue_url: "$state.nodes.create_issue.result.issue_url",
+    });
+    flow.spec.graph.transitions.create_issue = {
+      route: "missing",
+      cases: { next: "check" },
+      fallback: { end: true },
+    };
+
+    expect(validatePragmaFlowDataContracts(flow)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "flow.route.field_invalid",
+          stepId: "create_issue",
+          path: ["spec", "graph", "transitions", "create_issue"],
+        }),
+      ]),
+    );
+  });
+
+  it("requires complete type-aware routes in the canonical validator", () => {
+    const flow = issueFlow({
+      issue_number: "$state.nodes.create_issue.result.issue_number",
+      issue_url: "$state.nodes.create_issue.result.issue_url",
+    });
+    flow.spec.graph.steps.create_issue!.output = {
+      schema: {
+        type: "object",
+        properties: {
+          ...ISSUE_OUTPUT.properties,
+          labels: { type: "array", items: { type: "string" } },
+          has_issue: { type: "boolean" },
+          outcome: { type: "string" },
+        },
+        required: ["issue_number", "issue_url", "labels", "has_issue", "outcome"],
+        additionalProperties: false,
+      },
+    };
+
+    flow.spec.graph.transitions.create_issue = {
+      route: "labels",
+      branches: [],
+      fallback: "check",
+    };
+    expect(validatePragmaFlowDataContracts(flow)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "flow.route.branches_missing",
+          stepId: "create_issue",
+        }),
+      ]),
+    );
+
+    flow.spec.graph.transitions.create_issue = {
+      route: "has_issue",
+      cases: { true: { end: true } },
+    };
+    expect(validatePragmaFlowDataContracts(flow)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "flow.route.boolean_incomplete",
+          stepId: "create_issue",
+        }),
+      ]),
+    );
+
+    flow.spec.graph.transitions.create_issue = {
+      route: "outcome",
+      cases: { success: { end: true } },
+    };
+    expect(validatePragmaFlowDataContracts(flow)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "flow.route.fallback_missing",
+          stepId: "create_issue",
+        }),
+      ]),
+    );
+  });
+
+  it("validates every nested Flow input mapping against the target input contract", () => {
+    const child = PragmaFlowResourceSchema.parse({
+      apiVersion: "pragma/v3",
+      kind: "Flow",
+      metadata: {
+        id: "7k2m9q4v8np6r3dt",
+        name: "Child",
+        description: "Typed child Flow.",
+        tags: [],
+      },
+      spec: {
+        input: {
+          schema: {
+            type: "object",
+            properties: { goal: { type: "string" } },
+            required: ["goal"],
+            additionalProperties: false,
+          },
+        },
+        graph: {
+          start: "finish",
+          steps: {
+            finish: {
+              human: {
+                selectionMode: "single",
+                prompt: { segments: [{ text: "Finish?" }] },
+                options: [
+                  { value: "yes", label: "Yes" },
+                  { value: "no", label: "No" },
+                ],
+              },
+            },
+          },
+          loops: {},
+          transitions: { finish: { end: true } },
+        },
+      },
+    });
+    const parent = PragmaFlowResourceSchema.parse({
+      apiVersion: "pragma/v3",
+      kind: "Flow",
+      metadata: {
+        id: "t9ne4d8njvvxv2ea",
+        name: "Parent",
+        description: "Typed parent Flow.",
+        tags: [],
+      },
+      spec: {
+        input: {
+          schema: {
+            type: "object",
+            properties: { goal: { type: "number" } },
+            required: ["goal"],
+            additionalProperties: false,
+          },
+        },
+        graph: {
+          start: "child",
+          steps: {
+            child: { flow: { ref: canonicalPragmaResourceRef(child) } },
+          },
+          loops: {},
+          transitions: { child: { end: true } },
+        },
+      },
+    });
+    const resources = new Map<string, PragmaResource>([[canonicalPragmaResourceRef(child), child]]);
+
+    expect(
+      validatePragmaFlowDataContracts(parent, {
+        resolveResource: (ref) => resources.get(ref),
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        code: "flow.contract.type_mismatch",
+        stepId: "child",
+        path: ["spec", "graph", "steps", "child", "input"],
+      }),
+    ]);
+  });
+
+  it("surfaces terminal contract failures through project validation before save", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-flow-contract-"));
+    const entry = join(root, "pragma.yaml");
+    await writeFile(entry, formatPragmaYaml(issueFlow()));
+
+    const diagnostics = await (await loadPragmaProject(entry)).validate();
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "flow.output.terminal_incompatible",
+          path: ["spec", "graph", "transitions", "check"],
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/interpreter/test/pragma-dsl.test.ts
+++ b/packages/interpreter/test/pragma-dsl.test.ts
@@ -719,6 +719,7 @@ describe("Pragma YAML DSL", () => {
                   required: ["approved"],
                   additionalProperties: false,
                 },
+                value: { approved: true },
               },
               graph: {
                 start: "approve",


### PR DESCRIPTION
## Summary

- validate Flow input mappings, prompt variables, routing fields, nested Flow contracts, explicit result mappings, and every terminal output path before save or compilation
- apply the same contract validation in the Interpreter, Desktop editor, and default Agent draft workflow using the draft's pinned project revision
- preserve Start, End, and Fail node selection when result-source edits rebuild the canvas
- remove the obsolete Desktop-only route validator and consolidate its coverage in the canonical Interpreter validator

## Root cause

Flow validation previously checked only a subset of prompt references and did not prove that every terminal path satisfied the declared Flow output schema. Default Agent drafts also lacked a resource resolver for nested Flow contracts. Separately, canvas rebuilds restored selection only for semantic or logic nodes, so editing an End node result mapping cleared the active selection.

## Impact

Invalid Flow data contracts now fail during authoring instead of at runtime, including the Human-terminal scenario reported in the issue. Editing an End node's result source no longer returns the user to Flow settings.

## Validation

- `pnpm check`
- `pnpm build`
- Interpreter: 56 tests passed
- Desktop: 408 tests passed
- Desktop preload bundle verification passed
- Claude Code review completed; all three confirmed findings were fixed

Fixes #40