### PR TITLE
Fix Flow editor selection update loop

### DIFF
--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.test.ts
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.test.ts
@@ -30,6 +30,7 @@ import {
   normalizePromptSegments,
   promptSegmentsFromEditorNodes,
   PromptTemplateEditor,
+  rebuildCanvasNodesPreservingSelection,
   removeEdgeFromFlow,
   removeHumanOption,
   resourceTargets,
@@ -190,7 +191,7 @@ describe("Flow editor canvas", () => {
 
     const terminalResultNodes = buildCanvasNodes(flow, {}, new Set(), END_NODE_ID);
     flow.spec.output.value = { result: "$node.output.result" };
-    const mappedResultNodes = buildCanvasNodes(flow, {}, new Set(), END_NODE_ID);
+    const mappedResultNodes = rebuildCanvasNodesPreservingSelection(flow, terminalResultNodes);
 
     expect(terminalResultNodes.find((node) => node.id === END_NODE_ID)?.selected).toBe(true);
     expect(mappedResultNodes.find((node) => node.id === END_NODE_ID)?.selected).toBe(true);

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/FlowEditor.tsx
@@ -446,15 +446,9 @@ function FlowEditorCanvas(props: {
 
   useEffect(() => {
     setNodes((current) => {
-      return buildCanvasNodes(
-        flow,
-        canvasPositions(current),
-        invalidStepIds,
-        selectedNodeId,
-        logicDraftIds,
-      );
+      return rebuildCanvasNodesPreservingSelection(flow, current, invalidStepIds, logicDraftIds);
     });
-  }, [flow, invalidStepIds, logicDraftIds, selectedNodeId, setNodes]);
+  }, [flow, invalidStepIds, logicDraftIds, setNodes]);
 
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {
@@ -4332,6 +4326,22 @@ export function inspectorNodeId(
   return node?.type === "step" || node?.type === "logic" || node?.type === "terminal"
     ? node.id
     : null;
+}
+
+export function rebuildCanvasNodesPreservingSelection(
+  flow: PragmaFlowResource,
+  currentNodes: readonly WorkflowCanvasNode[],
+  invalidStepIds: ReadonlySet<string> = new Set(),
+  logicDraftIds: readonly string[] = [],
+): WorkflowCanvasNode[] {
+  const selectedNodeId = inspectorNodeId(currentNodes.find((node) => node.selected));
+  return buildCanvasNodes(
+    flow,
+    canvasPositions(currentNodes),
+    invalidStepIds,
+    selectedNodeId,
+    logicDraftIds,
+  );
 }
 
 export function buildCanvasEdges(flow: PragmaFlowResource): Edge[] {


### PR DESCRIPTION
## Summary

- stop rebuilding React Flow nodes in response to `selectedNodeId` changes
- preserve Start, End, Fail, step, and logic selections by deriving the retained selection from the current controlled node collection during semantic rebuilds
- exercise the exact selection-preserving rebuild helper in the End result-source regression test

## Root cause

PR #41 added `selectedNodeId` to the node rebuild effect so terminal selection would survive result-source edits. React Flow also reports controlled node selection through `onSelectionChange`; feeding that value back into `setNodes` from an effect created a selection → node rebuild → selection feedback loop and eventually `Maximum update depth exceeded` when opening the Flow editor.

The rebuild now reads the already-selected node from the functional `setNodes(current => ...)` snapshot. Selection changes no longer trigger semantic node reconstruction, while result-source edits still preserve the selected End node.

## Impact

Opening the Flow editor no longer crashes, and changing the End result source continues to keep the End inspector selected.

## Validation

- `pnpm check`
- `pnpm build`
- Desktop: 408 tests passed
- Desktop preload bundle verification passed

Fixes #40