### PR TITLE
Add Qoder CLI runtime and optimize Mission startup latency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ tsconfig.base.json
 @pragma/runtime-pi
 @pragma/runtime-codex
 @pragma/runtime-claude-code
+@pragma/runtime-qodercli
 @pragma/desktop
 @pragma/examples
 @pragma/plugin-memory
@@ -180,6 +181,12 @@ runtime-codex -> runtime-pi
 runtime-codex -> runtime-claude-code
 runtime-claude-code -> runtime-pi
 runtime-claude-code -> runtime-codex
+runtime-qodercli -> runtime-pi
+runtime-qodercli -> runtime-codex
+runtime-qodercli -> runtime-claude-code
+runtime-pi -> runtime-qodercli
+runtime-codex -> runtime-qodercli
+runtime-claude-code -> runtime-qodercli
 server -> client
 server -> web
 core -> web
@@ -244,7 +251,7 @@ Server 与 Agent 的关系：
 - Core 通过可选 `UsageSink` 发出逐 Runtime turn 的 token observation，但不持久化跨 Execution
   的统计账本；Desktop/Server 等 Host 负责统计持久化、保留和查询策略。
 - Server/Worker 可以调用 Core；Core 不应该反向调用 Server 应用层。
-- 本地 Claude Code、Codex、自研执行环境属于 Runtime Adapter 的实现目标，由 Desktop App 承载本地连接、授权和执行桥接，不改变 Server 调度 Agent 的依赖方向。
+- 本地 Claude Code、Codex、Qoder CLI、自研执行环境属于 Runtime Adapter 的实现目标，由 Desktop App 承载本地连接、授权和执行桥接，不改变 Server 调度 Agent 的依赖方向。
 
 本地存储边界：
 
@@ -301,7 +308,7 @@ Cloud Server / Worker
 → Desktop App
 → Local Permission Guard
 → Local Agent Adapter
-→ Claude Code / Codex / 自研本地 Agent
+→ Claude Code / Codex / Qoder CLI / 自研本地 Agent
 ```
 
 云端职责：
@@ -318,7 +325,7 @@ Desktop App 职责：
 
 - 负责用户登录、设备绑定、本地工作区选择。
 - 主动连接云端，避免云端直接访问用户机器或要求本机暴露公网端口。
-- 注册本机可用 Runtime 能力，例如 Claude Code、Codex、自研本地 Agent。
+- 注册本机可用 Runtime 能力，例如 Claude Code、Codex、Qoder CLI、自研本地 Agent。
 - 承载本地权限闸门，包括文件读取、文件写入、shell、网络、secrets、git 操作。
 - 调用本地 Agent，并把过程事件流式回传云端。
 - 在需要时展示本地确认 UI，例如执行 shell、修改文件、读取敏感目录。
@@ -517,7 +524,7 @@ createDatabaseClient()
 - ExpertAgent 公共实现，包括上下文系统、AGENTS.md 加载、subAgent 声明和系统提示词组装。
 - RuntimeAdapter 与 RuntimeAgentSession 核心接口。
 - RuntimeResolver、不可变 Runtime Environment binding、运行事件、会话、取消、错误等公共运行协议。
-- 未来本地 Claude Code、Codex、自研执行环境通过独立 Runtime Adapter 包对接。
+- 未来本地 Claude Code、Codex、Qoder CLI、自研执行环境通过独立 Runtime Adapter 包对接。
 
 当前保留：
 
@@ -702,6 +709,10 @@ Server health: ok
 ```bash
 pnpm --filter @pragma/desktop dev
 ```
+
+使用内置 Qoder CLI Runtime 前，主机必须已安装可直接执行的 `qodercli`。可先运行
+`qodercli --version` 验证；认证可复用本机已完成的 Qoder CLI 登录状态，或通过
+`QODER_PERSONAL_ACCESS_TOKEN` 提供 PAT。非标准安装路径使用 `QODERCLI_PATH` 指向原生可执行文件。
 
 > **Electron 42 注意事项：** 从 Electron 42 开始，`postinstall` 不再自动下载 Electron 二进制文件，改为首次运行 Electron CLI 时才下载。Desktop 的 `predev` 会通过 `prepare:electron` 调用 `install-electron`，避免新成员首次 `dev` 时遇到缺失二进制的错误。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,8 +268,10 @@ Server 与 Agent 的关系：
   `~/.pragma/data/objects/sha256/`，所有 Revision 在 Project 删除前都是强引用根。
 - Agent 插件按 package fingerprint 全局缓存到 `~/.pragma/cache/plugins/sha256/`；
   `cache/agents/<agentId>/` 只保存绑定元数据，不复制插件包。
-- Codex 使用共享只读 cache base 与 Runtime Context 私有 overlay；sessions、SQLite、日志和配置
-  不得跨 Context 共享，`CODEX_SQLITE_HOME` 必须指向私有目录。
+- Codex 使用最小化 Runtime Context 私有 Home：sessions、SQLite、日志、配置和 Agent Skills
+  不得跨 Context 共享，`CODEX_SQLITE_HOME` 必须指向私有目录。宿主
+  `~/.codex/plugins/cache` 作为可重建缓存可以直接链接共享；不得复制或扫描完整
+  `plugins`、`packages`、通用 `cache` 或宿主 sessions 树。
 - Runtime 进程停止不等于持久数据删除。Mission 删除必须按 owner 图级联移动 ExpertSession、
   Execution、Runtime Session 和 ownership claim 到带 journal 的回收站。
 - 外部 ID 目录段统一通过 `@pragma/core` 的 `PragmaPaths` 编码和解析，具体 Runtime 或插件 loader 不自行拼接管理路径。

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Pragma helps experienced AI users turn repeatable working methods into runnable assets. A method can combine expert definitions, tools, memory, approval gates, runtime choices, model configuration, and delivery checks. Other users can run the method without understanding the orchestration underneath.
 
-Pragma is not another chatbot, coding agent, expert marketplace, or low-code workflow builder. It is an open organization layer above models and specialized agent harnesses: Codex, Claude Code, PI, and future runtime adapters can all become execution options for different tasks.
+Pragma is not another chatbot, coding agent, expert marketplace, or low-code workflow builder. It is an open organization layer above models and specialized agent harnesses: Codex, Claude Code, Qoder CLI, PI, and future runtime adapters can all become execution options for different tasks.
 
 ## Why Pragma?
 
@@ -55,7 +55,7 @@ Pragma treats this method as the product object users discover, run, revise, and
 | Primary role        | Specialized coding harness              | Integrated AI workspace with expert ecosystem | Node-based automation or LLM workflow design | Organization layer across models and agent harnesses                         |
 | Core object         | Coding session, subagent, skills, hooks | Experts, expert teams, skills, projects       | Graphs, nodes, triggers, integrations        | Runtime, Expert, ExpertTeam, Flow, Mission                                   |
 | Main strength       | Deep software engineering execution     | Low-friction all-in-one user experience       | Visual composition and automation            | Harness-neutral execution and reusable AI-native methods                     |
-| Runtime model       | Claude Code is the harness              | Product-owned execution system                | Usually one orchestration engine             | Codex, Claude Code, PI, and future adapters are pluggable runtimes           |
+| Runtime model       | Claude Code is the harness              | Product-owned execution system                | Usually one orchestration engine             | Codex, Claude Code, Qoder CLI, PI, and future adapters are pluggable runtimes |
 | Sharing unit        | Repo config, skills, plugins            | Experts, teams, skills, workspace assets      | Templates and workflows                      | Methods with runtime requirements, permissions, validation, and deliverables |
 | Pragma relationship | Can be used as a runtime                | Adjacent product category                     | Adjacent implementation style                | Coordinates execution combinations across runtimes                           |
 
@@ -83,7 +83,7 @@ Pragma currently provides:
 - `ExpertTeam` and `Flow` foundations for coordinated execution.
 - Context systems backed by in-memory or filesystem stores.
 - Managed tools, MCP tool integration, plugin loading, and approval policies.
-- Runtime adapter contracts and PI / Codex / Claude Code runtime packages.
+- Runtime adapter contracts and PI / Codex / Claude Code / Qoder CLI runtime packages.
 - Runtime context, session ownership, invocation, event, usage, and handoff primitives.
 - Browser-safe shared schemas and DTOs built with Zod.
 - Web, server, worker, desktop, client SDK, and infrastructure package boundaries in a pnpm monorepo.
@@ -206,6 +206,7 @@ packages/
   runtime/pi/     PI runtime adapter
   runtime/codex/  Codex local runtime adapter
   runtime/claude-code/ Claude Code local runtime adapter
+  runtime/qodercli/ Qoder CLI local runtime adapter
   eslint-config/  Shared ESLint config
   tsconfig/       Shared TypeScript config
 

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
           "@pragma/runtime-claude-code",
           "@pragma/runtime-codex",
           "@pragma/runtime-pi",
+          "@pragma/runtime-qodercli",
           "@pragma/core",
           "@pragma/interpreter",
           "@pragma/shared",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -34,6 +34,7 @@
     "@pragma/runtime-claude-code": "workspace:*",
     "@pragma/runtime-codex": "workspace:*",
     "@pragma/runtime-pi": "workspace:*",
+    "@pragma/runtime-qodercli": "workspace:*",
     "@pragma/shared": "workspace:*",
     "@pragma/default-agent": "workspace:*",
     "@xyflow/react": "^12.11.2",

--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -179,6 +179,8 @@ export async function createDesktopApplicationContainer(
   await runtimeEnvironments.initialize();
   const runtimes = createRuntimeEnvironmentService({
     store: runtimeEnvironments,
+    logger: mainLogger,
+    getToolPermissionMode,
     factories: createBuiltInRuntimeFactories(
       modelProviderStore,
       getToolPermissionMode,

--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import type { BrowserWindow } from "electron";
 import {
+  createStorageCapacityGuard,
   PragmaPaths,
   runStorageMaintenance,
   type PragmaLogger,
@@ -47,6 +48,7 @@ import { createPluginCredentialStore } from "../features/plugins/plugin-credenti
 import { installPluginHandlers } from "../features/plugins/plugin-ipc.ts";
 import { createPluginStore } from "../features/plugins/plugin-store.ts";
 import { installPragmaProjectHandlers } from "../features/projects/pragma-project-ipc.ts";
+import { createDesktopPragmaBlueprintCacheStore } from "../features/projects/pragma-blueprint-cache-store.ts";
 import { createPragmaProjectStore } from "../features/projects/pragma-project-store.ts";
 import { installWorkflowLayoutHandlers } from "../features/projects/workflow-layout-ipc.ts";
 import { createWorkflowLayoutStore } from "../features/projects/workflow-layout-store.ts";
@@ -105,6 +107,10 @@ export async function createDesktopApplicationContainer(
     );
   }
   const maintenance = await runStorageMaintenance({ paths: pragmaPaths });
+  const storageCapacityGuard = createStorageCapacityGuard({
+    paths: pragmaPaths,
+    initialOverview: maintenance.after,
+  });
   if (maintenance.before.totalBytes >= maintenance.before.softLimitBytes) {
     mainLogger.warn(
       "desktop.storage_pressure_gc",
@@ -140,12 +146,14 @@ export async function createDesktopApplicationContainer(
     warn: (message, error) => mainLogger.warn("desktop.system_expert_warning", message, { error }),
   });
   await systemExperts.initialize();
+  const blueprintCache = createDesktopPragmaBlueprintCacheStore(pragmaPaths);
   const pragmaProjectStore = createPragmaProjectStore({
     projectsPath,
     objectsPath: pragmaPaths.contentObjectsRoot(),
     projectViewsPath: pragmaPaths.projectViewsCacheRoot(),
     storagePaths: pragmaPaths,
     loggerProvider,
+    blueprintCache,
     reservedResourceRefs: new Set([BUILT_IN_PRAGMA_REF]),
   });
   installWorkflowLayoutHandlers(
@@ -301,6 +309,8 @@ export async function createDesktopApplicationContainer(
     runtimesForToolPermissionMode: (mode) => runtimes.forToolPermissionMode(mode),
     automaticHumanInteractionHandlerForToolPermissionMode: (mode) =>
       createAutomaticToolPermissionHandler(() => mode),
+    assertStorageWriteAllowed: async () => await storageCapacityGuard.assertWriteAllowed(),
+    getSystemExecutorFingerprint: (mission) => systemExperts.fingerprint(mission.executor.ref),
     compileSystemExecutor: async ({ mission, runtimes: scopedRuntimes }) => {
       if (mission.executor.ref !== BUILT_IN_PRAGMA_REF) return undefined;
       if (defaultAgentToolsRef.current === undefined) {
@@ -334,6 +344,7 @@ export async function createDesktopApplicationContainer(
             : { modelSelection: defaults.modelSelection }),
         },
         tools: defaultAgentToolsRef.current,
+        blueprintCache,
         ...(definition.customized
           ? { expertResource: systemExperts.getResource(BUILT_IN_PRAGMA_REF) }
           : {}),
@@ -442,6 +453,7 @@ export async function createDesktopApplicationContainer(
     dispose: () => {
       unsubscribeUsageUpdates();
       automationService.stop();
+      storageCapacityGuard.close();
       usageStore.close();
     },
   };

--- a/apps/desktop/src/main/bootstrap/application.ts
+++ b/apps/desktop/src/main/bootstrap/application.ts
@@ -37,11 +37,19 @@ export function startDesktopApplication(): void {
       component: "desktop.renderer",
       scope: { processKind: "desktop-renderer" },
     });
+    const attributes = {
+      errorMessage: record.data.errorMessage,
+      stack: record.data.stack,
+      missionId: record.data.missionId,
+      executionId: record.data.executionId,
+      elapsedMs: record.data.elapsedMs,
+    };
+    if (record.data.level === "info") {
+      logger.info(record.data.event, record.data.message, attributes);
+      return;
+    }
     if (record.data.level === "warn") {
-      logger.warn(record.data.event, record.data.message, {
-        errorMessage: record.data.errorMessage,
-        stack: record.data.stack,
-      });
+      logger.warn(record.data.event, record.data.message, attributes);
       return;
     }
     const error = new Error(record.data.errorMessage ?? record.data.message);

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -145,6 +145,99 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     expect(followUpAdmissionMs).toBeLessThan(250);
   });
 
+  it("creates a successor Session when the live execution definition changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-definition-successor-"));
+    temporaryPaths.push(root);
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Start with the first definition",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(
+        snapshot.resources.find((resource) => resource.kind === "Expert")!,
+      ),
+    });
+    const runtime = defineRuntimeDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: (context) => ({ id: `runtime-${context.systemSessionId}` }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      startTurn: () => ({ outputText: "done", runtimeSessionId: "runtime" }),
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    let definitionVersion = 1;
+    const compileSystemExecutor = vi.fn(async () => {
+      const expert = await defineExpert({
+        id: "1xddvess309a6gme",
+        name: "Writer",
+        description: "Writes concise answers",
+        tags: [],
+        scope: "Writing",
+        instructions: `Definition ${definitionVersion}`,
+        workspace: root,
+        pragmaHome: join(root, "state"),
+        defaultRuntimeId: "fake",
+      });
+      return {
+        ref: mission.executor.ref,
+        value: expert,
+        fingerprint: String(definitionVersion).repeat(64),
+        projectFingerprint: "a".repeat(64),
+        environmentFingerprint: {
+          environmentId: "desktop",
+          projectFingerprint: "a".repeat(64),
+          value: "b".repeat(64),
+          resources: [],
+          plugins: [],
+        },
+        rootRuntimeId: "fake",
+        dependencies: [],
+      };
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome: join(root, "state"),
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: "fake",
+      }),
+      compileSystemExecutor,
+      getSystemExecutorFingerprint: () => `definition-${definitionVersion}`,
+      assertStorageWriteAllowed: async () => undefined,
+    });
+
+    await runner.run(mission.id);
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+    const originalSessionId = (await missions.get(mission.id)).execution?.sessionId;
+    expect(originalSessionId).toMatch(/^[0-9a-f-]{36}$/);
+    definitionVersion = 2;
+
+    await runner.sendMessage({
+      id: mission.id,
+      content: "Continue with the changed definition",
+      requestId: "00000000-0000-4000-8000-000000000098",
+    });
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+
+    expect((await missions.get(mission.id)).execution?.sessionId).not.toBe(originalSessionId);
+    expect(compileSystemExecutor).toHaveBeenCalledTimes(2);
+  });
+
   it("limits deletion reconciliation to the target Mission and does not let analytics block deletion", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-mission-usage-delete-"));
     temporaryPaths.push(root);

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -85,6 +85,66 @@ afterEach(async () => {
 });
 
 describe("MissionRunner", { timeout: 15_000 }, () => {
+  it("skips compilation for a follow-up on the live Mission Session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-followup-fast-path-"));
+    temporaryPaths.push(root);
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const compile = vi.spyOn(project, "compile");
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Start the Mission",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(
+        snapshot.resources.find((resource) => resource.kind === "Expert")!,
+      ),
+    });
+    const runtime = defineRuntimeDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      startTurn: () => ({ outputText: "done", runtimeSessionId: "runtime" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome: join(root, "state"),
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: "fake",
+      }),
+      assertStorageWriteAllowed: async () => undefined,
+    });
+
+    await runner.run(mission.id);
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+    const followUpStartedAt = performance.now();
+    await runner.sendMessage({
+      id: mission.id,
+      content: "Continue without recompiling",
+      requestId: "00000000-0000-4000-8000-000000000099",
+    });
+    const followUpAdmissionMs = performance.now() - followUpStartedAt;
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+
+    expect(compile).toHaveBeenCalledTimes(1);
+    expect(followUpAdmissionMs).toBeLessThan(250);
+  });
+
   it("limits deletion reconciliation to the target Mission and does not let analytics block deletion", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-mission-usage-delete-"));
     temporaryPaths.push(root);

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -988,6 +988,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         provider: "openai",
         model: "test",
         usage: {
+          measurement: "reported",
           input: 0,
           output: 0,
           cacheRead: 0,
@@ -1025,6 +1026,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         provider: "openai",
         model: "test",
         usage: {
+          measurement: "reported",
           input: 0,
           output: 0,
           cacheRead: 0,
@@ -1389,7 +1391,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     });
     await executions.create(
       {
-        schemaVersion: "pragma.execution/v7",
+        schemaVersion: "pragma.execution/v8",
         executionId,
         version: 0,
         kind: "expert-turn",
@@ -1788,7 +1790,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     });
     await executions.create(
       {
-        schemaVersion: "pragma.execution/v7",
+        schemaVersion: "pragma.execution/v8",
         executionId,
         version: 0,
         kind: "expert-turn",

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -23,6 +23,7 @@ import {
   type ExpertAgentHumanResponse,
   type ExpertSession,
   type MutableExecution,
+  type PragmaLogger,
   type RuntimeResolver,
   type RuntimeContextWindowUsage,
   type RuntimeModelSelection,
@@ -533,11 +534,31 @@ export function createMissionRunner(options: {
     readonly startedAt: string;
     readonly inputMessageId: string;
     readonly sessionId?: string | undefined;
+    readonly acceptedAt?: number | undefined;
     readonly onFinished?: (() => void | Promise<void>) | undefined;
   }): void => {
+    let firstProjectionLogged = false;
     const live = observeMissionChat(
       input.handle,
-      (patches) => emitChatPatches(input.missionId, patches),
+      (patches) => {
+        emitChatPatches(input.missionId, patches);
+        if (
+          !firstProjectionLogged &&
+          input.acceptedAt !== undefined &&
+          patches.some(isVisibleTextProjectionPatch)
+        ) {
+          firstProjectionLogged = true;
+          logger.info(
+            "mission.first_ui_projection",
+            "Mission emitted its first UI-visible text projection",
+            {
+              missionId: input.missionId,
+              executionId: input.handle.executionId,
+              elapsedMs: elapsedMissionMs(input.acceptedAt),
+            },
+          );
+        }
+      },
       () => invalidateChat(input.missionId),
       (item) => {
         const sessionId = item.source.sessionId;
@@ -578,7 +599,17 @@ export function createMissionRunner(options: {
           input.missionId,
           input.handle.executionId,
         ),
-    ).finally(async () => await forgetActive(input.missionId, input.handle.executionId));
+    )
+      .then(() => {
+        if (input.acceptedAt !== undefined) {
+          logger.info("mission.final_result", "Mission execution reached a final result", {
+            missionId: input.missionId,
+            executionId: input.handle.executionId,
+            elapsedMs: elapsedMissionMs(input.acceptedAt),
+          });
+        }
+      })
+      .finally(async () => await forgetActive(input.missionId, input.handle.executionId));
     active.set(input.missionId, { handle: input.handle, settlement });
     invalidateChat(input.missionId);
     invalidateWork(input.missionId);
@@ -593,18 +624,35 @@ export function createMissionRunner(options: {
   };
 
   const runMission = async (id: string): Promise<Mission> => {
+    const acceptedAt = performance.now();
+    logger.info("mission.message_accepted", "Mission request accepted", {
+      missionId: id,
+      kind: "initial",
+    });
+    const capacityCheckStartedAt = performance.now();
     await assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome }));
+    logMissionPhase(logger, id, "storage_capacity_check", capacityCheckStartedAt, acceptedAt);
     const mission = await options.missions.get(id);
     if (active.has(mission.id)) return mission;
     const { app, runtimes: baseRuntimes } = executionContext(mission);
     const runtimes = withMissionRuntimeBinding(baseRuntimes, await readMissionRootContext(mission));
+    let phaseStartedAt = performance.now();
     const compiled = await compileMissionExecutor(mission, runtimes);
+    logMissionPhase(logger, mission.id, "default_agent_compile", phaseStartedAt, acceptedAt);
     const modelSelection = toRuntimeModelSelection(mission.modelOverride);
     if (mission.modelOverride !== undefined) {
+      phaseStartedAt = performance.now();
       await runtimes.bind({
         runtimeId: requireRootRuntimeId(compiled),
         modelSelection,
       });
+      logMissionPhase(
+        logger,
+        mission.id,
+        "runtime_bind_model_validation",
+        phaseStartedAt,
+        acceptedAt,
+      );
     }
     const startedAt = new Date().toISOString();
 
@@ -665,6 +713,7 @@ export function createMissionRunner(options: {
         handle,
         startedAt: executionStartedAt,
         inputMessageId,
+        acceptedAt,
       });
       return running;
     }
@@ -673,6 +722,7 @@ export function createMissionRunner(options: {
       mission.execution !== undefined &&
       mission.execution.sessionId !== undefined &&
       ["queued", "running", "waiting"].includes(mission.execution.status);
+    phaseStartedAt = performance.now();
     const session =
       sessions.get(mission.id) ??
       (await openMissionExpertSession({
@@ -683,6 +733,9 @@ export function createMissionRunner(options: {
         modelSelection,
         createSuccessorOnMismatch: true,
       }));
+    logMissionPhase(logger, mission.id, "expert_session_open", phaseStartedAt, acceptedAt, {
+      cacheHit: sessions.has(mission.id),
+    });
     sessions.set(mission.id, session);
     const recoveredPrompt = recoverable
       ? (await session.getPromptQueue()).find(
@@ -704,6 +757,7 @@ export function createMissionRunner(options: {
     const inputMessageId = recoverable
       ? mission.execution!.inputMessageId
       : mission.initialMessageId;
+    phaseStartedAt = performance.now();
     const turn =
       recoveredTurn ??
       (await session.prompt(
@@ -719,6 +773,7 @@ export function createMissionRunner(options: {
           requestId: recoverable ? randomUUID() : inputMessageId,
         },
       ));
+    logMissionPhase(logger, mission.id, "expert_session_prompt", phaseStartedAt, acceptedAt);
     const executionStartedAt =
       recoveredTurn === undefined ? startedAt : mission.execution!.startedAt;
     await options.missions.appendExecutionReference({
@@ -740,6 +795,7 @@ export function createMissionRunner(options: {
       startedAt: executionStartedAt,
       inputMessageId,
       sessionId: session.sessionId,
+      acceptedAt,
       onFinished: async () => await waitForExpertTurnSettlement(session, turn.requestId),
     });
     return running;
@@ -750,7 +806,15 @@ export function createMissionRunner(options: {
     readonly content: string;
     readonly requestId: string;
   }): Promise<Mission> => {
+    const acceptedAt = performance.now();
+    logger.info("mission.message_accepted", "Mission request accepted", {
+      missionId: input.id,
+      requestId: input.requestId,
+      kind: "followup",
+    });
+    const capacityCheckStartedAt = performance.now();
     await assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome }));
+    logMissionPhase(logger, input.id, "storage_capacity_check", capacityCheckStartedAt, acceptedAt);
     const mission = await options.missions.get(input.id);
     const { app, runtimes: baseRuntimes } = executionContext(mission);
     const rootContext = await readMissionRootContext(mission);
@@ -764,13 +828,23 @@ export function createMissionRunner(options: {
     if (active.has(mission.id)) {
       throw new Error("Wait for the current expert turn before sending another message.");
     }
+    let phaseStartedAt = performance.now();
     const compiled = await compileMissionExecutor(mission, runtimes);
+    logMissionPhase(logger, mission.id, "default_agent_compile", phaseStartedAt, acceptedAt);
     const modelSelection = toRuntimeModelSelection(mission.modelOverride);
     if (mission.modelOverride !== undefined) {
+      phaseStartedAt = performance.now();
       await runtimes.bind({
         runtimeId: requireRootRuntimeId(compiled),
         modelSelection,
       });
+      logMissionPhase(
+        logger,
+        mission.id,
+        "runtime_bind_model_validation",
+        phaseStartedAt,
+        acceptedAt,
+      );
     }
     if ("kind" in compiled.value && compiled.value.kind === "flow") {
       throw new Error("Flow missions cannot receive chat messages.");
@@ -786,6 +860,8 @@ export function createMissionRunner(options: {
     )
       ? undefined
       : desiredModelSelection;
+    const sessionCacheHit = sessions.has(mission.id);
+    phaseStartedAt = performance.now();
     const session =
       sessions.get(mission.id) ??
       (await openMissionExpertSession({
@@ -796,16 +872,21 @@ export function createMissionRunner(options: {
         modelSelection,
         createSuccessorOnMismatch: true,
       }));
+    logMissionPhase(logger, mission.id, "expert_session_open", phaseStartedAt, acceptedAt, {
+      cacheHit: sessionCacheHit,
+    });
     sessions.set(mission.id, session);
     await options.missions.appendUserMessage(mission.id, {
       id: input.requestId,
       content: input.content,
       createdAt: new Date().toISOString(),
     });
+    phaseStartedAt = performance.now();
     const turn = await session.prompt(input.content, {
       requestId: input.requestId,
       ...(promptModelSelection === undefined ? {} : { modelSelection: promptModelSelection }),
     });
+    logMissionPhase(logger, mission.id, "expert_session_prompt", phaseStartedAt, acceptedAt);
     const startedAt = new Date().toISOString();
     await options.missions.appendExecutionReference({
       missionId: mission.id,
@@ -826,6 +907,7 @@ export function createMissionRunner(options: {
       startedAt,
       inputMessageId: input.requestId,
       sessionId: session.sessionId,
+      acceptedAt,
       onFinished: async () => await waitForExpertTurnSettlement(session, turn.requestId),
     });
     return running;
@@ -2083,6 +2165,38 @@ function observeMissionChat(
     await Promise.allSettled([outputTask, eventTask]);
   };
   return chat;
+}
+
+function isVisibleTextProjectionPatch(patch: MissionChatPatch): boolean {
+  if (patch.type === "entry.append") {
+    return patch.field === "content" && patch.delta.length > 0;
+  }
+  return (
+    patch.type === "entry.upsert" &&
+    (patch.entry.kind === "assistant" || patch.entry.kind === "thinking") &&
+    patch.entry.content.length > 0
+  );
+}
+
+function logMissionPhase(
+  logger: Pick<PragmaLogger, "info">,
+  missionId: string,
+  phase: string,
+  phaseStartedAt: number,
+  acceptedAt: number,
+  attributes: Record<string, unknown> = {},
+): void {
+  logger.info("mission.prepare_phase", `Mission preparation phase completed: ${phase}`, {
+    missionId,
+    phase,
+    durationMs: elapsedMissionMs(phaseStartedAt),
+    elapsedMs: elapsedMissionMs(acceptedAt),
+    ...attributes,
+  });
+}
+
+function elapsedMissionMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
 function consumeLiveChatOutput(

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -7,6 +7,7 @@ import {
   createFileExpertSessionStore,
   ExecutionWorkHistoryReader,
   ExpertAgentHumanRequestSchema,
+  fingerprintExpertExecutionDefinition,
   isExpertTeam,
   StoredExecutionView,
   PragmaPaths,
@@ -21,6 +22,7 @@ import {
   type ExpertAgentAutomaticHumanInteractionHandler,
   type ExpertAgentHumanRequest,
   type ExpertAgentHumanResponse,
+  type ExpertDefinition,
   type ExpertSession,
   type MutableExecution,
   type PragmaLogger,
@@ -181,6 +183,10 @@ export function createMissionRunner(options: {
         readonly runtimes: RuntimeResolver;
       }) => Promise<CompiledResource<InvocableResource> | undefined>)
     | undefined;
+  readonly getSystemExecutorFingerprint?:
+    | ((mission: Mission) => string | undefined | Promise<string | undefined>)
+    | undefined;
+  readonly assertStorageWriteAllowed?: (() => Promise<void>) | undefined;
 }): MissionRunner {
   const logger = createPragmaLogger(options.loggerProvider, {
     component: "desktop.mission-runner",
@@ -253,6 +259,8 @@ export function createMissionRunner(options: {
   };
   const active = new Map<string, ActiveMissionExecution>();
   const sessions = new Map<string, ExpertSession>();
+  const sessionCompilationIdentities = new Map<string, string>();
+  const sessionDefinitionFingerprints = new Map<string, string>();
   const pendingOperations = new Map<string, PendingMissionOperation>();
   const chatListeners = new Set<(update: MissionChatUpdate) => void>();
   const chatRevisions = new Map<string, number>();
@@ -395,6 +403,33 @@ export function createMissionRunner(options: {
             },
           }),
     });
+  };
+
+  const compilationIdentity = async (mission: Mission): Promise<string> =>
+    createHash("sha256")
+      .update(
+        JSON.stringify({
+          project: mission.project,
+          executor: mission.executor,
+          systemExecutorFingerprint:
+            (await options.getSystemExecutorFingerprint?.(mission)) ?? null,
+          toolPermissionMode: mission.toolPermissionMode,
+          modelOverride: mission.modelOverride ?? null,
+        }),
+      )
+      .digest("hex");
+
+  const rememberSessionCompilation = (
+    missionId: string,
+    identity: string,
+    compiled: CompiledResource<InvocableResource>,
+  ): void => {
+    if ("kind" in compiled.value && compiled.value.kind === "flow") return;
+    sessionCompilationIdentities.set(missionId, identity);
+    sessionDefinitionFingerprints.set(
+      missionId,
+      fingerprintExpertExecutionDefinition(compiled.value),
+    );
   };
 
   const readMissionRootContext = async (
@@ -630,7 +665,8 @@ export function createMissionRunner(options: {
       kind: "initial",
     });
     const capacityCheckStartedAt = performance.now();
-    await assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome }));
+    await (options.assertStorageWriteAllowed?.() ??
+      assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome })));
     logMissionPhase(logger, id, "storage_capacity_check", capacityCheckStartedAt, acceptedAt);
     const mission = await options.missions.get(id);
     if (active.has(mission.id)) return mission;
@@ -638,9 +674,10 @@ export function createMissionRunner(options: {
     const runtimes = withMissionRuntimeBinding(baseRuntimes, await readMissionRootContext(mission));
     let phaseStartedAt = performance.now();
     const compiled = await compileMissionExecutor(mission, runtimes);
+    const compiledIdentity = await compilationIdentity(mission);
     logMissionPhase(logger, mission.id, "default_agent_compile", phaseStartedAt, acceptedAt);
     const modelSelection = toRuntimeModelSelection(mission.modelOverride);
-    if (mission.modelOverride !== undefined) {
+    if (mission.modelOverride !== undefined && compiled !== undefined) {
       phaseStartedAt = performance.now();
       await runtimes.bind({
         runtimeId: requireRootRuntimeId(compiled),
@@ -737,6 +774,7 @@ export function createMissionRunner(options: {
       cacheHit: sessions.has(mission.id),
     });
     sessions.set(mission.id, session);
+    rememberSessionCompilation(mission.id, compiledIdentity, compiled);
     const recoveredPrompt = recoverable
       ? (await session.getPromptQueue()).find(
           (prompt) =>
@@ -813,7 +851,8 @@ export function createMissionRunner(options: {
       kind: "followup",
     });
     const capacityCheckStartedAt = performance.now();
-    await assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome }));
+    await (options.assertStorageWriteAllowed?.() ??
+      assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome })));
     logMissionPhase(logger, input.id, "storage_capacity_check", capacityCheckStartedAt, acceptedAt);
     const mission = await options.missions.get(input.id);
     const { app, runtimes: baseRuntimes } = executionContext(mission);
@@ -828,11 +867,21 @@ export function createMissionRunner(options: {
     if (active.has(mission.id)) {
       throw new Error("Wait for the current expert turn before sending another message.");
     }
+    const desiredCompilationIdentity = await compilationIdentity(mission);
+    let session = sessions.get(mission.id);
+    let compiled: CompiledResource<InvocableResource> | undefined;
     let phaseStartedAt = performance.now();
-    const compiled = await compileMissionExecutor(mission, runtimes);
-    logMissionPhase(logger, mission.id, "default_agent_compile", phaseStartedAt, acceptedAt);
+    const compilationCacheHit =
+      session !== undefined &&
+      sessionCompilationIdentities.get(mission.id) === desiredCompilationIdentity;
+    if (!compilationCacheHit) {
+      compiled = await compileMissionExecutor(mission, runtimes);
+    }
+    logMissionPhase(logger, mission.id, "default_agent_compile", phaseStartedAt, acceptedAt, {
+      cacheHit: compilationCacheHit,
+    });
     const modelSelection = toRuntimeModelSelection(mission.modelOverride);
-    if (mission.modelOverride !== undefined) {
+    if (mission.modelOverride !== undefined && compiled !== undefined) {
       phaseStartedAt = performance.now();
       await runtimes.bind({
         runtimeId: requireRootRuntimeId(compiled),
@@ -846,13 +895,22 @@ export function createMissionRunner(options: {
         acceptedAt,
       );
     }
-    if ("kind" in compiled.value && compiled.value.kind === "flow") {
-      throw new Error("Flow missions cannot receive chat messages.");
+    let compiledExpert: ExpertDefinition | undefined;
+    if (compiled !== undefined) {
+      if ("kind" in compiled.value && compiled.value.kind === "flow") {
+        throw new Error("Flow missions cannot receive chat messages.");
+      }
+      compiledExpert = compiled.value;
     }
-    const rootExpert = isExpertTeam(compiled.value) ? compiled.value.coordinator : compiled.value;
+    const rootExpert =
+      compiledExpert === undefined
+        ? undefined
+        : isExpertTeam(compiledExpert)
+          ? compiledExpert.coordinator
+          : compiledExpert;
     const desiredModelSelection =
       mission.execution?.sessionId === undefined
-        ? (modelSelection ?? rootExpert.models?.default)
+        ? (modelSelection ?? rootExpert?.models?.default)
         : modelSelection;
     const promptModelSelection = matchesBoundModel(
       desiredModelSelection,
@@ -860,22 +918,42 @@ export function createMissionRunner(options: {
     )
       ? undefined
       : desiredModelSelection;
-    const sessionCacheHit = sessions.has(mission.id);
+    if (compiledExpert !== undefined && session !== undefined) {
+      const nextDefinitionFingerprint = fingerprintExpertExecutionDefinition(compiledExpert);
+      const previousDefinitionFingerprint = sessionDefinitionFingerprints.get(mission.id);
+      if (
+        previousDefinitionFingerprint !== undefined &&
+        previousDefinitionFingerprint !== nextDefinitionFingerprint
+      ) {
+        await session.close("Mission executor definition changed.");
+        sessions.delete(mission.id);
+        sessionCompilationIdentities.delete(mission.id);
+        sessionDefinitionFingerprints.delete(mission.id);
+        session = undefined;
+      }
+    }
+    const sessionCacheHit = session !== undefined;
     phaseStartedAt = performance.now();
-    const session =
-      sessions.get(mission.id) ??
-      (await openMissionExpertSession({
+    if (session === undefined) {
+      if (compiled === undefined) {
+        throw new Error("Mission Session cache was unavailable without a compiled executor.");
+      }
+      session = await openMissionExpertSession({
         mission,
         compiled,
         app,
         sessionId: mission.execution?.sessionId,
         modelSelection,
         createSuccessorOnMismatch: true,
-      }));
+      });
+    }
     logMissionPhase(logger, mission.id, "expert_session_open", phaseStartedAt, acceptedAt, {
       cacheHit: sessionCacheHit,
     });
     sessions.set(mission.id, session);
+    if (compiled !== undefined) {
+      rememberSessionCompilation(mission.id, desiredCompilationIdentity, compiled);
+    }
     await options.missions.appendUserMessage(mission.id, {
       id: input.requestId,
       content: input.content,
@@ -930,7 +1008,7 @@ export function createMissionRunner(options: {
     else prospective.modelOverride = input.modelOverride;
     const baseRuntimes = runtimeResolverForToolPermissionMode(input.toolPermissionMode);
     const runtimes = withMissionRuntimeBinding(baseRuntimes, await readMissionRootContext(mission));
-    await compileMissionExecutor(prospective, runtimes);
+    const compiled = await compileMissionExecutor(prospective, runtimes);
     if (input.toolPermissionMode !== mission.toolPermissionMode) {
       await sessions.get(mission.id)?.refreshRuntimeSessions();
     }
@@ -941,6 +1019,9 @@ export function createMissionRunner(options: {
         : { modelOverride: prospective.modelOverride }),
     });
     executionContexts.get(mission.id)?.setToolPermissionMode(input.toolPermissionMode);
+    if (sessions.has(mission.id)) {
+      rememberSessionCompilation(mission.id, await compilationIdentity(updated), compiled);
+    }
     return updated;
   };
 
@@ -964,6 +1045,8 @@ export function createMissionRunner(options: {
     if (session !== undefined) {
       await session.close("Mission deleted.");
       sessions.delete(id);
+      sessionCompilationIdentities.delete(id);
+      sessionDefinitionFingerprints.delete(id);
     }
     const paths = new PragmaPaths({ pragmaHome: options.pragmaHome });
     const sources = [
@@ -1063,7 +1146,8 @@ export function createMissionRunner(options: {
   };
 
   const compactMissionContext = async (id: string): Promise<MissionContextWindowState> => {
-    await assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome }));
+    await (options.assertStorageWriteAllowed?.() ??
+      assertStorageWriteAllowed(new PragmaPaths({ pragmaHome: options.pragmaHome })));
     const mission = await options.missions.get(id);
     if (mission.executor.kind === "flow") {
       throw new Error("Flow missions do not expose a chat context to compact.");
@@ -1087,12 +1171,15 @@ export function createMissionRunner(options: {
     }
     const { app, runtimes: baseRuntimes } = executionContext(mission);
     const runtimes = withMissionRuntimeBinding(baseRuntimes, rootContext);
-    const compiled = await compileMissionExecutor(mission, runtimes);
-    if ("kind" in compiled.value && compiled.value.kind === "flow") {
-      throw new Error("Flow missions do not expose a chat context to compact.");
+    let session = sessions.get(id);
+    if (session === undefined) {
+      const compiled = await compileMissionExecutor(mission, runtimes);
+      if ("kind" in compiled.value && compiled.value.kind === "flow") {
+        throw new Error("Flow missions do not expose a chat context to compact.");
+      }
+      session = await resumeMissionSession(mission, compiled, app, sessionId);
+      rememberSessionCompilation(id, await compilationIdentity(mission), compiled);
     }
-    const session =
-      sessions.get(id) ?? (await resumeMissionSession(mission, compiled, app, sessionId));
     sessions.set(id, session);
     const usage = await session.compactRootContext();
     invalidateChat(id);

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -918,6 +918,7 @@ export function createMissionRunner(options: {
     )
       ? undefined
       : desiredModelSelection;
+    let definitionChanged = false;
     if (compiledExpert !== undefined && session !== undefined) {
       const nextDefinitionFingerprint = fingerprintExpertExecutionDefinition(compiledExpert);
       const previousDefinitionFingerprint = sessionDefinitionFingerprints.get(mission.id);
@@ -930,6 +931,7 @@ export function createMissionRunner(options: {
         sessionCompilationIdentities.delete(mission.id);
         sessionDefinitionFingerprints.delete(mission.id);
         session = undefined;
+        definitionChanged = true;
       }
     }
     const sessionCacheHit = session !== undefined;
@@ -938,14 +940,24 @@ export function createMissionRunner(options: {
       if (compiled === undefined) {
         throw new Error("Mission Session cache was unavailable without a compiled executor.");
       }
-      session = await openMissionExpertSession({
-        mission,
-        compiled,
-        app,
-        sessionId: mission.execution?.sessionId,
-        modelSelection,
-        createSuccessorOnMismatch: true,
-      });
+      if (definitionChanged) {
+        session = await createMissionExpertSession(compiled, app, { modelSelection });
+        await interruptSupersededMissionSession(mission);
+        logger.warn(
+          "mission.session_successor_created",
+          `Created a successor ExpertSession for Mission ${mission.id} after its execution definition changed.`,
+          { sessionId: session.sessionId },
+        );
+      } else {
+        session = await openMissionExpertSession({
+          mission,
+          compiled,
+          app,
+          sessionId: mission.execution?.sessionId,
+          modelSelection,
+          createSuccessorOnMismatch: true,
+        });
+      }
     }
     logMissionPhase(logger, mission.id, "expert_session_open", phaseStartedAt, acceptedAt, {
       cacheHit: sessionCacheHit,

--- a/apps/desktop/src/main/features/projects/pragma-blueprint-cache-store.ts
+++ b/apps/desktop/src/main/features/projects/pragma-blueprint-cache-store.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { PragmaBlueprintCacheStore } from "@pragma/interpreter";
+import type { PragmaPaths } from "@pragma/core";
+
+export function createDesktopPragmaBlueprintCacheStore(
+  paths: PragmaPaths,
+): PragmaBlueprintCacheStore {
+  return {
+    async read(key) {
+      try {
+        return await readFile(paths.compilerBlueprintCache(key));
+      } catch (error) {
+        if (isNodeError(error, "ENOENT")) return undefined;
+        throw error;
+      }
+    },
+    async write(key, value) {
+      const target = paths.compilerBlueprintCache(key);
+      await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+      const temporary = `${target}.${randomUUID()}.tmp`;
+      try {
+        await writeFile(temporary, value, { mode: 0o600 });
+        await rename(temporary, target);
+      } finally {
+        await rm(temporary, { force: true });
+      }
+    },
+    async remove(key) {
+      await rm(paths.compilerBlueprintCache(key), { force: true });
+    },
+  };
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}

--- a/apps/desktop/src/main/features/projects/pragma-project-store.ts
+++ b/apps/desktop/src/main/features/projects/pragma-project-store.ts
@@ -25,6 +25,7 @@ import {
   type InvocableResource,
   type PragmaProjectRevisionLocation,
   type PragmaProjectSourceRepository,
+  type PragmaBlueprintCacheStore,
   type PragmaProjectChangeSetInput,
   type PragmaResourceIdentityMigration,
 } from "@pragma/interpreter";
@@ -165,6 +166,7 @@ export function createPragmaProjectStore(options: {
   readonly projectId?: string;
   readonly reservedResourceRefs?: ReadonlySet<string> | undefined;
   readonly loggerProvider?: PragmaLoggerProvider | undefined;
+  readonly blueprintCache?: PragmaBlueprintCacheStore | undefined;
 }): PragmaProjectStore {
   const projectId = options.projectId ?? "studio";
   const repository = createDesktopProjectSourceRepository({
@@ -174,6 +176,7 @@ export function createPragmaProjectStore(options: {
   });
   const service = new PragmaProjectService({
     repository,
+    blueprintCache: options.blueprintCache,
     externalResourceRefs: options.reservedResourceRefs,
     loggerProvider: options.loggerProvider,
   });
@@ -433,6 +436,8 @@ export function createPragmaProjectStore(options: {
       return await loadPragmaProject(location.entryFile, {
         rootDir: location.rootDir,
         requireLock: true,
+        sourceIdentity: location.snapshotHash ?? location.projectFingerprint,
+        blueprintCache: options.blueprintCache,
       });
     },
     readIdentityMigrations,

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   codexRuntimePermissionsForMode,
   createRuntimeEnvironmentService,
+  qoderRuntimePermissionForMode,
   type RuntimeEnvironmentAdapterFactory,
 } from "./runtime-environment-service.ts";
 import { createRuntimeEnvironmentStore } from "./runtime-environment-store.ts";
@@ -77,6 +78,16 @@ describe("Codex tool permission mapping", () => {
     ["full-access", "danger-full-access", "never"],
   ] as const)("maps %s to sandbox=%s and approval=%s", (mode, sandboxMode, approvalPolicy) => {
     expect(codexRuntimePermissionsForMode(mode)).toEqual({ sandboxMode, approvalPolicy });
+  });
+});
+
+describe("Qoder CLI tool permission mapping", () => {
+  it.each([
+    ["request-approval", "default"],
+    ["auto-approve", "auto"],
+    ["full-access", "bypassPermissions"],
+  ] as const)("maps %s to %s", (mode, permissionMode) => {
+    expect(qoderRuntimePermissionForMode(mode)).toBe(permissionMode);
   });
 });
 

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.test.ts
@@ -3,8 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { defineRuntimeDriver } from "@pragma/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import type { DesktopToolPermissionMode } from "../../../shared/contracts/index.ts";
 import {
   codexRuntimePermissionsForMode,
   createRuntimeEnvironmentService,
@@ -68,6 +69,143 @@ describe("RuntimeEnvironmentService", () => {
         },
       }),
     ).rejects.toThrow("thinking level is unavailable");
+  });
+
+  it("reuses one adapter for the same immutable revision and permission mode", async () => {
+    const pragmaHome = await mkdtemp(join(tmpdir(), "pragma-runtime-cache-"));
+    const store = createRuntimeEnvironmentStore({
+      pragmaHome,
+      builtIns: [definition("runtime", "Runtime")],
+      defaultRuntimeId: "runtime",
+    });
+    let createCount = 0;
+    let modelCatalogCallCount = 0;
+    let liveDiscoveryCount = 0;
+    let currentPermissionMode: DesktopToolPermissionMode = "request-approval";
+    const cachedFactory: RuntimeEnvironmentAdapterFactory = {
+      id: "test.runtime",
+      version: "v1",
+      create: (environment) => {
+        createCount += 1;
+        let cachedModels:
+          | readonly {
+              id: string;
+              displayName: string;
+              provider: {
+                kind: "registered";
+                id: string;
+                displayName: string;
+              };
+            }[]
+          | undefined;
+        return defineRuntimeDriver({
+          descriptor: {
+            id: environment.id,
+            kind: "test",
+            displayName: environment.displayName,
+          },
+          listModels: async () => {
+            modelCatalogCallCount += 1;
+            if (cachedModels === undefined) {
+              liveDiscoveryCount += 1;
+              cachedModels = [
+                {
+                  id: "model",
+                  displayName: "Model",
+                  provider: { kind: "registered", id: "provider", displayName: "Provider" },
+                },
+              ];
+            }
+            return cachedModels;
+          },
+          createSession: () => ({}),
+          startTurn: () => ({ outputText: "" }),
+          mapEvent: () => ({ events: [] }),
+        });
+      },
+    };
+    const service = createRuntimeEnvironmentService({
+      store,
+      factories: [cachedFactory],
+      getToolPermissionMode: () => currentPermissionMode,
+    });
+    const selection = { model: { providerId: "provider", modelId: "model" } };
+
+    const [first, second] = await Promise.all([
+      service.bind({ modelSelection: selection }),
+      service.bind({ modelSelection: selection }),
+    ]);
+    await service.resolve({ binding: first.binding, modelSelection: selection });
+    await service.list();
+
+    expect(first.adapter).toBe(second.adapter);
+    expect(createCount).toBe(1);
+    // Model selection remains validated on every boundary. The long-lived adapter owns the
+    // runtime-specific catalog cache, so external discovery is not reset by materialization.
+    expect(modelCatalogCallCount).toBe(3);
+    expect(liveDiscoveryCount).toBe(1);
+
+    await service.forToolPermissionMode("full-access").bind();
+    expect(createCount).toBe(2);
+
+    currentPermissionMode = "full-access";
+    await service.bind();
+    expect(createCount).toBe(2);
+
+    currentPermissionMode = "auto-approve";
+    await service.bind();
+    expect(createCount).toBe(3);
+
+    const original = (await store.getRevision("runtime"))!;
+    await store.update({
+      expectedRevision: original.revision,
+      definition: { ...original.definition, displayName: "Runtime v2" },
+    });
+    await service.bind();
+    expect(createCount).toBe(4);
+  });
+
+  it("evicts a failed adapter materialization so a later bind can recover", async () => {
+    const pragmaHome = await mkdtemp(join(tmpdir(), "pragma-runtime-cache-retry-"));
+    const store = createRuntimeEnvironmentStore({
+      pragmaHome,
+      builtIns: [definition("runtime", "Runtime")],
+      defaultRuntimeId: "runtime",
+    });
+    let createCount = 0;
+    const retryingFactory: RuntimeEnvironmentAdapterFactory = {
+      id: "test.runtime",
+      version: "v1",
+      create: async (environment) => {
+        createCount += 1;
+        if (createCount === 1) throw new Error("transient adapter failure");
+        return defineRuntimeDriver({
+          descriptor: {
+            id: environment.id,
+            kind: "test",
+            displayName: environment.displayName,
+          },
+          createSession: () => ({}),
+          startTurn: () => ({ outputText: "" }),
+          mapEvent: () => ({ events: [] }),
+        });
+      },
+    };
+    const warn = vi.fn();
+    const service = createRuntimeEnvironmentService({
+      store,
+      factories: [retryingFactory],
+      logger: { info: vi.fn(), warn },
+    });
+
+    await expect(service.bind()).rejects.toThrow("transient adapter failure");
+    await expect(service.bind()).resolves.toMatchObject({ binding: { runtimeId: "runtime" } });
+    expect(createCount).toBe(2);
+    expect(warn).toHaveBeenCalledWith(
+      "runtime.environment_adapter_materialization_failed",
+      expect.any(String),
+      expect.objectContaining({ runtimeId: "runtime", error: expect.any(Error) }),
+    );
   });
 });
 

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
@@ -11,6 +11,8 @@ import {
   type CodexRuntimeSandboxMode,
 } from "@pragma/runtime-codex";
 import { createPiRuntime } from "@pragma/runtime-pi";
+import { createQoderCliRuntime } from "@pragma/runtime-qodercli";
+import type { QoderCliRuntimePermissionMode } from "@pragma/runtime-qodercli";
 
 import type {
   DesktopToolPermissionMode,
@@ -205,6 +207,21 @@ export function createBuiltInRuntimeFactories(
       },
     },
     {
+      id: "pragma.runtime.qodercli",
+      version: "v1",
+      create: async (environment, context) => {
+        assertEmptyRuntimeConfig(environment);
+        const permissionMode = context?.toolPermissionMode ?? (await getToolPermissionMode());
+        return createQoderCliRuntime({
+          descriptor: { id: environment.id, displayName: environment.displayName },
+          ...(onModelCatalogUpdated === undefined
+            ? {}
+            : { onModelCatalogUpdated: () => onModelCatalogUpdated(environment.id) }),
+          permissionMode: qoderRuntimePermissionForMode(permissionMode),
+        });
+      },
+    },
+    {
       id: "pragma.runtime.pi",
       version: "v1",
       create: (environment) => {
@@ -225,6 +242,16 @@ export function codexRuntimePermissionsForMode(mode: DesktopToolPermissionMode):
   return mode === "full-access"
     ? { sandboxMode: "danger-full-access", approvalPolicy: "never" }
     : { sandboxMode: "workspace-write", approvalPolicy: "on-request" };
+}
+
+export function qoderRuntimePermissionForMode(
+  mode: DesktopToolPermissionMode,
+): QoderCliRuntimePermissionMode {
+  return mode === "request-approval"
+    ? "default"
+    : mode === "auto-approve"
+      ? "auto"
+      : "bypassPermissions";
 }
 
 function factoryRef(id: string, version: string): string {

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
@@ -3,6 +3,7 @@ import type {
   RuntimeAdapter,
   RuntimeModelSelection,
   RuntimeResolver,
+  PragmaLogger,
 } from "@pragma/core";
 import { createClaudeCodeRuntime } from "@pragma/runtime-claude-code";
 import {
@@ -48,8 +49,14 @@ export interface RuntimeEnvironmentService extends RuntimeResolver {
 export function createRuntimeEnvironmentService(options: {
   readonly store: RuntimeEnvironmentStore;
   readonly factories: readonly RuntimeEnvironmentAdapterFactory[];
+  readonly logger?: Pick<PragmaLogger, "info" | "warn"> | undefined;
+  readonly getToolPermissionMode?:
+    | (() => DesktopToolPermissionMode | Promise<DesktopToolPermissionMode>)
+    | undefined;
 }): RuntimeEnvironmentService {
+  const MATERIALIZED_ADAPTER_CACHE_LIMIT = 64;
   const factories = new Map<string, RuntimeEnvironmentAdapterFactory>();
+  const materializedAdapters = new Map<string, Promise<RuntimeAdapter>>();
   for (const factory of options.factories) {
     const ref = factoryRef(factory.id, factory.version);
     if (factories.has(ref)) throw new Error(`Duplicate Runtime adapter factory: ${ref}.`);
@@ -60,15 +67,89 @@ export function createRuntimeEnvironmentService(options: {
     revision: RuntimeEnvironmentRevision,
     toolPermissionMode?: DesktopToolPermissionMode,
   ): Promise<ResolvedRuntime> => {
+    const effectiveToolPermissionMode =
+      toolPermissionMode ?? (await options.getToolPermissionMode?.());
     const definition = revision.definition;
     const ref = factoryRef(definition.adapter.id, definition.adapter.version);
     const factory = factories.get(ref);
     if (factory === undefined)
       throw new Error(`Runtime adapter factory is not registered: ${ref}.`);
-    const adapter = await factory.create(
-      definition,
-      toolPermissionMode === undefined ? undefined : { toolPermissionMode },
-    );
+    const cacheKey = [
+      revision.runtimeId,
+      revision.revision,
+      revision.fingerprint,
+      ref,
+      effectiveToolPermissionMode ?? "default",
+    ].join("\0");
+    let adapterPromise = materializedAdapters.get(cacheKey);
+    const cacheHit = adapterPromise !== undefined;
+    if (adapterPromise === undefined) {
+      const materializeStartedAt = performance.now();
+      adapterPromise = Promise.resolve(
+        factory.create(
+          definition,
+          effectiveToolPermissionMode === undefined
+            ? undefined
+            : { toolPermissionMode: effectiveToolPermissionMode },
+        ),
+      );
+      void adapterPromise
+        .then(
+          () => {
+            options.logger?.info(
+              "runtime.environment_adapter_materialized",
+              "Runtime Environment adapter materialized",
+              {
+                runtimeId: revision.runtimeId,
+                revision: revision.revision,
+                fingerprint: revision.fingerprint,
+                toolPermissionMode: effectiveToolPermissionMode ?? "default",
+                durationMs: environmentElapsedMs(materializeStartedAt),
+              },
+            );
+          },
+          (error: unknown) => {
+            if (materializedAdapters.get(cacheKey) === adapterPromise) {
+              materializedAdapters.delete(cacheKey);
+            }
+            options.logger?.warn(
+              "runtime.environment_adapter_materialization_failed",
+              "Runtime Environment adapter materialization failed",
+              {
+                runtimeId: revision.runtimeId,
+                revision: revision.revision,
+                fingerprint: revision.fingerprint,
+                toolPermissionMode: effectiveToolPermissionMode ?? "default",
+                durationMs: environmentElapsedMs(materializeStartedAt),
+                error,
+              },
+            );
+          },
+        )
+        .catch(() => undefined);
+      materializedAdapters.set(cacheKey, adapterPromise);
+      while (materializedAdapters.size > MATERIALIZED_ADAPTER_CACHE_LIMIT) {
+        const oldest = materializedAdapters.keys().next().value as string | undefined;
+        if (oldest === undefined || oldest === cacheKey) break;
+        materializedAdapters.delete(oldest);
+      }
+    } else {
+      materializedAdapters.delete(cacheKey);
+      materializedAdapters.set(cacheKey, adapterPromise);
+    }
+    const adapter = await adapterPromise;
+    if (cacheHit) {
+      options.logger?.info(
+        "runtime.environment_adapter_cache_hit",
+        "Reused a Runtime Environment adapter",
+        {
+          runtimeId: revision.runtimeId,
+          revision: revision.revision,
+          fingerprint: revision.fingerprint,
+          toolPermissionMode: effectiveToolPermissionMode ?? "default",
+        },
+      );
+    }
     if (adapter.descriptor.id !== definition.id) {
       throw new Error(
         `Runtime adapter identity mismatch: expected ${definition.id}, received ${adapter.descriptor.id}.`,
@@ -92,7 +173,19 @@ export function createRuntimeEnvironmentService(options: {
     if (resolved.adapter.listModels === undefined) {
       throw new Error(`Runtime does not expose a model catalog: ${resolved.binding.runtimeId}.`);
     }
+    const discoveryStartedAt = performance.now();
     const models = await resolved.adapter.listModels();
+    options.logger?.info(
+      "runtime.model_catalog_validation",
+      "Runtime model selection catalog validation completed",
+      {
+        runtimeId: resolved.binding.runtimeId,
+        revision: resolved.binding.revision,
+        fingerprint: resolved.binding.fingerprint,
+        durationMs: environmentElapsedMs(discoveryStartedAt),
+        modelCount: models.length,
+      },
+    );
     const model = models.find(
       (candidate) =>
         candidate.id === selection.model.modelId &&
@@ -160,6 +253,10 @@ export function createRuntimeEnvironmentService(options: {
         ),
       ),
   };
+}
+
+function environmentElapsedMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
 export function createBuiltInRuntimeFactories(

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-store.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-store.test.ts
@@ -17,6 +17,7 @@ describe("RuntimeEnvironmentStore", () => {
       "pi",
       "codex",
       "claude-code",
+      "qodercli",
     ]);
 
     const original = (await store.getRevision("pi"))!;
@@ -35,4 +36,43 @@ describe("RuntimeEnvironmentStore", () => {
       "Set another default",
     );
   });
+
+  it("reconciles newly added built-ins without replacing an existing catalog", async () => {
+    const pragmaHome = await mkdtemp(join(tmpdir(), "pragma-runtime-reconcile-"));
+    const original = createRuntimeEnvironmentStore({
+      pragmaHome,
+      builtIns: [
+        definition("pi", "PI Runtime", "pragma.runtime.pi"),
+        definition("codex", "Codex", "pragma.runtime.codex"),
+      ],
+      defaultRuntimeId: "pi",
+    });
+    await original.initialize();
+    await original.setDefaultRuntimeId("codex");
+
+    const reconciled = createRuntimeEnvironmentStore({ pragmaHome });
+    await reconciled.initialize();
+
+    expect(await reconciled.getDefaultRuntimeId()).toBe("codex");
+    expect((await reconciled.listHeads()).map((head) => head.entry.runtimeId)).toEqual([
+      "pi",
+      "codex",
+      "claude-code",
+      "qodercli",
+    ]);
+    expect((await reconciled.getRevision("qodercli"))?.definition.adapter.id).toBe(
+      "pragma.runtime.qodercli",
+    );
+  });
 });
+
+function definition(id: string, displayName: string, adapterId: string) {
+  return {
+    schemaVersion: "pragma.runtime-environment/v1" as const,
+    id,
+    adapter: { id: adapterId, version: "v1" },
+    displayName,
+    origin: "built-in" as const,
+    config: {},
+  };
+}

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-store.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-store.ts
@@ -20,6 +20,7 @@ export const DEFAULT_RUNTIME_ENVIRONMENTS: readonly RuntimeEnvironmentDefinition
   environment("pi", "PI Runtime", "pragma.runtime.pi"),
   environment("codex", "Codex", "pragma.runtime.codex"),
   environment("claude-code", "Claude Code", "pragma.runtime.claude-code"),
+  environment("qodercli", "Qoder CLI", "pragma.runtime.qodercli"),
 ];
 
 export interface RuntimeEnvironmentHead {
@@ -79,9 +80,28 @@ export function createRuntimeEnvironmentStore(options: {
 
   const initialize = async (): Promise<void> => {
     await withFileLock(lockPath, async () => {
-      if ((await readOptionalJson(catalogPath)) !== undefined) return;
       if (!builtIns.some((definition) => definition.id === configuredDefault)) {
         throw new Error(`Default Runtime Environment is not built in: ${configuredDefault}.`);
+      }
+      const storedCatalog = await readOptionalJson(catalogPath);
+      if (storedCatalog !== undefined) {
+        const catalog = RuntimeEnvironmentCatalogSchema.parse(storedCatalog);
+        const entries = catalog.entries.map((value) =>
+          RuntimeEnvironmentCatalogEntrySchema.parse(value),
+        );
+        const knownIds = new Set(entries.map((entry) => entry.runtimeId));
+        const missing = builtIns.filter((definition) => !knownIds.has(definition.id));
+        if (missing.length === 0) return;
+
+        const now = new Date().toISOString();
+        const additions: RuntimeEnvironmentCatalogEntry[] = [];
+        for (const definition of missing) {
+          const revision = createRevision(definition, 1, "active", now);
+          await persistRevision(revision);
+          additions.push({ runtimeId: definition.id, latestRevision: 1 });
+        }
+        await writeCatalog(catalogPath, catalog.defaultRuntimeId, [...entries, ...additions]);
+        return;
       }
       const now = new Date().toISOString();
       const entries: RuntimeEnvironmentCatalogEntry[] = [];

--- a/apps/desktop/src/main/features/usage/usage-store.test.ts
+++ b/apps/desktop/src/main/features/usage/usage-store.test.ts
@@ -280,6 +280,7 @@ function observation(): RuntimeUsageObservation {
     },
     executor: { id: "expert-1", name: "expert-1" },
     usage: {
+      measurement: "reported",
       input: 100,
       output: 20,
       cacheRead: 30,

--- a/apps/desktop/src/main/features/usage/usage-store.ts
+++ b/apps/desktop/src/main/features/usage/usage-store.ts
@@ -266,6 +266,7 @@ export async function createDesktopUsageStore(input: {
             .digest("hex"),
           runId: `recovery:${observation.invocationId}`,
           usage: {
+            measurement: observation.usage.measurement,
             ...recovered,
             totalTokens,
             cost: {
@@ -478,6 +479,7 @@ function observationSignature(observation: RuntimeUsageObservation): string {
         runtimeId: observation.runtimeId,
         modelSelection: observation.modelSelection,
         usage: {
+          measurement: observation.usage.measurement,
           input: observation.usage.input,
           output: observation.usage.output,
           cacheRead: observation.usage.cacheRead,

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -13,6 +13,13 @@ export const missions = {
   contextPercentValue: "{{value}}%",
   contextCurrent: "Current context",
   contextTotal: "Total context",
+  usageMeasurement: "Measurement",
+  usageMeasurementValue: {
+    reported: "Reported by runtime",
+    derived: "Derived from runtime data",
+    estimated: "Estimated",
+    unknown: "Unknown",
+  },
   contextUnknown: "Unknown",
   contextUsageInvalid:
     "Runtime reported invalid context usage. Raw values are shown for diagnosis.",

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -181,4 +181,5 @@ export const missions = {
   statusSucceeded: "Succeeded",
   statusCancelled: "Cancelled",
   statusReady: "Ready",
+  statusPreparing: "Preparing",
 } as const;

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -176,4 +176,5 @@ export const missions = {
   statusSucceeded: "成功",
   statusCancelled: "已取消",
   statusReady: "就绪",
+  statusPreparing: "准备中",
 } as const;

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -13,6 +13,13 @@ export const missions = {
   contextPercentValue: "{{value}}%",
   contextCurrent: "当前上下文",
   contextTotal: "总上下文",
+  usageMeasurement: "统计口径",
+  usageMeasurementValue: {
+    reported: "运行时上报",
+    derived: "基于运行时数据推导",
+    estimated: "估算",
+    unknown: "未知",
+  },
   contextUnknown: "未知",
   contextUsageInvalid: "运行时上报的上下文用量异常，已保留原始数值用于诊断。",
   contextCompact: "压缩上下文",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -176,4 +176,5 @@ export const missions = {
   statusSucceeded: "成功",
   statusCancelled: "已取消",
   statusReady: "就緒",
+  statusPreparing: "準備中",
 } as const;

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -13,6 +13,13 @@ export const missions = {
   contextPercentValue: "{{value}}%",
   contextCurrent: "目前上下文",
   contextTotal: "總上下文",
+  usageMeasurement: "統計口徑",
+  usageMeasurementValue: {
+    reported: "執行階段回報",
+    derived: "依執行階段資料推導",
+    estimated: "估算",
+    unknown: "未知",
+  },
   contextUnknown: "未知",
   contextUsageInvalid: "執行階段回報的上下文用量異常，已保留原始數值供診斷。",
   contextCompact: "壓縮上下文",

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -47,6 +47,7 @@ describe("MissionsPage", () => {
 
     expect(html).toContain("mission-thinking-placeholder");
     expect(html).toContain("Product Designer is thinking");
+    expect(html).toContain("Preparing");
   });
 
   it("collapses search with upward-moving content and restores it in the reverse direction", () => {

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -1163,8 +1163,11 @@ export function MissionDetailFragment(props: {
     let refreshing = false;
     let refreshQueued = false;
     let frame: number | undefined;
+    let paintFrame: number | undefined;
+    let paintConfirmationFrame: number | undefined;
     let hiddenTimer: ReturnType<typeof setTimeout> | undefined;
     let pending: MissionChatUpdate[] = [];
+    const paintedExecutions = new Set<string>();
 
     const drainPending = (
       base: MissionChatSnapshot,
@@ -1238,11 +1241,36 @@ export function MissionDetailFragment(props: {
     const unsubscribe = api.subscribeMissionChat(props.mission.id, (update) => {
       pending.push(update);
       scheduleFlush();
+      const executionId = firstVisiblePatchExecutionId(update, chatRef.current);
+      if (executionId === undefined || paintedExecutions.has(executionId)) return;
+      paintedExecutions.add(executionId);
+      const receivedAt = performance.now();
+      api.reportRendererLog({
+        level: "info",
+        event: "mission.first_ui_token_received",
+        message: "Renderer received the first UI-visible Mission token",
+        missionId: props.mission.id,
+        executionId,
+      });
+      paintFrame = requestAnimationFrame(() => {
+        paintConfirmationFrame = requestAnimationFrame(() => {
+          api.reportRendererLog({
+            level: "info",
+            event: "mission.first_ui_token_painted",
+            message: "Renderer painted the first UI-visible Mission token",
+            missionId: props.mission.id,
+            executionId,
+            elapsedMs: Math.round((performance.now() - receivedAt) * 100) / 100,
+          });
+        });
+      });
     });
     void refresh().catch(() => undefined);
     return () => {
       cancelled = true;
       if (frame !== undefined) cancelAnimationFrame(frame);
+      if (paintFrame !== undefined) cancelAnimationFrame(paintFrame);
+      if (paintConfirmationFrame !== undefined) cancelAnimationFrame(paintConfirmationFrame);
       if (hiddenTimer !== undefined) clearTimeout(hiddenTimer);
       unsubscribe();
     };
@@ -3092,6 +3120,32 @@ export function applyMissionChatPatches(
     };
   }
   return { ...snapshot, revision, entries };
+}
+
+function firstVisiblePatchExecutionId(
+  update: MissionChatUpdate,
+  snapshot: MissionChatSnapshot | null,
+): string | undefined {
+  if (update.kind !== "patch") return undefined;
+  for (const patch of update.patches) {
+    if (patch.type === "entry.upsert") {
+      if (
+        (patch.entry.kind === "assistant" || patch.entry.kind === "thinking") &&
+        patch.entry.content.length > 0
+      ) {
+        return patch.entry.executionId ?? snapshot?.execution?.id;
+      }
+      continue;
+    }
+    if (patch.type !== "entry.append" || patch.field !== "content" || patch.delta.length === 0) {
+      continue;
+    }
+    return (
+      snapshot?.entries.find((entry) => entry.id === patch.entryId)?.executionId ??
+      snapshot?.execution?.id
+    );
+  }
+  return undefined;
 }
 
 export function shouldClearMissionThinkingPlaceholder(

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -1669,7 +1669,11 @@ export function MissionDetailFragment(props: {
           <h1 title={props.mission.title}>{props.mission.title}</h1>
           <p>
             <span className="mission-ready-dot" aria-hidden="true" />
-            {missionStatusLabel(props.mission)}
+            {missionStatusLabel(
+              props.mission,
+              clientOperation.kind === "sending" ||
+                (props.mission.execution === undefined && thinkingRequestId !== null),
+            )}
             <span aria-hidden="true">·</span>
             <Folder size={16} aria-hidden="true" />
             {props.mission.workspace.basename}
@@ -3268,8 +3272,15 @@ function workStatusLabel(status: MissionWorkRecord["status"]): string {
   }
 }
 
-function missionStatusLabel(mission: Mission | MissionSummary): string {
+export function missionStatusLabel(mission: Mission | MissionSummary, preparing = false): string {
   if (mission.lifecycleStatus === "completed") return i18n.t("statusCompleted", { ns: "missions" });
+  if (
+    preparing &&
+    (mission.execution === undefined ||
+      !["queued", "running", "waiting"].includes(mission.execution.status))
+  ) {
+    return i18n.t("statusPreparing", { ns: "missions" });
+  }
   switch (mission.execution?.status) {
     case "queued":
       return i18n.t("statusQueued", { ns: "missions" });

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -2287,6 +2287,12 @@ export function ContextWindowControl(props: {
                   : tokenFormatter.format(usage.contextWindowTokens)}
               </dd>
             </div>
+            {usage === undefined ? null : (
+              <div>
+                <dt>{t("usageMeasurement")}</dt>
+                <dd>{t(`usageMeasurementValue.${usage.measurement}`)}</dd>
+              </div>
+            )}
           </dl>
           <button
             className="mission-context-compact"

--- a/apps/desktop/src/shared/contracts/logging.ts
+++ b/apps/desktop/src/shared/contracts/logging.ts
@@ -2,11 +2,14 @@ import { z } from "zod";
 
 export const DesktopRendererLogSchema = z
   .object({
-    level: z.enum(["warn", "error"]),
+    level: z.enum(["info", "warn", "error"]),
     event: z.string().regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/),
     message: z.string().min(1).max(8_192),
     errorMessage: z.string().max(8_192).optional(),
     stack: z.string().max(32_768).optional(),
+    missionId: z.string().min(1).optional(),
+    executionId: z.string().min(1).optional(),
+    elapsedMs: z.number().nonnegative().finite().optional(),
   })
   .strict();
 export type DesktopRendererLog = z.infer<typeof DesktopRendererLogSchema>;

--- a/docs/adr/008-process-shared-execution-mcp-gateway.md
+++ b/docs/adr/008-process-shared-execution-mcp-gateway.md
@@ -7,14 +7,14 @@ Accepted
 ## Context
 
 PI runs inside the Pragma Node.js process and can call managed tools directly. Codex app-server and
-Claude Code run as child processes, so Pragma must expose default, managed, and upstream MCP tools
+Claude Code and Qoder CLI run as child processes, so Pragma must expose default, managed, and upstream MCP tools
 through a transport those processes can consume. Opening one loopback HTTP server per Runtime Session
 provided isolation but multiplied listeners, ports, and cleanup responsibilities as concurrency grew.
 
 ## Decision
 
-Each Pragma Node.js process owns one lazy loopback Execution MCP Gateway. The first Codex or Claude
-Code Runtime Session registration starts a listener on an operating-system-assigned port bound to
+Each Pragma Node.js process owns one lazy loopback Execution MCP Gateway. The first Codex, Claude
+Code, or Qoder CLI Runtime Session registration starts a listener on an operating-system-assigned port bound to
 `127.0.0.1`. The last registration disposal closes the listener; a later registration starts it again.
 
 Every Runtime Session keeps an independent MCP server, transport, tool set, context, approval handler,
@@ -23,14 +23,14 @@ and execution state behind the shared listener. The Gateway routes
 derived from external or system Session IDs, are not logged, and are revoked when the registration is
 disposed. Unknown and revoked routes return 404.
 
-Runtime Session identity remains separate from endpoint authorization. Codex and Claude Code use the
+Runtime Session identity remains separate from endpoint authorization. Codex, Claude Code, and Qoder CLI use the
 stable, short MCP configuration key `pragma`; a restored Session receives a new endpoint token and
 may receive a new listener port. Exposed tool names are deterministically bounded so the fully
 qualified `mcp__pragma__<tool>` name stays within the Runtime limit. PI does not use the Gateway.
 
 ## Consequences
 
-- Concurrent Codex and Claude Code Sessions share one HTTP listener without sharing tools or state.
+- Concurrent Codex, Claude Code, and Qoder CLI Sessions share one HTTP listener without sharing tools or state.
 - `PragmaApp` does not need a new process-lifecycle or `dispose()` API.
 - Session cleanup must always dispose its registration, including partial Runtime initialization.
 - The Gateway serializes start, registration, unregistration, and idle shutdown to avoid lifecycle races.

--- a/docs/adr/016-local-storage-lifecycle-and-content-addressing.md
+++ b/docs/adr/016-local-storage-lifecycle-and-content-addressing.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Accepted; the Codex cache-base decision is superseded by ADR 026.
 
 ## Context
 
@@ -27,12 +27,12 @@ across every revision and project. All revision manifests are GC roots until the
 explicitly deleted. Checkout directories are rebuildable hard-link views and never constitute
 authoritative project data.
 
-Codex uses one Pragma-managed immutable base per cache fingerprint and a private overlay per Runtime
-Context. The base owns rebuildable plugin, package, and catalog caches. The overlay owns generated
-configuration, skills links, native sessions, logs, temporary files, and a separate
-`CODEX_SQLITE_HOME`. Authentication has one Pragma credential projection. A writable Codex home is
-never shared between contexts. Mission-owned native sessions are retained until Mission deletion;
-stopping a process is not a storage deletion operation.
+Codex Runtime Context storage originally used one Pragma-managed immutable cache base per
+fingerprint and a private overlay. ADR 026 replaces that cache-base portion with a minimal
+per-Context Home projection. Generated configuration, copied Agent Skills, native sessions, logs,
+temporary files, and `CODEX_SQLITE_HOME` remain private. Authentication continues to use one Pragma
+credential projection. Mission-owned native sessions are retained until Mission deletion; stopping
+a process is not a storage deletion operation.
 
 Terminal Executions first materialize a Mission conversation projection, then move their canonical
 JSONL events into a gzip archive. The archive is readable through `ExecutionStore` while retained,
@@ -59,8 +59,8 @@ a process or machine failure without orphaning the legacy backup.
 
 - One small project change adds one blob, its ancestor trees, and a revision manifest instead of a
   complete project directory.
-- Identical Codex and plugin cache bytes have one physical owner, while mutable session data remains
-  isolated.
+- Mutable Codex session data remains isolated; ADR 026 defines how rebuildable native caches are
+  projected without a Pragma-owned full cache snapshot.
 - Keeping all Missions and all revisions can still consume the configured persistent capacity; the
   hard limit makes this bounded and requires an explicit owner deletion decision.
 - Mission chat remains readable after Execution diagnostic archives expire.

--- a/docs/adr/026-codex-minimal-home-projection.md
+++ b/docs/adr/026-codex-minimal-home-projection.md
@@ -1,0 +1,46 @@
+# ADR 026: Codex minimal Home projection
+
+## Status
+
+Accepted.
+
+## Context
+
+ADR 016 isolated Codex Runtime Contexts with a private writable Home backed by a versioned cache
+base. The base copied and fingerprinted the complete host `plugins`, `packages`, and `cache`
+directories. Current Codex installations can keep hundreds of megabytes of plugin packages and
+standalone releases there, even though an app-server Session only needs a small configuration
+snapshot, its own mutable state, and access to the rebuildable native plugin cache.
+
+Building the base made Session startup depend on the total host cache size. A symbolic link into the
+base also did not enforce filesystem immutability, so the cost did not establish a complete
+read-only boundary.
+
+## Decision
+
+Each Codex Runtime Context receives a minimal private `CODEX_HOME`:
+
+- `sessions`, logs, temporary files, configuration, model-cache state, and Agent Skills are private;
+- `CODEX_SQLITE_HOME` is a separate private directory;
+- authentication is projected through Pragma's protected credential store;
+- small user configuration files and a relative custom model catalog are atomically copied;
+- a fresh Context may seed `models_cache.json`, bound to the effective provider and catalog
+  configuration;
+- the host `~/.codex/plugins/cache` is linked directly as shared, rebuildable cache;
+- complete `plugins`, `packages`, generic `cache`, and host `sessions` trees are neither scanned nor
+  copied.
+
+If a host plugin cache exists but cannot be linked, Session preparation fails explicitly instead of
+copying the tree or silently removing native plugin capability. Existing Pragma cache bases are not
+deleted during preparation. The lease-aware storage maintenance path remains their bounded,
+recoverable cleanup mechanism.
+
+## Consequences
+
+- Managed Home preparation is independent of host package and plugin byte size.
+- Native plugin cache updates are visible across concurrent Contexts; it is explicitly classified as
+  rebuildable host cache rather than authoritative Session state.
+- Session history, SQLite databases, configuration, permissions, sandbox behavior, and Agent Skills
+  remain isolated.
+- Restoring a legacy Context replaces only known links into Pragma's old base and never follows them
+  to delete the base.

--- a/docs/adr/027-mission-latency-cache-and-runtime-warmup.md
+++ b/docs/adr/027-mission-latency-cache-and-runtime-warmup.md
@@ -1,0 +1,114 @@
+# ADR 027: Mission latency cache and Runtime warmup boundaries
+
+- Status: Accepted
+- Date: 2026-07-29
+
+## Context
+
+Desktop Mission traces showed that projection into the UI takes only 0–2 ms, while a new Mission
+spent roughly 1 second checking storage, 4–5.5 seconds compiling, 2–5 seconds initializing a
+Runtime, and 7–8 seconds waiting for the model's first token. Follow-up turns repeated about four
+seconds of compilation even though an `ExpertSession` already pinned the compiled execution
+definition.
+
+The compiler also repeated source parsing, artifact hashing, resource resolution, and environment
+work. Runtime adapters reconstructed MCP tool registries for sessions with identical immutable MCP
+configuration.
+
+## Decision
+
+### Follow-up Session fast path
+
+A live Mission `ExpertSession` is authoritative for follow-up turns while its compilation identity
+matches the Mission. The identity includes the immutable Project revision, executor reference,
+system Expert fingerprint, tool permission mode, and model override.
+
+Follow-up skips compilation on an identity hit. A miss recompiles. If the resulting execution
+definition fingerprint differs from the live Session fingerprint, Desktop closes the old Session
+and creates a successor rather than mutating a running `ExpertSession`.
+
+### Compiler-owned Blueprint cache
+
+`@pragma/interpreter` owns:
+
+- the cache key and compiler version;
+- the serializable Blueprint schema and validation;
+- L1 memory eviction and concurrent-load coalescing;
+- reconstruction, corruption handling, and fail-open behavior.
+
+The Host implements only `PragmaBlueprintCacheStore` byte `read`, `write`, and optional `remove`.
+Desktop stores L2 entries below `~/.pragma/cache/compiler-blueprints/sha256/`. Other Hosts may use
+memory, a directory, a database, or object storage without changing compiler semantics.
+
+The Blueprint contains normalized immutable DSL resources, relative provenance, artifact hashes,
+and diagnostics. It never contains an `ExpertSession`, Runtime session, resolved secret, mutable
+plugin instance, or other execution state. The source identity must name immutable content, such as
+a Project `snapshotHash`. Compiler-version changes produce a new key.
+
+Open immutable projects have a bounded service-level LRU. Validation is single-flight per project.
+Resource, plugin, and declarative dependency resolution is promise-memoized during one compile.
+Independent plugin, Runtime, Capability, and Context Store resolution starts concurrently after a
+cache miss. Artifact hashes from the loader are passed to adapters as verified values instead of
+being recalculated.
+
+### Storage admission
+
+Desktop creates one `StorageCapacityGuard` from the startup maintenance result. A fresh, below-soft
+limit snapshot admits writes without rescanning the Pragma home. The guard refreshes in the
+background, coalesces concurrent refreshes, synchronously refreshes stale or pressured snapshots,
+and preserves the hard-limit cleanup behavior.
+
+### Runtime reuse
+
+Codex and QoderCLI use a reference-counted MCP Tool Registry pool. External MCP configurations use
+a stable, redacted fingerprint; in-process configurations use object identity because functions
+must not be merged by serialization. Idle registries are bounded and expire.
+
+Sharing one Codex app-server process across Missions is not adopted. ADR 026 and the storage rules
+require each Runtime Context to have a private `CODEX_HOME`, `CODEX_SQLITE_HOME`, session tree,
+configuration, and logs. A single process has process-wide environment and configuration and would
+therefore weaken isolation, complicate ownership and cancellation, and risk cross-Context state.
+Each Mission continues to own an independent Codex thread and private process. Only explicitly
+rebuildable caches and the MCP Registry pool are shared. A future multiplexed Runtime protocol may
+revisit this if it can bind home, credentials, tools, cancellation, and accounting per thread.
+
+### Latency observations
+
+The diagnostic timeline distinguishes:
+
+1. `mission.message_accepted`;
+2. `mission.prepare_phase` for storage, compile/cache, binding, Session open, and prompt;
+3. `runtime.model_request_dispatched`;
+4. adapter ACK (`runtime.codex_request_acknowledged` or
+   `runtime.qodercli_request_acknowledged`);
+5. `runtime.first_protocol_event`;
+6. `runtime.first_reasoning_delta`;
+7. `runtime.first_text_delta`;
+8. `mission.first_ui_projection`;
+9. Renderer `mission.first_ui_token_received` and `mission.first_ui_token_painted`;
+10. `mission.final_result`.
+
+No prompt, model output, token, credential, or raw MCP configuration is logged.
+
+## Performance gates
+
+Deterministic tests enforce the local overhead gates:
+
+- warm live-Session follow-up admission below 250 ms;
+- warm serialized Blueprint load below 200 ms;
+- fresh storage admission snapshot below 50 ms.
+
+These gates cover Pragma-controlled overhead and deliberately exclude provider/model TTFT. Release
+profiling must group traces by Runtime, model, thinking level, tool count, context length bucket,
+Prompt Cache status, and cache-hit tier before changing model defaults or thinking policy.
+
+## Consequences
+
+Warm follow-ups avoid compilation entirely. New Missions and changed definitions still validate
+against an immutable cached Blueprint, then create fresh Core objects and mutable Sessions.
+Compiler cache corruption degrades to a cache miss. Cache entries remain rebuildable and are pruned
+by normal storage maintenance.
+
+Model TTFT remains an external and workload-sensitive component. The new milestones make model,
+thinking level, tool count, context length, and Prompt Cache experiments comparable without
+misattributing Runtime or UI time to the provider.

--- a/docs/architecture/current-architecture-overview.md
+++ b/docs/architecture/current-architecture-overview.md
@@ -44,7 +44,7 @@ Pragma 已经形成一个质量较好的**本地 Agent 执行内核**：Expert�
             ▼                           ▼
 ┌─────────────────────────┐   ┌─────────────────────────────┐
 │ @pragma/runtime-*       │   │ plugins/*                   │
-│ PI / Codex / Claude Code│   │ Memory / Repo Manager       │
+│ PI / Codex / Claude / Qoder│ │ Memory / Repo Manager       │
 └───────────┬─────────────┘   └─────────────────────────────┘
             │
             ▼
@@ -59,7 +59,7 @@ Pragma 已经形成一个质量较好的**本地 Agent 执行内核**：Expert�
 | 多专家协作         | 普通 Expert launcher 与 `defineExpertTeam()` 共用子 Invocation 委派机制              | 局部 subagent 与团队治理边界清晰                   |
 | Flow               | Task、HumanTask、Expert、Team、子 Flow 共用 Invocation Tree                          | 顶层对象收敛合理，恢复语义已有测试                 |
 | Execution          | Execution、Invocation、Canonical Event、Output 投影、ExpertSession 均有持久化 schema | 领域骨架完整；文件存储仍不适合直接上云             |
-| Runtime            | PI、Codex、Claude Code 分包实现统一 Runtime Driver                                   | 是目前最成熟、最值得保留的扩展边界                 |
+| Runtime            | PI、Codex、Claude Code、Qoder CLI 分包实现统一 Runtime Driver                        | 是目前最成熟、最值得保留的扩展边界                 |
 | Session 所有权     | ExpertSession / FlowExecution 显式拥有 Runtime Session，并有 claim、lease 和恢复校验 | 对避免 Session 串用和 TOCTOU 很重要，设计合理      |
 | Plugin             | 插件可贡献 MCP、Skill、Model、Tool、Approval 和生命周期 Hook                         | 扩展面丰富，但 SPI 与具体能力边界还可收敛          |
 | Context            | ContextSystem 支持多 Store、元数据、检索、写入与装配                                 | 能力完整，但实现体量已经过大                       |
@@ -84,7 +84,7 @@ Pragma 已经形成一个质量较好的**本地 Agent 执行内核**：Expert�
 
 ### 1. Core 不依赖具体 Runtime
 
-`@pragma/runtime-pi`、`@pragma/runtime-codex`、`@pragma/runtime-claude-code` 独立依赖 `@pragma/core`，Core 不反向依赖具体 Runtime。这使 Worker、Desktop 或未来云端执行器可以按部署环境装配 Runtime。
+`@pragma/runtime-pi`、`@pragma/runtime-codex`、`@pragma/runtime-claude-code`、`@pragma/runtime-qodercli` 独立依赖 `@pragma/core`，Core 不反向依赖具体 Runtime。这使 Worker、Desktop 或未来云端执行器可以按部署环境装配 Runtime。
 
 建议继续保持 Runtime 包彼此隔离，不引入跨 Runtime 的共享实现包；真正通用的契约或纯逻辑应回到 Core 或 Shared。
 
@@ -236,7 +236,7 @@ Desktop 将 Runtime environment 保存为独立的 Adapter binding：`runtimeId`
 获取显示名称、模型、Provider 和思考深度，不按已知 Runtime ID 分支。一个损坏或未知 Factory 的环境
 只会报告自身不可用，不影响其他环境和 Desktop 启动。
 
-PI Adapter 的模型目录来自 Desktop 注册的 Model Provider；Codex 和 Claude Code Adapter 使用各自的
+PI Adapter 的模型目录来自 Desktop 注册的 Model Provider；Codex、Claude Code 和 Qoder CLI Adapter 使用各自的
 原生模型发现能力。模型身份统一为 `providerId + modelId`，思考深度必须属于所选模型声明的集合。PI
 还会把声明集合与自身真实支持的思考深度取交集。RuntimeProfile 不再承载 Provider credential；凭据只
 由具体 Runtime Factory/Adapter 在运行时解析。

--- a/docs/architecture/diagnostic-logging.md
+++ b/docs/architecture/diagnostic-logging.md
@@ -333,12 +333,12 @@ Desktop creates the provider before storage bootstrap so bootstrap failures are 
   Expert compilation;
 - flushes on `before-quit` with a bounded deadline.
 
-The renderer cannot import Node-only Core. `@pragma/shared` defines a narrow report request and
-Desktop's preload exposes:
+The renderer cannot import Node-only Core. Desktop's browser-safe shared contracts define a narrow
+report request and Desktop's preload exposes:
 
 ```ts
 pragmaDesktop.diagnostics.report({
-  level: "warn" | "error" | "fatal",
+  level: "info" | "warn" | "error",
   component: "desktop.renderer",
   event,
   message,
@@ -348,8 +348,9 @@ pragmaDesktop.diagnostics.report({
 ```
 
 Main supplies trusted timestamp, boot/process identity, sequence, and final redaction. Renderer
-cannot choose file paths or bypass redaction. Routine renderer info/debug logs are disabled by
-default to avoid noisy IPC.
+cannot choose file paths or bypass redaction. Renderer info reports are reserved for bounded
+lifecycle measurements such as the first visible Mission token received and painted. Token chunks
+and routine UI activity are not reported.
 
 User-visible fatal pages show a short diagnostic id and actions to copy it or open the diagnostic
 folder. They do not show a raw stack by default.

--- a/docs/architecture/local-agent-bridge.md
+++ b/docs/architecture/local-agent-bridge.md
@@ -6,7 +6,7 @@
 
 本地 Agent 的入口是 Desktop App，不是 `apps/local-runner`。
 
-Desktop App 负责连接云端、注册本地能力、承载本地权限闸门，并调用本机 Claude Code、Codex 或自研 Agent。云端 Server/Worker 负责调度、治理、审计和 Trace。
+Desktop App 负责连接云端、注册本地能力、承载本地权限闸门，并调用本机 Claude Code、Codex、Qoder CLI 或自研 Agent。云端 Server/Worker 负责调度、治理、审计和 Trace。
 
 ## 架构链路
 
@@ -25,6 +25,7 @@ Desktop App
 ├── Workspace Scope
 ├── Claude Code Adapter
 ├── Codex Adapter
+├── Qoder CLI Adapter
 └── Self-hosted Agent Adapter
 ```
 
@@ -47,7 +48,7 @@ Desktop App
 - 本地工作区选择。
 - 主动连接云端 Runtime Gateway。
 - 注册本机 Runtime 能力。
-- 调用本机 Claude Code、Codex 或自研 Agent。
+- 调用本机 Claude Code、Codex、Qoder CLI 或自研 Agent。
 - 拦截文件、shell、git、网络和 secrets 访问。
 - 在敏感操作前展示本地确认 UI。
 - 回传日志、增量输出、tool call、diff、artifact 和最终结果。
@@ -61,6 +62,7 @@ Desktop App
 ```text
 Claude Code
 Codex
+Qoder CLI
 Self-hosted Agent
 企业内部 Agent
 ```

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -50,7 +50,7 @@ examples    -> runtime-* / plugin-* / core -> shared
 
 Cross-package imports must use `@pragma/*` names, not relative paths.
 
-Expert Agents are cloud-first execution units scheduled by Server/Worker. Future local Claude Code, Codex, or self-hosted runtimes should be reached through the Desktop App local bridge. The Desktop App actively connects to the cloud Runtime Gateway, registers local capabilities, enforces local permissions, and invokes local Agent adapters. Do not add `apps/local-runner`; the product entry for local Agent bridging is `apps/desktop`.
+Expert Agents are cloud-first execution units scheduled by Server/Worker. Local Claude Code, Codex, Qoder CLI, or self-hosted runtimes should be reached through the Desktop App local bridge. The Desktop App actively connects to the cloud Runtime Gateway, registers local capabilities, enforces local permissions, and invokes local Agent adapters. Do not add `apps/local-runner`; the product entry for local Agent bridging is `apps/desktop`.
 
 Current runtime implementations:
 
@@ -87,7 +87,7 @@ client SDKs, Web UI, or database packages. `@pragma/interpreter` depends on Core
 to compile portable YAML declarations, while `@pragma/interpreter/ast` stays browser-safe. Concrete
 runtime packages depend on `@pragma/core` and are assembled by application entry points such as
 Worker. The default runtime selection is an application-layer decision; Worker currently registers
-PI and Codex runtimes and uses PI by default.
+PI, Codex, Claude Code, and Qoder CLI runtimes and uses PI by default.
 
 `@pragma/default-agent` owns the portable built-in general-purpose Pragma Agent definition and application-neutral host ports.
 It does not depend on Desktop, Electron, Web, Server, database code, or a concrete Runtime Adapter.

--- a/docs/conventions/runtime-usage-accounting.md
+++ b/docs/conventions/runtime-usage-accounting.md
@@ -61,8 +61,13 @@ Codex reports cached input as a subset of `input_tokens`. The adapter must subtr
 
 Verified against `@qoder-ai/qoder-agent-sdk 1.0.15`. The final `SDKResultMessage.usage` is the
 current query snapshot and reports uncached input, cache reads, cache creation, and output as
-separate categories. The adapter maps it as `reported` and must not add `modelUsage` or account
-quota data to the same turn.
+separate categories. The adapter maps a non-zero snapshot as `reported` and must not add
+`modelUsage` or account quota data to the same turn.
+
+Some Qoder CLI model providers return an all-zero final usage snapshot even though the model
+completed the request. In that case only, the adapter estimates the managed turn input and output
+with its deterministic token estimator and marks the snapshot as `estimated`. This fallback does
+not use context-window occupancy as cumulative Mission usage.
 
 `Query.getUsageInfo()` is an account credit/quota snapshot. It is diagnostic account state, not
 per-turn token usage or dollar cost.

--- a/docs/conventions/runtime-usage-accounting.md
+++ b/docs/conventions/runtime-usage-accounting.md
@@ -8,6 +8,8 @@ Runtime adapters must treat model usage emitted during a single runtime turn as 
 - Do not sum multiple usage-bearing events from the same Claude Code or Codex turn.
 - Runtime driver retry attempts are separate turns; the driver may add usage across attempts.
 - Session fallback readers should prefer per-turn usage over thread/session cumulative usage.
+- Every usage value declares whether it is `reported`, `derived`, `estimated`, or legacy `unknown`.
+  Aggregation retains the least precise measurement.
 
 ## Claude Code
 
@@ -55,6 +57,16 @@ Therefore the Codex adapter should prefer `last` / `last_token_usage` for a Prag
 
 Codex reports cached input as a subset of `input_tokens`. The adapter must subtract `cached_input_tokens` when mapping the mutually exclusive Pragma `input` and `cacheRead` categories.
 
+## Qoder CLI
+
+Verified against `@qoder-ai/qoder-agent-sdk 1.0.15`. The final `SDKResultMessage.usage` is the
+current query snapshot and reports uncached input, cache reads, cache creation, and output as
+separate categories. The adapter maps it as `reported` and must not add `modelUsage` or account
+quota data to the same turn.
+
+`Query.getUsageInfo()` is an account credit/quota snapshot. It is diagnostic account state, not
+per-turn token usage or dollar cost.
+
 ## Context-window occupancy
 
 Context-window occupancy is a separate runtime concern from billing usage. It is always scoped to
@@ -69,6 +81,10 @@ ExpertSession, or delegated-agent usage totals.
   never be used as context-window occupancy. Codex measurements are marked as `reported`.
 - Claude Code uses the most recent root assistant-message usage with the matching
   `result.modelUsage[model].contextWindow` denominator and marks the value as `derived`.
+- Qoder CLI uses `Query.getContextUsage()` and marks its current-session numerator and denominator
+  as `reported`. If that control request is unavailable, the adapter estimates the active managed
+  prompt and message state with a deterministic ASCII/non-ASCII heuristic and marks the result as
+  `estimated`; the fallback is an occupancy signal, not a billing-grade token count.
 - Immediately after compaction, a runtime may know the denominator while the new numerator is not
   yet available. In that case `usedTokens` and `percent` are `null`; callers must not substitute
   cumulative billing usage.

--- a/docs/migrations/local-storage-v3-ai-migration.md
+++ b/docs/migrations/local-storage-v3-ai-migration.md
@@ -144,7 +144,8 @@ Manifest 的 `updatedAt`，其他 Revision 使用目录 `mtime`，并在迁移�
 - 不迁移 `home/plugins/`、`home/packages/`、`home/cache/`、`home/skills/`、`home/logs/`、`home/tmp/`、
   Session 级 `auth.json`、复制的 `.env`、`config.json`、`config.toml` 或 `instructions.md`。
 - 不创建共享 Codex base、skills cache、链接或 `layout.json`；下一次 Runtime 恢复时由当前代码从用户
-  `CODEX_HOME` 重新生成。
+  `CODEX_HOME` 生成最小私有 Home，仅链接可重建的 `plugins/cache`，并将当前 Agent Skills 单独复制
+  到该 Context。
 - 如果当前用户的 `~/.codex/auth.json` 存在，可将其快照到
   `data/credentials/codex/auth.json`；不得从多个 Session 盲目选择互相冲突的 auth 副本。
 - 对每个非空 Codex `runtimeSessionRef.id`，必须在迁移后的 `home/sessions/` 或

--- a/examples/test/console-usage.test.ts
+++ b/examples/test/console-usage.test.ts
@@ -6,6 +6,7 @@ describe("console usage summary", () => {
   it("formats a session usage total", () => {
     expect(
       formatConsoleUsage({
+        measurement: "reported",
         input: 1_500,
         output: 150,
         cacheRead: 300,

--- a/packages/core/src/execution/execution-store.ts
+++ b/packages/core/src/execution/execution-store.ts
@@ -30,6 +30,7 @@ import {
 import {
   executionRecordMigrationChain,
   migrateExecutionInvocationsV5ToV6,
+  migrateInvocationUsageV7ToV8,
 } from "../storage/migrations/execution/index.ts";
 import { PragmaPaths } from "../storage/pragma-paths.ts";
 import {
@@ -279,14 +280,14 @@ export function createFileExecutionStore(
         const nextExecution = ExecutionRecordSchema.parse({
           ...current,
           ...request.executionPatch,
-          schemaVersion: "pragma.execution/v7",
+          schemaVersion: "pragma.execution/v8",
           executionId: request.executionId,
           version: current.version + 1,
           lastAppliedSequence: lastSequence,
           updatedAt: now,
         });
         const journal = ExecutionCommitJournalSchema.parse({
-          schemaVersion: "pragma.execution-transaction/v8",
+          schemaVersion: "pragma.execution-transaction/v9",
           commitId: request.commitId,
           signature,
           execution: nextExecution,
@@ -727,10 +728,13 @@ async function migrateExecutionState(paths: PragmaPaths, executionId: string): P
   const upgraded = executionRecordMigrationChain.upgrade(value);
   if (!upgraded.migrated) return;
   const storedInvocations = (await readJsonIfExists(paths.executionInvocations(executionId))) ?? [];
+  const usageMigratedInvocations = Array.isArray(storedInvocations)
+    ? storedInvocations.map(migrateInvocationUsageV7ToV8)
+    : storedInvocations;
   const invocations =
     upgraded.fromVersion === 5
-      ? migrateExecutionInvocationsV5ToV6(storedInvocations)
-      : InvocationSchema.array().parse(storedInvocations);
+      ? migrateExecutionInvocationsV5ToV6(usageMigratedInvocations)
+      : InvocationSchema.array().parse(usageMigratedInvocations);
   await applyAtomicStateMigration({
     aggregateRoot: paths.executionRoot(executionId),
     journalFile: paths.executionMigration(executionId),

--- a/packages/core/src/execution/expert-session-store.ts
+++ b/packages/core/src/execution/expert-session-store.ts
@@ -82,7 +82,7 @@ export function createFileExpertSessionStore(options: {
         const parsedRecord = ExpertSessionRecordSchema.parse(record);
         const rootContext = parsedRecord.contexts[parsedRecord.rootContextId]!;
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v6",
+          schemaVersion: "pragma.expert-session-transaction/v7",
           session: parsedRecord,
           prompts: [],
           events: [
@@ -165,7 +165,7 @@ export function createFileExpertSessionStore(options: {
         });
         const nextPrompts = PromptRequestSchema.array().parse([...prompts, prompt]);
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v6",
+          schemaVersion: "pragma.expert-session-transaction/v7",
           session: nextSession,
           prompts: nextPrompts,
           events: materializeSessionEvents(sessionId, events, [
@@ -213,7 +213,7 @@ export function createFileExpertSessionStore(options: {
         );
         const next = await action({ session: session.data, prompts });
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v6",
+          schemaVersion: "pragma.expert-session-transaction/v7",
           session: next.session,
           prompts: next.prompts,
           events: materializeSessionEvents(

--- a/packages/core/src/execution/expert-session.ts
+++ b/packages/core/src/execution/expert-session.ts
@@ -527,7 +527,7 @@ class ExpertSessionImpl implements ExpertSession {
     const modelSelection = options.modelSelection;
     const definitionKind = isExpertTeam(this.expert) ? "expert-team" : "expert";
     const execution: ExecutionRecord = {
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
       executionId: id,
       version: 0,
       kind: "expert-turn",

--- a/packages/core/src/execution/runtime-message-accumulator.ts
+++ b/packages/core/src/execution/runtime-message-accumulator.ts
@@ -147,6 +147,7 @@ export class RuntimeMessageAccumulator {
 }
 
 const EMPTY_USAGE: AgentMessageUsage = {
+  measurement: "reported",
   input: 0,
   output: 0,
   cacheRead: 0,

--- a/packages/core/src/expert-tools-mcp-server.ts
+++ b/packages/core/src/expert-tools-mcp-server.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { Readable } from "node:stream";
+import { isDeepStrictEqual } from "node:util";
 
 import {
   fromJsonSchema,
@@ -745,15 +746,81 @@ function toMcpInputSchema(schema: unknown): StandardSchemaWithJSON | undefined {
     return fromJsonSchema(defaultObjectJsonSchema());
   }
 
-  if (isStandardSchemaWithJson(schema)) {
+  // Zod decorates materialized z.toJSONSchema() results with Standard Schema metadata.
+  // Normalize those JSON documents instead of treating them as executable validators.
+  if (isStandardSchemaWithJson(schema) && !isJsonSchemaRecord(schema)) {
     return schema;
   }
 
   if (isRecord(schema)) {
-    return fromJsonSchema(schema as JsonSchemaType);
+    return fromJsonSchema(normalizeMcpJsonSchema(schema) as JsonSchemaType);
   }
 
   return fromJsonSchema(defaultObjectJsonSchema());
+}
+
+function isJsonSchemaRecord(schema: unknown): boolean {
+  if (!isRecord(schema)) return false;
+
+  return [
+    "$schema",
+    "$ref",
+    "$defs",
+    "definitions",
+    "type",
+    "properties",
+    "items",
+    "allOf",
+    "anyOf",
+    "oneOf",
+    "additionalProperties",
+  ].some((keyword) => Object.hasOwn(schema, keyword));
+}
+
+function normalizeMcpJsonSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const root = schema;
+
+  const visit = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      return value.map(visit);
+    }
+    if (!isRecord(value)) {
+      return value;
+    }
+
+    const reference = value["$ref"];
+    if (typeof reference === "string") {
+      const target = resolveLocalJsonSchemaReference(root, reference);
+      const siblings = Object.fromEntries(Object.entries(value).filter(([key]) => key !== "$ref"));
+      if (
+        target !== undefined &&
+        Object.keys(siblings).length > 0 &&
+        isDeepStrictEqual(siblings, target)
+      ) {
+        return { $ref: reference };
+      }
+    }
+
+    return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, visit(child)]));
+  };
+
+  return visit(schema) as Record<string, unknown>;
+}
+
+function resolveLocalJsonSchemaReference(
+  root: Record<string, unknown>,
+  reference: string,
+): unknown {
+  if (!reference.startsWith("#/")) return undefined;
+
+  let current: unknown = root;
+  for (const encodedSegment of reference.slice(2).split("/")) {
+    if (!isRecord(current)) return undefined;
+    const segment = decodeURIComponent(encodedSegment).replaceAll("~1", "/").replaceAll("~0", "~");
+    if (!Object.hasOwn(current, segment)) return undefined;
+    current = current[segment];
+  }
+  return current;
 }
 
 function defaultObjectJsonSchema(): JsonSchemaType {

--- a/packages/core/src/flow/flow-execution.ts
+++ b/packages/core/src/flow/flow-execution.ts
@@ -102,7 +102,7 @@ export class FlowExecutionManager {
     await validateFlowRuntimeConfiguration(flow, this.runtimes, runtimeId);
     const now = new Date().toISOString();
     const record: ExecutionRecord = {
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
       executionId,
       version: 0,
       kind: "flow",

--- a/packages/core/src/mcp-tool-registry-cache-key.ts
+++ b/packages/core/src/mcp-tool-registry-cache-key.ts
@@ -1,0 +1,55 @@
+import { createHash } from "node:crypto";
+
+import type { IExpertAgentMcpConfig, IExpertAgentMcpServer } from "./agent/expert-agent.ts";
+
+export function mcpToolRegistryCacheKey(
+  config: IExpertAgentMcpConfig | undefined,
+): string | IExpertAgentMcpConfig {
+  if (config === undefined) return "empty";
+  if (Object.values(config.mcpServers).some((server) => server.transport === "in-process")) {
+    return config;
+  }
+  const normalized = Object.entries(config.mcpServers)
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([id, server]) => [id, normalizeExternalMcpServer(server)]);
+  return createHash("sha256").update(stableStringify(normalized)).digest("hex");
+}
+
+function normalizeExternalMcpServer(server: IExpertAgentMcpServer): unknown {
+  if (server.transport === "in-process") {
+    throw new Error("In-process MCP Servers use object-identity cache keys.");
+  }
+  return {
+    ...server,
+    ...(server.transport === "stdio"
+      ? {
+          env: Object.entries(server.env ?? {}).toSorted(([left], [right]) =>
+            left.localeCompare(right),
+          ),
+        }
+      : server.token === undefined
+        ? {}
+        : {
+            token: createHash("sha256").update(server.token).digest("hex"),
+          }),
+    allowTools: [...(server.allowTools ?? [])].toSorted(),
+    disallowTools: [...(server.disallowTools ?? [])].toSorted(),
+    toolApprovals: Object.entries(server.toolApprovals ?? {}).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    return `{${Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}

--- a/packages/core/src/mcp-tools.ts
+++ b/packages/core/src/mcp-tools.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import {
   Client,
   SSEClientTransport,
@@ -12,6 +10,8 @@ import type {
   IExpertAgentMcpConfig,
   IExpertAgentMcpServer,
 } from "@pragma/core";
+
+import { mcpToolRegistryCacheKey } from "./mcp-tool-registry-cache-key.ts";
 
 export interface McpToolRegistry {
   readonly tools: readonly McpManagedTool[];
@@ -166,44 +166,6 @@ export function createMcpToolRegistryPool(
         }),
       );
     },
-  };
-}
-
-function mcpToolRegistryCacheKey(
-  config: IExpertAgentMcpConfig | undefined,
-): string | IExpertAgentMcpConfig {
-  if (config === undefined) return "empty";
-  if (Object.values(config.mcpServers).some((server) => server.transport === "in-process")) {
-    return config;
-  }
-  const normalized = Object.entries(config.mcpServers)
-    .toSorted(([left], [right]) => left.localeCompare(right))
-    .map(([id, server]) => [id, normalizeExternalMcpServer(server)]);
-  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
-}
-
-function normalizeExternalMcpServer(server: IExpertAgentMcpServer): unknown {
-  if (server.transport === "in-process") {
-    throw new Error("In-process MCP Servers use object-identity cache keys.");
-  }
-  return {
-    ...server,
-    ...(server.transport === "stdio"
-      ? {
-          env: Object.entries(server.env ?? {}).toSorted(([left], [right]) =>
-            left.localeCompare(right),
-          ),
-        }
-      : server.token === undefined
-        ? {}
-        : {
-            token: createHash("sha256").update(server.token).digest("hex"),
-          }),
-    allowTools: [...(server.allowTools ?? [])].toSorted(),
-    disallowTools: [...(server.disallowTools ?? [])].toSorted(),
-    toolApprovals: Object.entries(server.toolApprovals ?? {}).toSorted(([left], [right]) =>
-      left.localeCompare(right),
-    ),
   };
 }
 

--- a/packages/core/src/mcp-tools.ts
+++ b/packages/core/src/mcp-tools.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   Client,
   SSEClientTransport,
@@ -14,6 +16,16 @@ import type {
 export interface McpToolRegistry {
   readonly tools: readonly McpManagedTool[];
   readonly dispose: () => Promise<void>;
+}
+
+export interface McpToolRegistryLease {
+  readonly registry: McpToolRegistry;
+  readonly release: () => Promise<void>;
+}
+
+export interface McpToolRegistryPool {
+  readonly acquire: (config: IExpertAgentMcpConfig | undefined) => Promise<McpToolRegistryLease>;
+  readonly close: () => Promise<void>;
 }
 
 export interface McpManagedTool extends ExpertAgentManagedTool<string, unknown> {
@@ -63,6 +75,135 @@ export async function createMcpToolRegistry(
   return {
     tools,
     dispose: () => disposeMcpClients(clients),
+  };
+}
+
+export function createMcpToolRegistryPool(
+  options: {
+    readonly idleTtlMs?: number | undefined;
+    readonly maxIdleEntries?: number | undefined;
+  } = {},
+): McpToolRegistryPool {
+  const idleTtlMs = options.idleTtlMs ?? 5 * 60_000;
+  const maxIdleEntries = options.maxIdleEntries ?? 32;
+  const entries = new Map<
+    string | IExpertAgentMcpConfig,
+    {
+      readonly opening: Promise<McpToolRegistry>;
+      references: number;
+      releasedAt?: number | undefined;
+      timer?: ReturnType<typeof setTimeout> | undefined;
+    }
+  >();
+  let closed = false;
+
+  const disposeEntry = async (key: string | IExpertAgentMcpConfig): Promise<void> => {
+    const entry = entries.get(key);
+    if (entry === undefined || entry.references > 0) return;
+    entries.delete(key);
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    const registry = await entry.opening.catch(() => undefined);
+    await registry?.dispose();
+  };
+
+  const trimIdle = async (): Promise<void> => {
+    const idle = [...entries.entries()]
+      .filter(([, entry]) => entry.references === 0)
+      .toSorted(([, left], [, right]) => (left.releasedAt ?? 0) - (right.releasedAt ?? 0));
+    const excess = Math.max(0, idle.length - maxIdleEntries);
+    await Promise.all(idle.slice(0, excess).map(async ([key]) => await disposeEntry(key)));
+  };
+
+  return {
+    async acquire(config) {
+      if (closed) throw new Error("MCP Tool Registry pool is closed.");
+      const key = mcpToolRegistryCacheKey(config);
+      let entry = entries.get(key);
+      if (entry === undefined) {
+        const opening = createMcpToolRegistry(config);
+        entry = { opening, references: 0 };
+        entries.set(key, entry);
+        void opening.catch(() => {
+          if (entries.get(key)?.opening === opening) entries.delete(key);
+        });
+      }
+      if (entry.timer !== undefined) clearTimeout(entry.timer);
+      entry.timer = undefined;
+      entry.releasedAt = undefined;
+      entry.references += 1;
+      let released = false;
+      const registry = await entry.opening;
+      return {
+        registry,
+        async release() {
+          if (released) return;
+          released = true;
+          const current = entries.get(key);
+          if (current === undefined) return;
+          current.references = Math.max(0, current.references - 1);
+          if (current.references > 0) return;
+          current.releasedAt = Date.now();
+          current.timer = setTimeout(() => {
+            void disposeEntry(key).catch(() => undefined);
+          }, idleTtlMs);
+          current.timer.unref();
+          await trimIdle();
+        },
+      };
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      const values = [...entries.values()];
+      entries.clear();
+      for (const entry of values) {
+        if (entry.timer !== undefined) clearTimeout(entry.timer);
+      }
+      await Promise.allSettled(
+        values.map(async (entry) => {
+          const registry = await entry.opening;
+          await registry.dispose();
+        }),
+      );
+    },
+  };
+}
+
+function mcpToolRegistryCacheKey(
+  config: IExpertAgentMcpConfig | undefined,
+): string | IExpertAgentMcpConfig {
+  if (config === undefined) return "empty";
+  if (Object.values(config.mcpServers).some((server) => server.transport === "in-process")) {
+    return config;
+  }
+  const normalized = Object.entries(config.mcpServers)
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([id, server]) => [id, normalizeExternalMcpServer(server)]);
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+}
+
+function normalizeExternalMcpServer(server: IExpertAgentMcpServer): unknown {
+  if (server.transport === "in-process") {
+    throw new Error("In-process MCP Servers use object-identity cache keys.");
+  }
+  return {
+    ...server,
+    ...(server.transport === "stdio"
+      ? {
+          env: Object.entries(server.env ?? {}).toSorted(([left], [right]) =>
+            left.localeCompare(right),
+          ),
+        }
+      : server.token === undefined
+        ? {}
+        : {
+            token: createHash("sha256").update(server.token).digest("hex"),
+          }),
+    allowTools: [...(server.allowTools ?? [])].toSorted(),
+    disallowTools: [...(server.disallowTools ?? [])].toSorted(),
+    toolApprovals: Object.entries(server.toolApprovals ?? {}).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    ),
   };
 }
 

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -1022,8 +1022,8 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
       const turnResult = await (async () => {
         const requestStartedAt = performance.now();
         this.options.logger.info(
-          "runtime.model_request_started",
-          "Runtime adapter started the native model request",
+          "runtime.model_request_dispatched",
+          "Runtime adapter dispatched the native model request",
           { runId, attempt, isRetry: attempt > 1 },
         );
         try {

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -311,6 +311,10 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       systemSessionId,
     },
   });
+  const sessionStartedAt = performance.now();
+  logger.info("runtime.session_prepare_started", "Runtime Session preparation started", {
+    restoring: request.runtimeSession !== undefined,
+  });
   if (request.owner.ownerId.trim() === "") {
     throw new Error("Runtime Session ownerId must not be empty.");
   }
@@ -337,9 +341,12 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
   };
   const persistenceSpec = driver.resolvePersistence?.(prepareContext);
 
+  let phaseStartedAt = performance.now();
   await assertRuntimeCanUse(driver, descriptor);
+  logRuntimePhase(logger, "runtime.can_use", phaseStartedAt, sessionStartedAt);
   assertRequestedRuntimeSessionMatches(request.runtimeSession, descriptor);
 
+  phaseStartedAt = performance.now();
   let sessionRecord: RuntimeSessionRecord;
   if (request.runtimeSession === undefined) {
     sessionRecord = await createRuntimeSessionRecord({
@@ -361,6 +368,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       workspace: agent.workspace,
     });
   }
+  logRuntimePhase(logger, "runtime.session_record", phaseStartedAt, sessionStartedAt);
 
   let restoredRuntimeSessionId: string | undefined;
   let lifecycle: AgentLifecycle<ExpertAgentRunContext | undefined> | undefined;
@@ -372,6 +380,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       await ensureRuntimeSessionDir(persistenceSpec.sessionDir);
     }
 
+    phaseStartedAt = performance.now();
     const preparation = await dispatchExpertAgentHook(agent.hooks, "beforeSessionCreate", {
       agent,
       context: runContext,
@@ -387,7 +396,9 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
         preparation?.processEnvironment,
       ),
     };
+    logRuntimePhase(logger, "runtime.before_session_hook", phaseStartedAt, sessionStartedAt);
 
+    phaseStartedAt = performance.now();
     const restored = await persistenceProvider.restore({
       agentId: agent.id,
       owner: request.owner,
@@ -400,9 +411,18 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       metadata: persistenceSpec?.metadata,
     });
     restoredRuntimeSessionId = restored.restoredRuntimeSessionId;
+    logRuntimePhase(logger, "runtime.persistence_restore", phaseStartedAt, sessionStartedAt);
 
-    const prepared = (await driver.prepare?.(prepareContext)) ?? ({} as TPrepared);
-    const agentContext = await agent.buildContext(runContext, request.contextAssembly);
+    phaseStartedAt = performance.now();
+    const [prepared, agentContext] = await Promise.all([
+      Promise.resolve(driver.prepare?.(prepareContext)).then((value) => value ?? ({} as TPrepared)),
+      agent.buildContext(runContext, request.contextAssembly),
+    ]);
+    logRuntimePhase(logger, "runtime.prepare_and_context", phaseStartedAt, sessionStartedAt, {
+      systemPromptCharacters: agentContext.systemPrompt.length,
+      startupMessageCount: agentContext.startupMessages.length,
+      toolCount: agent.tools?.length ?? 0,
+    });
     let currentRuntimeSessionId = restoredRuntimeSessionId ?? request.runtimeSession?.id ?? "";
 
     const readSessionInfo = (): RuntimeSessionInfo => ({
@@ -507,10 +527,12 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       prepared,
       sessionInfo: readSessionInfo(),
     };
+    phaseStartedAt = performance.now();
     nativeSession =
       request.runtimeSession === undefined
         ? await driver.createSession(sessionContext)
         : await (driver.restoreSession ?? driver.createSession)(sessionContext);
+    logRuntimePhase(logger, "runtime.native_session_create", phaseStartedAt, sessionStartedAt);
     const snapshot = driver.readSession?.(nativeSession, { agent, runContext });
     currentRuntimeSessionId = snapshot?.runtimeSessionId ?? currentRuntimeSessionId;
     sessionRecord = await updateRuntimeSessionRecord(pragmaPaths, sessionRecord, {
@@ -570,6 +592,10 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       logger,
     });
     await request.onSessionInfo?.(readSessionInfo());
+    logger.info("runtime.session_ready", "Runtime Session preparation completed", {
+      elapsedMs: elapsedRuntimeMs(sessionStartedAt),
+      restored: request.runtimeSession !== undefined,
+    });
 
     return managedSession;
   } catch (error) {
@@ -994,8 +1020,14 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
           : createRuntimeOutputRetryPrompt(parseResult);
       controller.resetCapture();
       const turnResult = await (async () => {
+        const requestStartedAt = performance.now();
+        this.options.logger.info(
+          "runtime.model_request_started",
+          "Runtime adapter started the native model request",
+          { runId, attempt, isRetry: attempt > 1 },
+        );
         try {
-          return await this.options.driver.startTurn(this.options.nativeSession, {
+          const result = await this.options.driver.startTurn(this.options.nativeSession, {
             runId,
             attempt,
             isRetry: attempt > 1,
@@ -1008,6 +1040,12 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
             source: controller.source,
             stream: controller.writer,
           });
+          this.options.logger.info(
+            "runtime.model_request_finished",
+            "Runtime adapter finished the native model request",
+            { runId, attempt, durationMs: elapsedRuntimeMs(requestStartedAt) },
+          );
+          return result;
         } catch (error) {
           usage = mergeUsage(usage, controller.getUsage());
           observeUsage(usage);
@@ -1055,6 +1093,25 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
 
     return createRuntimeRunResult(runId, parseResult.value, usage);
   }
+}
+
+function logRuntimePhase(
+  logger: PragmaLogger,
+  phase: string,
+  phaseStartedAt: number,
+  sessionStartedAt: number,
+  attributes: Record<string, unknown> = {},
+): void {
+  logger.info("runtime.session_phase", `Runtime Session phase completed: ${phase}`, {
+    phase,
+    durationMs: elapsedRuntimeMs(phaseStartedAt),
+    elapsedMs: elapsedRuntimeMs(sessionStartedAt),
+    ...attributes,
+  });
+}
+
+function elapsedRuntimeMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
 interface RuntimeExecutionBinding {

--- a/packages/core/src/runtime/stream-controller.ts
+++ b/packages/core/src/runtime/stream-controller.ts
@@ -112,6 +112,8 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   let outputText = "";
   let usage: AgentMessageUsage | undefined;
   let runtimeSessionId: string | undefined;
+  const streamStartedAt = performance.now();
+  let firstNativeDeltaLogged = false;
 
   const emit = (event: RuntimeStreamEventInput): void => {
     const emitted = emitter.emit(event);
@@ -128,6 +130,17 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   };
 
   const applyMappingResult = (result: RuntimeEventMappingResult): void => {
+    if (!firstNativeDeltaLogged && containsNativeDelta(result)) {
+      firstNativeDeltaLogged = true;
+      options.logger.info(
+        "runtime.first_native_delta",
+        "Runtime emitted its first native text or thinking delta",
+        {
+          runId: options.runId,
+          elapsedMs: Math.round((performance.now() - streamStartedAt) * 100) / 100,
+        },
+      );
+    }
     for (const event of result.events ?? []) {
       emit(event);
     }
@@ -172,6 +185,17 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
       emitter.complete();
     },
   };
+}
+
+function containsNativeDelta(result: RuntimeEventMappingResult): boolean {
+  if (result.outputDelta !== undefined && result.outputDelta.length > 0) return true;
+  return (result.events ?? []).some(
+    (event) =>
+      (event.type === "message.delta" || event.type === "thought.delta") &&
+      "delta" in event.payload &&
+      typeof event.payload.delta === "string" &&
+      event.payload.delta.length > 0,
+  );
 }
 
 export function createRuntimeStreamEventFactory(

--- a/packages/core/src/runtime/stream-controller.ts
+++ b/packages/core/src/runtime/stream-controller.ts
@@ -113,7 +113,9 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   let usage: AgentMessageUsage | undefined;
   let runtimeSessionId: string | undefined;
   const streamStartedAt = performance.now();
-  let firstNativeDeltaLogged = false;
+  let firstNativeEventLogged = false;
+  let firstReasoningDeltaLogged = false;
+  let firstTextDeltaLogged = false;
 
   const emit = (event: RuntimeStreamEventInput): void => {
     const emitted = emitter.emit(event);
@@ -130,16 +132,23 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   };
 
   const applyMappingResult = (result: RuntimeEventMappingResult): void => {
-    if (!firstNativeDeltaLogged && containsNativeDelta(result)) {
-      firstNativeDeltaLogged = true;
+    if (!firstReasoningDeltaLogged && containsReasoningDelta(result)) {
+      firstReasoningDeltaLogged = true;
       options.logger.info(
-        "runtime.first_native_delta",
-        "Runtime emitted its first native text or thinking delta",
+        "runtime.first_reasoning_delta",
+        "Runtime emitted its first reasoning delta",
         {
           runId: options.runId,
           elapsedMs: Math.round((performance.now() - streamStartedAt) * 100) / 100,
         },
       );
+    }
+    if (!firstTextDeltaLogged && containsTextDelta(result)) {
+      firstTextDeltaLogged = true;
+      options.logger.info("runtime.first_text_delta", "Runtime emitted its first text delta", {
+        runId: options.runId,
+        elapsedMs: Math.round((performance.now() - streamStartedAt) * 100) / 100,
+      });
     }
     for (const event of result.events ?? []) {
       emit(event);
@@ -160,6 +169,17 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
     source,
     writer: {
       writeNative(event) {
+        if (!firstNativeEventLogged) {
+          firstNativeEventLogged = true;
+          options.logger.info(
+            "runtime.first_protocol_event",
+            "Runtime delivered its first native protocol event",
+            {
+              runId: options.runId,
+              elapsedMs: Math.round((performance.now() - streamStartedAt) * 100) / 100,
+            },
+          );
+        }
         applyMappingResult(
           options.mapEvent(event, {
             runId: options.runId,
@@ -187,11 +207,21 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   };
 }
 
-function containsNativeDelta(result: RuntimeEventMappingResult): boolean {
+function containsTextDelta(result: RuntimeEventMappingResult): boolean {
   if (result.outputDelta !== undefined && result.outputDelta.length > 0) return true;
   return (result.events ?? []).some(
     (event) =>
-      (event.type === "message.delta" || event.type === "thought.delta") &&
+      event.type === "message.delta" &&
+      "delta" in event.payload &&
+      typeof event.payload.delta === "string" &&
+      event.payload.delta.length > 0,
+  );
+}
+
+function containsReasoningDelta(result: RuntimeEventMappingResult): boolean {
+  return (result.events ?? []).some(
+    (event) =>
+      event.type === "thought.delta" &&
       "delta" in event.payload &&
       typeof event.payload.delta === "string" &&
       event.payload.delta.length > 0,

--- a/packages/core/src/runtime/usage.ts
+++ b/packages/core/src/runtime/usage.ts
@@ -26,6 +26,7 @@ export interface UsageSink {
 }
 
 export interface RuntimeTokenUsageInput {
+  readonly measurement?: AgentMessageUsage["measurement"] | undefined;
   readonly inputTokens: number;
   readonly inputTokensIncludeCacheRead: boolean;
   readonly outputTokens: number;
@@ -36,6 +37,7 @@ export interface RuntimeTokenUsageInput {
 
 export function createEmptyUsage(): AgentMessageUsage {
   return {
+    measurement: "reported",
     input: 0,
     output: 0,
     cacheRead: 0,
@@ -62,6 +64,7 @@ export function createUsageFromTokenCounts(usage: RuntimeTokenUsageInput): Agent
   const cacheWrite1h = normalizeTokenCount(usage.cacheWrite1hTokens);
 
   return {
+    measurement: usage.measurement ?? "reported",
     input,
     output,
     cacheRead,
@@ -91,6 +94,7 @@ export function mergeUsage(
   }
 
   return {
+    measurement: mergeUsageMeasurement(current.measurement, next.measurement),
     input: current.input + next.input,
     output: current.output + next.output,
     cacheRead: current.cacheRead + next.cacheRead,
@@ -107,6 +111,20 @@ export function mergeUsage(
       total: current.cost.total + next.cost.total,
     },
   };
+}
+
+const USAGE_MEASUREMENT_RANK = {
+  reported: 0,
+  derived: 1,
+  estimated: 2,
+  unknown: 3,
+} as const;
+
+function mergeUsageMeasurement(
+  current: AgentMessageUsage["measurement"],
+  next: AgentMessageUsage["measurement"],
+): AgentMessageUsage["measurement"] {
+  return USAGE_MEASUREMENT_RANK[current] >= USAGE_MEASUREMENT_RANK[next] ? current : next;
 }
 
 export function mergeUsages(

--- a/packages/core/src/storage/migrations/execution-transaction/index.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/index.ts
@@ -1,17 +1,22 @@
 import { defineStateMigrationChain } from "../../state-migration.ts";
 import { executionTransactionV6ToV7Step } from "./steps/v6-to-v7.ts";
 import { executionTransactionV7ToV8Step } from "./steps/v7-to-v8.ts";
-import { ExecutionCommitJournalV8Schema, type ExecutionCommitJournalV8 } from "./schemas/v8.ts";
+import { executionTransactionV8ToV9Step } from "./steps/v8-to-v9.ts";
+import { ExecutionCommitJournalV9Schema, type ExecutionCommitJournalV9 } from "./schemas/v9.ts";
 
 export {
-  ExecutionCommitJournalV8Schema as ExecutionCommitJournalSchema,
-  type ExecutionCommitJournalV8 as ExecutionCommitJournal,
-} from "./schemas/v8.ts";
+  ExecutionCommitJournalV9Schema as ExecutionCommitJournalSchema,
+  type ExecutionCommitJournalV9 as ExecutionCommitJournal,
+} from "./schemas/v9.ts";
 
 export const executionCommitJournalMigrationChain =
-  defineStateMigrationChain<ExecutionCommitJournalV8>({
+  defineStateMigrationChain<ExecutionCommitJournalV9>({
     family: "pragma.execution-transaction",
-    currentVersion: 8,
-    currentSchema: ExecutionCommitJournalV8Schema,
-    steps: [executionTransactionV6ToV7Step, executionTransactionV7ToV8Step],
+    currentVersion: 9,
+    currentSchema: ExecutionCommitJournalV9Schema,
+    steps: [
+      executionTransactionV6ToV7Step,
+      executionTransactionV7ToV8Step,
+      executionTransactionV8ToV9Step,
+    ],
   });

--- a/packages/core/src/storage/migrations/execution-transaction/schemas/v6.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/schemas/v6.ts
@@ -2,6 +2,7 @@ import { ExecutionEventSchema, InvocationSchema } from "@pragma/shared";
 import { z } from "zod";
 
 import { ExecutionRecordV5Schema } from "../../execution/schemas/v5.ts";
+import { AgentMessageUsageV7Schema } from "../../execution/schemas/v7.ts";
 import { RuntimeContextRecordV4Schema } from "../../expert-session/schemas/v4.ts";
 
 const DefinitionReferenceV5Schema = z.object({
@@ -16,6 +17,7 @@ const InvocationV5Schema = InvocationSchema.omit({
 }).extend({
   definition: DefinitionReferenceV5Schema,
   output: z.unknown().optional(),
+  usage: AgentMessageUsageV7Schema.optional(),
 });
 
 const AgentInstanceV1Schema = z.object({

--- a/packages/core/src/storage/migrations/execution-transaction/schemas/v7.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/schemas/v7.ts
@@ -2,6 +2,7 @@ import { ExecutionEventSchema, InvocationSchema } from "@pragma/shared";
 import { z } from "zod";
 
 import { ExecutionRecordV6Schema } from "../../execution/schemas/v6.ts";
+import { AgentMessageUsageV7Schema } from "../../execution/schemas/v7.ts";
 import { RuntimeContextRecordV4Schema } from "../../expert-session/schemas/v4.ts";
 
 const DefinitionReferenceV6Schema = z.object({
@@ -12,6 +13,7 @@ const DefinitionReferenceV6Schema = z.object({
 
 const InvocationV6Schema = InvocationSchema.extend({
   definition: DefinitionReferenceV6Schema,
+  usage: AgentMessageUsageV7Schema.optional(),
 });
 
 const AgentInstanceV1DefinitionSchema = z.object({

--- a/packages/core/src/storage/migrations/execution-transaction/schemas/v8.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/schemas/v8.ts
@@ -6,14 +6,21 @@ import {
 } from "@pragma/shared";
 import { z } from "zod";
 
-import { ExecutionRecordV7Schema } from "../../execution/schemas/v7.ts";
+import {
+  AgentMessageUsageV7Schema,
+  ExecutionRecordV7Schema,
+} from "../../execution/schemas/v7.ts";
+
+const InvocationV7Schema = InvocationSchema.extend({
+  usage: AgentMessageUsageV7Schema.optional(),
+});
 
 export const ExecutionCommitJournalV8Schema = z.object({
   schemaVersion: z.literal("pragma.execution-transaction/v8"),
   commitId: z.string().min(1),
   signature: z.string().length(64),
   execution: ExecutionRecordV7Schema,
-  invocations: InvocationSchema.array(),
+  invocations: InvocationV7Schema.array(),
   agents: AgentInstanceSchema.array(),
   contexts: RuntimeContextRecordSchema.array(),
   events: ExecutionEventSchema.array(),

--- a/packages/core/src/storage/migrations/execution-transaction/schemas/v9.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/schemas/v9.ts
@@ -1,0 +1,23 @@
+import {
+  AgentInstanceSchema,
+  ExecutionEventSchema,
+  InvocationSchema,
+  RuntimeContextRecordSchema,
+} from "@pragma/shared";
+import { z } from "zod";
+
+import { ExecutionRecordV8Schema } from "../../execution/schemas/v8.ts";
+
+export const ExecutionCommitJournalV9Schema = z.object({
+  schemaVersion: z.literal("pragma.execution-transaction/v9"),
+  commitId: z.string().min(1),
+  signature: z.string().length(64),
+  execution: ExecutionRecordV8Schema,
+  invocations: InvocationSchema.array(),
+  agents: AgentInstanceSchema.array(),
+  contexts: RuntimeContextRecordSchema.array(),
+  events: ExecutionEventSchema.array(),
+  eventIds: z.array(z.string().min(1)),
+});
+
+export type ExecutionCommitJournalV9 = z.infer<typeof ExecutionCommitJournalV9Schema>;

--- a/packages/core/src/storage/migrations/execution-transaction/steps/v7-to-v8.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/steps/v7-to-v8.ts
@@ -1,5 +1,5 @@
 import type { StateMigrationStep } from "../../../state-migration.ts";
-import { executionRecordMigrationChain } from "../../execution/index.ts";
+import { executionV6ToV7Step } from "../../execution/steps/v6-to-v7.ts";
 import { ExecutionCommitJournalV7Schema } from "../schemas/v7.ts";
 import { ExecutionCommitJournalV8Schema } from "../schemas/v8.ts";
 
@@ -12,7 +12,7 @@ export const executionTransactionV7ToV8Step = {
     return ExecutionCommitJournalV8Schema.parse({
       ...journal,
       schemaVersion: "pragma.execution-transaction/v8",
-      execution: executionRecordMigrationChain.upgrade(journal.execution).value,
+      execution: executionV6ToV7Step.migrate(journal.execution),
       invocations: journal.invocations.map((invocation) => ({
         ...invocation,
         definition: {

--- a/packages/core/src/storage/migrations/execution-transaction/steps/v8-to-v9.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/steps/v8-to-v9.ts
@@ -1,0 +1,22 @@
+import type { StateMigrationStep } from "../../../state-migration.ts";
+import {
+  executionV7ToV8Step,
+  migrateInvocationUsageV7ToV8,
+} from "../../execution/steps/v7-to-v8.ts";
+import { ExecutionCommitJournalV8Schema } from "../schemas/v8.ts";
+import { ExecutionCommitJournalV9Schema } from "../schemas/v9.ts";
+
+export const executionTransactionV8ToV9Step = {
+  fromVersion: 8,
+  toVersion: 9,
+  inputSchema: ExecutionCommitJournalV8Schema,
+  migrate(value) {
+    const current = ExecutionCommitJournalV8Schema.parse(value);
+    return ExecutionCommitJournalV9Schema.parse({
+      ...current,
+      schemaVersion: "pragma.execution-transaction/v9",
+      execution: executionV7ToV8Step.migrate(current.execution),
+      invocations: current.invocations.map(migrateInvocationUsageV7ToV8),
+    });
+  },
+} satisfies StateMigrationStep;

--- a/packages/core/src/storage/migrations/execution/index.ts
+++ b/packages/core/src/storage/migrations/execution/index.ts
@@ -3,16 +3,19 @@ import { ExecutionRecordSchema, type ExecutionRecord } from "@pragma/shared";
 import { defineStateMigrationChain } from "../../state-migration.ts";
 import { executionV5ToV6Step } from "./steps/v5-to-v6.ts";
 import { executionV6ToV7Step } from "./steps/v6-to-v7.ts";
+import { executionV7ToV8Step } from "./steps/v7-to-v8.ts";
 
 export { ExecutionRecordV5Schema } from "./schemas/v5.ts";
 export { ExecutionRecordV6Schema } from "./schemas/v6.ts";
 export { ExecutionRecordV7Schema } from "./schemas/v7.ts";
+export { ExecutionRecordV8Schema } from "./schemas/v8.ts";
 export { migrateExecutionInvocationsV5ToV6 } from "./steps/v5-to-v6.ts";
 export { executionV5ToV6Step } from "./steps/v5-to-v6.ts";
+export { migrateInvocationUsageV7ToV8 } from "./steps/v7-to-v8.ts";
 
 export const executionRecordMigrationChain = defineStateMigrationChain<ExecutionRecord>({
   family: "pragma.execution",
-  currentVersion: 7,
+  currentVersion: 8,
   currentSchema: ExecutionRecordSchema,
-  steps: [executionV5ToV6Step, executionV6ToV7Step],
+  steps: [executionV5ToV6Step, executionV6ToV7Step, executionV7ToV8Step],
 });

--- a/packages/core/src/storage/migrations/execution/schemas/v7.ts
+++ b/packages/core/src/storage/migrations/execution/schemas/v7.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const AgentMessageUsageV7Schema = z.object({
+export const AgentMessageUsageV7Schema = z.object({
   input: z.number().nonnegative(),
   output: z.number().nonnegative(),
   cacheRead: z.number().nonnegative(),

--- a/packages/core/src/storage/migrations/execution/schemas/v8.ts
+++ b/packages/core/src/storage/migrations/execution/schemas/v8.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+const AgentMessageUsageV8Schema = z.object({
+  measurement: z.enum(["reported", "derived", "estimated", "unknown"]),
+  input: z.number().nonnegative(),
+  output: z.number().nonnegative(),
+  cacheRead: z.number().nonnegative(),
+  cacheWrite: z.number().nonnegative(),
+  cacheWrite1h: z.number().nonnegative().optional(),
+  totalTokens: z.number().nonnegative(),
+  cost: z.object({
+    input: z.number().nonnegative(),
+    output: z.number().nonnegative(),
+    cacheRead: z.number().nonnegative(),
+    cacheWrite: z.number().nonnegative(),
+    total: z.number().nonnegative(),
+  }),
+});
+
+const InvocationHandoffV8Schema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("inline"), value: z.unknown() }),
+  z.object({
+    type: z.literal("context"),
+    summary: z.string(),
+    contexts: z
+      .array(
+        z.object({
+          namespace: z.literal("pragma.handoff"),
+          id: z.string().min(1),
+          revision: z.string().min(1),
+          sizeBytes: z.number().int().nonnegative(),
+          mediaType: z.string().min(1),
+        }),
+      )
+      .min(1),
+  }),
+]);
+
+export const ExecutionRecordV8Schema = z.object({
+  schemaVersion: z.literal("pragma.execution/v8"),
+  executionId: z.string().min(1),
+  version: z.number().int().nonnegative(),
+  kind: z.enum(["expert-turn", "flow"]),
+  definition: z.object({
+    id: z.string().min(1),
+    kind: z.enum(["flow", "task", "human-task", "expert", "expert-team"]),
+  }),
+  rootInvocationId: z.string().min(1),
+  status: z.enum([
+    "queued",
+    "running",
+    "waiting",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "interrupted",
+  ]),
+  input: z.unknown(),
+  state: z.record(z.string(), z.unknown()).default({}),
+  output: InvocationHandoffV8Schema.optional(),
+  usage: AgentMessageUsageV8Schema.optional(),
+  error: z.unknown().optional(),
+  lastAppliedSequence: z.number().int().nonnegative(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type ExecutionRecordV8 = z.infer<typeof ExecutionRecordV8Schema>;

--- a/packages/core/src/storage/migrations/execution/steps/v7-to-v8.ts
+++ b/packages/core/src/storage/migrations/execution/steps/v7-to-v8.ts
@@ -1,0 +1,37 @@
+import type { StateMigrationStep } from "../../../state-migration.ts";
+import { InvocationSchema } from "@pragma/shared";
+import { ExecutionRecordV7Schema } from "../schemas/v7.ts";
+import { ExecutionRecordV8Schema } from "../schemas/v8.ts";
+
+export const executionV7ToV8Step = {
+  fromVersion: 7,
+  toVersion: 8,
+  inputSchema: ExecutionRecordV7Schema,
+  migrate(value) {
+    const current = ExecutionRecordV7Schema.parse(value);
+    return ExecutionRecordV8Schema.parse({
+      ...current,
+      schemaVersion: "pragma.execution/v8",
+      ...(current.usage === undefined
+        ? {}
+        : { usage: { measurement: "unknown", ...current.usage } }),
+    });
+  },
+} satisfies StateMigrationStep;
+
+export function migrateInvocationUsageV7ToV8(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return value;
+  const invocation = value as Record<string, unknown>;
+  const usage = invocation["usage"];
+  if (usage === null || typeof usage !== "object" || Array.isArray(usage)) {
+    return value;
+  }
+  const usageRecord = usage as Record<string, unknown>;
+  return InvocationSchema.parse({
+    ...invocation,
+    usage:
+      typeof usageRecord["measurement"] === "string"
+        ? usage
+        : { measurement: "unknown", ...usageRecord },
+  });
+}

--- a/packages/core/src/storage/migrations/expert-session-transaction/index.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/index.ts
@@ -1,20 +1,25 @@
 import { defineStateMigrationChain } from "../../state-migration.ts";
 import { expertSessionTransactionV4ToV5Step } from "./steps/v4-to-v5.ts";
 import { expertSessionTransactionV5ToV6Step } from "./steps/v5-to-v6.ts";
+import { expertSessionTransactionV6ToV7Step } from "./steps/v6-to-v7.ts";
 import {
-  ExpertSessionTransactionJournalV6Schema,
-  type ExpertSessionTransactionJournalV6,
-} from "./schemas/v6.ts";
+  ExpertSessionTransactionJournalV7Schema,
+  type ExpertSessionTransactionJournalV7,
+} from "./schemas/v7.ts";
 
 export {
-  ExpertSessionTransactionJournalV6Schema as ExpertSessionTransactionJournalSchema,
-  type ExpertSessionTransactionJournalV6 as ExpertSessionTransactionJournal,
-} from "./schemas/v6.ts";
+  ExpertSessionTransactionJournalV7Schema as ExpertSessionTransactionJournalSchema,
+  type ExpertSessionTransactionJournalV7 as ExpertSessionTransactionJournal,
+} from "./schemas/v7.ts";
 
 export const expertSessionTransactionMigrationChain =
-  defineStateMigrationChain<ExpertSessionTransactionJournalV6>({
+  defineStateMigrationChain<ExpertSessionTransactionJournalV7>({
     family: "pragma.expert-session-transaction",
-    currentVersion: 6,
-    currentSchema: ExpertSessionTransactionJournalV6Schema,
-    steps: [expertSessionTransactionV4ToV5Step, expertSessionTransactionV5ToV6Step],
+    currentVersion: 7,
+    currentSchema: ExpertSessionTransactionJournalV7Schema,
+    steps: [
+      expertSessionTransactionV4ToV5Step,
+      expertSessionTransactionV5ToV6Step,
+      expertSessionTransactionV6ToV7Step,
+    ],
   });

--- a/packages/core/src/storage/migrations/expert-session-transaction/schemas/v6.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/schemas/v6.ts
@@ -1,7 +1,10 @@
 import { ExpertSessionEventSchema, InvocationSchema, PromptRequestSchema } from "@pragma/shared";
 import { z } from "zod";
 
-import { ExecutionRecordV7Schema } from "../../execution/schemas/v7.ts";
+import {
+  AgentMessageUsageV7Schema,
+  ExecutionRecordV7Schema,
+} from "../../execution/schemas/v7.ts";
 import { ExpertSessionRecordV5Schema } from "../../expert-session/schemas/v5.ts";
 
 export const ExpertSessionTransactionJournalV6Schema = z
@@ -11,7 +14,9 @@ export const ExpertSessionTransactionJournalV6Schema = z
     prompts: PromptRequestSchema.array(),
     events: ExpertSessionEventSchema.array(),
     execution: ExecutionRecordV7Schema.optional(),
-    rootInvocation: InvocationSchema.optional(),
+    rootInvocation: InvocationSchema.extend({
+      usage: AgentMessageUsageV7Schema.optional(),
+    }).optional(),
   })
   .refine(
     (journal) => (journal.execution === undefined) === (journal.rootInvocation === undefined),

--- a/packages/core/src/storage/migrations/expert-session-transaction/schemas/v7.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/schemas/v7.ts
@@ -1,0 +1,23 @@
+import { ExpertSessionEventSchema, InvocationSchema, PromptRequestSchema } from "@pragma/shared";
+import { z } from "zod";
+
+import { ExecutionRecordV8Schema } from "../../execution/schemas/v8.ts";
+import { ExpertSessionRecordV5Schema } from "../../expert-session/schemas/v5.ts";
+
+export const ExpertSessionTransactionJournalV7Schema = z
+  .object({
+    schemaVersion: z.literal("pragma.expert-session-transaction/v7"),
+    session: ExpertSessionRecordV5Schema,
+    prompts: PromptRequestSchema.array(),
+    events: ExpertSessionEventSchema.array(),
+    execution: ExecutionRecordV8Schema.optional(),
+    rootInvocation: InvocationSchema.optional(),
+  })
+  .refine(
+    (journal) => (journal.execution === undefined) === (journal.rootInvocation === undefined),
+    "ExpertSession transaction execution and rootInvocation must be provided together.",
+  );
+
+export type ExpertSessionTransactionJournalV7 = z.infer<
+  typeof ExpertSessionTransactionJournalV7Schema
+>;

--- a/packages/core/src/storage/migrations/expert-session-transaction/steps/v6-to-v7.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/steps/v6-to-v7.ts
@@ -1,0 +1,26 @@
+import type { StateMigrationStep } from "../../../state-migration.ts";
+import {
+  executionV7ToV8Step,
+  migrateInvocationUsageV7ToV8,
+} from "../../execution/steps/v7-to-v8.ts";
+import { ExpertSessionTransactionJournalV6Schema } from "../schemas/v6.ts";
+import { ExpertSessionTransactionJournalV7Schema } from "../schemas/v7.ts";
+
+export const expertSessionTransactionV6ToV7Step = {
+  fromVersion: 6,
+  toVersion: 7,
+  inputSchema: ExpertSessionTransactionJournalV6Schema,
+  migrate(value) {
+    const current = ExpertSessionTransactionJournalV6Schema.parse(value);
+    return ExpertSessionTransactionJournalV7Schema.parse({
+      ...current,
+      schemaVersion: "pragma.expert-session-transaction/v7",
+      ...(current.execution === undefined
+        ? {}
+        : {
+            execution: executionV7ToV8Step.migrate(current.execution),
+            rootInvocation: migrateInvocationUsageV7ToV8(current.rootInvocation),
+          }),
+    });
+  },
+} satisfies StateMigrationStep;

--- a/packages/core/src/storage/pragma-paths.ts
+++ b/packages/core/src/storage/pragma-paths.ts
@@ -305,6 +305,17 @@ export class PragmaPaths {
     return join(this.cacheRoot(), "agents");
   }
 
+  compilerBlueprintsCacheRoot(): string {
+    return join(this.cacheRoot(), "compiler-blueprints", "sha256");
+  }
+
+  compilerBlueprintCache(key: string): string {
+    if (!/^[a-f0-9]{64}$/.test(key)) {
+      throw new Error(`Invalid compiler Blueprint cache key: ${key}.`);
+    }
+    return join(this.compilerBlueprintsCacheRoot(), key.slice(0, 2), `${key}.json`);
+  }
+
   pluginPackagesCacheRoot(): string {
     return join(this.cacheRoot(), "plugins", "sha256");
   }

--- a/packages/core/src/storage/storage-maintenance.ts
+++ b/packages/core/src/storage/storage-maintenance.ts
@@ -31,6 +31,13 @@ export interface StorageMaintenanceResult {
   readonly reclaimedContentBytes: number;
 }
 
+export interface StorageCapacityGuard {
+  assertWriteAllowed(): Promise<void>;
+  refresh(): Promise<StorageOverview>;
+  current(): StorageOverview | undefined;
+  close(): void;
+}
+
 export class StorageCapacityExceededError extends Error {
   constructor(readonly overview: StorageOverview) {
     super(
@@ -74,6 +81,82 @@ export async function assertStorageWriteAllowed(
   if (maintenance.after.totalBytes >= policy.globalHardLimitBytes) {
     throw new StorageCapacityExceededError(maintenance.after);
   }
+}
+
+export function createStorageCapacityGuard(input: {
+  readonly paths: PragmaPaths;
+  readonly policy?: StoragePolicy | undefined;
+  readonly initialOverview?: StorageOverview | undefined;
+  readonly refreshIntervalMs?: number | undefined;
+  readonly maxSnapshotAgeMs?: number | undefined;
+  readonly now?: (() => number) | undefined;
+}): StorageCapacityGuard {
+  const policy = input.policy ?? DEFAULT_STORAGE_POLICY;
+  const refreshIntervalMs = input.refreshIntervalMs ?? 30_000;
+  const maxSnapshotAgeMs =
+    input.maxSnapshotAgeMs ??
+    (refreshIntervalMs > 0 ? refreshIntervalMs * 2 : Number.POSITIVE_INFINITY);
+  const now = input.now ?? Date.now;
+  let overview = input.initialOverview;
+  let inspectedAt = overview === undefined ? 0 : now();
+  let refreshing: Promise<StorageOverview> | undefined;
+  let closed = false;
+
+  const refresh = async (): Promise<StorageOverview> => {
+    if (refreshing !== undefined) return await refreshing;
+    const operation = inspectStorage(input.paths, policy).then((next) => {
+      overview = next;
+      inspectedAt = now();
+      return next;
+    });
+    refreshing = operation;
+    try {
+      return await operation;
+    } finally {
+      if (refreshing === operation) refreshing = undefined;
+    }
+  };
+
+  const interval =
+    refreshIntervalMs <= 0
+      ? undefined
+      : setInterval(() => {
+          if (!closed) void refresh().catch(() => undefined);
+        }, refreshIntervalMs);
+  interval?.unref();
+
+  return {
+    async assertWriteAllowed() {
+      let current = overview;
+      const age = now() - inspectedAt;
+      if (
+        current === undefined ||
+        current.totalBytes >= policy.globalSoftLimitBytes ||
+        age >= maxSnapshotAgeMs
+      ) {
+        current = await refresh();
+      } else if (refreshIntervalMs > 0 && age >= refreshIntervalMs) {
+        void refresh().catch(() => undefined);
+      }
+      if (current.totalBytes < policy.globalHardLimitBytes) return;
+      const maintenance = await runStorageMaintenance({
+        paths: input.paths,
+        policy,
+        pressure: true,
+      });
+      overview = maintenance.after;
+      inspectedAt = now();
+      if (maintenance.after.totalBytes >= policy.globalHardLimitBytes) {
+        throw new StorageCapacityExceededError(maintenance.after);
+      }
+    },
+    refresh,
+    current: () => overview,
+    close() {
+      closed = true;
+      if (interval !== undefined) clearInterval(interval);
+    },
+  };
 }
 
 export async function runStorageMaintenance(input: {
@@ -189,6 +272,7 @@ interface Candidate {
 
 async function collectCacheCandidates(paths: PragmaPaths): Promise<Candidate[]> {
   return [
+    ...(await hashDirectoryCandidates(paths.compilerBlueprintsCacheRoot())),
     ...(await hashDirectoryCandidates(paths.pluginPackagesCacheRoot())),
     ...(await unleasedCodexBaseCandidates(paths)),
     ...(await hashDirectoryCandidates(join(paths.codexRuntimeCacheRoot(), "skills"))),

--- a/packages/core/src/storage/storage-maintenance.ts
+++ b/packages/core/src/storage/storage-maintenance.ts
@@ -190,11 +190,41 @@ interface Candidate {
 async function collectCacheCandidates(paths: PragmaPaths): Promise<Candidate[]> {
   return [
     ...(await hashDirectoryCandidates(paths.pluginPackagesCacheRoot())),
-    ...(await directChildren(join(paths.codexRuntimeCacheRoot(), "bases"))),
+    ...(await unleasedCodexBaseCandidates(paths)),
     ...(await hashDirectoryCandidates(join(paths.codexRuntimeCacheRoot(), "skills"))),
     ...(await unleasedProjectViewCandidates(paths)),
     ...(await directChildren(paths.agentsCacheRoot())),
   ];
+}
+
+async function unleasedCodexBaseCandidates(paths: PragmaPaths): Promise<Candidate[]> {
+  const candidates = (await directChildren(join(paths.codexRuntimeCacheRoot(), "bases"))).filter(
+    (candidate) => /^[a-f0-9]{64}$/.test(basename(candidate.path)),
+  );
+  const leasesRoot = join(paths.codexRuntimeCacheRoot(), "base-leases");
+  const leasedFingerprints = new Set<string>();
+  for (const leaseDirectory of await directChildren(leasesRoot)) {
+    const fingerprint = basename(leaseDirectory.path);
+    if (!/^[a-f0-9]{64}$/.test(fingerprint)) continue;
+    if ((await stat(leaseDirectory.path).catch(() => undefined))?.isDirectory() !== true) continue;
+    let leased = false;
+    for (const lease of await directChildren(leaseDirectory.path)) {
+      let pid: unknown;
+      try {
+        pid = (JSON.parse(await readFile(lease.path, "utf8")) as { readonly pid?: unknown }).pid;
+      } catch {
+        pid = undefined;
+      }
+      if (typeof pid === "number" && isProcessAlive(pid)) {
+        leased = true;
+      } else {
+        await rm(lease.path, { force: true });
+      }
+    }
+    if (leased) leasedFingerprints.add(fingerprint);
+    else await removeEmptyDirectory(leaseDirectory.path);
+  }
+  return candidates.filter((candidate) => !leasedFingerprints.has(basename(candidate.path)));
 }
 
 async function unleasedProjectViewCandidates(paths: PragmaPaths): Promise<Candidate[]> {

--- a/packages/core/test/context-resolution.test.ts
+++ b/packages/core/test/context-resolution.test.ts
@@ -215,7 +215,7 @@ async function createFixture(options: { readonly closeFirst?: boolean } = {}) {
   const expert = { id: "expert" };
   await store.create(
     {
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
       executionId: "execution",
       version: 0,
       kind: "flow",

--- a/packages/core/test/execution-event-log.test.ts
+++ b/packages/core/test/execution-event-log.test.ts
@@ -294,6 +294,7 @@ describe("Execution canonical event log", () => {
         signature: "a".repeat(64),
         execution: {
           ...execution,
+          schemaVersion: "pragma.execution/v7",
           version: 1,
           status: "succeeded",
           output: { type: "inline", value: "recovered" },
@@ -418,6 +419,7 @@ describe("Execution canonical event log", () => {
       provider: "openai",
       model: "test",
       usage: {
+        measurement: "reported" as const,
         input: 0,
         output: 0,
         cacheRead: 0,
@@ -683,7 +685,7 @@ async function fixture() {
   const timestamp = new Date().toISOString();
   const definition = { id: "flow", kind: "flow" as const };
   const execution: ExecutionRecord = {
-    schemaVersion: "pragma.execution/v7",
+    schemaVersion: "pragma.execution/v8",
     executionId: "execution",
     version: 0,
     kind: "flow",

--- a/packages/core/test/execution-state-migration.test.ts
+++ b/packages/core/test/execution-state-migration.test.ts
@@ -58,7 +58,7 @@ describe("Execution state migration", () => {
       },
     ]);
     await expect(readJson(paths.executionState("team-run"))).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
       output: { type: "inline", value: { summary: "cancelled team" } },
     });
     await expect(readJson(paths.executionInvocations("team-run"))).resolves.toMatchObject([
@@ -77,7 +77,7 @@ describe("Execution state migration", () => {
     const store = createFileExecutionStore({ pragmaHome: home });
     await store.create(
       {
-        schemaVersion: "pragma.execution/v7",
+        schemaVersion: "pragma.execution/v8",
         executionId: "current",
         version: 0,
         kind: "expert-turn",
@@ -105,7 +105,7 @@ describe("Execution state migration", () => {
     const before = await readFile(paths.executionState("current"), "utf8");
 
     await expect(store.get("current")).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
     });
 
     expect(await readFile(paths.executionState("current"), "utf8")).toBe(before);
@@ -133,7 +133,7 @@ describe("Execution state migration", () => {
     const store = createFileExecutionStore({ pragmaHome: home });
 
     await expect(store.get("v6-run")).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
       definition: { id: "team", kind: "expert-team" },
       output: { type: "inline", value: { summary: "v6 result" } },
     });
@@ -150,11 +150,93 @@ describe("Execution state migration", () => {
     ]);
   });
 
+  it("marks migrated v7 usage precision as unknown", async () => {
+    const home = await temporaryRoot("pragma-execution-v7-usage-");
+    const paths = new PragmaPaths({ pragmaHome: home });
+    await writeLegacyExecution(paths, "v7-usage");
+    await writeJson(paths.executionState("v7-usage"), {
+      ...legacyExecution("v7-usage"),
+      schemaVersion: "pragma.execution/v7",
+      definition: { id: "team", kind: "expert-team" },
+      output: { type: "inline", value: "legacy output" },
+      usage: {
+        input: 100,
+        output: 20,
+        cacheRead: 10,
+        cacheWrite: 5,
+        totalTokens: 135,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+    });
+    const invocations = legacyInvocations();
+    await writeJson(paths.executionInvocations("v7-usage"), [
+      {
+        ...invocations[0],
+        definition: { id: "team", kind: "expert-team" },
+        output: { type: "inline", value: "legacy output" },
+        usage: {
+          input: 10,
+          output: 2,
+          cacheRead: 1,
+          cacheWrite: 0,
+          totalTokens: 13,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+      },
+      ...invocations.slice(1).map((invocation) => ({
+        ...invocation,
+        definition: {
+          id: (invocation.definition as { readonly id: string }).id,
+          kind: (invocation.definition as { readonly kind: string }).kind,
+        },
+        ...((invocation.definition as { readonly kind: string }).kind === "task"
+          ? {}
+          : { output: { type: "inline", value: invocation.output } }),
+      })),
+    ]);
+
+    await expect(createFileExecutionStore({ pragmaHome: home }).get("v7-usage")).resolves
+      .toMatchObject({
+        schemaVersion: "pragma.execution/v8",
+        usage: {
+          measurement: "unknown",
+          input: 100,
+          output: 20,
+          cacheRead: 10,
+          cacheWrite: 5,
+          totalTokens: 135,
+        },
+      });
+    const migratedInvocations = await createFileExecutionStore({
+      pragmaHome: home,
+    }).listInvocations("v7-usage");
+    expect(migratedInvocations[0]).toMatchObject({
+      usage: {
+        measurement: "unknown",
+        input: 10,
+        output: 2,
+        totalTokens: 13,
+      },
+    });
+  });
+
   it("rejects a future Execution schema without mutating it", async () => {
     const home = await temporaryRoot("pragma-execution-future-");
     const paths = new PragmaPaths({ pragmaHome: home });
     const file = paths.executionState("future");
-    const future = { schemaVersion: "pragma.execution/v8", executionId: "future" };
+    const future = { schemaVersion: "pragma.execution/v9", executionId: "future" };
     await writeJson(file, future);
     const before = await readFile(file, "utf8");
 
@@ -184,6 +266,20 @@ describe("Execution state migration", () => {
           ...legacyInvocations()[0],
           status: "succeeded",
           output: "journal invocation result",
+          usage: {
+            input: 8,
+            output: 2,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 10,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
         },
       ],
       agents: [],
@@ -194,13 +290,16 @@ describe("Execution state migration", () => {
 
     const store = createFileExecutionStore({ pragmaHome: home });
     await expect(store.get("journal-run")).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
       version: 1,
       status: "succeeded",
       output: { type: "inline", value: "journal result" },
     });
     await expect(store.listInvocations("journal-run")).resolves.toMatchObject([
-      { output: { type: "inline", value: "journal invocation result" } },
+      {
+        output: { type: "inline", value: "journal invocation result" },
+        usage: { measurement: "unknown", totalTokens: 10 },
+      },
     ]);
     await expect(readFile(transactionFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -356,6 +356,7 @@ function createOrchestrationRuntime(
 }
 
 const orchestrationUsage: AgentMessageUsage = {
+  measurement: "reported",
   input: 10,
   output: 2,
   cacheRead: 1,
@@ -809,6 +810,7 @@ describe("ExpertSession", () => {
 
   it("persists turn usage and exposes a session total without consuming events", async () => {
     const perTurnUsage: AgentMessageUsage = {
+      measurement: "reported",
       input: 100,
       output: 20,
       cacheRead: 30,
@@ -826,6 +828,7 @@ describe("ExpertSession", () => {
     await expect(first.usage).resolves.toEqual(perTurnUsage);
     await expect(second.usage).resolves.toEqual(perTurnUsage);
     expect(await session.getUsage()).toEqual({
+      measurement: "reported",
       input: 200,
       output: 40,
       cacheRead: 60,
@@ -841,6 +844,7 @@ describe("ExpertSession", () => {
 
   it("emits one Host usage observation per settled Runtime turn without coupling execution", async () => {
     const perTurnUsage: AgentMessageUsage = {
+      measurement: "reported",
       input: 100,
       output: 20,
       cacheRead: 30,
@@ -1788,7 +1792,7 @@ describe("ExpertSession", () => {
     );
     expect((await session.getState()).executionIds).toContain(executionId);
     expect(await executions.get(executionId)).toMatchObject({
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
     });
     expect((await session.getPromptQueue())[0]?.requestId).toBe("journal-request");
     expect((await session.listEvents()).items.map((event) => event.type)).toContain(
@@ -2983,7 +2987,7 @@ describe("Execution observation", () => {
     const now = new Date().toISOString();
     await writer.create(
       {
-        schemaVersion: "pragma.execution/v7",
+        schemaVersion: "pragma.execution/v8",
         executionId: "cross-process",
         version: 0,
         kind: "flow",
@@ -3104,6 +3108,7 @@ describe("Expert lifecycle orchestration", () => {
   it("persists aggregate usage across the original turn and orchestration continuation", async () => {
     const result = await runScenario("usage");
     expect(result.tree.invocation.usage).toEqual({
+      measurement: "reported",
       input: 20,
       output: 4,
       cacheRead: 2,

--- a/packages/core/test/expert-tools-mcp-server.test.ts
+++ b/packages/core/test/expert-tools-mcp-server.test.ts
@@ -150,6 +150,76 @@ describe.sequential("Expert tools MCP Gateway", () => {
     const restoredClient = await connectClient(restored.url, "bounded-restored-client");
     expect((await restoredClient.listTools()).tools.map((tool) => tool.name)).toContain(firstName);
   });
+
+  it("removes only redundant constraints beside local JSON Schema references", async () => {
+    const expert = await defineExpert({
+      id: "runtime-schema-normalization",
+      name: "Runtime schema normalization",
+      description: "MCP Gateway schema normalization test",
+      tags: [],
+      scope: "test",
+      workspace: process.cwd(),
+      tools: [
+        {
+          name: "recursive_schema",
+          description: "Accept a recursive schema.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              redundant: {
+                oneOf: [{ type: "string" }, { type: "number" }],
+                $ref: "#/$defs/value",
+              },
+              meaningful: {
+                $ref: "#/$defs/value",
+                description: "Keep this independent annotation.",
+              },
+            },
+            $defs: {
+              value: {
+                oneOf: [{ type: "string" }, { type: "number" }],
+              },
+            },
+          },
+          async call() {
+            return { text: "ok" };
+          },
+        },
+      ],
+    });
+    const registration = await registerExpertToolsMcpSession({
+      agent: expert,
+      getContext: () => undefined,
+      logger: createPragmaLogger(undefined, {
+        component: "runtime.adapter",
+        scope: { agentId: expert.id },
+      }),
+      state: {},
+    });
+    registrations.add(registration);
+    const client = await connectClient(registration.url, "schema-normalization-client");
+    const schema = (await client.listTools()).tools.find(
+      (tool) => tool.name === "recursive_schema",
+    )?.inputSchema;
+
+    expect(schema).toMatchObject({
+      properties: {
+        redundant: { $ref: "#/$defs/value" },
+        meaningful: {
+          $ref: "#/$defs/value",
+          description: "Keep this independent annotation.",
+        },
+      },
+      $defs: {
+        value: {
+          oneOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+    });
+    expect(
+      (schema as { properties?: { redundant?: unknown } }).properties?.redundant,
+    ).not.toHaveProperty("oneOf");
+  });
 });
 
 async function registerTestSession(

--- a/packages/core/test/handoff.test.ts
+++ b/packages/core/test/handoff.test.ts
@@ -213,7 +213,7 @@ async function createFixture() {
   const now = new Date().toISOString();
   await executions.create(
     {
-      schemaVersion: "pragma.execution/v7",
+      schemaVersion: "pragma.execution/v8",
       executionId: "execution",
       version: 0,
       kind: "expert-turn",

--- a/packages/core/test/human-interaction-recovery.test.ts
+++ b/packages/core/test/human-interaction-recovery.test.ts
@@ -199,7 +199,7 @@ describe("ExpertSession human interaction recovery", () => {
     });
     await executions.create(
       {
-        schemaVersion: "pragma.execution/v7",
+        schemaVersion: "pragma.execution/v8",
         executionId,
         version: 0,
         kind: "expert-turn",

--- a/packages/core/test/mcp-tool-registry-pool.test.ts
+++ b/packages/core/test/mcp-tool-registry-pool.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createMcpToolRegistryPool } from "../src/mcp-tools.ts";
+import type { IExpertAgentMcpConfig } from "../src/agent/expert-agent.ts";
+
+describe("McpToolRegistryPool", () => {
+  it("shares one Registry while leases use the same MCP configuration", async () => {
+    const listTools = vi.fn(async () => [
+      { name: "search", description: "Search", inputSchema: { type: "object" } },
+    ]);
+    const dispose = vi.fn(async () => undefined);
+    const config: IExpertAgentMcpConfig = {
+      mcpServers: {
+        docs: {
+          name: "Docs",
+          transport: "in-process",
+          timeout: 1_000,
+          inProcess: {
+            listTools,
+            async callTool() {
+              return { content: [] };
+            },
+            dispose,
+          },
+        },
+      },
+    };
+    const pool = createMcpToolRegistryPool({ maxIdleEntries: 0 });
+
+    const first = await pool.acquire(config);
+    const second = await pool.acquire(config);
+
+    expect(first.registry).toBe(second.registry);
+    expect(listTools).toHaveBeenCalledOnce();
+    await first.release();
+    expect(dispose).not.toHaveBeenCalled();
+    await second.release();
+    expect(dispose).toHaveBeenCalledOnce();
+    await pool.close();
+  });
+
+  it("does not merge distinct in-process MCP configurations", async () => {
+    const configuration = (): IExpertAgentMcpConfig => ({
+      mcpServers: {
+        local: {
+          name: "Local",
+          transport: "in-process",
+          timeout: 1_000,
+          inProcess: {
+            async listTools() {
+              return [];
+            },
+            async callTool() {
+              return { content: [] };
+            },
+          },
+        },
+      },
+    });
+    const pool = createMcpToolRegistryPool({ maxIdleEntries: 0 });
+
+    const first = await pool.acquire(configuration());
+    const second = await pool.acquire(configuration());
+
+    expect(first.registry).not.toBe(second.registry);
+    await Promise.all([first.release(), second.release()]);
+    await pool.close();
+  });
+});

--- a/packages/core/test/mcp-tool-registry-pool.test.ts
+++ b/packages/core/test/mcp-tool-registry-pool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { mcpToolRegistryCacheKey } from "../src/mcp-tool-registry-cache-key.ts";
 import { createMcpToolRegistryPool } from "../src/mcp-tools.ts";
 import type { IExpertAgentMcpConfig } from "../src/agent/expert-agent.ts";
 
@@ -65,5 +66,40 @@ describe("McpToolRegistryPool", () => {
     expect(first.registry).not.toBe(second.registry);
     await Promise.all([first.release(), second.release()]);
     await pool.close();
+  });
+
+  it("uses the same cache key for equivalent external configurations", () => {
+    const first = {
+      mcpServers: {
+        docs: {
+          name: "Docs",
+          transport: "streamable-http",
+          url: "https://docs.example.test/mcp",
+          token: "secret",
+          allowTools: ["read", "search"],
+          toolApprovals: {
+            search: { mode: "ask" },
+            read: { mode: "none" },
+          },
+        },
+      },
+    } satisfies IExpertAgentMcpConfig;
+    const second = {
+      mcpServers: {
+        docs: {
+          toolApprovals: {
+            read: { mode: "none" },
+            search: { mode: "ask" },
+          },
+          allowTools: ["search", "read"],
+          token: "secret",
+          url: "https://docs.example.test/mcp",
+          transport: "streamable-http",
+          name: "Docs",
+        },
+      },
+    } satisfies IExpertAgentMcpConfig;
+
+    expect(mcpToolRegistryCacheKey(first)).toBe(mcpToolRegistryCacheKey(second));
   });
 });

--- a/packages/core/test/runtime-message-accumulator.test.ts
+++ b/packages/core/test/runtime-message-accumulator.test.ts
@@ -61,6 +61,7 @@ describe("RuntimeMessageAccumulator", () => {
       provider: "runtime",
       model: "model",
       usage: {
+        measurement: "reported" as const,
         input: 0,
         output: 0,
         cacheRead: 0,
@@ -91,6 +92,7 @@ describe("RuntimeMessageAccumulator", () => {
       provider: "pi",
       model: "test",
       usage: {
+        measurement: "reported" as const,
         input: 0,
         output: 0,
         cacheRead: 0,

--- a/packages/core/test/storage-maintenance.test.ts
+++ b/packages/core/test/storage-maintenance.test.ts
@@ -8,6 +8,7 @@ import { PragmaPaths } from "../src/storage/pragma-paths.ts";
 import { moveOwnedStorageToTrash } from "../src/storage/deletion-transaction.ts";
 import {
   assertStorageWriteAllowed,
+  createStorageCapacityGuard,
   runStorageMaintenance,
 } from "../src/storage/storage-maintenance.ts";
 import { DEFAULT_STORAGE_POLICY } from "../src/storage/storage-policy.ts";
@@ -21,6 +22,68 @@ afterEach(async () => {
 });
 
 describe("runStorageMaintenance", () => {
+  it("reuses a fresh startup overview for storage admission", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-storage-capacity-guard-"));
+    roots.push(root);
+    const paths = new PragmaPaths({ pragmaHome: root });
+    const overview = {
+      totalBytes: 0,
+      dataBytes: 0,
+      stateBytes: 0,
+      archiveBytes: 0,
+      cacheBytes: 0,
+      temporaryBytes: 0,
+      trashBytes: 0,
+      softLimitBytes: DEFAULT_STORAGE_POLICY.globalSoftLimitBytes,
+      hardLimitBytes: DEFAULT_STORAGE_POLICY.globalHardLimitBytes,
+    };
+    const guard = createStorageCapacityGuard({
+      paths,
+      initialOverview: overview,
+      refreshIntervalMs: 0,
+    });
+
+    const startedAt = performance.now();
+    await guard.assertWriteAllowed();
+    const admissionMs = performance.now() - startedAt;
+
+    expect(guard.current()).toBe(overview);
+    expect(admissionMs).toBeLessThan(50);
+    guard.close();
+  });
+
+  it("refreshes a stale storage admission snapshot", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-storage-capacity-stale-"));
+    roots.push(root);
+    const paths = new PragmaPaths({ pragmaHome: root });
+    let now = 0;
+    const guard = createStorageCapacityGuard({
+      paths,
+      initialOverview: {
+        totalBytes: 0,
+        dataBytes: 0,
+        stateBytes: 0,
+        archiveBytes: 0,
+        cacheBytes: 0,
+        temporaryBytes: 0,
+        trashBytes: 0,
+        softLimitBytes: DEFAULT_STORAGE_POLICY.globalSoftLimitBytes,
+        hardLimitBytes: DEFAULT_STORAGE_POLICY.globalHardLimitBytes,
+      },
+      refreshIntervalMs: 0,
+      maxSnapshotAgeMs: 10,
+      now: () => now,
+    });
+    await mkdir(paths.dataRoot(), { recursive: true });
+    await writeFile(join(paths.dataRoot(), "data.bin"), "updated");
+    now = 20;
+
+    await guard.assertWriteAllowed();
+
+    expect(guard.current()?.dataBytes).toBeGreaterThan(0);
+    guard.close();
+  });
+
   it("removes empty and stale project view lease directories", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-storage-maintenance-"));
     roots.push(root);

--- a/packages/core/test/storage-maintenance.test.ts
+++ b/packages/core/test/storage-maintenance.test.ts
@@ -78,6 +78,44 @@ describe("runStorageMaintenance", () => {
     await expect(stat(lease)).resolves.toBeDefined();
   });
 
+  it("keeps a leased Codex base, removes an unleased base, and ignores cache metadata", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-storage-codex-base-"));
+    roots.push(root);
+    const paths = new PragmaPaths({ pragmaHome: root });
+    const activeFingerprint = "d".repeat(64);
+    const staleFingerprint = "e".repeat(64);
+    const bases = join(paths.codexRuntimeCacheRoot(), "bases");
+    const activeBase = join(bases, activeFingerprint);
+    const staleBase = join(bases, staleFingerprint);
+    const sourceIndex = join(bases, "source-index");
+    const leaseDirectory = join(paths.codexRuntimeCacheRoot(), "base-leases", activeFingerprint);
+    await Promise.all([
+      mkdir(activeBase, { recursive: true }),
+      mkdir(staleBase, { recursive: true }),
+      mkdir(sourceIndex, { recursive: true }),
+      mkdir(leaseDirectory, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(activeBase, ".complete"), `${activeFingerprint}\n`),
+      writeFile(join(staleBase, ".complete"), `${staleFingerprint}\n`),
+      writeFile(join(sourceIndex, "source.json"), "{}\n"),
+      writeFile(join(leaseDirectory, "active.lease"), JSON.stringify({ pid: process.pid })),
+    ]);
+
+    await runStorageMaintenance({
+      paths,
+      policy: {
+        ...DEFAULT_STORAGE_POLICY,
+        cacheLimitBytes: 0,
+        cacheTtlMs: 0,
+      },
+    });
+
+    await expect(stat(activeBase)).resolves.toBeDefined();
+    await expect(stat(staleBase)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(sourceIndex)).resolves.toBeDefined();
+  });
+
   it("purges completed fresh trash under hard-limit pressure", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-storage-maintenance-pressure-"));
     roots.push(root);

--- a/packages/default-agent/package.json
+++ b/packages/default-agent/package.json
@@ -27,6 +27,7 @@
     "zod": "latest"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0-alpha.2",
     "@pragma/tsconfig": "workspace:*",
     "@types/node": "latest",
     "typescript": "latest",

--- a/packages/default-agent/src/builtin.ts
+++ b/packages/default-agent/src/builtin.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import { access, mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import type {
@@ -9,6 +9,7 @@ import type {
   RuntimeResolver,
   RuntimeModelSelection,
 } from "@pragma/core";
+import { withFileLock } from "@pragma/core";
 import {
   loadPragmaProject,
   formatPragmaYaml,
@@ -17,6 +18,7 @@ import {
   type PragmaCompileOptions,
   type PragmaAdapterHost,
   type PragmaBindingRecord,
+  type PragmaProject,
 } from "@pragma/interpreter";
 import {
   PragmaBundleSchema,
@@ -28,6 +30,7 @@ import {
 import { BUILT_IN_PRAGMA_FILES } from "./builtin.generated.ts";
 
 export const BUILT_IN_PRAGMA_REF = "expert:0000000000pragma" as const;
+const builtInProjectCache = new Map<string, Promise<PragmaProject>>();
 
 export function builtInPragmaResource(): PragmaExpertResource {
   return PragmaExpertResourceSchema.parse(
@@ -56,16 +59,22 @@ export async function materializeBuiltInDefaultAgent(
   expertResource?: PragmaExpertResource,
   additionalResources: readonly PragmaResource[] = [],
 ): Promise<string> {
-  const targetRoot = join(root, builtInPragmaFingerprint(expertResource, additionalResources));
-  for (const [relativePath, source] of Object.entries(BUILT_IN_PRAGMA_FILES)) {
-    const target = join(targetRoot, relativePath);
-    await mkdir(dirname(target), { recursive: true, mode: 0o700 });
-    await writeFile(
-      target,
-      customizedBuiltInSource(relativePath, source, expertResource, additionalResources),
-      { mode: 0o600 },
-    );
-  }
+  const fingerprint = builtInPragmaFingerprint(expertResource, additionalResources);
+  const targetRoot = join(root, fingerprint);
+  const complete = join(targetRoot, ".complete");
+  await withFileLock(`${targetRoot}.lock`, async () => {
+    if (await exists(complete)) return;
+    for (const [relativePath, source] of Object.entries(BUILT_IN_PRAGMA_FILES)) {
+      const target = join(targetRoot, relativePath);
+      await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+      await writeFile(
+        target,
+        customizedBuiltInSource(relativePath, source, expertResource, additionalResources),
+        { mode: 0o600 },
+      );
+    }
+    await writeFile(complete, `${fingerprint}\n`, { mode: 0o600 });
+  });
   return join(targetRoot, "pragma.yaml");
 }
 
@@ -88,7 +97,20 @@ export async function compileBuiltInDefaultAgent(options: {
     options.expertResource,
     options.additionalResources,
   );
-  const project = await loadPragmaProject(entry, { rootDir: dirname(entry) });
+  let projectPromise = builtInProjectCache.get(entry);
+  if (projectPromise === undefined) {
+    projectPromise = loadPragmaProject(entry, { rootDir: dirname(entry) });
+    builtInProjectCache.set(entry, projectPromise);
+    void projectPromise.catch(() => {
+      if (builtInProjectCache.get(entry) === projectPromise) builtInProjectCache.delete(entry);
+    });
+    while (builtInProjectCache.size > 16) {
+      const oldest = builtInProjectCache.keys().next().value as string | undefined;
+      if (oldest === undefined || oldest === entry) break;
+      builtInProjectCache.delete(oldest);
+    }
+  }
+  const project = await projectPromise;
   return await project.compile<Expert>(BUILT_IN_PRAGMA_REF, {
     workspace: options.workspace,
     pragmaHome: options.pragmaHome,
@@ -104,6 +126,15 @@ export async function compileBuiltInDefaultAgent(options: {
     ...(options.plugins === undefined ? {} : { plugins: options.plugins }),
     adapterHost: defaultAgentAdapterHost(dirname(entry), options.tools, options.adapterHost),
   });
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function defaultAgentAdapterHost(

--- a/packages/default-agent/src/builtin.ts
+++ b/packages/default-agent/src/builtin.ts
@@ -18,6 +18,7 @@ import {
   type PragmaCompileOptions,
   type PragmaAdapterHost,
   type PragmaBindingRecord,
+  type PragmaBlueprintCacheStore,
   type PragmaProject,
 } from "@pragma/interpreter";
 import {
@@ -91,6 +92,7 @@ export async function compileBuiltInDefaultAgent(options: {
   readonly adapterHost?: PragmaCompileOptions["adapterHost"];
   readonly tools: readonly ExpertAgentManagedTool<string, ExpertAgentToolCallResult>[];
   readonly loggerProvider?: PragmaCompileOptions["loggerProvider"];
+  readonly blueprintCache?: PragmaBlueprintCacheStore | undefined;
 }): Promise<CompiledResource<Expert>> {
   const entry = await materializeBuiltInDefaultAgent(
     options.definitionStateRoot,
@@ -99,7 +101,11 @@ export async function compileBuiltInDefaultAgent(options: {
   );
   let projectPromise = builtInProjectCache.get(entry);
   if (projectPromise === undefined) {
-    projectPromise = loadPragmaProject(entry, { rootDir: dirname(entry) });
+    projectPromise = loadPragmaProject(entry, {
+      rootDir: dirname(entry),
+      sourceIdentity: builtInPragmaFingerprint(options.expertResource, options.additionalResources),
+      blueprintCache: options.blueprintCache,
+    });
     builtInProjectCache.set(entry, projectPromise);
     void projectPromise.catch(() => {
       if (builtInProjectCache.get(entry) === projectPromise) builtInProjectCache.delete(entry);

--- a/packages/default-agent/test/builtin.test.ts
+++ b/packages/default-agent/test/builtin.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -209,6 +209,22 @@ describe("built-in Pragma Agent DSL", () => {
       project.listResources().filter((candidate) => candidate.kind === "Capability"),
     ).toHaveLength(3);
     expect(await project.validate()).toEqual([]);
+  });
+
+  it("reuses a completed immutable materialization across concurrent callers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-default-agent-cache-"));
+    const [first, second] = await Promise.all([
+      materializeBuiltInDefaultAgent(root),
+      materializeBuiltInDefaultAgent(root),
+    ]);
+    expect(first).toBe(second);
+    const before = await stat(first);
+    const third = await materializeBuiltInDefaultAgent(root);
+    expect(third).toBe(first);
+    expect((await stat(third)).mtimeMs).toBe(before.mtimeMs);
+    await expect(readFile(join(dirname(first), ".complete"), "utf8")).resolves.toMatch(
+      /^[a-f0-9]{64}\n$/,
+    );
   });
 
   it("keeps every YAML example in the Skill structurally valid", async () => {

--- a/packages/default-agent/test/builtin.test.ts
+++ b/packages/default-agent/test/builtin.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { Expert } from "@pragma/core";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { createPragmaLogger, registerExpertToolsMcpSession, type Expert } from "@pragma/core";
 import { loadPragmaProject, parsePragmaYaml } from "@pragma/interpreter";
 import { PragmaCapabilityResourceSchema, PragmaResourceSchema } from "@pragma/interpreter/ast";
 import { describe, expect, it } from "vitest";
@@ -92,6 +93,35 @@ describe("built-in Pragma Agent DSL", () => {
     expect(compiled.value.instructions).toContain("identify yourself as Pragma");
     expect(compiled.value.instructions).toContain("default general-purpose Agent");
     expect(compiled.value.instructions).toContain("not the limit of your role");
+
+    const registration = await registerExpertToolsMcpSession({
+      agent: compiled.value,
+      getContext: () => undefined,
+      logger: createPragmaLogger(undefined, {
+        component: "runtime.adapter",
+        scope: { agentId: compiled.value.id },
+      }),
+      state: {},
+    });
+    const client = new Client(
+      { name: "pragma-default-agent-schema-test", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    try {
+      await client.connect(new StreamableHTTPClientTransport(new URL(registration.url)));
+      const catalog = await client.listTools();
+      expect(catalog.tools.map((tool) => tool.name)).toContain("create_flow_draft");
+      expect(catalog.tools.map((tool) => tool.name)).toContain("update_flow_draft");
+      expect(
+        catalog.tools.flatMap((tool) => [
+          ...findConflictingReferenceSiblings(tool.inputSchema),
+          ...findConflictingReferenceSiblings(tool.outputSchema),
+        ]),
+      ).toEqual([]);
+    } finally {
+      await client.close().catch(() => undefined);
+      await registration.dispose();
+    }
   });
 
   it("keeps generated assets byte-identical to the DSL source tree", async () => {
@@ -194,6 +224,34 @@ describe("built-in Pragma Agent DSL", () => {
     }
   });
 });
+
+function findConflictingReferenceSiblings(
+  schema: unknown,
+  path: readonly (string | number)[] = [],
+): readonly string[] {
+  if (Array.isArray(schema)) {
+    return schema.flatMap((value, index) =>
+      findConflictingReferenceSiblings(value, [...path, index]),
+    );
+  }
+  if (schema === null || typeof schema !== "object") return [];
+
+  const record = schema as Record<string, unknown>;
+  const conflicts =
+    typeof record["$ref"] === "string" &&
+    ["allOf", "anyOf", "oneOf", "type", "properties", "items"].some(
+      (keyword) => record[keyword] !== undefined,
+    )
+      ? [path.join(".")]
+      : [];
+
+  return [
+    ...conflicts,
+    ...Object.entries(record).flatMap(([key, value]) =>
+      findConflictingReferenceSiblings(value, [...path, key]),
+    ),
+  ];
+}
 
 async function filesAt(path: string): Promise<string[]> {
   const entries = await readdir(path, { withFileTypes: true });

--- a/packages/interpreter/src/application/project-service.ts
+++ b/packages/interpreter/src/application/project-service.ts
@@ -32,6 +32,7 @@ import {
   formatPragmaYaml,
   loadPragmaProject,
   type CompiledResource,
+  type PragmaBlueprintCacheStore,
   type PragmaCompileOptions,
   type PragmaEnvironmentInspection,
   type PragmaProject,
@@ -89,6 +90,7 @@ export interface PragmaProjectSnapshot {
 
 export interface PragmaProjectServiceOptions {
   readonly repository: PragmaProjectSourceRepository;
+  readonly blueprintCache?: PragmaBlueprintCacheStore | undefined;
   readonly resourceAdapters?: PragmaResourceAdapterRegistry | undefined;
   readonly externalResourceRefs?: ReadonlySet<PragmaResourceRef> | undefined;
   readonly loggerProvider?: PragmaLoggerProvider | undefined;
@@ -105,6 +107,7 @@ const PROJECT_CHANGE_SET_COMMIT_ATTEMPTS = 8;
 export class PragmaProjectService {
   private readonly adapters: PragmaResourceAdapterRegistry;
   private readonly logger: PragmaLogger;
+  private readonly openedProjects = new Map<string, Promise<PragmaProject>>();
 
   constructor(private readonly options: PragmaProjectServiceOptions) {
     this.adapters = options.resourceAdapters ?? createDefaultPragmaResourceAdapterRegistry();
@@ -291,6 +294,7 @@ export class PragmaProjectService {
     readonly resolveExternalInvocable?: PragmaCompileOptions["resolveExternalInvocable"];
     readonly plugins?: PragmaPluginResolver | undefined;
   }): Promise<CompiledResource<T>> {
+    const startedAt = performance.now();
     this.logger.info("interpreter.compile_started", "Pragma project compilation started.", {
       projectId: input.projectId,
       revision: input.revision,
@@ -322,6 +326,7 @@ export class PragmaProjectService {
         projectId: input.projectId,
         revision: input.revision,
         ref: input.ref,
+        durationMs: elapsedMilliseconds(startedAt),
       });
       return compiled;
     } catch (error) {
@@ -361,12 +366,64 @@ export class PragmaProjectService {
     location: PragmaProjectRevisionLocation,
     requireLock: boolean,
   ): Promise<PragmaProject> {
-    return await loadPragmaProject(location.entryFile, {
-      rootDir: location.rootDir,
-      requireLock,
-      resourceAdapters: this.adapters,
-      externalResourceRefs: this.options.externalResourceRefs,
-    });
+    const sourceIdentity = location.snapshotHash ?? location.projectFingerprint;
+    if (sourceIdentity === undefined) {
+      return await loadPragmaProject(location.entryFile, {
+        rootDir: location.rootDir,
+        requireLock,
+        resourceAdapters: this.adapters,
+        externalResourceRefs: this.options.externalResourceRefs,
+      });
+    }
+    const key = `${sourceIdentity}\0${requireLock ? "locked" : "unlocked"}`;
+    let project = this.openedProjects.get(key);
+    if (project === undefined) {
+      project = loadPragmaProject(location.entryFile, {
+        rootDir: location.rootDir,
+        requireLock,
+        sourceIdentity,
+        blueprintCache: this.options.blueprintCache,
+        onBlueprintCacheLookup: (observation) => {
+          this.logger.info(
+            "interpreter.blueprint_cache_lookup",
+            observation.hit
+              ? "Pragma project Blueprint cache hit."
+              : "Pragma project Blueprint cache miss.",
+            {
+              projectId: location.projectId,
+              revision: location.revision,
+              cacheTier: observation.tier,
+              cacheHit: observation.hit,
+              durationMs: observation.durationMs,
+            },
+          );
+        },
+        resourceAdapters: this.adapters,
+        externalResourceRefs: this.options.externalResourceRefs,
+      });
+      this.openedProjects.set(key, project);
+      void project.catch(() => {
+        if (this.openedProjects.get(key) === project) this.openedProjects.delete(key);
+      });
+      while (this.openedProjects.size > 128) {
+        const oldest = this.openedProjects.keys().next().value as string | undefined;
+        if (oldest === undefined || oldest === key) break;
+        this.openedProjects.delete(oldest);
+      }
+    } else {
+      this.logger.info(
+        "interpreter.project_cache_hit",
+        "Reused the open immutable Pragma project.",
+        {
+          projectId: location.projectId,
+          revision: location.revision,
+          cacheTier: "service",
+        },
+      );
+      this.openedProjects.delete(key);
+      this.openedProjects.set(key, project);
+    }
+    return await project;
   }
 
   async materializeChangeSet(
@@ -460,6 +517,10 @@ export class PragmaProjectService {
     ]);
     return new Map([...files].filter(([path]) => !managedPaths.has(path)));
   }
+}
+
+function elapsedMilliseconds(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
 export interface PragmaInterpreter {

--- a/packages/interpreter/src/compiler/pragma-project.ts
+++ b/packages/interpreter/src/compiler/pragma-project.ts
@@ -84,6 +84,24 @@ export interface LoadPragmaProjectOptions {
   readonly serializers?: DefinitionSerializerRegistry | undefined;
   readonly resourceAdapters?: PragmaResourceAdapterRegistry | undefined;
   readonly externalResourceRefs?: ReadonlySet<PragmaResourceRef> | undefined;
+  readonly sourceIdentity?: string | undefined;
+  readonly blueprintCache?: PragmaBlueprintCacheStore | undefined;
+  readonly onBlueprintCacheLookup?:
+    | ((observation: PragmaBlueprintCacheObservation) => void)
+    | undefined;
+}
+
+export interface PragmaBlueprintCacheStore {
+  readonly read: (key: string) => Promise<Uint8Array | undefined>;
+  readonly write: (key: string, value: Uint8Array) => Promise<void>;
+  readonly remove?: ((key: string) => Promise<void>) | undefined;
+}
+
+export interface PragmaBlueprintCacheObservation {
+  readonly key: string;
+  readonly tier: "memory" | "host" | "miss";
+  readonly hit: boolean;
+  readonly durationMs: number;
 }
 
 export type PragmaCompileOptions = PragmaCompileHost;
@@ -154,6 +172,39 @@ interface PragmaProvenance {
   readonly root: IndexedResource;
 }
 
+const PragmaProjectBlueprintSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.project-blueprint/v1"),
+    compilerVersion: z.literal(COMPILER_VERSION),
+    sourceIdentity: z.string().min(1),
+    entry: z.string().min(1),
+    resources: z.array(
+      z
+        .object({
+          resource: PragmaResourceSchema,
+          source: z.string().min(1),
+          normalized: z.string(),
+          contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+        })
+        .strict(),
+    ),
+    artifacts: z.array(
+      z
+        .object({
+          source: z.string().min(1),
+          contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+        })
+        .strict(),
+    ),
+    diagnostics: z.array(PragmaDiagnosticSchema),
+  })
+  .strict();
+
+type PragmaProjectBlueprint = z.infer<typeof PragmaProjectBlueprintSchema>;
+const projectBlueprintMemoryCache = new Map<string, PragmaProjectBlueprint>();
+const projectBlueprintLoads = new Map<string, Promise<PragmaProjectBlueprint | undefined>>();
+const PROJECT_BLUEPRINT_MEMORY_LIMIT = 128;
+
 export async function loadPragmaProject(
   entryFile: string,
   options: LoadPragmaProjectOptions = {},
@@ -163,14 +214,194 @@ export async function loadPragmaProject(
   const rootDir = await realpath(configuredRoot);
   const canonicalEntry = await realpath(absoluteEntry);
   const adapters = options.resourceAdapters ?? createDefaultPragmaResourceAdapterRegistry();
+  const blueprintKey =
+    options.sourceIdentity === undefined
+      ? undefined
+      : sha256(
+          stableStringify({
+            compilerVersion: COMPILER_VERSION,
+            sourceIdentity: options.sourceIdentity,
+            entry: relative(rootDir, canonicalEntry),
+            resourceAdapters: adapters.fingerprint(),
+          }),
+        );
+  if (blueprintKey !== undefined) {
+    const cacheStartedAt = performance.now();
+    const cached = await loadProjectBlueprint(blueprintKey, options.blueprintCache);
+    notifyBlueprintCacheLookup(options, {
+      key: blueprintKey,
+      tier: cached.tier,
+      hit: cached.blueprint !== undefined,
+      durationMs: elapsedMilliseconds(cacheStartedAt),
+    });
+    if (
+      cached.blueprint !== undefined &&
+      cached.blueprint.sourceIdentity === options.sourceIdentity &&
+      cached.blueprint.entry === relative(rootDir, canonicalEntry)
+    ) {
+      return projectFromBlueprint(cached.blueprint, rootDir, canonicalEntry, options);
+    }
+  }
   const loader = new SourceLoader(rootDir, adapters);
   await loader.loadEntry(canonicalEntry);
   await loader.collectArtifacts();
-  return new PragmaProjectImpl(
+  const project = new PragmaProjectImpl(
     canonicalEntry,
     loader.resources,
     loader.artifacts,
     loader.diagnostics,
+    options,
+  );
+  if (blueprintKey !== undefined && options.sourceIdentity !== undefined) {
+    const blueprint = createProjectBlueprint(
+      options.sourceIdentity,
+      rootDir,
+      canonicalEntry,
+      loader,
+    );
+    rememberProjectBlueprint(blueprintKey, blueprint);
+    if (options.blueprintCache !== undefined) {
+      void options.blueprintCache
+        .write(blueprintKey, new TextEncoder().encode(JSON.stringify(blueprint)))
+        .catch(() => undefined);
+    }
+  }
+  return project;
+}
+
+async function loadProjectBlueprint(
+  key: string,
+  store: PragmaBlueprintCacheStore | undefined,
+): Promise<{
+  readonly blueprint: PragmaProjectBlueprint | undefined;
+  readonly tier: PragmaBlueprintCacheObservation["tier"];
+}> {
+  const memory = projectBlueprintMemoryCache.get(key);
+  if (memory !== undefined) {
+    projectBlueprintMemoryCache.delete(key);
+    projectBlueprintMemoryCache.set(key, memory);
+    return { blueprint: memory, tier: "memory" };
+  }
+  if (store === undefined) return { blueprint: undefined, tier: "miss" };
+  const pending = projectBlueprintLoads.get(key);
+  if (pending !== undefined) {
+    return { blueprint: await pending, tier: "host" };
+  }
+  const loading = (async () => {
+    try {
+      const encoded = await store.read(key);
+      if (encoded === undefined) return undefined;
+      const parsed = PragmaProjectBlueprintSchema.safeParse(
+        JSON.parse(new TextDecoder().decode(encoded)) as unknown,
+      );
+      if (!parsed.success) {
+        await store.remove?.(key).catch(() => undefined);
+        return undefined;
+      }
+      rememberProjectBlueprint(key, parsed.data);
+      return parsed.data;
+    } catch {
+      return undefined;
+    }
+  })();
+  projectBlueprintLoads.set(key, loading);
+  try {
+    const blueprint = await loading;
+    return { blueprint, tier: blueprint === undefined ? "miss" : "host" };
+  } finally {
+    if (projectBlueprintLoads.get(key) === loading) projectBlueprintLoads.delete(key);
+  }
+}
+
+function notifyBlueprintCacheLookup(
+  options: LoadPragmaProjectOptions,
+  observation: PragmaBlueprintCacheObservation,
+): void {
+  try {
+    options.onBlueprintCacheLookup?.(observation);
+  } catch {
+    // Cache telemetry must never affect project loading.
+  }
+}
+
+function elapsedMilliseconds(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
+}
+
+function rememberProjectBlueprint(key: string, blueprint: PragmaProjectBlueprint): void {
+  projectBlueprintMemoryCache.delete(key);
+  projectBlueprintMemoryCache.set(key, blueprint);
+  while (projectBlueprintMemoryCache.size > PROJECT_BLUEPRINT_MEMORY_LIMIT) {
+    const oldest = projectBlueprintMemoryCache.keys().next().value as string | undefined;
+    if (oldest === undefined || oldest === key) break;
+    projectBlueprintMemoryCache.delete(oldest);
+  }
+}
+
+function createProjectBlueprint(
+  sourceIdentity: string,
+  rootDir: string,
+  entryFile: string,
+  loader: SourceLoader,
+): PragmaProjectBlueprint {
+  const relativeSource = (source: string): string => {
+    const value = relative(rootDir, source);
+    if (value === "" || value.startsWith("..") || isAbsolute(value)) {
+      throw new Error(`Blueprint source escapes the project root: ${source}`);
+    }
+    return value;
+  };
+  return PragmaProjectBlueprintSchema.parse({
+    schemaVersion: "pragma.project-blueprint/v1",
+    compilerVersion: COMPILER_VERSION,
+    sourceIdentity,
+    entry: relativeSource(entryFile),
+    resources: [...loader.resources.values()].map((indexed) => ({
+      resource: indexed.resource,
+      source: relativeSource(indexed.source),
+      normalized: indexed.normalized,
+      contentHash: indexed.contentHash,
+    })),
+    artifacts: [...loader.artifacts].map(([source, contentHash]) => ({ source, contentHash })),
+    diagnostics: loader.diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      ...(diagnostic.source === undefined ? {} : { source: relativeSource(diagnostic.source) }),
+    })),
+  });
+}
+
+function projectFromBlueprint(
+  blueprint: PragmaProjectBlueprint,
+  rootDir: string,
+  entryFile: string,
+  options: LoadPragmaProjectOptions,
+): PragmaProject {
+  const resolveSource = (source: string): string => {
+    const value = resolve(rootDir, source);
+    const child = relative(rootDir, value);
+    if (child.startsWith("..") || isAbsolute(child)) {
+      throw new Error(`Blueprint source escapes the project root: ${source}`);
+    }
+    return value;
+  };
+  return new PragmaProjectImpl(
+    entryFile,
+    new Map(
+      blueprint.resources.map((indexed) => [
+        canonicalRef(indexed.resource),
+        {
+          resource: indexed.resource,
+          source: resolveSource(indexed.source),
+          normalized: indexed.normalized,
+          contentHash: indexed.contentHash,
+        },
+      ]),
+    ),
+    new Map(blueprint.artifacts.map((artifact) => [artifact.source, artifact.contentHash])),
+    blueprint.diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      ...(diagnostic.source === undefined ? {} : { source: resolveSource(diagnostic.source) }),
+    })),
     options,
   );
 }
@@ -386,6 +617,8 @@ class SourceLoader {
 }
 
 class PragmaProjectImpl implements PragmaProject {
+  private validation: Promise<readonly PragmaDiagnostic[]> | undefined;
+
   constructor(
     readonly entryFile: string,
     private readonly resources: ReadonlyMap<string, IndexedResource>,
@@ -401,6 +634,11 @@ class PragmaProjectImpl implements PragmaProject {
   }
 
   async validate(): Promise<readonly PragmaDiagnostic[]> {
+    this.validation ??= this.validateOnce();
+    return await this.validation;
+  }
+
+  private async validateOnce(): Promise<readonly PragmaDiagnostic[]> {
     const diagnostics = [...this.sourceDiagnostics];
     const adapters = this.options.resourceAdapters ?? createDefaultPragmaResourceAdapterRegistry();
     for (const indexed of this.resources.values()) {
@@ -436,7 +674,7 @@ class PragmaProjectImpl implements PragmaProject {
       host.resourceAdapters ??
       this.options.resourceAdapters ??
       createDefaultPragmaResourceAdapterRegistry();
-    const adapterHost = createAdapterHost(host);
+    const adapterHost = createAdapterHost(host, this.artifacts);
     diagnostics.push(...validateExtensionEnvironment(this.resources, host));
     if (host.plugins !== undefined) {
       for (const indexed of this.resources.values()) {
@@ -526,16 +764,24 @@ class PragmaProjectImpl implements PragmaProject {
       host.resourceAdapters ??
       this.options.resourceAdapters ??
       createDefaultPragmaResourceAdapterRegistry();
-    const adapterHost = createAdapterHost(host);
+    const adapterHost = createAdapterHost(host, this.artifacts);
     const resolvedResources = new Map<
       string,
       { readonly contribution: PragmaResourceContribution; readonly health: PragmaResourceHealth }
+    >();
+    const resolvingResources = new Map<
+      string,
+      Promise<{
+        readonly contribution: PragmaResourceContribution;
+        readonly health: PragmaResourceHealth;
+      }>
     >();
     const resolvedPlugins: {
       readonly expertRef: string;
       readonly ref: string;
       readonly resolution: PragmaPluginResolution;
     }[] = [];
+    const resolvingPlugins = new Map<string, Promise<PragmaPluginResolution>>();
 
     const resolveDeclarative = async <TContribution extends PragmaResourceContribution>(
       resourceRef: string,
@@ -553,27 +799,45 @@ class PragmaProjectImpl implements PragmaProject {
           readonly health: PragmaResourceHealth;
         };
       }
-      const baseResolved = await resourceAdapters.resolve<TContribution>(
-        indexed.resource,
-        adapterHost,
-      );
-      const resolved =
-        indexed.resource.kind === "RuntimeProfile" && host.runtimes !== undefined
-          ? await verifyRuntimeEnvironment(
-              baseResolved as PragmaResourceInspection<PragmaRuntimeProfileContribution>,
-              host.runtimes,
-              false,
-            )
-          : baseResolved;
-      if (resolved.health.status !== "ready" || resolved.contribution === undefined) {
-        throw new PragmaResourceNeedsAttentionError(resolved.health);
+      const pending = resolvingResources.get(key);
+      if (pending !== undefined) {
+        return (await pending) as {
+          readonly contribution: TContribution;
+          readonly health: PragmaResourceHealth;
+        };
       }
-      const value = {
-        contribution: resolved.contribution as TContribution,
-        health: resolved.health,
-      };
-      resolvedResources.set(key, value);
-      return value;
+      const resolving = (async () => {
+        const baseResolved = await resourceAdapters.resolve<TContribution>(
+          indexed.resource as PragmaDeclarativeResource,
+          adapterHost,
+        );
+        const resolved =
+          indexed.resource.kind === "RuntimeProfile" && host.runtimes !== undefined
+            ? await verifyRuntimeEnvironment(
+                baseResolved as PragmaResourceInspection<PragmaRuntimeProfileContribution>,
+                host.runtimes,
+                false,
+              )
+            : baseResolved;
+        if (resolved.health.status !== "ready" || resolved.contribution === undefined) {
+          throw new PragmaResourceNeedsAttentionError(resolved.health);
+        }
+        const value = {
+          contribution: resolved.contribution,
+          health: resolved.health,
+        };
+        resolvedResources.set(key, value);
+        return value;
+      })();
+      resolvingResources.set(key, resolving);
+      try {
+        return (await resolving) as {
+          readonly contribution: TContribution;
+          readonly health: PragmaResourceHealth;
+        };
+      } finally {
+        if (resolvingResources.get(key) === resolving) resolvingResources.delete(key);
+      }
     };
 
     const resolveRuntime = async (runtimeRef: string): Promise<PragmaRuntimeProfileContribution> =>
@@ -660,17 +924,21 @@ class PragmaProjectImpl implements PragmaProject {
                 );
               }
               const expertRef = canonicalRef(indexed.resource) as `expert:${string}`;
-              const resolution = await host.plugins.resolve({
-                expertRef,
-                binding,
-              });
-              assertPluginResolution(binding.ref, resolution);
-              resolvedPlugins.push({
-                expertRef,
-                ref: binding.ref,
-                resolution,
-              });
-              return resolution;
+              const resolutionKey = stableStringify({ expertRef, binding });
+              let resolving = resolvingPlugins.get(resolutionKey);
+              if (resolving === undefined) {
+                resolving = host.plugins.resolve({ expertRef, binding }).then((resolution) => {
+                  assertPluginResolution(binding.ref, resolution);
+                  resolvedPlugins.push({
+                    expertRef,
+                    ref: binding.ref,
+                    resolution,
+                  });
+                  return resolution;
+                });
+                resolvingPlugins.set(resolutionKey, resolving);
+              }
+              return await resolving;
             },
           },
         );
@@ -759,11 +1027,6 @@ class PragmaProjectImpl implements PragmaProject {
         models,
         ...(rootModelSelection === undefined ? {} : { modelSelection: rootModelSelection }),
       };
-      for (const resolved of resolvedResources.values()) {
-        if ("runtimeId" in resolved.contribution) {
-          await host.runtimes.bind({ runtimeId: resolved.contribution.runtimeId });
-        }
-      }
     }
     const projectFingerprint = this.createLock().projectFingerprint;
     const fingerprintResources = [...resolvedResources.entries()]
@@ -981,24 +1244,25 @@ async function compileExpert(
     ) => Promise<PragmaPluginResolution>;
   },
 ): Promise<Expert> {
-  const plugins = await Promise.all(resource.spec.plugins.map(resolvers.resolvePlugin));
-  const runtime =
+  const [plugins, runtime, capabilities, contextStores] = await Promise.all([
+    Promise.all(resource.spec.plugins.map(resolvers.resolvePlugin)),
     executionOverride !== undefined || resource.spec.runtime === undefined
-      ? undefined
-      : await resolvers.resolveRuntime(resource.spec.runtime.ref);
-  const capabilities = await Promise.all(
-    resource.spec.capabilities.map(async (binding) => ({
-      binding,
-      contribution: await resolvers.resolveCapability(binding.ref),
-    })),
-  );
-  const contextStores = await Promise.all(
-    resource.spec.contextStores.map(async (binding) => ({
-      namespace: binding.namespace,
-      required: binding.required,
-      contribution: await resolvers.resolveContextStore(binding.ref),
-    })),
-  );
+      ? Promise.resolve(undefined)
+      : resolvers.resolveRuntime(resource.spec.runtime.ref),
+    Promise.all(
+      resource.spec.capabilities.map(async (binding) => ({
+        binding,
+        contribution: await resolvers.resolveCapability(binding.ref),
+      })),
+    ),
+    Promise.all(
+      resource.spec.contextStores.map(async (binding) => ({
+        namespace: binding.namespace,
+        required: binding.required,
+        contribution: await resolvers.resolveContextStore(binding.ref),
+      })),
+    ),
+  ]);
   const capabilityTools: ExpertAgentManagedTool<string, ExpertAgentToolCallResult>[] = [];
   const skillConfigs: IExpertAgentSkillsConfig[] = [];
   const mcpConfigs: IExpertAgentMcpConfig[] = [];
@@ -1978,7 +2242,7 @@ function mergeMcp(configs: readonly IExpertAgentMcpConfig[]): IExpertAgentMcpCon
   return Object.keys(servers).length === 0 ? undefined : { mcpServers: servers };
 }
 
-function createAdapterHost(host: PragmaCompileHost) {
+function createAdapterHost(host: PragmaCompileHost, artifacts: ReadonlyMap<string, string>) {
   const external = host.adapterHost;
   const root = resolve(host.projectRoot ?? external?.projectRoot ?? host.workspace);
   return {
@@ -2005,10 +2269,15 @@ function createAdapterHost(host: PragmaCompileHost) {
         throw new Error(`Artifact source escapes the project root: ${source.path}`);
       }
       const info = await lstat(path);
+      const contentHash = artifacts.get(source.path);
+      if (contentHash === undefined) {
+        throw new Error(`Project artifact was not indexed: ${source.path}`);
+      }
       return {
         source,
         path,
-        contentHash: await hashArtifactPath(path),
+        contentHash,
+        verified: true,
         ...(info.isFile() ? { text: await readFile(path, "utf8") } : {}),
       };
     },

--- a/packages/interpreter/src/compiler/pragma-project.ts
+++ b/packages/interpreter/src/compiler/pragma-project.ts
@@ -203,6 +203,7 @@ const PragmaProjectBlueprintSchema = z
 type PragmaProjectBlueprint = z.infer<typeof PragmaProjectBlueprintSchema>;
 const projectBlueprintMemoryCache = new Map<string, PragmaProjectBlueprint>();
 const projectBlueprintLoads = new Map<string, Promise<PragmaProjectBlueprint | undefined>>();
+const projectBlueprintBuilds = new Map<string, Promise<PragmaProjectBlueprint>>();
 const PROJECT_BLUEPRINT_MEMORY_LIMIT = 128;
 
 export async function loadPragmaProject(
@@ -214,18 +215,19 @@ export async function loadPragmaProject(
   const rootDir = await realpath(configuredRoot);
   const canonicalEntry = await realpath(absoluteEntry);
   const adapters = options.resourceAdapters ?? createDefaultPragmaResourceAdapterRegistry();
+  const sourceIdentity = options.sourceIdentity;
   const blueprintKey =
-    options.sourceIdentity === undefined
+    sourceIdentity === undefined
       ? undefined
       : sha256(
           stableStringify({
             compilerVersion: COMPILER_VERSION,
-            sourceIdentity: options.sourceIdentity,
+            sourceIdentity,
             entry: relative(rootDir, canonicalEntry),
             resourceAdapters: adapters.fingerprint(),
           }),
         );
-  if (blueprintKey !== undefined) {
+  if (blueprintKey !== undefined && sourceIdentity !== undefined) {
     const cacheStartedAt = performance.now();
     const cached = await loadProjectBlueprint(blueprintKey, options.blueprintCache);
     notifyBlueprintCacheLookup(options, {
@@ -236,37 +238,62 @@ export async function loadPragmaProject(
     });
     if (
       cached.blueprint !== undefined &&
-      cached.blueprint.sourceIdentity === options.sourceIdentity &&
+      cached.blueprint.sourceIdentity === sourceIdentity &&
       cached.blueprint.entry === relative(rootDir, canonicalEntry)
     ) {
       return projectFromBlueprint(cached.blueprint, rootDir, canonicalEntry, options);
     }
+    const blueprint = await buildProjectBlueprint(
+      blueprintKey,
+      sourceIdentity,
+      rootDir,
+      canonicalEntry,
+      adapters,
+      options.blueprintCache,
+    );
+    return projectFromBlueprint(blueprint, rootDir, canonicalEntry, options);
   }
   const loader = new SourceLoader(rootDir, adapters);
   await loader.loadEntry(canonicalEntry);
   await loader.collectArtifacts();
-  const project = new PragmaProjectImpl(
+  return new PragmaProjectImpl(
     canonicalEntry,
     loader.resources,
     loader.artifacts,
     loader.diagnostics,
     options,
   );
-  if (blueprintKey !== undefined && options.sourceIdentity !== undefined) {
-    const blueprint = createProjectBlueprint(
-      options.sourceIdentity,
-      rootDir,
-      canonicalEntry,
-      loader,
-    );
-    rememberProjectBlueprint(blueprintKey, blueprint);
-    if (options.blueprintCache !== undefined) {
-      void options.blueprintCache
-        .write(blueprintKey, new TextEncoder().encode(JSON.stringify(blueprint)))
+}
+
+async function buildProjectBlueprint(
+  key: string,
+  sourceIdentity: string,
+  rootDir: string,
+  entryFile: string,
+  adapters: PragmaResourceAdapterRegistry,
+  store: PragmaBlueprintCacheStore | undefined,
+): Promise<PragmaProjectBlueprint> {
+  const pending = projectBlueprintBuilds.get(key);
+  if (pending !== undefined) return await pending;
+  const building = (async () => {
+    const loader = new SourceLoader(rootDir, adapters);
+    await loader.loadEntry(entryFile);
+    await loader.collectArtifacts();
+    const blueprint = createProjectBlueprint(sourceIdentity, rootDir, entryFile, loader);
+    rememberProjectBlueprint(key, blueprint);
+    if (store !== undefined) {
+      void store
+        .write(key, new TextEncoder().encode(JSON.stringify(blueprint)))
         .catch(() => undefined);
     }
+    return blueprint;
+  })();
+  projectBlueprintBuilds.set(key, building);
+  try {
+    return await building;
+  } finally {
+    if (projectBlueprintBuilds.get(key) === building) projectBlueprintBuilds.delete(key);
   }
-  return project;
 }
 
 async function loadProjectBlueprint(
@@ -674,7 +701,11 @@ class PragmaProjectImpl implements PragmaProject {
       host.resourceAdapters ??
       this.options.resourceAdapters ??
       createDefaultPragmaResourceAdapterRegistry();
-    const adapterHost = createAdapterHost(host, this.artifacts);
+    const adapterHost = createAdapterHost(
+      host,
+      this.artifacts,
+      this.options.sourceIdentity !== undefined,
+    );
     diagnostics.push(...validateExtensionEnvironment(this.resources, host));
     if (host.plugins !== undefined) {
       for (const indexed of this.resources.values()) {
@@ -764,7 +795,11 @@ class PragmaProjectImpl implements PragmaProject {
       host.resourceAdapters ??
       this.options.resourceAdapters ??
       createDefaultPragmaResourceAdapterRegistry();
-    const adapterHost = createAdapterHost(host, this.artifacts);
+    const adapterHost = createAdapterHost(
+      host,
+      this.artifacts,
+      this.options.sourceIdentity !== undefined,
+    );
     const resolvedResources = new Map<
       string,
       { readonly contribution: PragmaResourceContribution; readonly health: PragmaResourceHealth }
@@ -2242,7 +2277,11 @@ function mergeMcp(configs: readonly IExpertAgentMcpConfig[]): IExpertAgentMcpCon
   return Object.keys(servers).length === 0 ? undefined : { mcpServers: servers };
 }
 
-function createAdapterHost(host: PragmaCompileHost, artifacts: ReadonlyMap<string, string>) {
+function createAdapterHost(
+  host: PragmaCompileHost,
+  artifacts: ReadonlyMap<string, string>,
+  artifactsAreImmutable: boolean,
+) {
   const external = host.adapterHost;
   const root = resolve(host.projectRoot ?? external?.projectRoot ?? host.workspace);
   return {
@@ -2277,7 +2316,7 @@ function createAdapterHost(host: PragmaCompileHost, artifacts: ReadonlyMap<strin
         source,
         path,
         contentHash,
-        verified: true,
+        ...(artifactsAreImmutable ? { verified: true } : {}),
         ...(info.isFile() ? { text: await readFile(path, "utf8") } : {}),
       };
     },

--- a/packages/interpreter/src/runtime/resource-adapters.ts
+++ b/packages/interpreter/src/runtime/resource-adapters.ts
@@ -50,6 +50,7 @@ export interface PragmaArtifactRecord {
   readonly contentHash: string;
   readonly path?: string | undefined;
   readonly text?: string | undefined;
+  readonly verified?: boolean | undefined;
 }
 
 export interface PragmaAdapterHost {
@@ -138,6 +139,10 @@ export class PragmaResourceAdapterRegistry {
     if (this.adapters.has(key)) throw new Error(`Duplicate Pragma resource adapter: ${key}`);
     this.adapters.set(key, adapter as unknown as PragmaResourceAdapter<PragmaDeclarativeResource>);
     return this;
+  }
+
+  fingerprint(): string {
+    return sha256([...this.adapters.keys()].toSorted().join("\n"));
   }
 
   validate(resource: PragmaDeclarativeResource): readonly PragmaDiagnostic[] {
@@ -728,10 +733,15 @@ async function verifiedArtifact(
       `Artifact integrity mismatch for ${source.type === "project" ? source.path : source.uri}.`,
     );
   }
-  if (artifact.text !== undefined && sha256(artifact.text) !== artifact.contentHash) {
+  if (
+    artifact.verified !== true &&
+    artifact.text !== undefined &&
+    sha256(artifact.text) !== artifact.contentHash
+  ) {
     throw new Error("Artifact text does not match its contentHash.");
   }
   if (
+    artifact.verified !== true &&
     artifact.path !== undefined &&
     (await hashArtifactPath(artifact.path)) !== artifact.contentHash
   ) {

--- a/packages/interpreter/test/blueprint-cache.test.ts
+++ b/packages/interpreter/test/blueprint-cache.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  PragmaBlueprintCacheObservation,
+  PragmaBlueprintCacheStore,
+} from "../src/compiler/pragma-project.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.resetModules();
+  await Promise.all(roots.splice(0).map(async (root) => await rm(root, { recursive: true })));
+});
+
+describe("Pragma project Blueprint cache", () => {
+  it("rehydrates a serialized Blueprint from the Host cache within the warm-load gate", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-blueprint-cache-"));
+    roots.push(root);
+    const entry = join(root, "pragma.yaml");
+    await writeFile(
+      entry,
+      ["apiVersion: pragma/v3", "kind: Bundle", "imports: []", "resources: []", ""].join("\n"),
+    );
+    const values = new Map<string, Uint8Array>();
+    const store: PragmaBlueprintCacheStore = {
+      read: async (key) => values.get(key),
+      write: async (key, value) => {
+        values.set(key, value);
+      },
+    };
+    const firstObservations: PragmaBlueprintCacheObservation[] = [];
+    const firstModule = await import("../src/compiler/pragma-project.ts");
+
+    await firstModule.loadPragmaProject(entry, {
+      rootDir: root,
+      sourceIdentity: "immutable-revision-1",
+      blueprintCache: store,
+      onBlueprintCacheLookup: (observation) => firstObservations.push(observation),
+    });
+    await vi.waitFor(() => expect(values.size).toBe(1));
+    expect(firstObservations).toEqual([expect.objectContaining({ tier: "miss", hit: false })]);
+
+    // A fresh module simulates a process whose compiler L1 is empty. Invalidating
+    // the source proves the result below came from the serialized Host Blueprint.
+    vi.resetModules();
+    await writeFile(entry, "not valid Pragma YAML\n");
+    const secondObservations: PragmaBlueprintCacheObservation[] = [];
+    const secondModule = await import("../src/compiler/pragma-project.ts");
+    const project = await secondModule.loadPragmaProject(entry, {
+      rootDir: root,
+      sourceIdentity: "immutable-revision-1",
+      blueprintCache: store,
+      onBlueprintCacheLookup: (observation) => secondObservations.push(observation),
+    });
+    expect(project.listResources()).toEqual([]);
+    expect(secondObservations).toEqual([expect.objectContaining({ tier: "host", hit: true })]);
+    expect(secondObservations[0]!.durationMs).toBeLessThan(200);
+  }, 15_000);
+});

--- a/packages/interpreter/test/blueprint-cache.test.ts
+++ b/packages/interpreter/test/blueprint-cache.test.ts
@@ -17,6 +17,36 @@ afterEach(async () => {
 });
 
 describe("Pragma project Blueprint cache", () => {
+  it("coalesces concurrent source builds after a cache miss", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-blueprint-single-flight-"));
+    roots.push(root);
+    const entry = join(root, "pragma.yaml");
+    await writeFile(
+      entry,
+      ["apiVersion: pragma/v3", "kind: Bundle", "imports: []", "resources: []", ""].join("\n"),
+    );
+    const write = vi.fn(async () => undefined);
+    const store: PragmaBlueprintCacheStore = {
+      read: async () => undefined,
+      write,
+    };
+    const compiler = await import("../src/compiler/pragma-project.ts");
+
+    await Promise.all([
+      compiler.loadPragmaProject(entry, {
+        rootDir: root,
+        sourceIdentity: "immutable-single-flight-revision",
+        blueprintCache: store,
+      }),
+      compiler.loadPragmaProject(entry, {
+        rootDir: root,
+        sourceIdentity: "immutable-single-flight-revision",
+        blueprintCache: store,
+      }),
+    ]);
+    await vi.waitFor(() => expect(write).toHaveBeenCalledOnce());
+  });
+
   it("rehydrates a serialized Blueprint from the Host cache within the warm-load gate", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-blueprint-cache-"));
     roots.push(root);

--- a/packages/interpreter/test/resource-adapters.test.ts
+++ b/packages/interpreter/test/resource-adapters.test.ts
@@ -13,9 +13,38 @@ import {
   PragmaResourceAdapterRegistry,
   type PragmaAdapterHost,
 } from "../src/index.ts";
-import type { PragmaCapabilityResource, PragmaRuntimeProfileResource } from "../src/ast/index.ts";
+import type {
+  PragmaArtifactSource,
+  PragmaCapabilityResource,
+  PragmaRuntimeProfileResource,
+} from "../src/ast/index.ts";
 
 describe("Pragma resource adapters", () => {
+  it("rejects a mutable project artifact that changes after project loading", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mutable-project-artifact-"));
+    const artifact = join(root, "tool.js");
+    await writeFile(artifact, "export default 'original';");
+    await writeFile(
+      join(root, "pragma.yaml"),
+      formatPragmaYaml(codeResource({ type: "project", path: "tool.js" })),
+    );
+    const project = await loadPragmaProject(join(root, "pragma.yaml"));
+    await writeFile(artifact, "export default 'changed';");
+
+    const inspection = await project.inspectEnvironment({ workspace: root });
+
+    expect(inspection.resources).toEqual([
+      expect.objectContaining({
+        status: "needs_attention",
+        issues: [
+          expect.objectContaining({
+            message: expect.stringContaining("does not match its contentHash"),
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("reports mismatched external artifact bytes as needs_attention", async () => {
     const expected = sha256("expected");
     const source = {
@@ -222,11 +251,7 @@ describe("Pragma resource adapters", () => {
   });
 });
 
-function codeResource(source: {
-  readonly type: "registry";
-  readonly uri: string;
-  readonly integrity: `sha256:${string}`;
-}): PragmaCapabilityResource {
+function codeResource(source: PragmaArtifactSource): PragmaCapabilityResource {
   return {
     apiVersion: "pragma/v3",
     kind: "Capability",

--- a/packages/runtime/claude-code/test/session.test.ts
+++ b/packages/runtime/claude-code/test/session.test.ts
@@ -28,6 +28,7 @@ describe("Claude Code context window", () => {
           },
         },
         {
+          measurement: "reported",
           input: 41_000,
           output: 1_000,
           cacheRead: 8_000,

--- a/packages/runtime/codex/src/adapter.ts
+++ b/packages/runtime/codex/src/adapter.ts
@@ -97,6 +97,7 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
         };
       },
       async createSession(ctx): Promise<CodexDriverSession> {
+        const sessionStartedAt = performance.now();
         assertRuntimeManagedProvider(
           ctx.request.modelSelection?.model.providerId,
           "openai",
@@ -116,37 +117,65 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
             ctx.persistence.restoredRuntimeSessionId ?? ctx.request.runtimeSession?.id ?? "",
         };
         const sessionDir = ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("codex");
-        const codex = await prepareManagedCodexHome({
-          agent: ctx.agent,
-          sessionDir,
-          pragmaPaths: ctx.paths.pragma,
-          env: ctx.processEnvironment,
-          logger: ctx.logger,
-        });
-        if (state.threadId !== "") {
-          const exists = await nativeSessionFileExists(
-            join(codex.home, "sessions"),
-            state.threadId,
-          );
-          if (!exists) {
-            throw new Error(`Codex runtime session file was not found: ${state.threadId}.`);
-          }
-        }
+        const codexHomePromise = timedCodexPhase(
+          ctx.logger,
+          "managed_home",
+          sessionStartedAt,
+          async () =>
+            await prepareManagedCodexHome({
+              agent: ctx.agent,
+              sessionDir,
+              pragmaPaths: ctx.paths.pragma,
+              env: ctx.processEnvironment,
+              logger: ctx.logger,
+            }),
+        );
+        const registryPromise = timedCodexPhase(
+          ctx.logger,
+          "mcp_tool_registry",
+          sessionStartedAt,
+          async () => await createMcpToolRegistry(ctx.agent.mcp),
+        );
         let mcpToolRegistry: McpToolRegistry | undefined;
         let expertToolsMcpRegistration: CodexExpertToolsMcpSessionRegistration | undefined;
         let client: CodexAppServerClient | undefined;
 
         try {
-          mcpToolRegistry = await createMcpToolRegistry(ctx.agent.mcp);
-          expertToolsMcpRegistration = await registerCodexExpertToolsMcpSession({
-            agent: ctx.agent,
-            getContext: () => ctx.lifecycle.currentContext,
-            humanInteractionHandler: ctx.request.humanInteractionHandler,
-            logger: ctx.logger,
-            mcpTools: mcpToolRegistry.tools,
-            state: toolRuntimeState,
-            executionContext: ctx.request.executionContext,
-          });
+          const [codex, registry] = await Promise.all([codexHomePromise, registryPromise]);
+          mcpToolRegistry = registry;
+          const [restoreExists, registration] = await Promise.all([
+            state.threadId === ""
+              ? Promise.resolve(true)
+              : timedCodexPhase(
+                  ctx.logger,
+                  "restore_session_lookup",
+                  sessionStartedAt,
+                  async () =>
+                    await nativeSessionFileExists(join(codex.home, "sessions"), state.threadId),
+                ),
+            timedCodexPhase(ctx.logger, "mcp_tool_registration", sessionStartedAt, async () =>
+              registerCodexExpertToolsMcpSession({
+                agent: ctx.agent,
+                getContext: () => ctx.lifecycle.currentContext,
+                humanInteractionHandler: ctx.request.humanInteractionHandler,
+                logger: ctx.logger,
+                mcpTools: mcpToolRegistry!.tools,
+                state: toolRuntimeState,
+                executionContext: ctx.request.executionContext,
+              }),
+            ),
+          ]);
+          if (!restoreExists) {
+            await registration.dispose();
+            throw new Error(`Codex runtime session file was not found: ${state.threadId}.`);
+          }
+          expertToolsMcpRegistration = registration;
+          ctx.logger.info(
+            "runtime.codex_process_spawn_requested",
+            "Codex app-server native process spawn requested",
+            { elapsedMs: codexElapsedMs(sessionStartedAt), executablePath },
+          );
+          const processStartedAt = performance.now();
           client = await CodexAppServerClient.start({
             executablePath,
             args: appendCodexExecutionMcpConfig(
@@ -173,17 +202,32 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
               ctx.logger.debug("runtime.codex_stderr", "Codex app-server stderr", { chunk });
             },
           });
-          const threadStartResult = await startOrResumeThread({
-            client,
-            runtimeSessionId: state.threadId,
-            cwd: ctx.workspace,
-            model: defaultModelName,
-            thinkingLevel: defaultThinkingLevel,
-            developerInstructions: ctx.agentContext.systemPrompt,
-            sandboxMode: options.sandboxMode,
-            approvalPolicy: options.approvalPolicy,
+          ctx.logger.info("runtime.codex_initialized", "Codex app-server initialized", {
+            durationMs: codexElapsedMs(processStartedAt),
+            elapsedMs: codexElapsedMs(sessionStartedAt),
           });
+          const threadStartResult = await timedCodexPhase(
+            ctx.logger,
+            state.threadId === "" ? "thread_start" : "thread_resume",
+            sessionStartedAt,
+            async () =>
+              await startOrResumeThread({
+                client: client!,
+                runtimeSessionId: state.threadId,
+                cwd: ctx.workspace,
+                model: defaultModelName,
+                thinkingLevel: defaultThinkingLevel,
+                developerInstructions: ctx.agentContext.systemPrompt,
+                sandboxMode: options.sandboxMode,
+                approvalPolicy: options.approvalPolicy,
+              }),
+          );
           state.threadId = threadStartResult.threadId;
+          ctx.logger.info("runtime.codex_session_ready", "Codex Session preparation completed", {
+            elapsedMs: codexElapsedMs(sessionStartedAt),
+            systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+            toolCount: mcpToolRegistry.tools.length,
+          });
 
           return {
             ...createCodexNativeSession({
@@ -201,6 +245,10 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
             expertToolsMcpRegistration,
           };
         } catch (error) {
+          if (mcpToolRegistry === undefined) {
+            const registry = await Promise.allSettled([registryPromise]);
+            if (registry[0]?.status === "fulfilled") mcpToolRegistry = registry[0].value;
+          }
           try {
             await disposeCodexRuntimeResources(
               client,
@@ -266,6 +314,26 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
       createProcessEnvironment: () => ({ ...process.env, ...(options.env ?? {}) }),
     },
   );
+}
+
+async function timedCodexPhase<T>(
+  logger: Pick<PragmaLogger, "info">,
+  phase: string,
+  sessionStartedAt: number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  const value = await operation();
+  logger.info("runtime.codex_prepare_phase", `Codex preparation phase completed: ${phase}`, {
+    phase,
+    durationMs: codexElapsedMs(startedAt),
+    elapsedMs: codexElapsedMs(sessionStartedAt),
+  });
+  return value;
+}
+
+function codexElapsedMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
 function assertRuntimeManagedProvider(

--- a/packages/runtime/codex/src/adapter.ts
+++ b/packages/runtime/codex/src/adapter.ts
@@ -1,9 +1,14 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { McpToolRegistry, RuntimeAdapter, RuntimeCanUseResult } from "@pragma/core";
+import type {
+  McpToolRegistry,
+  McpToolRegistryLease,
+  RuntimeAdapter,
+  RuntimeCanUseResult,
+} from "@pragma/core";
 import {
-  createMcpToolRegistry,
+  createMcpToolRegistryPool,
   defineRuntimeDriver,
   type PragmaLogger,
   type RuntimeSessionPersistenceSpec,
@@ -56,11 +61,14 @@ const DEFAULT_CODEX_CLIENT_INFO = {
 };
 
 interface CodexDriverSession extends CodexNativeSession {
+  readonly logger: PragmaLogger;
   readonly mcpToolRegistry: McpToolRegistry;
+  readonly mcpToolRegistryLease: McpToolRegistryLease;
   readonly expertToolsMcpRegistration: CodexExpertToolsMcpSessionRegistration;
 }
 
 export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): RuntimeAdapter {
+  const mcpToolRegistries = createMcpToolRegistryPool();
   const executablePath =
     options.executablePath ??
     (options.spawn === undefined ? resolveCodexExecutablePath(options) : "codex");
@@ -130,19 +138,24 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
               logger: ctx.logger,
             }),
         );
-        const registryPromise = timedCodexPhase(
+        const registryLeasePromise = timedCodexPhase(
           ctx.logger,
           "mcp_tool_registry",
           sessionStartedAt,
-          async () => await createMcpToolRegistry(ctx.agent.mcp),
+          async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
         );
         let mcpToolRegistry: McpToolRegistry | undefined;
+        let mcpToolRegistryLease: McpToolRegistryLease | undefined;
         let expertToolsMcpRegistration: CodexExpertToolsMcpSessionRegistration | undefined;
         let client: CodexAppServerClient | undefined;
 
         try {
-          const [codex, registry] = await Promise.all([codexHomePromise, registryPromise]);
-          mcpToolRegistry = registry;
+          const [codex, registryLease] = await Promise.all([
+            codexHomePromise,
+            registryLeasePromise,
+          ]);
+          mcpToolRegistryLease = registryLease;
+          mcpToolRegistry = registryLease.registry;
           const [restoreExists, registration] = await Promise.all([
             state.threadId === ""
               ? Promise.resolve(true)
@@ -241,19 +254,24 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
                 ? ctx.agentContext.startupMessages
                 : [],
             }),
+            logger: ctx.logger,
             mcpToolRegistry,
+            mcpToolRegistryLease,
             expertToolsMcpRegistration,
           };
         } catch (error) {
-          if (mcpToolRegistry === undefined) {
-            const registry = await Promise.allSettled([registryPromise]);
-            if (registry[0]?.status === "fulfilled") mcpToolRegistry = registry[0].value;
+          if (mcpToolRegistryLease === undefined) {
+            const registry = await Promise.allSettled([registryLeasePromise]);
+            if (registry[0]?.status === "fulfilled") {
+              mcpToolRegistryLease = registry[0].value;
+              mcpToolRegistry = registry[0].value.registry;
+            }
           }
           try {
             await disposeCodexRuntimeResources(
               client,
               expertToolsMcpRegistration,
-              mcpToolRegistry,
+              mcpToolRegistryLease,
               ctx.logger,
             );
           } catch (cleanupError) {
@@ -274,19 +292,33 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
       listMessages: listCodexMessages,
       consumeStartupMessages: consumeCodexStartupMessages,
       async startTurn(session, turn) {
+        const requestStartedAt = performance.now();
         assertRuntimeManagedProvider(turn.modelSelection?.model.providerId, "openai", "Codex");
         const modelName = turn.modelSelection?.model.modelId ?? session.defaultModelName;
         const thinkingLevel = turn.modelSelection?.thinkingLevel ?? session.defaultThinkingLevel;
         if (modelName !== undefined || thinkingLevel !== undefined) {
           assertCodexModelSelection(await listModels(), modelName, thinkingLevel);
         }
-        return await startCodexTurn(session, {
-          ...turn,
-          modelSelection:
-            modelName === undefined
-              ? undefined
-              : { model: { providerId: "openai", modelId: modelName }, thinkingLevel },
-        });
+        return await startCodexTurn(
+          session,
+          {
+            ...turn,
+            modelSelection:
+              modelName === undefined
+                ? undefined
+                : { model: { providerId: "openai", modelId: modelName }, thinkingLevel },
+          },
+          () => {
+            session.logger.info(
+              "runtime.codex_request_acknowledged",
+              "Codex acknowledged the native turn request",
+              {
+                runId: turn.runId,
+                elapsedMs: codexElapsedMs(requestStartedAt),
+              },
+            );
+          },
+        );
       },
       mapEvent: mapCodexNotificationToRuntimeEvent,
       async collectUsage(session, ctx) {
@@ -303,7 +335,7 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
         await disposeCodexRuntimeResources(
           session.client,
           session.expertToolsMcpRegistration,
-          session.mcpToolRegistry,
+          session.mcpToolRegistryLease,
           ctx.logger,
         );
       },
@@ -392,13 +424,13 @@ function createCodexRuntimeCanUse(
 async function disposeCodexRuntimeResources(
   client: CodexAppServerClient | undefined,
   expertToolsMcpRegistration: CodexExpertToolsMcpSessionRegistration | undefined,
-  mcpToolRegistry: McpToolRegistry | undefined,
+  mcpToolRegistryLease: McpToolRegistryLease | undefined,
   logger: PragmaLogger,
 ): Promise<void> {
   const results = await Promise.allSettled([
     Promise.resolve().then(() => client?.close()),
     expertToolsMcpRegistration?.dispose() ?? Promise.resolve(),
-    mcpToolRegistry?.dispose() ?? Promise.resolve(),
+    mcpToolRegistryLease?.release() ?? Promise.resolve(),
   ]);
   const errors = results.flatMap((result) =>
     result.status === "rejected" ? [result.reason as unknown] : [],

--- a/packages/runtime/codex/src/app-server-client.ts
+++ b/packages/runtime/codex/src/app-server-client.ts
@@ -91,17 +91,30 @@ export class CodexAppServerClient {
       cwd: options.cwd,
       env: options.env,
     });
-    const client = new CodexAppServerClient(process, options);
-
-    await client.request("initialize", {
-      clientInfo: options.clientInfo,
-      capabilities: {
-        experimentalApi: true,
-      },
-    });
-    client.notify("initialized", {});
-
-    return client;
+    let client: CodexAppServerClient | undefined;
+    try {
+      client = new CodexAppServerClient(process, options);
+      await client.request("initialize", {
+        clientInfo: options.clientInfo,
+        capabilities: {
+          experimentalApi: true,
+        },
+      });
+      client.notify("initialized", {});
+      return client;
+    } catch (error) {
+      try {
+        if (client === undefined) {
+          process.stdin.end();
+          process.kill("SIGTERM");
+        } else {
+          client.close();
+        }
+      } catch {
+        process.kill("SIGKILL");
+      }
+      throw error;
+    }
   }
 
   async startThread(options: CodexThreadStartOptions): Promise<string> {

--- a/packages/runtime/codex/src/codex-home.ts
+++ b/packages/runtime/codex/src/codex-home.ts
@@ -1,12 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
-  access,
-  copyFile,
-  cp,
   lstat,
   mkdir,
   readFile,
-  readdir,
   readlink,
   rename,
   rm,
@@ -14,10 +10,10 @@ import {
   symlink,
   writeFile,
 } from "node:fs/promises";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 
-import { type Expert, type PragmaLogger, type PragmaPaths, withFileLock } from "@pragma/core";
+import { type Expert, type PragmaLogger, type PragmaPaths } from "@pragma/core";
 import { materializeCodexSkills } from "./skills.ts";
 
 export interface PrepareManagedCodexHomeOptions {
@@ -25,14 +21,12 @@ export interface PrepareManagedCodexHomeOptions {
   readonly sessionDir: string;
   readonly pragmaPaths: PragmaPaths;
   readonly env?: NodeJS.ProcessEnv | undefined;
-  readonly logger: Pick<PragmaLogger, "warn">;
+  readonly logger: Pick<PragmaLogger, "info" | "warn">;
 }
 
 export interface ManagedCodexHome {
   readonly home: string;
   readonly sqliteHome: string;
-  readonly sharedBase: string;
-  readonly baseFingerprint: string;
 }
 
 const CODEX_PRIVATE_CONFIG_FILES = [
@@ -41,7 +35,9 @@ const CODEX_PRIVATE_CONFIG_FILES = [
   "config.toml",
   "instructions.md",
 ] as const;
-const CODEX_SHARED_CACHE_DIRECTORIES = ["plugins", "packages", "cache"] as const;
+const CODEX_MODELS_CACHE_FILE = "models_cache.json";
+const CODEX_MODELS_CACHE_BINDING_FILE = ".models_cache_config.sha256";
+const CODEX_LEGACY_LAYOUT_SCHEMA = "pragma.codex-home/v2";
 
 export async function prepareManagedCodexHome({
   agent,
@@ -50,10 +46,11 @@ export async function prepareManagedCodexHome({
   env,
   logger,
 }: PrepareManagedCodexHomeOptions): Promise<ManagedCodexHome> {
+  const startedAt = performance.now();
   const home = join(sessionDir, "home");
   const sqliteHome = join(sessionDir, "sqlite");
   const sourceHome = resolveSourceCodexHome(env);
-  const shared = await prepareSharedBase(sourceHome, pragmaPaths);
+  const freshHome = (await lstat(home).catch(() => undefined)) === undefined;
 
   await mkdir(home, { recursive: true, mode: 0o700 });
   await Promise.all([
@@ -62,96 +59,287 @@ export async function prepareManagedCodexHome({
     mkdir(join(home, "tmp"), { recursive: true, mode: 0o700 }),
     mkdir(sqliteHome, { recursive: true, mode: 0o700 }),
   ]);
-  await exposeManagedAuth(sourceHome, home, pragmaPaths, logger);
-  await copyPrivateConfigFiles(sourceHome, home, logger);
-  await exposeSharedCacheDirectories(shared.root, home);
+
+  const configSnapshot = await copyPrivateConfigFiles(sourceHome, home);
+  await Promise.all([
+    exposeManagedAuth(sourceHome, home, pragmaPaths, logger),
+    exposeSharedPluginCache(sourceHome, home, pragmaPaths),
+  ]);
+  const modelCatalog = await syncRelativeModelCatalog(sourceHome, home, configSnapshot.configToml);
+  const seededModelsCache = await syncModelsCache({
+    sourceHome,
+    home,
+    freshHome,
+    configSnapshot,
+    modelCatalog,
+  });
   await materializeCodexSkills({
     agent,
     codexHome: home,
-    sharedSkillsRoot: join(pragmaPaths.codexRuntimeCacheRoot(), "skills"),
   });
-  await writeFile(
-    join(sessionDir, "layout.json"),
-    `${JSON.stringify(
-      {
-        schemaVersion: "pragma.codex-home/v2",
-        baseFingerprint: shared.fingerprint,
-        sharedBase: shared.root,
-      },
-      undefined,
-      2,
-    )}\n`,
-    { mode: 0o600 },
+  await removeLegacyLayout(sessionDir, pragmaPaths);
+
+  logger.info(
+    "runtime.codex_minimal_home_ready",
+    "Prepared a minimal isolated Codex home without copying host cache trees",
+    {
+      durationMs: elapsedMs(startedAt),
+      copiedConfigBytes: configSnapshot.totalBytes + (modelCatalog?.bytes.byteLength ?? 0),
+      copiedConfigFiles: configSnapshot.files.length + (modelCatalog === undefined ? 0 : 1),
+      pluginCacheMode: "shared-host-link",
+      seededModelsCache,
+    },
   );
 
-  return {
-    home,
-    sqliteHome,
-    sharedBase: shared.root,
-    baseFingerprint: shared.fingerprint,
-  };
+  return { home, sqliteHome };
 }
 
 function resolveSourceCodexHome(env: NodeJS.ProcessEnv | undefined): string {
-  return env?.CODEX_HOME ?? process.env["CODEX_HOME"] ?? join(homedir(), ".codex");
+  return resolve(env?.CODEX_HOME ?? process.env["CODEX_HOME"] ?? join(homedir(), ".codex"));
 }
 
-async function prepareSharedBase(
+interface ConfigSnapshot {
+  readonly files: readonly string[];
+  readonly values: ReadonlyMap<string, Uint8Array>;
+  readonly configToml?: string | undefined;
+  readonly totalBytes: number;
+}
+
+async function copyPrivateConfigFiles(sourceHome: string, home: string): Promise<ConfigSnapshot> {
+  const files: string[] = [];
+  const values = new Map<string, Uint8Array>();
+  let totalBytes = 0;
+
+  for (const file of CODEX_PRIVATE_CONFIG_FILES) {
+    const source = join(sourceHome, file);
+    const target = join(home, file);
+    const bytes = await readOptionalRegularFile(source);
+    if (bytes === undefined) {
+      await removeManagedFile(target);
+      continue;
+    }
+    await atomicWriteFile(target, bytes);
+    files.push(file);
+    values.set(file, bytes);
+    totalBytes += bytes.byteLength;
+  }
+
+  const sourceConfigBytes = values.get("config.toml");
+  let configToml: string | undefined;
+  if (sourceConfigBytes !== undefined) {
+    await sanitizeCopiedCodexConfig(join(home, "config.toml"));
+    const effectiveConfig = await readFile(join(home, "config.toml"));
+    values.set("config.toml", effectiveConfig);
+    configToml = effectiveConfig.toString("utf8");
+  }
+  return {
+    files,
+    values,
+    configToml,
+    totalBytes,
+  };
+}
+
+interface CopiedModelCatalog {
+  readonly relativePath: string;
+  readonly bytes: Uint8Array;
+}
+
+async function syncRelativeModelCatalog(
   sourceHome: string,
-  paths: PragmaPaths,
-): Promise<{ readonly root: string; readonly fingerprint: string }> {
-  const bases = join(paths.codexRuntimeCacheRoot(), "bases");
-  const staging = join(bases, `.snapshot-${randomUUID()}.tmp`);
-  await mkdir(staging, { recursive: true, mode: 0o700 });
-  try {
-    for (const name of CODEX_SHARED_CACHE_DIRECTORIES) {
-      const source = join(sourceHome, name);
-      if ((await stat(source).catch(() => undefined))?.isDirectory() !== true) continue;
-      await cp(source, join(staging, name), { recursive: true, dereference: true });
-    }
-    const fingerprint = await fingerprintSharedDirectories(staging);
-    const root = join(bases, fingerprint);
-    const complete = join(root, ".complete");
-    await withFileLock(`${root}.lock`, async () => {
-      try {
-        await access(complete);
-        return;
-      } catch (error) {
-        if (!isNotFoundError(error)) throw error;
-      }
-      await writeFile(join(staging, ".complete"), `${fingerprint}\n`, { mode: 0o600 });
-      await rm(root, { recursive: true, force: true });
-      await rename(staging, root);
-    });
-    return { root, fingerprint };
-  } finally {
-    await rm(staging, { recursive: true, force: true });
+  home: string,
+  configToml: string | undefined,
+): Promise<CopiedModelCatalog | undefined> {
+  if (configToml === undefined) return undefined;
+  const configuredPath = readRootTomlString(configToml, "model_catalog_json");
+  if (
+    configuredPath === undefined ||
+    isAbsolute(configuredPath) ||
+    configuredPath.startsWith("~/") ||
+    configuredPath.startsWith("~\\")
+  ) {
+    return undefined;
   }
+
+  const relativePath = normalize(configuredPath);
+  if (
+    relativePath === "" ||
+    relativePath === "." ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`)
+  ) {
+    throw new Error(`Codex model_catalog_json must stay inside CODEX_HOME: ${configuredPath}`);
+  }
+  const source = resolve(sourceHome, relativePath);
+  if (!isPathInside(sourceHome, source)) {
+    throw new Error(`Codex model_catalog_json must stay inside CODEX_HOME: ${configuredPath}`);
+  }
+  const bytes = await readRequiredRegularFile(source, "Codex model catalog");
+  await atomicWriteFile(join(home, relativePath), bytes);
+  return { relativePath, bytes };
 }
 
-async function fingerprintSharedDirectories(sourceHome: string): Promise<string> {
-  const hash = createHash("sha256").update("pragma.codex-shared-base/v1\0");
-  for (const name of CODEX_SHARED_CACHE_DIRECTORIES) {
-    const root = join(sourceHome, name);
-    if ((await stat(root).catch(() => undefined))?.isDirectory() !== true) continue;
-    const files = await collectFiles(root);
-    for (const file of files) {
-      const path = relative(sourceHome, file).split(sep).join("/");
-      const bytes = await readFile(file);
-      hash.update(`${path.length}:${path}:${bytes.byteLength}:`).update(bytes).update("\0");
+function readRootTomlString(content: string, key: string): string | undefined {
+  let insideTable = false;
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith("[")) {
+      insideTable = true;
+      continue;
+    }
+    if (insideTable) continue;
+    const match = new RegExp(`^${escapeRegExp(key)}\\s*=\\s*(.*)$`).exec(trimmed);
+    if (match === null) continue;
+    const literal = match[1]?.trim() ?? "";
+    if (literal.startsWith('"')) {
+      const stringMatch = /^"(?:\\.|[^"\\])*"/.exec(literal);
+      if (stringMatch === null || !hasOnlyTomlComment(literal.slice(stringMatch[0].length))) {
+        throw new Error(`Codex ${key} must be a single-line TOML string.`);
+      }
+      try {
+        return JSON.parse(stringMatch[0]) as string;
+      } catch (error) {
+        throw new Error(`Codex ${key} contains an invalid TOML string.`, { cause: error });
+      }
+    }
+    if (literal.startsWith("'")) {
+      const end = literal.indexOf("'", 1);
+      if (end < 0 || !hasOnlyTomlComment(literal.slice(end + 1))) {
+        throw new Error(`Codex ${key} must be a single-line TOML string.`);
+      }
+      return literal.slice(1, end);
+    }
+    throw new Error(`Codex ${key} must be a quoted TOML string.`);
+  }
+  return undefined;
+}
+
+function hasOnlyTomlComment(value: string): boolean {
+  const remaining = value.trim();
+  return remaining === "" || remaining.startsWith("#");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function syncModelsCache({
+  sourceHome,
+  home,
+  freshHome,
+  configSnapshot,
+  modelCatalog,
+}: {
+  readonly sourceHome: string;
+  readonly home: string;
+  readonly freshHome: boolean;
+  readonly configSnapshot: ConfigSnapshot;
+  readonly modelCatalog: CopiedModelCatalog | undefined;
+}): Promise<boolean> {
+  const binding = fingerprintModelConfiguration(configSnapshot, modelCatalog);
+  const bindingPath = join(home, CODEX_MODELS_CACHE_BINDING_FILE);
+  const cachePath = join(home, CODEX_MODELS_CACHE_FILE);
+  const previousBinding = await readFile(bindingPath, "utf8").catch(() => undefined);
+
+  if (previousBinding?.trim() === binding) {
+    const cacheInfo = await lstat(cachePath).catch(() => undefined);
+    if (cacheInfo !== undefined && !cacheInfo.isFile()) await rm(cachePath, { recursive: true });
+    return false;
+  }
+
+  await rm(cachePath, { recursive: true, force: true });
+  let seeded = false;
+  if (freshHome && previousBinding === undefined) {
+    const sharedCache = await readOptionalRegularFile(join(sourceHome, CODEX_MODELS_CACHE_FILE));
+    if (sharedCache !== undefined) {
+      await atomicWriteFile(cachePath, sharedCache);
+      seeded = true;
     }
   }
+  await atomicWriteFile(bindingPath, Buffer.from(`${binding}\n`));
+  return seeded;
+}
+
+function fingerprintModelConfiguration(
+  configSnapshot: ConfigSnapshot,
+  modelCatalog: CopiedModelCatalog | undefined,
+): string {
+  const hash = createHash("sha256").update("pragma.codex-model-cache-binding/v1\0");
+  for (const file of ["config.json", "config.toml"] as const) {
+    const bytes = configSnapshot.values.get(file);
+    hash.update(`${file}\0`);
+    if (bytes === undefined) hash.update("missing\0");
+    else hash.update(`${bytes.byteLength}\0`).update(bytes).update("\0");
+  }
+  if (modelCatalog === undefined) hash.update("model_catalog_json\0none\0");
+  else
+    hash
+      .update(
+        `model_catalog_json\0${modelCatalog.relativePath}\0${modelCatalog.bytes.byteLength}\0`,
+      )
+      .update(modelCatalog.bytes)
+      .update("\0");
   return hash.digest("hex");
 }
 
-async function collectFiles(root: string): Promise<string[]> {
-  const files: string[] = [];
-  for (const entry of await readdir(root, { withFileTypes: true })) {
-    const path = join(root, entry.name);
-    if (entry.isDirectory()) files.push(...(await collectFiles(path)));
-    else if (entry.isFile()) files.push(path);
+async function exposeSharedPluginCache(
+  sourceHome: string,
+  home: string,
+  pragmaPaths: PragmaPaths,
+): Promise<void> {
+  const plugins = join(home, "plugins");
+  await replaceLegacyPluginsRoot(plugins, pragmaPaths);
+  await mkdir(plugins, { recursive: true, mode: 0o700 });
+
+  const source = join(sourceHome, "plugins", "cache");
+  const target = join(plugins, "cache");
+  const sourceInfo = await stat(source).catch((error: unknown) => {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  });
+  if (sourceInfo === undefined) {
+    await replaceWithPrivateDirectory(target);
+  } else {
+    if (!sourceInfo.isDirectory()) {
+      throw new Error(`Codex plugin cache is not a directory: ${source}`);
+    }
+    await replaceSymlink(source, target, "dir");
   }
-  return files.toSorted();
+
+  await Promise.all([
+    removeLegacyBaseLink(join(home, "packages"), pragmaPaths),
+    removeLegacyBaseLink(join(home, "cache"), pragmaPaths),
+  ]);
+}
+
+async function replaceLegacyPluginsRoot(plugins: string, pragmaPaths: PragmaPaths): Promise<void> {
+  const current = await lstat(plugins).catch(() => undefined);
+  if (current === undefined || !current.isSymbolicLink()) return;
+  if (!(await linkTargetsLegacyBase(plugins, pragmaPaths))) {
+    throw new Error(
+      `Codex managed plugins path points outside the legacy Pragma cache: ${plugins}`,
+    );
+  }
+  await rm(plugins);
+}
+
+async function removeLegacyBaseLink(path: string, pragmaPaths: PragmaPaths): Promise<void> {
+  const current = await lstat(path).catch(() => undefined);
+  if (current?.isSymbolicLink() !== true) return;
+  if (await linkTargetsLegacyBase(path, pragmaPaths)) await rm(path);
+}
+
+async function linkTargetsLegacyBase(path: string, pragmaPaths: PragmaPaths): Promise<boolean> {
+  const linked = resolve(dirname(path), await readlink(path));
+  return isPathInside(join(pragmaPaths.codexRuntimeCacheRoot(), "bases"), linked);
+}
+
+async function replaceWithPrivateDirectory(path: string): Promise<void> {
+  const current = await lstat(path).catch(() => undefined);
+  if (current?.isDirectory() === true && !current.isSymbolicLink()) return;
+  await rm(path, { recursive: true, force: true });
+  await mkdir(path, { recursive: true, mode: 0o700 });
 }
 
 async function exposeManagedAuth(
@@ -161,15 +349,16 @@ async function exposeManagedAuth(
   logger: Pick<PragmaLogger, "warn">,
 ): Promise<void> {
   const source = join(sourceHome, "auth.json");
-  if ((await stat(source).catch(() => undefined))?.isFile() !== true) return;
+  const sourceBytes = await readOptionalRegularFile(source);
+  if (sourceBytes === undefined) {
+    await removeManagedFile(join(home, "auth.json"));
+    return;
+  }
   const credential = join(paths.credentialsRoot(), "codex", "auth.json");
   await mkdir(dirname(credential), { recursive: true, mode: 0o700 });
-  const sourceBytes = await readFile(source);
   const current = await readFile(credential).catch(() => undefined);
   if (current === undefined || !current.equals(sourceBytes)) {
-    const temporary = `${credential}.${randomUUID()}.tmp`;
-    await writeFile(temporary, sourceBytes, { mode: 0o600 });
-    await rename(temporary, credential);
+    await atomicWriteFile(credential, sourceBytes);
   }
   try {
     await replaceSymlink(credential, join(home, "auth.json"), "file");
@@ -179,57 +368,36 @@ async function exposeManagedAuth(
       "Codex managed home could not link the Pragma credential projection",
       { error },
     );
-    await copyFile(credential, join(home, "auth.json"));
+    await atomicWriteFile(join(home, "auth.json"), sourceBytes);
   }
 }
 
-async function copyPrivateConfigFiles(
-  sourceHome: string,
-  home: string,
-  logger: Pick<PragmaLogger, "warn">,
-): Promise<void> {
-  for (const file of CODEX_PRIVATE_CONFIG_FILES) {
-    try {
-      await copyFile(join(sourceHome, file), join(home, file));
-    } catch (error) {
-      if (!isNotFoundError(error)) {
-        logger.warn(
-          "runtime.codex_config_snapshot_failed",
-          "Codex managed home could not snapshot a private config file",
-          { file, error },
-        );
-      }
-    }
-  }
-  await sanitizeCopiedCodexConfig(join(home, "config.toml"), logger);
-}
-
-async function exposeSharedCacheDirectories(sharedBase: string, home: string): Promise<void> {
-  for (const name of CODEX_SHARED_CACHE_DIRECTORIES) {
-    const source = join(sharedBase, name);
-    if ((await stat(source).catch(() => undefined))?.isDirectory() !== true) continue;
-    await replaceSymlink(source, join(home, name), "dir");
-  }
-}
-
-async function sanitizeCopiedCodexConfig(
-  configPath: string,
-  logger: Pick<PragmaLogger, "warn">,
-): Promise<void> {
-  let content: string;
+async function removeLegacyLayout(sessionDir: string, paths: PragmaPaths): Promise<void> {
+  const layout = join(sessionDir, "layout.json");
+  let value: unknown;
   try {
-    content = await readFile(configPath, "utf8");
+    value = JSON.parse(await readFile(layout, "utf8"));
   } catch (error) {
-    if (!isNotFoundError(error))
-      logger.warn(
-        "runtime.codex_config_read_failed",
-        "Codex managed home could not read config.toml",
-        { error },
-      );
-    return;
+    if (isNotFoundError(error) || error instanceof SyntaxError) return;
+    throw error;
   }
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    "schemaVersion" in value &&
+    value.schemaVersion === CODEX_LEGACY_LAYOUT_SCHEMA &&
+    "sharedBase" in value &&
+    typeof value.sharedBase === "string" &&
+    isPathInside(join(paths.codexRuntimeCacheRoot(), "bases"), value.sharedBase)
+  ) {
+    await rm(layout, { force: true });
+  }
+}
+
+async function sanitizeCopiedCodexConfig(configPath: string): Promise<void> {
+  const content = await readFile(configPath, "utf8");
   const sanitized = stripSkillsConfigEntries(content);
-  if (sanitized !== content) await writeFile(configPath, sanitized, { mode: 0o600 });
+  if (sanitized !== content) await atomicWriteFile(configPath, Buffer.from(sanitized));
 }
 
 function stripSkillsConfigEntries(content: string): string {
@@ -263,6 +431,60 @@ async function replaceSymlink(source: string, target: string, type: "dir" | "fil
   await mkdir(dirname(target), { recursive: true, mode: 0o700 });
   await rm(target, { recursive: true, force: true });
   await symlink(source, target, type === "dir" && process.platform === "win32" ? "junction" : type);
+}
+
+async function readOptionalRegularFile(path: string): Promise<Buffer | undefined> {
+  let info;
+  try {
+    info = await stat(path);
+  } catch (error) {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  }
+  if (!info.isFile()) throw new Error(`Codex managed file source is not a regular file: ${path}`);
+  return await readFile(path);
+}
+
+async function readRequiredRegularFile(path: string, label: string): Promise<Buffer> {
+  const bytes = await readOptionalRegularFile(path);
+  if (bytes === undefined) throw new Error(`${label} was not found: ${path}`);
+  return bytes;
+}
+
+async function removeManagedFile(path: string): Promise<void> {
+  await rm(path, { recursive: true, force: true });
+}
+
+async function atomicWriteFile(path: string, bytes: Uint8Array): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, bytes, { mode: 0o600 });
+    try {
+      await rename(temporary, path);
+    } catch (error) {
+      if (!isWindowsReplaceError(error)) throw error;
+      await rm(path, { recursive: true, force: true });
+      await rename(temporary, path);
+    }
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+function isWindowsReplaceError(error: unknown): boolean {
+  if (process.platform !== "win32" || error === null || typeof error !== "object") return false;
+  const code = "code" in error ? error.code : undefined;
+  return code === "EEXIST" || code === "EPERM";
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const path = relative(resolve(root), resolve(candidate));
+  return path === "" || (path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path));
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
 function isNotFoundError(error: unknown): boolean {

--- a/packages/runtime/codex/src/session.ts
+++ b/packages/runtime/codex/src/session.ts
@@ -137,6 +137,7 @@ export function consumeCodexStartupMessages(
 export async function startCodexTurn(
   session: CodexNativeSession,
   turn: RuntimeTurnContext<CodexRuntimeNotification>,
+  onAcknowledged?: (() => void) | undefined,
 ): Promise<RuntimeTurnResult> {
   let outputText = "";
   let assistantUsage: AgentMessageUsage | undefined;
@@ -179,6 +180,7 @@ export async function startCodexTurn(
         turn.prompt,
       ),
     });
+    onAcknowledged?.();
     await observer.completed;
   } finally {
     unsubscribe();

--- a/packages/runtime/codex/src/skills.ts
+++ b/packages/runtime/codex/src/skills.ts
@@ -1,23 +1,11 @@
 import type { Expert } from "@pragma/core";
-import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import {
-  access,
-  cp,
-  mkdir,
-  readFile,
-  rename,
-  rm,
-  stat,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
+import { access, cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 
 export interface MaterializeCodexSkillsOptions {
   readonly agent: Expert;
   readonly codexHome: string;
-  readonly sharedSkillsRoot?: string | undefined;
 }
 
 const FRONTMATTER_DELIMITER = "---";
@@ -26,7 +14,6 @@ const NON_ALPHANUMERIC = /[^a-z0-9]+/g;
 export async function materializeCodexSkills({
   agent,
   codexHome,
-  sharedSkillsRoot,
 }: MaterializeCodexSkillsOptions): Promise<void> {
   const skillsDir = join(codexHome, "skills");
 
@@ -46,25 +33,7 @@ export async function materializeCodexSkills({
     });
     const slug = await allocateSkillSlug(skillsDir, usedSlugs, sanitizeSkillName(skill.name));
     const targetDir = join(skillsDir, slug);
-    if (sharedSkillsRoot === undefined) {
-      await copySkill(source, targetDir, slug, skill.description);
-      continue;
-    }
-    const fingerprint = await fingerprintSkill(source, slug, skill.description);
-    const sharedTarget = join(sharedSkillsRoot, fingerprint.slice(0, 2), fingerprint);
-    if ((await stat(sharedTarget).catch(() => undefined))?.isDirectory() !== true) {
-      const staging = `${sharedTarget}.${randomUUID()}.tmp`;
-      await mkdir(dirname(sharedTarget), { recursive: true, mode: 0o700 });
-      await copySkill(source, staging, slug, skill.description);
-      try {
-        await rename(staging, sharedTarget);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      } finally {
-        await rm(staging, { recursive: true, force: true });
-      }
-    }
-    await symlink(sharedTarget, targetDir, process.platform === "win32" ? "junction" : "dir");
+    await copySkill(source, targetDir, slug, skill.description);
   }
 }
 
@@ -83,32 +52,6 @@ async function copySkill(
     join(targetDir, "SKILL.md"),
     ensureSkillFrontmatter(await readFile(source.skillFile, "utf8"), { name: slug, description }),
   );
-}
-
-async function fingerprintSkill(
-  source: { readonly dir: string; readonly skillFile: string },
-  slug: string,
-  description: string,
-): Promise<string> {
-  const hash = createHash("sha256").update(`pragma.codex-skill/v1\0${slug}\0${description}\0`);
-  const visit = async (directory: string): Promise<void> => {
-    for (const entry of (
-      await import("node:fs/promises").then(({ readdir }) =>
-        readdir(directory, { withFileTypes: true }),
-      )
-    ).toSorted((left, right) => left.name.localeCompare(right.name))) {
-      if (entry.name === "node_modules") continue;
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) await visit(path);
-      else if (entry.isFile()) {
-        const relativePath = path.slice(source.dir.length + 1);
-        const bytes = await readFile(path);
-        hash.update(`${relativePath.length}:${relativePath}:${bytes.byteLength}:`).update(bytes);
-      }
-    }
-  };
-  await visit(source.dir);
-  return hash.digest("hex");
 }
 
 async function resolveSkillSource({

--- a/packages/runtime/codex/test/app-server-client.test.ts
+++ b/packages/runtime/codex/test/app-server-client.test.ts
@@ -1,0 +1,39 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { CodexAppServerClient } from "../src/app-server-client.ts";
+
+describe("CodexAppServerClient", () => {
+  it("terminates a spawned process when initialization fails", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough;
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stdin = new PassThrough();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = vi.fn(() => true);
+
+    const start = CodexAppServerClient.start({
+      executablePath: "codex",
+      args: ["app-server"],
+      cwd: process.cwd(),
+      env: {},
+      clientInfo: { name: "test", title: "Test", version: "0.0.0" },
+      spawn: () => {
+        queueMicrotask(() => {
+          child.emit("error", new Error("initialization failed"));
+        });
+        return child as unknown as ChildProcessWithoutNullStreams;
+      },
+    });
+
+    await expect(start).rejects.toThrow("initialization failed");
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});

--- a/packages/runtime/codex/test/codex-home.test.ts
+++ b/packages/runtime/codex/test/codex-home.test.ts
@@ -1,4 +1,15 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,58 +29,267 @@ afterEach(async () => {
 });
 
 describe("managed Codex home", () => {
-  it("exposes authentication and copies environment-based runtime configuration", async () => {
-    const root = await mkdtemp(join(tmpdir(), "pragma-codex-home-"));
-    temporaryDirectories.push(root);
+  it("copies only private configuration and links authentication and the host plugin cache", async () => {
+    const root = await createTemporaryRoot("pragma-codex-home-");
     const sharedCodexHome = join(root, "shared");
     const sessionDir = join(root, "session");
-    await mkdir(sharedCodexHome, { recursive: true });
+    const pluginCache = join(sharedCodexHome, "plugins", "cache");
+    await mkdir(pluginCache, { recursive: true });
     await Promise.all([
       writeFile(join(sharedCodexHome, "auth.json"), '{"auth_mode":"chatgpt"}'),
       writeFile(join(sharedCodexHome, ".env"), "HTTPS_PROXY=http://127.0.0.1:7890\n"),
+      writeFile(join(sharedCodexHome, "config.toml"), 'model = "gpt-test"\n'),
+      writeFile(join(pluginCache, "catalog.json"), "{}\n"),
     ]);
 
-    await mkdir(join(sharedCodexHome, "plugins", "cache"), { recursive: true });
-    await writeFile(join(sharedCodexHome, "plugins", "cache", "catalog.json"), "{}\n");
-    const managed = await prepareManagedCodexHome({
-      agent: { workspace: root } as Expert,
-      sessionDir,
-      pragmaPaths: new PragmaPaths({ pragmaHome: join(root, "pragma") }),
-      env: { CODEX_HOME: sharedCodexHome },
-      logger: { warn: vi.fn() },
-    });
+    const managed = await prepare(root, sessionDir, sharedCodexHome);
 
     await expect(readFile(join(managed.home, "auth.json"), "utf8")).resolves.toContain("chatgpt");
     await expect(readFile(join(managed.home, ".env"), "utf8")).resolves.toContain("HTTPS_PROXY");
-    await expect(
-      readFile(join(managed.home, "plugins", "cache", "catalog.json"), "utf8"),
-    ).resolves.toBe("{}\n");
+    await expect(readFile(join(managed.home, "config.toml"), "utf8")).resolves.toContain(
+      "gpt-test",
+    );
+    expect(await realpath(join(managed.home, "plugins", "cache"))).toBe(
+      await realpath(pluginCache),
+    );
+    expect((await lstat(join(managed.home, "plugins"))).isSymbolicLink()).toBe(false);
     expect(managed.sqliteHome).not.toContain(managed.home);
   });
 
-  it("shares the immutable base while keeping session state private", async () => {
-    const root = await mkdtemp(join(tmpdir(), "pragma-codex-shared-base-"));
-    temporaryDirectories.push(root);
+  it("shares only the rebuildable plugin cache while keeping concurrent session state private", async () => {
+    const root = await createTemporaryRoot("pragma-codex-concurrent-");
     const source = join(root, "source");
-    await mkdir(join(source, "plugins", "cache"), { recursive: true });
-    await writeFile(join(source, "plugins", "cache", "catalog.json"), "shared");
-    const paths = new PragmaPaths({ pragmaHome: join(root, "pragma") });
-    const prepare = async (name: string) =>
-      await prepareManagedCodexHome({
-        agent: { workspace: root } as Expert,
-        sessionDir: join(root, name),
-        pragmaPaths: paths,
-        env: { CODEX_HOME: source },
-        logger: { warn: vi.fn() },
-      });
+    const pluginCache = join(source, "plugins", "cache");
+    await mkdir(pluginCache, { recursive: true });
+    await writeFile(join(pluginCache, "catalog.json"), "shared");
 
-    const [first, second] = await Promise.all([prepare("first"), prepare("second")]);
+    const [first, second] = await Promise.all([
+      prepare(root, join(root, "first"), source),
+      prepare(root, join(root, "second"), source),
+    ]);
 
-    expect(first.sharedBase).toBe(second.sharedBase);
-    expect(await realpath(join(first.home, "plugins"))).toBe(
-      await realpath(join(second.home, "plugins")),
+    expect(await realpath(join(first.home, "plugins", "cache"))).toBe(
+      await realpath(join(second.home, "plugins", "cache")),
     );
     expect(join(first.home, "sessions")).not.toBe(join(second.home, "sessions"));
     expect(first.sqliteHome).not.toBe(second.sqliteHome);
+    await writeFile(join(first.home, "sessions", "first.jsonl"), "private");
+    await expect(stat(join(second.home, "sessions", "first.jsonl"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("copies Agent Skills into each Context instead of sharing mutable skill paths", async () => {
+    const root = await createTemporaryRoot("pragma-codex-private-skills-");
+    const source = join(root, "source");
+    const skill = join(root, "skill");
+    await Promise.all([
+      mkdir(join(source, "plugins", "cache"), { recursive: true }),
+      mkdir(skill, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(skill, "SKILL.md"), "---\nname: review\ndescription: Review\n---\nOriginal\n"),
+      writeFile(join(skill, "reference.md"), "shared source"),
+    ]);
+    const agent = {
+      workspace: root,
+      skills: {
+        skills: [
+          {
+            type: "local",
+            name: "review",
+            description: "Review",
+            path: join(skill, "SKILL.md"),
+          },
+        ],
+      },
+    } as unknown as Expert;
+
+    const [first, second] = await Promise.all([
+      prepare(root, join(root, "first"), source, agent),
+      prepare(root, join(root, "second"), source, agent),
+    ]);
+    const firstSkill = join(first.home, "skills", "review");
+    const secondSkill = join(second.home, "skills", "review");
+
+    expect((await lstat(firstSkill)).isSymbolicLink()).toBe(false);
+    expect((await lstat(secondSkill)).isSymbolicLink()).toBe(false);
+    expect(await realpath(firstSkill)).not.toBe(await realpath(secondSkill));
+    await writeFile(join(firstSkill, "reference.md"), "first only");
+    await expect(readFile(join(secondSkill, "reference.md"), "utf8")).resolves.toBe(
+      "shared source",
+    );
+  });
+
+  it("does not traverse or copy packages, general cache, or plugin staging trees", async () => {
+    const root = await createTemporaryRoot("pragma-codex-minimal-");
+    const source = join(root, "source");
+    await Promise.all([
+      mkdir(join(source, "plugins", "cache"), { recursive: true }),
+      mkdir(join(source, "plugins", ".remote-plugin-install-staging", "large"), {
+        recursive: true,
+      }),
+      mkdir(join(source, "packages"), { recursive: true }),
+      mkdir(join(source, "cache"), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(source, "plugins", "cache", "catalog.json"), "shared"),
+      writeFile(join(source, "plugins", ".remote-plugin-install-staging", "large", "ignored"), "x"),
+      writeFile(join(source, "packages", "ignored"), "x"),
+      writeFile(join(source, "cache", "ignored"), "x"),
+    ]);
+    await symlink(join(source, "packages"), join(source, "packages", "cycle"), "dir");
+
+    const managed = await prepare(root, join(root, "session"), source);
+
+    await expect(stat(join(managed.home, "packages"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(managed.home, "cache"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      stat(join(managed.home, "plugins", ".remote-plugin-install-staging")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      readdir(join(root, "pragma", "cache", "runtimes", "codex", "bases")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("seeds the models cache once, preserves a task refresh, and invalidates it on config changes", async () => {
+    const root = await createTemporaryRoot("pragma-codex-model-cache-");
+    const source = join(root, "source");
+    const session = join(root, "session");
+    await mkdir(join(source, "plugins", "cache"), { recursive: true });
+    await Promise.all([
+      writeFile(join(source, "config.toml"), 'model_provider = "provider-a"\n'),
+      writeFile(join(source, "models_cache.json"), '{"source":"shared"}'),
+    ]);
+
+    const first = await prepare(root, session, source);
+    await expect(readFile(join(first.home, "models_cache.json"), "utf8")).resolves.toContain(
+      "shared",
+    );
+    await writeFile(join(first.home, "models_cache.json"), '{"source":"task"}');
+
+    const reused = await prepare(root, session, source);
+    await expect(readFile(join(reused.home, "models_cache.json"), "utf8")).resolves.toContain(
+      "task",
+    );
+
+    await writeFile(join(source, "config.toml"), 'model_provider = "provider-b"\n');
+    const changed = await prepare(root, session, source);
+    await expect(stat(join(changed.home, "models_cache.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(join(changed.home, "config.toml"), "utf8")).resolves.toContain(
+      "provider-b",
+    );
+  });
+
+  it("copies a relative model catalog and rejects traversal outside the source home", async () => {
+    const root = await createTemporaryRoot("pragma-codex-model-catalog-");
+    const source = join(root, "source");
+    await mkdir(join(source, "catalogs"), { recursive: true });
+    await Promise.all([
+      mkdir(join(source, "plugins", "cache"), { recursive: true }),
+      writeFile(join(source, "config.toml"), 'model_catalog_json = "catalogs/models.json"\n'),
+      writeFile(join(source, "catalogs", "models.json"), '{"models":[]}'),
+    ]);
+
+    const managed = await prepare(root, join(root, "valid"), source);
+    await expect(
+      readFile(join(managed.home, "catalogs", "models.json"), "utf8"),
+    ).resolves.toContain("models");
+
+    await writeFile(join(source, "config.toml"), 'model_catalog_json = "../outside.json"\n');
+    await expect(prepare(root, join(root, "invalid"), source)).rejects.toThrow(
+      "must stay inside CODEX_HOME",
+    );
+  });
+
+  it("uses a private empty plugin cache when the host has no cache", async () => {
+    const root = await createTemporaryRoot("pragma-codex-empty-plugin-cache-");
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+
+    const managed = await prepare(root, join(root, "session"), source);
+
+    const cache = join(managed.home, "plugins", "cache");
+    expect((await stat(cache)).isDirectory()).toBe(true);
+    expect((await lstat(cache)).isSymbolicLink()).toBe(false);
+  });
+
+  it("migrates known legacy base links without deleting the base or private session state", async () => {
+    const root = await createTemporaryRoot("pragma-codex-legacy-base-");
+    const source = join(root, "source");
+    const session = join(root, "session");
+    const paths = new PragmaPaths({ pragmaHome: join(root, "pragma") });
+    const fingerprint = "a".repeat(64);
+    const base = join(paths.codexRuntimeCacheRoot(), "bases", fingerprint);
+    await Promise.all([
+      mkdir(join(source, "plugins", "cache"), { recursive: true }),
+      mkdir(join(base, "plugins", "cache"), { recursive: true }),
+      mkdir(join(base, "packages"), { recursive: true }),
+      mkdir(join(base, "cache"), { recursive: true }),
+      mkdir(join(session, "home", "sessions"), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(source, "plugins", "cache", "catalog.json"), "host"),
+      writeFile(join(base, "plugins", "cache", "catalog.json"), "legacy"),
+      writeFile(join(session, "home", "sessions", "resume.jsonl"), "keep"),
+      symlink(join(base, "plugins"), join(session, "home", "plugins"), "dir"),
+      symlink(join(base, "packages"), join(session, "home", "packages"), "dir"),
+      symlink(join(base, "cache"), join(session, "home", "cache"), "dir"),
+      writeFile(
+        join(session, "layout.json"),
+        `${JSON.stringify({
+          schemaVersion: "pragma.codex-home/v2",
+          sharedBase: base,
+          baseFingerprint: fingerprint,
+        })}\n`,
+      ),
+    ]);
+
+    const managed = await prepareWithPaths(root, session, source, paths);
+
+    expect(await realpath(join(managed.home, "plugins", "cache"))).toBe(
+      await realpath(join(source, "plugins", "cache")),
+    );
+    await expect(readFile(join(managed.home, "sessions", "resume.jsonl"), "utf8")).resolves.toBe(
+      "keep",
+    );
+    await expect(stat(join(managed.home, "packages"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(managed.home, "cache"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(session, "layout.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(base)).resolves.toBeDefined();
   });
 });
+
+async function createTemporaryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function prepare(root: string, sessionDir: string, source: string, agent?: Expert) {
+  return await prepareWithPaths(
+    root,
+    sessionDir,
+    source,
+    new PragmaPaths({ pragmaHome: join(root, "pragma") }),
+    agent,
+  );
+}
+
+async function prepareWithPaths(
+  root: string,
+  sessionDir: string,
+  source: string,
+  paths: PragmaPaths,
+  agent: Expert = { workspace: root } as Expert,
+) {
+  return await prepareManagedCodexHome({
+    agent,
+    sessionDir,
+    pragmaPaths: paths,
+    env: { CODEX_HOME: source },
+    logger: { info: vi.fn(), warn: vi.fn() },
+  });
+}

--- a/packages/runtime/pi/src/adapter.ts
+++ b/packages/runtime/pi/src/adapter.ts
@@ -9,7 +9,7 @@ import type {
   CreateAgentSessionOptions,
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import type { McpToolRegistry, RuntimeAdapter } from "@pragma/core";
+import type { McpToolRegistry, PragmaLogger, RuntimeAdapter } from "@pragma/core";
 import {
   createMcpToolRegistry,
   defineRuntimeDriver,
@@ -99,93 +99,217 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
         };
       },
       async createSession(ctx): Promise<PiDriverSession> {
+        const sessionStartedAt = performance.now();
         const selectedModel = ctx.request.modelSelection?.model;
         const selectedProviderId = selectedModel?.providerId;
-        const registeredProvider =
+        const registeredProviderPromise =
           selectedProviderId === undefined
-            ? undefined
-            : await options.modelProviders?.resolveProvider(selectedProviderId);
-        if (selectedProviderId !== undefined && registeredProvider === undefined) {
-          throw new Error(`PI model provider is not registered: ${selectedProviderId}`);
-        }
+            ? Promise.resolve(undefined)
+            : timedPiPhase(ctx.logger, "model_provider_resolve", sessionStartedAt, async () =>
+                options.modelProviders?.resolveProvider(selectedProviderId),
+              );
         const cwd = ctx.workspace;
         const settingsManager = SettingsManager.create(cwd);
-        const { modelRegistry, modelRuntime } = await createPiModelRuntime(
-          registeredProvider === undefined
-            ? []
-            : [modelProviderConverter.convertProvider(registeredProvider)],
-        );
         const loader = createResourceLoader(ctx.agent, cwd, ctx.agentContext.systemPrompt);
-        await loader.reload();
-        const mcpToolRegistry = await createMcpToolRegistry(ctx.agent.mcp);
-        const streamState: PiRuntimeStreamState = { logger: ctx.logger };
-        const resolvedTools = createResolvedPiTools({
-          agent: ctx.agent,
-          cwd,
-          mcpTools: mcpToolRegistry.tools,
-          parentSystemPrompt: ctx.agentContext.systemPrompt,
-          streamState,
-          lifecycle: ctx.lifecycle,
-          context: ctx.runContext,
-          executionContext: ctx.request.executionContext,
-          humanInteractionHandler: ctx.request.humanInteractionHandler,
-        });
-        const piSessionManagerResult = await createPiSessionManager(
-          cwd,
-          ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("pi"),
-          ctx.request.runtimeSession?.id,
+        const resourceReloadPromise = timedPiPhase(
+          ctx.logger,
+          "resource_loader_reload",
+          sessionStartedAt,
+          async () => await loader.reload(),
         );
-        const sessionOptions: CreateAgentSessionOptions = {
-          cwd,
-          modelRuntime,
-          resourceLoader: loader,
-          sessionManager: piSessionManagerResult.sessionManager,
-          settingsManager,
-        };
-        const defaultModel = resolveRequiredRuntimeModel(
-          selectedModel,
-          modelRegistry,
-          "agent default",
+        const mcpRegistryPromise = timedPiPhase(
+          ctx.logger,
+          "mcp_tool_registry",
+          sessionStartedAt,
+          async () => await createMcpToolRegistry(ctx.agent.mcp),
         );
-
-        if (defaultModel !== undefined) {
-          sessionOptions.model = defaultModel;
-        }
-        const defaultThinkingLevel = resolvePiThinkingLevel(
-          ctx.request.modelSelection?.thinkingLevel,
+        const sessionManagerPromise = timedPiPhase(
+          ctx.logger,
+          "session_manager",
+          sessionStartedAt,
+          async () =>
+            await createPiSessionManager(
+              cwd,
+              ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("pi"),
+              ctx.request.runtimeSession?.id,
+            ),
         );
-        if (defaultThinkingLevel !== undefined) {
-          sessionOptions.thinkingLevel = defaultThinkingLevel;
+        let registeredProvider: Awaited<typeof registeredProviderPromise>;
+        try {
+          registeredProvider = await registeredProviderPromise;
+        } catch (error) {
+          const preparation = await Promise.allSettled([
+            resourceReloadPromise,
+            mcpRegistryPromise,
+            sessionManagerPromise,
+          ]);
+          const registry = preparation[1];
+          if (registry?.status === "fulfilled") {
+            const cleanupError = await piRegistryCleanupError(registry.value);
+            if (cleanupError !== undefined) {
+              throw new AggregateError(
+                [error, cleanupError],
+                "PI model provider resolution and cleanup failed.",
+                { cause: error },
+              );
+            }
+          }
+          throw error;
         }
-
-        sessionOptions.customTools = [
-          ...resolvedTools.tools.map((tool) => tool.tool),
-          createPiSessionBashTool({
-            cwd,
-            processEnvironment: ctx.processEnvironment,
-            commandPrefix: settingsManager.getShellCommandPrefix(),
-            shellPath: settingsManager.getShellPath(),
-          }),
-        ];
-
-        const { session } = await createAgentSession(sessionOptions);
-        if (!piSessionManagerResult.resumedExistingSession) {
-          appendStartupMessages(session, ctx.agentContext.startupMessages);
+        if (selectedProviderId !== undefined && registeredProvider === undefined) {
+          const providerError = new Error(
+            `PI model provider is not registered: ${selectedProviderId}`,
+          );
+          const preparation = await Promise.allSettled([
+            resourceReloadPromise,
+            mcpRegistryPromise,
+            sessionManagerPromise,
+          ]);
+          const registry = preparation[1];
+          if (registry?.status === "fulfilled") {
+            const cleanupError = await piRegistryCleanupError(registry.value);
+            if (cleanupError !== undefined) {
+              throw new AggregateError(
+                [providerError, cleanupError],
+                "PI model provider validation and cleanup failed.",
+                { cause: providerError },
+              );
+            }
+          }
+          throw providerError;
         }
-
-        return {
-          ...createPiNativeSession({
+        const modelRuntimePromise = timedPiPhase(
+          ctx.logger,
+          "model_runtime",
+          sessionStartedAt,
+          async () =>
+            await createPiModelRuntime(
+              registeredProvider === undefined
+                ? []
+                : [modelProviderConverter.convertProvider(registeredProvider)],
+            ),
+        );
+        let modelRuntimeResult: Awaited<ReturnType<typeof createPiModelRuntime>>;
+        let mcpToolRegistry: McpToolRegistry;
+        let piSessionManagerResult: Awaited<ReturnType<typeof createPiSessionManager>>;
+        try {
+          [modelRuntimeResult, mcpToolRegistry, piSessionManagerResult] = await Promise.all([
+            modelRuntimePromise,
+            mcpRegistryPromise,
+            sessionManagerPromise,
+            resourceReloadPromise,
+          ]);
+        } catch (error) {
+          const registry = await Promise.allSettled([mcpRegistryPromise]);
+          if (registry[0]?.status === "fulfilled") {
+            const cleanupError = await piRegistryCleanupError(registry[0].value);
+            if (cleanupError !== undefined) {
+              throw new AggregateError(
+                [error, cleanupError],
+                "PI preparation and cleanup failed.",
+                { cause: error },
+              );
+            }
+          }
+          throw error;
+        }
+        let session: AgentSession | undefined;
+        try {
+          const { modelRegistry, modelRuntime } = modelRuntimeResult;
+          const streamState: PiRuntimeStreamState = { logger: ctx.logger };
+          const toolsStartedAt = performance.now();
+          const resolvedTools = createResolvedPiTools({
             agent: ctx.agent,
-            session,
+            cwd,
+            mcpTools: mcpToolRegistry.tools,
+            parentSystemPrompt: ctx.agentContext.systemPrompt,
             streamState,
-            models: {
-              defaultModel: selectedModel,
-              modelRegistry,
-              modelRuntime,
-            },
-          }),
-          mcpToolRegistry,
-        };
+            lifecycle: ctx.lifecycle,
+            context: ctx.runContext,
+            executionContext: ctx.request.executionContext,
+            humanInteractionHandler: ctx.request.humanInteractionHandler,
+          });
+          logPiPhase(ctx.logger, "tool_schema_build", toolsStartedAt, sessionStartedAt, {
+            toolCount: resolvedTools.tools.length,
+            systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+          });
+          const sessionOptions: CreateAgentSessionOptions = {
+            cwd,
+            modelRuntime,
+            resourceLoader: loader,
+            sessionManager: piSessionManagerResult.sessionManager,
+            settingsManager,
+          };
+          const defaultModel = resolveRequiredRuntimeModel(
+            selectedModel,
+            modelRegistry,
+            "agent default",
+          );
+
+          if (defaultModel !== undefined) {
+            sessionOptions.model = defaultModel;
+          }
+          const defaultThinkingLevel = resolvePiThinkingLevel(
+            ctx.request.modelSelection?.thinkingLevel,
+          );
+          if (defaultThinkingLevel !== undefined) {
+            sessionOptions.thinkingLevel = defaultThinkingLevel;
+          }
+
+          sessionOptions.customTools = [
+            ...resolvedTools.tools.map((tool) => tool.tool),
+            createPiSessionBashTool({
+              cwd,
+              processEnvironment: ctx.processEnvironment,
+              commandPrefix: settingsManager.getShellCommandPrefix(),
+              shellPath: settingsManager.getShellPath(),
+            }),
+          ];
+
+          ({ session } = await timedPiPhase(
+            ctx.logger,
+            "agent_session_create",
+            sessionStartedAt,
+            async () => await createAgentSession(sessionOptions),
+          ));
+          if (!piSessionManagerResult.resumedExistingSession) {
+            appendStartupMessages(session, ctx.agentContext.startupMessages);
+          }
+          ctx.logger.info("runtime.pi_session_ready", "PI Session preparation completed", {
+            elapsedMs: piElapsedMs(sessionStartedAt),
+            toolCount: sessionOptions.customTools?.length ?? 0,
+            systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+          });
+
+          return {
+            ...createPiNativeSession({
+              agent: ctx.agent,
+              session,
+              streamState,
+              models: {
+                defaultModel: selectedModel,
+                modelRegistry,
+                modelRuntime,
+              },
+            }),
+            mcpToolRegistry,
+          };
+        } catch (error) {
+          const cleanupErrors = (
+            await Promise.allSettled([
+              Promise.resolve().then(() => session?.dispose()),
+              mcpToolRegistry.dispose(),
+            ])
+          ).flatMap((result) => (result.status === "rejected" ? [result.reason as unknown] : []));
+          if (cleanupErrors.length > 0) {
+            throw new AggregateError(
+              [error, ...cleanupErrors],
+              "PI runtime initialization and cleanup failed.",
+              { cause: error },
+            );
+          }
+          throw error;
+        }
       },
       readSession(session) {
         return {
@@ -229,6 +353,42 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
       sessionSyncCallback: options.sessionSyncCallback,
     },
   );
+}
+
+async function timedPiPhase<T>(
+  logger: Pick<PragmaLogger, "info">,
+  phase: string,
+  sessionStartedAt: number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  const value = await operation();
+  logPiPhase(logger, phase, startedAt, sessionStartedAt);
+  return value;
+}
+
+function logPiPhase(
+  logger: Pick<PragmaLogger, "info">,
+  phase: string,
+  phaseStartedAt: number,
+  sessionStartedAt: number,
+  attributes: Record<string, unknown> = {},
+): void {
+  logger.info("runtime.pi_prepare_phase", `PI preparation phase completed: ${phase}`, {
+    phase,
+    durationMs: piElapsedMs(phaseStartedAt),
+    elapsedMs: piElapsedMs(sessionStartedAt),
+    ...attributes,
+  });
+}
+
+function piElapsedMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
+}
+
+async function piRegistryCleanupError(registry: McpToolRegistry): Promise<unknown | undefined> {
+  const [result] = await Promise.allSettled([registry.dispose()]);
+  return result?.status === "rejected" ? result.reason : undefined;
 }
 
 export function createPiSessionBashTool(options: {

--- a/packages/runtime/pi/src/session.ts
+++ b/packages/runtime/pi/src/session.ts
@@ -217,6 +217,7 @@ function aggregateAssistantUsage(messages: readonly unknown[]): AgentMessageUsag
 
   return usages.reduce<AgentMessageUsage>(
     (total, usage) => ({
+      measurement: "reported",
       input: total.input + usage.input,
       output: total.output + usage.output,
       cacheRead: total.cacheRead + usage.cacheRead,
@@ -242,12 +243,16 @@ function readAssistantUsage(message: unknown): AgentMessageUsage | undefined {
     return undefined;
   }
 
-  const result = AgentMessageUsageSchema.safeParse(message["usage"]);
+  const result = AgentMessageUsageSchema.safeParse({
+    measurement: "reported",
+    ...(isRecord(message["usage"]) ? message["usage"] : {}),
+  });
   return result.success ? result.data : undefined;
 }
 
 function createEmptyUsage(): AgentMessageUsage {
   return {
+    measurement: "reported",
     input: 0,
     output: 0,
     cacheRead: 0,

--- a/packages/runtime/qodercli/package.json
+++ b/packages/runtime/qodercli/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pragma/runtime-qodercli",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./availability": {
+      "types": "./src/availability.ts",
+      "default": "./src/availability.ts"
+    },
+    "./models": {
+      "types": "./src/models.ts",
+      "default": "./src/models.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "eslint src test",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@pragma/core": "workspace:*",
+    "@pragma/shared": "workspace:*",
+    "@qoder-ai/qoder-agent-sdk": "1.0.15",
+    "zod": "latest"
+  },
+  "devDependencies": {
+    "@pragma/tsconfig": "workspace:*",
+    "@types/node": "latest",
+    "typescript": "latest",
+    "vitest": "latest"
+  }
+}

--- a/packages/runtime/qodercli/src/adapter.ts
+++ b/packages/runtime/qodercli/src/adapter.ts
@@ -2,12 +2,13 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import {
-  createMcpToolRegistry,
+  createMcpToolRegistryPool,
   defineRuntimeDriver,
   registerExpertToolsMcpSession,
   type ExpertToolsMcpSessionRegistration,
   type ExpertToolRuntimeState,
   type McpToolRegistry,
+  type McpToolRegistryLease,
   type PragmaLogger,
   type RuntimeAdapter,
   type RuntimeSessionPersistenceSpec,
@@ -48,10 +49,12 @@ const QODER_DESCRIPTOR = {
 
 interface QoderDriverSession extends QoderNativeSession {
   readonly mcpToolRegistry: McpToolRegistry;
+  readonly mcpToolRegistryLease: McpToolRegistryLease;
   readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
 }
 
 export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {}): RuntimeAdapter {
+  const mcpToolRegistries = createMcpToolRegistryPool();
   const descriptor = {
     ...QODER_DESCRIPTOR,
     ...options.descriptor,
@@ -105,24 +108,23 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
           sessionStartedAt,
           async () => await materializeQoderSkillPlugin(ctx.agent, sessionDir),
         );
-        const registryPromise = timedQoderPhase(
+        const registryLeasePromise = timedQoderPhase(
           ctx.logger,
           "mcp_tool_registry",
           sessionStartedAt,
-          async () => await createMcpToolRegistry(ctx.agent.mcp),
+          async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
         );
         let configDir: string;
         let plugin: Awaited<ReturnType<typeof materializeQoderSkillPlugin>>;
         let mcpToolRegistry: McpToolRegistry | undefined;
+        let mcpToolRegistryLease: McpToolRegistryLease | undefined;
         try {
-          [configDir, plugin, mcpToolRegistry] = await Promise.all([
-            configPromise,
-            pluginPromise,
-            registryPromise,
-          ]);
+          const prepared = await Promise.all([configPromise, pluginPromise, registryLeasePromise]);
+          [configDir, plugin, mcpToolRegistryLease] = prepared;
+          mcpToolRegistry = mcpToolRegistryLease.registry;
         } catch (error) {
-          const registry = await Promise.allSettled([registryPromise]);
-          if (registry[0]?.status === "fulfilled") await registry[0].value.dispose();
+          const registry = await Promise.allSettled([registryLeasePromise]);
+          if (registry[0]?.status === "fulfilled") await registry[0].value.release();
           throw error;
         }
         const restoredRuntimeSessionId =
@@ -190,10 +192,11 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
             toolNames: new Map(),
             sessionId: restoredRuntimeSessionId,
             mcpToolRegistry,
+            mcpToolRegistryLease,
             expertToolsMcpRegistration,
           };
         } catch (error) {
-          await disposeResources(expertToolsMcpRegistration, mcpToolRegistry);
+          await disposeResources(expertToolsMcpRegistration, mcpToolRegistryLease);
           throw error;
         }
       },
@@ -214,7 +217,7 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
       cancelTurn: cancelQoderTurn,
       async closeSession(session) {
         await closeQoderSession(session);
-        await disposeResources(session.expertToolsMcpRegistration, session.mcpToolRegistry);
+        await disposeResources(session.expertToolsMcpRegistration, session.mcpToolRegistryLease);
       },
     },
     {
@@ -269,9 +272,9 @@ function assertProvider(providerId: string | undefined): void {
 
 async function disposeResources(
   registration: ExpertToolsMcpSessionRegistration | undefined,
-  registry: McpToolRegistry | undefined,
+  registryLease: McpToolRegistryLease | undefined,
 ): Promise<void> {
-  const results = await Promise.allSettled([registration?.dispose(), registry?.dispose()]);
+  const results = await Promise.allSettled([registration?.dispose(), registryLease?.release()]);
   const errors = results.flatMap((result) =>
     result.status === "rejected" ? [result.reason as unknown] : [],
   );

--- a/packages/runtime/qodercli/src/adapter.ts
+++ b/packages/runtime/qodercli/src/adapter.ts
@@ -1,0 +1,224 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  createMcpToolRegistry,
+  defineRuntimeDriver,
+  registerExpertToolsMcpSession,
+  type ExpertToolsMcpSessionRegistration,
+  type ExpertToolRuntimeState,
+  type McpToolRegistry,
+  type RuntimeAdapter,
+  type RuntimeSessionPersistenceSpec,
+} from "@pragma/core";
+
+import { canUseQoderCliRuntime } from "./availability.ts";
+import { resolveQoderCliExecutablePath } from "./executable.ts";
+import { createQoderCliModelDiscovery } from "./models.ts";
+import { prepareManagedQoderConfig } from "./qoder-config.ts";
+import { resolveQoderAuth } from "./sdk-options.ts";
+import {
+  cancelQoderTurn,
+  closeQoderSession,
+  compactQoderContextWindow,
+  listQoderMessages,
+  mapQoderEvent,
+  readQoderContextWindow,
+  startQoderTurn,
+  type QoderNativeSession,
+} from "./session.ts";
+import { materializeQoderSkillPlugin } from "./skills.ts";
+import type { QoderCliRuntimeAdapterOptions } from "./types.ts";
+
+const QODER_DESCRIPTOR = {
+  id: "qodercli-local",
+  kind: "qodercli-local" as const,
+  displayName: "Qoder CLI Local",
+  capabilities: {
+    targets: ["agent"],
+    executionLocations: ["local"],
+    supportsAbort: true,
+    supportsMcp: true,
+    supportsModelDiscovery: true,
+    supportsStreaming: true,
+    supportsThinkingLevel: true,
+  },
+};
+
+interface QoderDriverSession extends QoderNativeSession {
+  readonly mcpToolRegistry: McpToolRegistry;
+  readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
+}
+
+export function createQoderCliRuntime(
+  options: QoderCliRuntimeAdapterOptions = {},
+): RuntimeAdapter {
+  const descriptor = {
+    ...QODER_DESCRIPTOR,
+    ...options.descriptor,
+    kind: options.descriptor?.kind ?? QODER_DESCRIPTOR.kind,
+    capabilities: {
+      ...QODER_DESCRIPTOR.capabilities,
+      ...options.descriptor?.capabilities,
+    },
+  };
+  const listModels = options.listModels ?? createQoderCliModelDiscovery(options);
+
+  return defineRuntimeDriver(
+    {
+      descriptor,
+      canUse: options.canUse ?? (() => canUseQoderCliRuntime(options)),
+      listModels,
+      outputRetryLimit: options.outputRetryLimit,
+      resolvePersistence(ctx): RuntimeSessionPersistenceSpec {
+        return {
+          mode: "checkpoint",
+          sessionDir: ctx.paths.runtimeSessionDir("qodercli"),
+          checkpointOn: [
+            "session.created",
+            "runtimeSessionId.changed",
+            "turn.completed",
+            "context.compacted",
+            "session.destroyed",
+          ],
+          metadata: { format: "qodercli-managed-config" },
+        };
+      },
+      async createSession(ctx): Promise<QoderDriverSession> {
+        assertProvider(ctx.request.modelSelection?.model.providerId);
+        const sessionDir =
+          ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("qodercli");
+        const configDir = await prepareManagedQoderConfig({
+          sessionDir,
+          env: ctx.processEnvironment,
+          logger: ctx.logger,
+        });
+        const restoredRuntimeSessionId =
+          ctx.persistence.restoredRuntimeSessionId ?? ctx.request.runtimeSession?.id ?? "";
+        if (
+          restoredRuntimeSessionId !== "" &&
+          !(await nativeSessionFileExists(
+            join(configDir, "projects"),
+            restoredRuntimeSessionId,
+          ))
+        ) {
+          throw new Error(
+            `Qoder CLI runtime session file was not found: ${restoredRuntimeSessionId}.`,
+          );
+        }
+        const plugin = await materializeQoderSkillPlugin(ctx.agent, sessionDir);
+        const toolRuntimeState: ExpertToolRuntimeState = {};
+        let mcpToolRegistry: McpToolRegistry | undefined;
+        let expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined;
+
+        try {
+          mcpToolRegistry = await createMcpToolRegistry(ctx.agent.mcp);
+          expertToolsMcpRegistration = await registerExpertToolsMcpSession({
+            agent: ctx.agent,
+            getContext: () => ctx.lifecycle.currentContext,
+            humanInteractionHandler: ctx.request.humanInteractionHandler,
+            logger: ctx.logger,
+            mcpTools: mcpToolRegistry.tools,
+            state: toolRuntimeState,
+            executionContext: ctx.request.executionContext,
+          });
+          return {
+            agent: ctx.agent,
+            auth: resolveQoderAuth(options),
+            executablePath: resolveQoderCliExecutablePath(options),
+            env: { ...ctx.processEnvironment },
+            configDir,
+            mcpServerUrl: expertToolsMcpRegistration.url,
+            plugin,
+            logger: ctx.logger,
+            humanInteractionHandler: ctx.request.humanInteractionHandler,
+            permissionMode: options.permissionMode ?? "default",
+            defaultModelName:
+              ctx.request.modelSelection?.model.modelId ?? options.defaultModelName,
+            defaultThinkingLevel:
+              ctx.request.modelSelection?.thinkingLevel ?? options.defaultThinkingLevel,
+            contextWindowOverride: options.contextWindowTokens,
+            compactModelName: options.compactModelName,
+            systemPrompt: ctx.agentContext.systemPrompt,
+            toolRuntimeState,
+            messages: [],
+            toolNames: new Map(),
+            sessionId: restoredRuntimeSessionId,
+            mcpToolRegistry,
+            expertToolsMcpRegistration,
+          };
+        } catch (error) {
+          await disposeResources(expertToolsMcpRegistration, mcpToolRegistry);
+          throw error;
+        }
+      },
+      readSession(session) {
+        return {
+          runtimeSessionId: session.sessionId,
+          messages: session.messages,
+        };
+      },
+      listMessages: listQoderMessages,
+      async startTurn(session, turn) {
+        assertProvider(turn.modelSelection?.model.providerId);
+        return await startQoderTurn(session, turn);
+      },
+      mapEvent: mapQoderEvent,
+      readContextWindow: readQoderContextWindow,
+      compactContext: compactQoderContextWindow,
+      cancelTurn: cancelQoderTurn,
+      async closeSession(session) {
+        await closeQoderSession(session);
+        await disposeResources(
+          session.expertToolsMcpRegistration,
+          session.mcpToolRegistry,
+        );
+      },
+    },
+    {
+      sessionRestoreHandler: options.sessionRestoreHandler,
+      sessionSyncCallback: options.sessionSyncCallback,
+      createProcessEnvironment: () => ({
+        ...process.env,
+        ...(options.env ?? {}),
+      }),
+    },
+  );
+}
+
+async function nativeSessionFileExists(
+  root: string,
+  runtimeSessionId: string,
+): Promise<boolean> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (await nativeSessionFileExists(path, runtimeSessionId)) return true;
+    } else if (entry.isFile() && entry.name === `${runtimeSessionId}.jsonl`) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function assertProvider(providerId: string | undefined): void {
+  if (providerId !== undefined && providerId !== "qoder") {
+    throw new Error("Qoder CLI runtime only supports provider qoder.");
+  }
+}
+
+async function disposeResources(
+  registration: ExpertToolsMcpSessionRegistration | undefined,
+  registry: McpToolRegistry | undefined,
+): Promise<void> {
+  const results = await Promise.allSettled([
+    registration?.dispose(),
+    registry?.dispose(),
+  ]);
+  const errors = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason as unknown] : [],
+  );
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) throw new AggregateError(errors, "Qoder runtime cleanup failed.");
+}

--- a/packages/runtime/qodercli/src/adapter.ts
+++ b/packages/runtime/qodercli/src/adapter.ts
@@ -8,6 +8,7 @@ import {
   type ExpertToolsMcpSessionRegistration,
   type ExpertToolRuntimeState,
   type McpToolRegistry,
+  type PragmaLogger,
   type RuntimeAdapter,
   type RuntimeSessionPersistenceSpec,
 } from "@pragma/core";
@@ -50,9 +51,7 @@ interface QoderDriverSession extends QoderNativeSession {
   readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
 }
 
-export function createQoderCliRuntime(
-  options: QoderCliRuntimeAdapterOptions = {},
-): RuntimeAdapter {
+export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {}): RuntimeAdapter {
   const descriptor = {
     ...QODER_DESCRIPTOR,
     ...options.descriptor,
@@ -85,42 +84,89 @@ export function createQoderCliRuntime(
         };
       },
       async createSession(ctx): Promise<QoderDriverSession> {
+        const sessionStartedAt = performance.now();
         assertProvider(ctx.request.modelSelection?.model.providerId);
         const sessionDir =
           ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("qodercli");
-        const configDir = await prepareManagedQoderConfig({
-          sessionDir,
-          env: ctx.processEnvironment,
-          logger: ctx.logger,
-        });
+        const configPromise = timedQoderPhase(
+          ctx.logger,
+          "prepare_managed_config",
+          sessionStartedAt,
+          async () =>
+            await prepareManagedQoderConfig({
+              sessionDir,
+              env: ctx.processEnvironment,
+              logger: ctx.logger,
+            }),
+        );
+        const pluginPromise = timedQoderPhase(
+          ctx.logger,
+          "skill_plugin_materialization",
+          sessionStartedAt,
+          async () => await materializeQoderSkillPlugin(ctx.agent, sessionDir),
+        );
+        const registryPromise = timedQoderPhase(
+          ctx.logger,
+          "mcp_tool_registry",
+          sessionStartedAt,
+          async () => await createMcpToolRegistry(ctx.agent.mcp),
+        );
+        let configDir: string;
+        let plugin: Awaited<ReturnType<typeof materializeQoderSkillPlugin>>;
+        let mcpToolRegistry: McpToolRegistry | undefined;
+        try {
+          [configDir, plugin, mcpToolRegistry] = await Promise.all([
+            configPromise,
+            pluginPromise,
+            registryPromise,
+          ]);
+        } catch (error) {
+          const registry = await Promise.allSettled([registryPromise]);
+          if (registry[0]?.status === "fulfilled") await registry[0].value.dispose();
+          throw error;
+        }
         const restoredRuntimeSessionId =
           ctx.persistence.restoredRuntimeSessionId ?? ctx.request.runtimeSession?.id ?? "";
-        if (
-          restoredRuntimeSessionId !== "" &&
-          !(await nativeSessionFileExists(
-            join(configDir, "projects"),
-            restoredRuntimeSessionId,
-          ))
-        ) {
-          throw new Error(
-            `Qoder CLI runtime session file was not found: ${restoredRuntimeSessionId}.`,
-          );
-        }
-        const plugin = await materializeQoderSkillPlugin(ctx.agent, sessionDir);
         const toolRuntimeState: ExpertToolRuntimeState = {};
-        let mcpToolRegistry: McpToolRegistry | undefined;
         let expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined;
 
         try {
-          mcpToolRegistry = await createMcpToolRegistry(ctx.agent.mcp);
-          expertToolsMcpRegistration = await registerExpertToolsMcpSession({
-            agent: ctx.agent,
-            getContext: () => ctx.lifecycle.currentContext,
-            humanInteractionHandler: ctx.request.humanInteractionHandler,
-            logger: ctx.logger,
-            mcpTools: mcpToolRegistry.tools,
-            state: toolRuntimeState,
-            executionContext: ctx.request.executionContext,
+          if (
+            restoredRuntimeSessionId !== "" &&
+            !(await timedQoderPhase(
+              ctx.logger,
+              "restore_session_lookup",
+              sessionStartedAt,
+              async () =>
+                await nativeSessionFileExists(
+                  join(configDir, "projects"),
+                  restoredRuntimeSessionId,
+                ),
+            ))
+          ) {
+            throw new Error(
+              `Qoder CLI runtime session file was not found: ${restoredRuntimeSessionId}.`,
+            );
+          }
+          expertToolsMcpRegistration = await timedQoderPhase(
+            ctx.logger,
+            "mcp_tool_registration",
+            sessionStartedAt,
+            async () =>
+              await registerExpertToolsMcpSession({
+                agent: ctx.agent,
+                getContext: () => ctx.lifecycle.currentContext,
+                humanInteractionHandler: ctx.request.humanInteractionHandler,
+                logger: ctx.logger,
+                mcpTools: mcpToolRegistry.tools,
+                state: toolRuntimeState,
+                executionContext: ctx.request.executionContext,
+              }),
+          );
+          ctx.logger.info("runtime.qodercli_session_ready", "Qoder Session preparation completed", {
+            elapsedMs: qoderElapsedMs(sessionStartedAt),
+            systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+            toolCount: mcpToolRegistry.tools.length,
           });
           return {
             agent: ctx.agent,
@@ -133,8 +179,7 @@ export function createQoderCliRuntime(
             logger: ctx.logger,
             humanInteractionHandler: ctx.request.humanInteractionHandler,
             permissionMode: options.permissionMode ?? "default",
-            defaultModelName:
-              ctx.request.modelSelection?.model.modelId ?? options.defaultModelName,
+            defaultModelName: ctx.request.modelSelection?.model.modelId ?? options.defaultModelName,
             defaultThinkingLevel:
               ctx.request.modelSelection?.thinkingLevel ?? options.defaultThinkingLevel,
             contextWindowOverride: options.contextWindowTokens,
@@ -169,10 +214,7 @@ export function createQoderCliRuntime(
       cancelTurn: cancelQoderTurn,
       async closeSession(session) {
         await closeQoderSession(session);
-        await disposeResources(
-          session.expertToolsMcpRegistration,
-          session.mcpToolRegistry,
-        );
+        await disposeResources(session.expertToolsMcpRegistration, session.mcpToolRegistry);
       },
     },
     {
@@ -186,10 +228,27 @@ export function createQoderCliRuntime(
   );
 }
 
-async function nativeSessionFileExists(
-  root: string,
-  runtimeSessionId: string,
-): Promise<boolean> {
+async function timedQoderPhase<T>(
+  logger: Pick<PragmaLogger, "info">,
+  phase: string,
+  sessionStartedAt: number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  const value = await operation();
+  logger.info("runtime.qodercli_prepare_phase", `Qoder preparation phase completed: ${phase}`, {
+    phase,
+    durationMs: qoderElapsedMs(startedAt),
+    elapsedMs: qoderElapsedMs(sessionStartedAt),
+  });
+  return value;
+}
+
+function qoderElapsedMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
+}
+
+async function nativeSessionFileExists(root: string, runtimeSessionId: string): Promise<boolean> {
   const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
     const path = join(root, entry.name);
@@ -212,10 +271,7 @@ async function disposeResources(
   registration: ExpertToolsMcpSessionRegistration | undefined,
   registry: McpToolRegistry | undefined,
 ): Promise<void> {
-  const results = await Promise.allSettled([
-    registration?.dispose(),
-    registry?.dispose(),
-  ]);
+  const results = await Promise.allSettled([registration?.dispose(), registry?.dispose()]);
   const errors = results.flatMap((result) =>
     result.status === "rejected" ? [result.reason as unknown] : [],
   );

--- a/packages/runtime/qodercli/src/availability.ts
+++ b/packages/runtime/qodercli/src/availability.ts
@@ -1,0 +1,32 @@
+import { canUseRuntimeBinary } from "@pragma/core/runtime/process-probe";
+import type { RuntimeCanUseResult } from "@pragma/core";
+import { BoundedLruCache } from "@pragma/shared";
+
+import { resolveQoderCliExecutablePath } from "./executable.ts";
+import type { QoderCliRuntimeAdapterOptions } from "./types.ts";
+
+const CACHE_TTL_MS = 60_000;
+const cache = new BoundedLruCache<string, { expiresAt: number; result: RuntimeCanUseResult }>(64);
+
+export async function canUseQoderCliRuntime(
+  options: QoderCliRuntimeAdapterOptions = {},
+): Promise<RuntimeCanUseResult> {
+  const executablePath = resolveQoderCliExecutablePath(options);
+  const key = `${executablePath}\0${options.env?.["PATH"] ?? ""}`;
+  const cached = cache.get(key);
+  if (cached !== undefined && cached.expiresAt > Date.now()) return cached.result;
+
+  const result = await canUseRuntimeBinary({
+    runtimeName: "Qoder CLI",
+    defaultExecutablePath: "qodercli",
+    executablePath,
+    args: ["--version"],
+    env: { ...process.env, ...(options.env ?? {}) },
+  });
+  const normalized = {
+    ...result,
+    details: { ...result.details, executablePath },
+  };
+  cache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, result: normalized });
+  return normalized;
+}

--- a/packages/runtime/qodercli/src/availability.ts
+++ b/packages/runtime/qodercli/src/availability.ts
@@ -7,6 +7,7 @@ import type { QoderCliRuntimeAdapterOptions } from "./types.ts";
 
 const CACHE_TTL_MS = 60_000;
 const cache = new BoundedLruCache<string, { expiresAt: number; result: RuntimeCanUseResult }>(64);
+const refreshes = new Map<string, Promise<RuntimeCanUseResult>>();
 
 export async function canUseQoderCliRuntime(
   options: QoderCliRuntimeAdapterOptions = {},
@@ -15,18 +16,27 @@ export async function canUseQoderCliRuntime(
   const key = `${executablePath}\0${options.env?.["PATH"] ?? ""}`;
   const cached = cache.get(key);
   if (cached !== undefined && cached.expiresAt > Date.now()) return cached.result;
+  const active = refreshes.get(key);
+  if (active !== undefined) return await active;
 
-  const result = await canUseRuntimeBinary({
+  const refresh = canUseRuntimeBinary({
     runtimeName: "Qoder CLI",
     defaultExecutablePath: "qodercli",
     executablePath,
     args: ["--version"],
     env: { ...process.env, ...(options.env ?? {}) },
+  }).then((result) => {
+    const normalized = {
+      ...result,
+      details: { ...result.details, executablePath },
+    };
+    cache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, result: normalized });
+    return normalized;
   });
-  const normalized = {
-    ...result,
-    details: { ...result.details, executablePath },
+  refreshes.set(key, refresh);
+  const clear = (): void => {
+    if (refreshes.get(key) === refresh) refreshes.delete(key);
   };
-  cache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, result: normalized });
-  return normalized;
+  void refresh.then(clear, clear);
+  return await refresh;
 }

--- a/packages/runtime/qodercli/src/executable.ts
+++ b/packages/runtime/qodercli/src/executable.ts
@@ -1,0 +1,89 @@
+import { accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import { posix, win32 } from "node:path";
+
+export interface QoderCliExecutableResolutionOptions {
+  readonly executablePath?: string | undefined;
+  readonly env?: NodeJS.ProcessEnv | undefined;
+  readonly homeDirectory?: string | undefined;
+  readonly platform?: NodeJS.Platform | undefined;
+  readonly isExecutable?: ((path: string) => boolean) | undefined;
+}
+
+export function resolveQoderCliExecutablePath(
+  options: QoderCliExecutableResolutionOptions = {},
+): string {
+  const platform = options.platform ?? process.platform;
+  if (options.executablePath !== undefined) {
+    return assertDirectlySpawnable(options.executablePath, platform);
+  }
+
+  const env = options.env ?? process.env;
+  const explicit = environmentValue(env, "QODERCLI_PATH", platform);
+  if (explicit !== undefined && explicit.trim() !== "") {
+    return assertDirectlySpawnable(explicit, platform);
+  }
+
+  const path = platform === "win32" ? win32 : posix;
+  const names = platform === "win32" ? ["qodercli.exe"] : ["qodercli"];
+  const canExecute = options.isExecutable ?? isExecutable;
+
+  for (const directory of (environmentValue(env, "PATH", platform) ?? "").split(
+    path.delimiter,
+  )) {
+    if (directory === "") continue;
+    for (const name of names) {
+      const candidate = path.join(directory, name);
+      if (canExecute(candidate)) return candidate;
+    }
+  }
+
+  const home =
+    options.homeDirectory ??
+    environmentValue(env, "HOME", platform) ??
+    environmentValue(env, "USERPROFILE", platform) ??
+    homedir();
+  const installDirectories = [
+    path.join(home, ".qoder", "local"),
+    path.join(home, ".local", "bin"),
+  ];
+  for (const directory of installDirectories) {
+    for (const name of names) {
+      const candidate = path.join(directory, name);
+      if (canExecute(candidate)) return candidate;
+    }
+  }
+
+  return "qodercli";
+}
+
+function assertDirectlySpawnable(path: string, platform: NodeJS.Platform): string {
+  if (platform === "win32" && path.toLowerCase().endsWith(".cmd")) {
+    throw new Error(
+      `Qoder CLI command shim is not directly spawnable: "${path}". ` +
+        "Configure QODERCLI_PATH to the native qodercli.exe installation.",
+    );
+  }
+  return path;
+}
+
+function environmentValue(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (platform !== "win32") return env[key];
+  const actual = Object.keys(env).find(
+    (candidate) => candidate.toLowerCase() === key.toLowerCase(),
+  );
+  return actual === undefined ? undefined : env[actual];
+}
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/runtime/qodercli/src/index.ts
+++ b/packages/runtime/qodercli/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./adapter.ts";
+export * from "./availability.ts";
+export * from "./executable.ts";
+export * from "./models.ts";
+export * from "./types.ts";

--- a/packages/runtime/qodercli/src/models.ts
+++ b/packages/runtime/qodercli/src/models.ts
@@ -1,0 +1,132 @@
+import type { RuntimeModel, RuntimeThinkingLevel } from "@pragma/core";
+import {
+  ProcessTransport,
+  query,
+  type ModelInfo,
+  type Query,
+} from "@qoder-ai/qoder-agent-sdk";
+
+import { resolveQoderCliExecutablePath } from "./executable.ts";
+import { resolveQoderAuth } from "./sdk-options.ts";
+import type { QoderCliRuntimeAdapterOptions } from "./types.ts";
+
+const THINKING_LABELS: Readonly<Record<string, string>> = {
+  none: "Disabled",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra high",
+  max: "Max",
+};
+
+export function createQoderCliModelDiscovery(
+  options: QoderCliRuntimeAdapterOptions,
+): () => Promise<readonly RuntimeModel[]> {
+  let cache:
+    | { readonly expiresAt: number; readonly models: readonly RuntimeModel[] }
+    | undefined;
+  let refresh: Promise<readonly RuntimeModel[]> | undefined;
+
+  return async () => {
+    if (cache === undefined) return await refreshCatalog();
+    if (cache.expiresAt <= Date.now() && refresh === undefined) {
+      refresh = refreshCatalog();
+      void refresh.then(
+        () => notifyModelCatalogUpdated(options.onModelCatalogUpdated),
+        () => undefined,
+      );
+    }
+    return cache.models;
+
+    async function refreshCatalog(): Promise<readonly RuntimeModel[]> {
+      let q: Query | undefined;
+      try {
+        q = query({
+          prompt: "",
+          options: {
+            auth: resolveQoderAuth(options),
+            transport: ProcessTransport.default,
+            pathToQoderCLIExecutable: resolveQoderCliExecutablePath(options),
+            env: { ...process.env, ...(options.env ?? {}) },
+            settingSources: [],
+            tools: [],
+          },
+        });
+        const models = (await q.getAvailableModels({ fetchStrategy: "live" }))
+          .filter((model) => model.isEnabled !== false)
+          .map(mapQoderModel);
+        if (models.length === 0) {
+          throw new Error("Qoder CLI model discovery returned no enabled models.");
+        }
+        cache = { expiresAt: Date.now() + 10 * 60_000, models };
+        return models;
+      } finally {
+        refresh = undefined;
+        await q?.close().catch(() => undefined);
+      }
+    }
+  };
+}
+
+function notifyModelCatalogUpdated(listener: (() => void) | undefined): void {
+  try {
+    listener?.();
+  } catch {
+    // Host cache invalidation is best-effort and must not fail a successful refresh.
+  }
+}
+
+export function mapQoderModel(model: ModelInfo): RuntimeModel {
+  const levels: RuntimeThinkingLevel[] = [];
+  if (model.supportsDisabled === true) {
+    levels.push({ value: "none", label: THINKING_LABELS["none"] ?? "Disabled" });
+  }
+  for (const effort of model.efforts ?? Object.keys(model.thinking_config?.enabled?.efforts ?? {})) {
+    levels.push({
+      value: effort,
+      label: THINKING_LABELS[effort] ?? effort,
+      description: model.thinking_config?.enabled?.efforts?.[effort]?.description,
+    });
+  }
+
+  return {
+    id: model.value,
+    displayName: model.displayName,
+    provider: { kind: "runtime-managed", id: "qoder", displayName: "Qoder" },
+    ...(model.isDefault === true ? { default: true } : {}),
+    ...(levels.length === 0
+      ? {}
+      : {
+          thinking: {
+            supportedLevels: levels,
+            defaultLevel:
+              model.defaultEffort ??
+              Object.entries(model.thinking_config?.enabled?.efforts ?? {}).find(
+                ([, entry]) => entry.is_default === true,
+              )?.[0],
+          },
+        }),
+  };
+}
+
+export function resolveQoderContextWindow(
+  model: ModelInfo | undefined,
+  override: number | undefined,
+): number {
+  const candidate =
+    override ??
+    model?.defaultContextWindow ??
+    model?.availableContextWindows?.[0] ??
+    model?.maxInputTokens ??
+    Object.values(model?.context_config ?? {}).find((entry) => entry.is_default === true)
+      ?.token_count ??
+    Object.values(model?.context_config ?? {})[0]?.token_count;
+
+  if (candidate === undefined || !Number.isFinite(candidate) || candidate <= 0) {
+    throw new Error(
+      `Qoder model ${model?.value ?? "(default)"} does not report a context window. ` +
+        "Configure contextWindowTokens explicitly.",
+    );
+  }
+  return Math.round(candidate);
+}

--- a/packages/runtime/qodercli/src/models.ts
+++ b/packages/runtime/qodercli/src/models.ts
@@ -1,10 +1,7 @@
+import { createHash } from "node:crypto";
+
 import type { RuntimeModel, RuntimeThinkingLevel } from "@pragma/core";
-import {
-  ProcessTransport,
-  query,
-  type ModelInfo,
-  type Query,
-} from "@qoder-ai/qoder-agent-sdk";
+import { ProcessTransport, query, type ModelInfo, type Query } from "@qoder-ai/qoder-agent-sdk";
 
 import { resolveQoderCliExecutablePath } from "./executable.ts";
 import { resolveQoderAuth } from "./sdk-options.ts";
@@ -18,25 +15,47 @@ const THINKING_LABELS: Readonly<Record<string, string>> = {
   xhigh: "Extra high",
   max: "Max",
 };
+const MODEL_CATALOG_TTL_MS = 10 * 60_000;
+const MODEL_CATALOG_CACHE_LIMIT = 16;
+
+interface QoderModelCatalogCacheEntry {
+  cache?: { readonly expiresAt: number; readonly models: readonly RuntimeModel[] } | undefined;
+  refresh?: Promise<readonly RuntimeModel[]> | undefined;
+}
+
+const modelCatalogs = new Map<string, QoderModelCatalogCacheEntry>();
 
 export function createQoderCliModelDiscovery(
   options: QoderCliRuntimeAdapterOptions,
 ): () => Promise<readonly RuntimeModel[]> {
-  let cache:
-    | { readonly expiresAt: number; readonly models: readonly RuntimeModel[] }
-    | undefined;
-  let refresh: Promise<readonly RuntimeModel[]> | undefined;
+  const key = qoderModelCatalogCacheKey(options);
+  const existingState = modelCatalogs.get(key);
+  const state: QoderModelCatalogCacheEntry = existingState ?? {};
+  if (existingState === undefined) {
+    modelCatalogs.set(key, state);
+    while (modelCatalogs.size > MODEL_CATALOG_CACHE_LIMIT) {
+      const oldest = modelCatalogs.keys().next().value as string | undefined;
+      if (oldest === undefined || oldest === key) break;
+      modelCatalogs.delete(oldest);
+    }
+  } else {
+    modelCatalogs.delete(key);
+    modelCatalogs.set(key, state);
+  }
 
   return async () => {
-    if (cache === undefined) return await refreshCatalog();
-    if (cache.expiresAt <= Date.now() && refresh === undefined) {
-      refresh = refreshCatalog();
-      void refresh.then(
+    if (state.cache === undefined) {
+      state.refresh ??= refreshCatalog();
+      return await state.refresh;
+    }
+    if (state.cache.expiresAt <= Date.now() && state.refresh === undefined) {
+      state.refresh = refreshCatalog();
+      void state.refresh.then(
         () => notifyModelCatalogUpdated(options.onModelCatalogUpdated),
         () => undefined,
       );
     }
-    return cache.models;
+    return state.cache.models;
 
     async function refreshCatalog(): Promise<readonly RuntimeModel[]> {
       let q: Query | undefined;
@@ -58,14 +77,29 @@ export function createQoderCliModelDiscovery(
         if (models.length === 0) {
           throw new Error("Qoder CLI model discovery returned no enabled models.");
         }
-        cache = { expiresAt: Date.now() + 10 * 60_000, models };
+        state.cache = { expiresAt: Date.now() + MODEL_CATALOG_TTL_MS, models };
         return models;
       } finally {
-        refresh = undefined;
+        state.refresh = undefined;
         await q?.close().catch(() => undefined);
       }
     }
   };
+}
+
+function qoderModelCatalogCacheKey(options: QoderCliRuntimeAdapterOptions): string {
+  return createHash("sha256")
+    .update("pragma.qoder-model-catalog/v1\0")
+    .update(resolveQoderCliExecutablePath(options))
+    .update("\0")
+    .update(JSON.stringify(options.auth ?? { type: "qodercli" }))
+    .update("\0")
+    .update(
+      JSON.stringify(
+        Object.entries(options.env ?? {}).toSorted(([left], [right]) => left.localeCompare(right)),
+      ),
+    )
+    .digest("hex");
 }
 
 function notifyModelCatalogUpdated(listener: (() => void) | undefined): void {
@@ -81,7 +115,8 @@ export function mapQoderModel(model: ModelInfo): RuntimeModel {
   if (model.supportsDisabled === true) {
     levels.push({ value: "none", label: THINKING_LABELS["none"] ?? "Disabled" });
   }
-  for (const effort of model.efforts ?? Object.keys(model.thinking_config?.enabled?.efforts ?? {})) {
+  for (const effort of model.efforts ??
+    Object.keys(model.thinking_config?.enabled?.efforts ?? {})) {
     levels.push({
       value: effort,
       label: THINKING_LABELS[effort] ?? effort,

--- a/packages/runtime/qodercli/src/qoder-config.ts
+++ b/packages/runtime/qodercli/src/qoder-config.ts
@@ -11,6 +11,18 @@ export interface PrepareManagedQoderConfigOptions {
 }
 
 const PRIVATE_STATE_DIRECTORIES = ["projects", "logs", "tmp"] as const;
+const SHARED_CONFIG_SNAPSHOTS = [
+  {
+    name: ".auth",
+    event: "runtime.qodercli_auth_snapshot_failed",
+    description: "local login state",
+  },
+  {
+    name: ".models",
+    event: "runtime.qodercli_model_catalog_snapshot_failed",
+    description: "local model catalog",
+  },
+] as const;
 
 export async function prepareManagedQoderConfig({
   sessionDir,
@@ -25,29 +37,35 @@ export async function prepareManagedQoderConfig({
     }),
   );
 
-  const targetAuth = join(configDir, ".auth");
-  try {
-    await access(targetAuth);
-  } catch (error) {
-    if (!isNotFoundError(error)) throw error;
-    const sourceAuth = join(resolveSharedQoderConfigDir(env), ".auth");
-    try {
-      await cp(sourceAuth, targetAuth, {
-        recursive: true,
-        dereference: true,
-        errorOnExist: true,
-        force: false,
-      });
-    } catch (copyError) {
-      if (!isNotFoundError(copyError)) {
-        logger.warn(
-          "runtime.qodercli_auth_snapshot_failed",
-          "Qoder CLI managed config could not snapshot the local login state",
-          { error: copyError },
-        );
+  const sharedConfigDir = resolveSharedQoderConfigDir(env);
+  await Promise.all(
+    SHARED_CONFIG_SNAPSHOTS.map(async (snapshot) => {
+      const target = join(configDir, snapshot.name);
+      try {
+        await access(target);
+        return;
+      } catch (error) {
+        if (!isNotFoundError(error)) throw error;
       }
-    }
-  }
+
+      try {
+        await cp(join(sharedConfigDir, snapshot.name), target, {
+          recursive: true,
+          dereference: true,
+          errorOnExist: true,
+          force: false,
+        });
+      } catch (copyError) {
+        if (!isNotFoundError(copyError)) {
+          logger.warn(
+            snapshot.event,
+            `Qoder CLI managed config could not snapshot the ${snapshot.description}`,
+            { error: copyError },
+          );
+        }
+      }
+    }),
+  );
 
   return configDir;
 }

--- a/packages/runtime/qodercli/src/qoder-config.ts
+++ b/packages/runtime/qodercli/src/qoder-config.ts
@@ -1,0 +1,71 @@
+import { access, cp, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { PragmaLogger } from "@pragma/core";
+
+export interface PrepareManagedQoderConfigOptions {
+  readonly sessionDir: string;
+  readonly env?: NodeJS.ProcessEnv | undefined;
+  readonly logger: Pick<PragmaLogger, "warn">;
+}
+
+const PRIVATE_STATE_DIRECTORIES = ["projects", "logs", "tmp"] as const;
+
+export async function prepareManagedQoderConfig({
+  sessionDir,
+  env,
+  logger,
+}: PrepareManagedQoderConfigOptions): Promise<string> {
+  const configDir = join(sessionDir, "config");
+  await mkdir(configDir, { recursive: true, mode: 0o700 });
+  await Promise.all(
+    PRIVATE_STATE_DIRECTORIES.map(async (directory) => {
+      await mkdir(join(configDir, directory), { recursive: true, mode: 0o700 });
+    }),
+  );
+
+  const targetAuth = join(configDir, ".auth");
+  try {
+    await access(targetAuth);
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
+    const sourceAuth = join(resolveSharedQoderConfigDir(env), ".auth");
+    try {
+      await cp(sourceAuth, targetAuth, {
+        recursive: true,
+        dereference: true,
+        errorOnExist: true,
+        force: false,
+      });
+    } catch (copyError) {
+      if (!isNotFoundError(copyError)) {
+        logger.warn(
+          "runtime.qodercli_auth_snapshot_failed",
+          "Qoder CLI managed config could not snapshot the local login state",
+          { error: copyError },
+        );
+      }
+    }
+  }
+
+  return configDir;
+}
+
+function resolveSharedQoderConfigDir(env: NodeJS.ProcessEnv | undefined): string {
+  const explicit = readNonEmpty(env?.["QODER_CONFIG_DIR"]);
+  if (explicit !== undefined) return explicit;
+  const qoderHome =
+    readNonEmpty(env?.["QODER_CLI_HOME"]) ??
+    readNonEmpty(process.env["QODER_CLI_HOME"]) ??
+    homedir();
+  return join(qoderHome, ".qoder");
+}
+
+function readNonEmpty(value: string | undefined): string | undefined {
+  return value === undefined || value.trim() === "" ? undefined : value;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error !== null && typeof error === "object" && "code" in error && error.code === "ENOENT";
+}

--- a/packages/runtime/qodercli/src/qoder-config.ts
+++ b/packages/runtime/qodercli/src/qoder-config.ts
@@ -70,14 +70,10 @@ export async function prepareManagedQoderConfig({
   return configDir;
 }
 
-function resolveSharedQoderConfigDir(env: NodeJS.ProcessEnv | undefined): string {
+export function resolveSharedQoderConfigDir(env: NodeJS.ProcessEnv | undefined): string {
   const explicit = readNonEmpty(env?.["QODER_CONFIG_DIR"]);
   if (explicit !== undefined) return explicit;
-  const qoderHome =
-    readNonEmpty(env?.["QODER_CLI_HOME"]) ??
-    readNonEmpty(process.env["QODER_CLI_HOME"]) ??
-    homedir();
-  return join(qoderHome, ".qoder");
+  return join(homedir(), ".qoder");
 }
 
 function readNonEmpty(value: string | undefined): string | undefined {

--- a/packages/runtime/qodercli/src/sdk-options.ts
+++ b/packages/runtime/qodercli/src/sdk-options.ts
@@ -1,0 +1,21 @@
+import {
+  accessToken,
+  accessTokenFromEnv,
+  qodercliAuth,
+  type AuthOptions,
+} from "@qoder-ai/qoder-agent-sdk";
+
+import type { QoderCliRuntimeAdapterOptions } from "./types.ts";
+
+export function resolveQoderAuth(options: QoderCliRuntimeAdapterOptions): AuthOptions {
+  if (options.auth?.type === "access-token") return accessToken(options.auth.token);
+  if (options.auth?.type === "access-token-env") {
+    return accessTokenFromEnv(options.auth.envVar);
+  }
+  if (options.auth?.type === "qodercli") return qodercliAuth();
+
+  const token = options.env?.["QODER_PERSONAL_ACCESS_TOKEN"];
+  return token !== undefined && token.trim() !== ""
+    ? accessTokenFromEnv()
+    : qodercliAuth();
+}

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -292,8 +292,8 @@ async function runQoderQuery(
         if (!firstSdkMessageLogged) {
           firstSdkMessageLogged = true;
           session.logger.info(
-            "runtime.qodercli_first_sdk_message",
-            "Qoder transport delivered its first SDK message",
+            "runtime.qodercli_request_acknowledged",
+            "Qoder acknowledged the native turn request with its first SDK message",
             {
               runId: turn.runId,
               elapsedMs: qoderTurnElapsedMs(queryStartedAt),

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -1,8 +1,4 @@
-import type {
-  AgentMessage,
-  AgentMessageUsage,
-  AgentAssistantMessage,
-} from "@pragma/shared";
+import type { AgentMessage, AgentMessageUsage, AgentAssistantMessage } from "@pragma/shared";
 import {
   createRuntimeContextWindowUsage,
   createUsageFromTokenCounts,
@@ -76,11 +72,13 @@ export interface QoderNativeSession {
   activeQuery?: Query | undefined;
   contextWindowUsage?: RuntimeContextWindowUsage | undefined;
   compactSummary?: string | undefined;
-  pendingCompaction?: {
-    trigger?: "manual" | "auto" | undefined;
-    preTokens?: number | undefined;
-    summary?: string | undefined;
-  } | undefined;
+  pendingCompaction?:
+    | {
+        trigger?: "manual" | "auto" | undefined;
+        preTokens?: number | undefined;
+        summary?: string | undefined;
+      }
+    | undefined;
   contextWindowTokens?: number | undefined;
 }
 
@@ -257,6 +255,7 @@ async function runQoderQuery(
   prompt: string,
   turn: RuntimeTurnContext<QoderNativeEvent>,
 ): Promise<SDKResultMessage> {
+  const queryStartedAt = performance.now();
   session.pendingCompaction = undefined;
   const q = createQuery(session, prompt, {
     modelName: turn.modelSelection?.model.modelId,
@@ -279,8 +278,42 @@ async function runQoderQuery(
   try {
     let result: SDKResultMessage | undefined;
     let iterationError: unknown;
+    let firstSdkMessageLogged = false;
+    let firstTextDeltaLogged = false;
     try {
+      session.logger.info(
+        "runtime.qodercli_process_spawn_requested",
+        "Qoder SDK iteration requested the native CLI process",
+        { runId: turn.runId, elapsedMs: qoderTurnElapsedMs(queryStartedAt) },
+      );
       for await (const message of q) {
+        if (!firstSdkMessageLogged) {
+          firstSdkMessageLogged = true;
+          session.logger.info(
+            "runtime.qodercli_first_sdk_message",
+            "Qoder transport delivered its first SDK message",
+            {
+              runId: turn.runId,
+              elapsedMs: qoderTurnElapsedMs(queryStartedAt),
+            },
+          );
+        }
+        if (!firstTextDeltaLogged && hasQoderTextDelta(message)) {
+          firstTextDeltaLogged = true;
+          session.logger.info(
+            "runtime.qodercli_first_text_delta",
+            "Qoder emitted its first text delta",
+            { runId: turn.runId, elapsedMs: qoderTurnElapsedMs(queryStartedAt) },
+          );
+        }
+        if (message.type === "system" && message.subtype === "init") {
+          session.logger.info("runtime.qodercli_initialized", "Qoder CLI initialized", {
+            runId: turn.runId,
+            elapsedMs: qoderTurnElapsedMs(queryStartedAt),
+            version: message.qodercli_version,
+            model: message.model,
+          });
+        }
         updateSessionId(session, message);
         emitSdkMessage(session, message, turn);
         if (message.type === "result") {
@@ -292,11 +325,16 @@ async function runQoderQuery(
     } catch (error) {
       iterationError = error;
     }
-    return requireSuccessfulQoderResult(
+    const successful = requireSuccessfulQoderResult(
       result,
       iterationError,
       "Qoder CLI ended without a result message.",
     );
+    session.logger.info("runtime.qodercli_final_result", "Qoder CLI returned a final result", {
+      runId: turn.runId,
+      elapsedMs: qoderTurnElapsedMs(queryStartedAt),
+    });
+    return successful;
   } finally {
     turn.signal.removeEventListener("abort", onAbort);
     session.activeQuery = undefined;
@@ -304,6 +342,20 @@ async function runQoderQuery(
     session.toolRuntimeState.source = undefined;
     await q.close().catch(() => undefined);
   }
+}
+
+function hasQoderTextDelta(message: SDKMessage): boolean {
+  if (message.type !== "stream_event") return false;
+  const delta = asRecord(message.event.delta);
+  return (
+    delta?.["type"] === "text_delta" &&
+    typeof delta["text"] === "string" &&
+    delta["text"].length > 0
+  );
+}
+
+function qoderTurnElapsedMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
 function createQuery(
@@ -363,16 +415,12 @@ function createQuery(
         ],
       },
       resolveModel(context) {
-        const isCompaction =
-          context.purpose === "compact" || context.purpose === "compression";
+        const isCompaction = context.purpose === "compact" || context.purpose === "compression";
         const resolvedModelName = isCompaction ? compactModelName : modelName;
         const selected =
           context.availableModels.find((model) => model.value === resolvedModelName) ??
           context.availableModels.find((model) => model.isDefault === true);
-        const contextWindow = resolveQoderContextWindow(
-          selected,
-          session.contextWindowOverride,
-        );
+        const contextWindow = resolveQoderContextWindow(selected, session.contextWindowOverride);
         if (!isCompaction) session.contextWindowTokens = contextWindow;
         return {
           model: resolvedModelName,
@@ -391,9 +439,7 @@ function createQuery(
   });
 }
 
-function createCanUseTool(
-  handler: ExpertAgentHumanInteractionHandler | undefined,
-): CanUseTool {
+function createCanUseTool(handler: ExpertAgentHumanInteractionHandler | undefined): CanUseTool {
   return async (toolName, input, options) => {
     if (toolName.startsWith("mcp__pragma__")) {
       return { behavior: "allow", updatedInput: input };
@@ -413,7 +459,7 @@ function createCanUseTool(
         behavior: "deny",
         message:
           response.kind === "tool_approval"
-            ? response.reason ?? "Tool call was denied."
+            ? (response.reason ?? "Tool call was denied.")
             : "Invalid approval response.",
       };
     }
@@ -447,10 +493,7 @@ function emitSdkMessage(
     const delta = asRecord(event.delta);
     if (delta?.["type"] === "text_delta" && typeof delta["text"] === "string") {
       turn.stream.writeNative({ kind: "message-delta", text: delta["text"] });
-    } else if (
-      delta?.["type"] === "thinking_delta" &&
-      typeof delta["thinking"] === "string"
-    ) {
+    } else if (delta?.["type"] === "thinking_delta" && typeof delta["thinking"] === "string") {
       turn.stream.writeNative({ kind: "thought-delta", text: delta["thinking"] });
     }
     const block = asRecord(event.content_block);
@@ -596,9 +639,7 @@ export function deriveQoderContextWindowUsage(
   });
 }
 
-function estimateContextUsage(
-  session: QoderNativeSession,
-): RuntimeContextWindowUsage | undefined {
+function estimateContextUsage(session: QoderNativeSession): RuntimeContextWindowUsage | undefined {
   if (session.contextWindowTokens === undefined) return undefined;
   const latestCompactionIndex = session.messages.findLastIndex(
     (message) => message.role === "compactionSummary",

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -97,8 +97,7 @@ export async function startQoderTurn(
   const prompt = [...turn.startupMessages.map((message) => message.content), turn.prompt].join(
     "\n\n",
   );
-  const result = await runQoderQuery(session, prompt, turn);
-  const usage = mapQoderUsage(result);
+  const { result, usage } = await runQoderQuery(session, prompt, turn);
   const assistant = createAssistantMessage(result, usage);
   appendPendingCompactionSummary(session);
   session.messages.push(assistant);
@@ -254,7 +253,10 @@ async function runQoderQuery(
   session: QoderNativeSession,
   prompt: string,
   turn: RuntimeTurnContext<QoderNativeEvent>,
-): Promise<SDKResultMessage> {
+): Promise<{
+  readonly result: SDKResultSuccess;
+  readonly usage: AgentMessageUsage;
+}> {
   const queryStartedAt = performance.now();
   session.pendingCompaction = undefined;
   const q = createQuery(session, prompt, {
@@ -319,22 +321,39 @@ async function runQoderQuery(
         if (message.type === "result") {
           result = message;
           session.contextWindowUsage = await readContextUsage(q, session, message);
-          turn.stream.writeNative({ kind: "usage", usage: mapQoderUsage(message) });
         }
       }
     } catch (error) {
       iterationError = error;
     }
-    const successful = requireSuccessfulQoderResult(
-      result,
-      iterationError,
-      "Qoder CLI ended without a result message.",
-    );
+    let successful: SDKResultSuccess;
+    try {
+      successful = requireSuccessfulQoderResult(
+        result,
+        iterationError,
+        "Qoder CLI ended without a result message.",
+      );
+    } catch (error) {
+      if (result !== undefined) {
+        turn.stream.writeNative({
+          kind: "usage",
+          usage: resolveQoderUsage(result, {
+            inputText: estimateQoderTurnInput(session, prompt),
+            outputText: readQoderResultOutput(result),
+          }),
+        });
+      }
+      throw error;
+    }
+    const usage = resolveQoderUsage(successful, {
+      inputText: estimateQoderTurnInput(session, prompt),
+      outputText: successful.result,
+    });
     session.logger.info("runtime.qodercli_final_result", "Qoder CLI returned a final result", {
       runId: turn.runId,
       elapsedMs: qoderTurnElapsedMs(queryStartedAt),
     });
-    return successful;
+    return { result: successful, usage };
   } finally {
     turn.signal.removeEventListener("abort", onAbort);
     session.activeQuery = undefined;
@@ -584,6 +603,25 @@ export function mapQoderUsage(result: SDKResultMessage): AgentMessageUsage {
   });
 }
 
+export function resolveQoderUsage(
+  result: SDKResultMessage,
+  fallback: {
+    readonly inputText: string;
+    readonly outputText: string;
+  },
+): AgentMessageUsage {
+  const reported = mapQoderUsage(result);
+  if (reported.totalTokens > 0) return reported;
+  return createUsageFromTokenCounts({
+    measurement: "estimated",
+    inputTokens: defaultTokenEstimator.count(fallback.inputText),
+    inputTokensIncludeCacheRead: false,
+    outputTokens: defaultTokenEstimator.count(fallback.outputText),
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+  });
+}
+
 export function requireSuccessfulQoderResult(
   result: SDKResultMessage | undefined,
   iterationError: unknown,
@@ -659,6 +697,28 @@ function estimateContextUsage(session: QoderNativeSession): RuntimeContextWindow
     contextWindowTokens: session.contextWindowTokens,
     measurement: "estimated",
   });
+}
+
+function estimateQoderTurnInput(session: QoderNativeSession, prompt: string): string {
+  const latestCompactionIndex = session.messages.findLastIndex(
+    (message) => message.role === "compactionSummary",
+  );
+  const activeMessages =
+    latestCompactionIndex < 0 ? session.messages : session.messages.slice(latestCompactionIndex);
+  const previousMessages =
+    activeMessages.at(-1)?.role === "user" ? activeMessages.slice(0, -1) : activeMessages;
+  return JSON.stringify({
+    systemPrompt: session.systemPrompt,
+    messages: previousMessages,
+    prompt,
+    ...(latestCompactionIndex < 0 && session.compactSummary !== undefined
+      ? { compactSummary: session.compactSummary }
+      : {}),
+  });
+}
+
+function readQoderResultOutput(result: SDKResultMessage): string {
+  return result.subtype === "success" ? result.result : result.errors.join("\n");
 }
 
 function createAssistantMessage(

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -1,0 +1,591 @@
+import type {
+  AgentMessage,
+  AgentMessageUsage,
+  AgentAssistantMessage,
+} from "@pragma/shared";
+import {
+  createRuntimeContextWindowUsage,
+  createUsageFromTokenCounts,
+  type Expert,
+  type ExpertAgentHumanInteractionHandler,
+  type ExpertToolRuntimeState,
+  type PragmaLogger,
+  type RuntimeContextWindowUsage,
+  type RuntimeEventMappingContext,
+  type RuntimeEventMappingResult,
+  type RuntimeTurnContext,
+  type RuntimeTurnResult,
+} from "@pragma/core";
+import {
+  ProcessTransport,
+  query,
+  type AuthOptions,
+  type CanUseTool,
+  type PostCompactHookInput,
+  type Query,
+  type SDKMessage,
+  type SDKResultMessage,
+} from "@qoder-ai/qoder-agent-sdk";
+
+import { resolveQoderContextWindow } from "./models.ts";
+import { defaultTokenEstimator } from "./token-estimator.ts";
+import type { QoderCliRuntimePermissionMode } from "./types.ts";
+
+export type QoderNativeEvent =
+  | { readonly kind: "message-delta"; readonly text: string }
+  | { readonly kind: "thought-delta"; readonly text: string }
+  | { readonly kind: "message-completed"; readonly text: string }
+  | {
+      readonly kind: "tool-started";
+      readonly id: string;
+      readonly name: string;
+      readonly input?: unknown;
+    }
+  | {
+      readonly kind: "tool-completed";
+      readonly id: string;
+      readonly name: string;
+      readonly output?: unknown;
+      readonly failed?: boolean;
+    }
+  | { readonly kind: "progress"; readonly stage: string; readonly data?: unknown }
+  | { readonly kind: "session"; readonly sessionId: string }
+  | { readonly kind: "usage"; readonly usage: AgentMessageUsage };
+
+export interface QoderNativeSession {
+  readonly agent: Expert;
+  readonly auth: AuthOptions;
+  readonly executablePath: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly configDir: string;
+  readonly mcpServerUrl: string;
+  readonly plugin: { readonly path: string; readonly skills: readonly string[] };
+  readonly logger: PragmaLogger;
+  readonly humanInteractionHandler?: ExpertAgentHumanInteractionHandler | undefined;
+  readonly permissionMode: QoderCliRuntimePermissionMode;
+  readonly defaultModelName?: string | undefined;
+  readonly defaultThinkingLevel?: string | undefined;
+  readonly contextWindowOverride?: number | undefined;
+  readonly compactModelName?: string | undefined;
+  readonly systemPrompt: string;
+  readonly toolRuntimeState: ExpertToolRuntimeState;
+  readonly messages: AgentMessage[];
+  readonly toolNames: Map<string, string>;
+  sessionId: string;
+  activeQuery?: Query | undefined;
+  contextWindowUsage?: RuntimeContextWindowUsage | undefined;
+  compactSummary?: string | undefined;
+  pendingCompaction?: {
+    trigger?: "manual" | "auto" | undefined;
+    preTokens?: number | undefined;
+    summary?: string | undefined;
+  } | undefined;
+  contextWindowTokens?: number | undefined;
+}
+
+export async function startQoderTurn(
+  session: QoderNativeSession,
+  turn: RuntimeTurnContext<QoderNativeEvent>,
+): Promise<RuntimeTurnResult> {
+  session.toolRuntimeState.runId = turn.runId;
+  session.toolRuntimeState.source = turn.source;
+  session.messages.push({
+    role: "user",
+    content: turn.rawQuery,
+    timestamp: Date.now(),
+  });
+
+  const prompt = [...turn.startupMessages.map((message) => message.content), turn.prompt].join(
+    "\n\n",
+  );
+  const result = await runQoderQuery(session, prompt, turn);
+  const usage = mapQoderUsage(result);
+  const assistant = createAssistantMessage(result, usage);
+  appendPendingCompactionSummary(session);
+  session.messages.push(assistant);
+  if (session.contextWindowUsage?.measurement === "estimated") {
+    session.contextWindowUsage = estimateContextUsage(session);
+  }
+
+  return {
+    outputText: result.subtype === "success" ? result.result : undefined,
+    usage,
+    runtimeSessionId: session.sessionId,
+  };
+}
+
+export function mapQoderEvent(
+  event: QoderNativeEvent,
+  context: RuntimeEventMappingContext,
+): RuntimeEventMappingResult {
+  switch (event.kind) {
+    case "message-delta":
+      return {
+        events: [context.events.messageDelta(event.text)],
+        outputDelta: event.text,
+      };
+    case "thought-delta":
+      return { events: [context.events.thoughtDelta(event.text)] };
+    case "message-completed":
+      return { events: [context.events.messageCompleted(event.text)] };
+    case "tool-started":
+      return {
+        events: [
+          context.events.toolStarted({
+            toolCallId: event.id,
+            toolName: event.name,
+            inputPreview: event.input,
+          }),
+        ],
+      };
+    case "tool-completed":
+      return {
+        events: [
+          event.failed === true
+            ? context.events.toolFailed({
+                toolCallId: event.id,
+                toolName: event.name,
+                message: typeof event.output === "string" ? event.output : "Qoder tool failed.",
+              })
+            : context.events.toolCompleted({
+                toolCallId: event.id,
+                toolName: event.name,
+                outputPreview: event.output,
+              }),
+        ],
+      };
+    case "progress":
+      return { events: [context.events.progress(event.stage, event.data)] };
+    case "session":
+      return { runtimeSessionId: event.sessionId };
+    case "usage":
+      return { usage: event.usage };
+  }
+}
+
+export function listQoderMessages(session: QoderNativeSession): readonly AgentMessage[] {
+  return session.messages;
+}
+
+export function readQoderContextWindow(
+  session: QoderNativeSession,
+): RuntimeContextWindowUsage | undefined {
+  return session.contextWindowUsage;
+}
+
+export async function compactQoderContextWindow(
+  session: QoderNativeSession,
+): Promise<RuntimeContextWindowUsage | undefined> {
+  if (session.sessionId === "") {
+    throw new Error("Cannot compact a Qoder session before its first turn.");
+  }
+
+  session.pendingCompaction = undefined;
+  const q = createQuery(session, "/compact", {
+    onPostCompact(input) {
+      session.compactSummary = input.compact_summary;
+      session.pendingCompaction = {
+        ...(session.pendingCompaction ?? {}),
+        trigger: input.trigger,
+        summary: input.compact_summary,
+      };
+    },
+  });
+  session.activeQuery = q;
+  try {
+    let result: SDKResultMessage | undefined;
+    const init = await q.initializationResult();
+    if (!init.commands.some((command) => command.name === "compact")) {
+      throw new Error("The installed Qoder CLI does not support the /compact command.");
+    }
+    for await (const message of q) {
+      updateSessionId(session, message);
+      if (
+        message.type === "system" &&
+        message.subtype === "compact_boundary" &&
+        message.compact_metadata.trigger === "manual"
+      ) {
+        session.pendingCompaction = {
+          ...(session.pendingCompaction ?? {}),
+          trigger: "manual",
+          preTokens: message.compact_metadata.pre_tokens,
+        };
+      }
+      if (message.type === "result") {
+        result = message;
+        session.contextWindowUsage = await readContextUsage(q, session);
+      }
+    }
+    if (result === undefined) {
+      throw new Error("Qoder CLI ended /compact without a result message.");
+    }
+    if (result.subtype !== "success") {
+      throw new Error(result.errors.join("\n") || `Qoder CLI failed: ${result.subtype}.`);
+    }
+    if (
+      session.pendingCompaction?.trigger !== "manual" ||
+      session.pendingCompaction.preTokens === undefined
+    ) {
+      throw new Error("Qoder CLI completed /compact without a manual compaction boundary.");
+    }
+    appendPendingCompactionSummary(session);
+    return session.contextWindowUsage;
+  } finally {
+    session.pendingCompaction = undefined;
+    session.activeQuery = undefined;
+    await q.close().catch(() => undefined);
+  }
+}
+
+export async function cancelQoderTurn(session: QoderNativeSession): Promise<void> {
+  await session.activeQuery?.interrupt().catch(() => undefined);
+}
+
+export async function closeQoderSession(session: QoderNativeSession): Promise<void> {
+  await session.activeQuery?.close().catch(() => undefined);
+  session.activeQuery = undefined;
+}
+
+async function runQoderQuery(
+  session: QoderNativeSession,
+  prompt: string,
+  turn: RuntimeTurnContext<QoderNativeEvent>,
+): Promise<SDKResultMessage> {
+  session.pendingCompaction = undefined;
+  const q = createQuery(session, prompt, {
+    modelName: turn.modelSelection?.model.modelId,
+    thinkingLevel: turn.modelSelection?.thinkingLevel,
+    onPostCompact(input) {
+      session.compactSummary = input.compact_summary;
+      session.pendingCompaction = {
+        ...(session.pendingCompaction ?? {}),
+        trigger: input.trigger,
+        summary: input.compact_summary,
+      };
+    },
+  });
+  session.activeQuery = q;
+  const onAbort = (): void => {
+    void q.interrupt().catch(() => undefined);
+  };
+  turn.signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    let result: SDKResultMessage | undefined;
+    for await (const message of q) {
+      updateSessionId(session, message);
+      emitSdkMessage(session, message, turn);
+      if (message.type === "result") {
+        result = message;
+        session.contextWindowUsage = await readContextUsage(q, session);
+        turn.stream.writeNative({ kind: "usage", usage: mapQoderUsage(message) });
+      }
+    }
+    if (result === undefined) throw new Error("Qoder CLI ended without a result message.");
+    if (result.subtype !== "success") {
+      throw new Error(result.errors.join("\n") || `Qoder CLI failed: ${result.subtype}.`);
+    }
+    return result;
+  } finally {
+    turn.signal.removeEventListener("abort", onAbort);
+    session.activeQuery = undefined;
+    session.toolRuntimeState.runId = undefined;
+    session.toolRuntimeState.source = undefined;
+    await q.close().catch(() => undefined);
+  }
+}
+
+function createQuery(
+  session: QoderNativeSession,
+  prompt: string,
+  options: {
+    readonly modelName?: string | undefined;
+    readonly thinkingLevel?: string | undefined;
+    readonly onPostCompact?: ((input: PostCompactHookInput) => void) | undefined;
+  },
+): Query {
+  const modelName = options.modelName ?? session.defaultModelName ?? "auto";
+  return query({
+    prompt,
+    options: {
+      auth: session.auth,
+      transport: ProcessTransport.default,
+      pathToQoderCLIExecutable: session.executablePath,
+      cwd: session.agent.workspace,
+      env: { ...session.env, QODER_CONFIG_DIR: session.configDir },
+      settingSources: [],
+      ...(session.sessionId === "" ? {} : { resume: session.sessionId }),
+      includePartialMessages: true,
+      includeHookEvents: true,
+      systemPrompt: { type: "preset", preset: "qodercli", append: session.systemPrompt },
+      mcpServers: {
+        pragma: {
+          type: "http",
+          url: session.mcpServerUrl,
+          tools: [{ name: "*", permission_policy: "always_allow" }],
+        },
+      },
+      allowedMcpServerNames: ["pragma"],
+      strictMcpConfig: true,
+      disallowedTools: ["AskUserQuestion"],
+      plugins: [{ type: "local", path: session.plugin.path }],
+      skills: [...session.plugin.skills],
+      permissionMode: session.permissionMode,
+      allowDangerouslySkipPermissions: session.permissionMode === "bypassPermissions",
+      ...(session.permissionMode === "bypassPermissions"
+        ? {}
+        : { canUseTool: createCanUseTool(session.humanInteractionHandler) }),
+      hooks: {
+        PostCompact: [
+          {
+            hooks: [
+              async (input) => {
+                if (input.hook_event_name === "PostCompact") {
+                  options.onPostCompact?.(input);
+                }
+                return {};
+              },
+            ],
+          },
+        ],
+      },
+      resolveModel(context) {
+        const selected =
+          context.availableModels.find((model) => model.value === modelName) ??
+          context.availableModels.find((model) => model.isDefault === true);
+        const contextWindow = resolveQoderContextWindow(
+          selected,
+          session.contextWindowOverride,
+        );
+        session.contextWindowTokens = contextWindow;
+        return {
+          model:
+            context.purpose === "compact" && session.compactModelName !== undefined
+              ? session.compactModelName
+              : modelName,
+          parameters: {
+            contextWindow,
+            ...(options.thinkingLevel === undefined
+              ? {}
+              : { reasoningEffort: options.thinkingLevel }),
+          },
+        };
+      },
+      stderr(data) {
+        session.logger.debug("runtime.qodercli_stderr", "Qoder CLI stderr", { data });
+      },
+    },
+  });
+}
+
+function createCanUseTool(
+  handler: ExpertAgentHumanInteractionHandler | undefined,
+): CanUseTool {
+  return async (toolName, input, options) => {
+    if (toolName.startsWith("mcp__pragma__")) {
+      return { behavior: "allow", updatedInput: input };
+    }
+    if (handler === undefined) {
+      return { behavior: "deny", message: "No approval handler is configured." };
+    }
+    const response = await handler({
+      kind: "tool_approval",
+      toolName,
+      toolCallId: options.toolUseID,
+      reason: options.decisionReason ?? "Qoder CLI requested tool approval.",
+      input,
+    });
+    if (response.kind !== "tool_approval" || !response.approved) {
+      return {
+        behavior: "deny",
+        message:
+          response.kind === "tool_approval"
+            ? response.reason ?? "Tool call was denied."
+            : "Invalid approval response.",
+      };
+    }
+    const updatedInput = response.updatedInput;
+    return {
+      behavior: "allow",
+      updatedInput:
+        updatedInput !== null && typeof updatedInput === "object" && !Array.isArray(updatedInput)
+          ? (updatedInput as Record<string, unknown>)
+          : input,
+    };
+  };
+}
+
+function emitSdkMessage(
+  session: QoderNativeSession,
+  message: SDKMessage,
+  turn: RuntimeTurnContext<QoderNativeEvent>,
+): void {
+  if (message.type === "stream_event") {
+    const event = message.event;
+    const delta = asRecord(event.delta);
+    if (delta?.["type"] === "text_delta" && typeof delta["text"] === "string") {
+      turn.stream.writeNative({ kind: "message-delta", text: delta["text"] });
+    } else if (
+      delta?.["type"] === "thinking_delta" &&
+      typeof delta["thinking"] === "string"
+    ) {
+      turn.stream.writeNative({ kind: "thought-delta", text: delta["thinking"] });
+    }
+    const block = asRecord(event.content_block);
+    if (event.type === "content_block_start" && block?.["type"] === "tool_use") {
+      const id = typeof block["id"] === "string" ? block["id"] : "";
+      const name = typeof block["name"] === "string" ? block["name"] : "qoder_tool";
+      if (id !== "") {
+        session.toolNames.set(id, name);
+        turn.stream.writeNative({ kind: "tool-started", id, name, input: block["input"] });
+      }
+    }
+    return;
+  }
+
+  if (message.type === "assistant") {
+    const text = message.message.content
+      .filter((block) => block.type === "text" && typeof block.text === "string")
+      .map((block) => block.text)
+      .join("");
+    if (text !== "") turn.stream.writeNative({ kind: "message-completed", text });
+    return;
+  }
+
+  if (message.type === "user") {
+    const content = Array.isArray(message.message.content) ? message.message.content : [];
+    for (const block of content) {
+      if (block.type !== "tool_result" || typeof block.tool_use_id !== "string") continue;
+      const name = session.toolNames.get(block.tool_use_id) ?? "qoder_tool";
+      turn.stream.writeNative({
+        kind: "tool-completed",
+        id: block.tool_use_id,
+        name,
+        output: block.content,
+        failed: block.is_error === true,
+      });
+    }
+    return;
+  }
+
+  if (message.type === "system" && message.subtype === "init") {
+    turn.stream.writeNative({ kind: "session", sessionId: message.session_id });
+    turn.stream.writeNative({
+      kind: "progress",
+      stage: "qoder.initialized",
+      data: { version: message.qodercli_version, model: message.model },
+    });
+    return;
+  }
+
+  if (message.type === "system" && message.subtype === "compact_boundary") {
+    session.pendingCompaction = {
+      ...(session.pendingCompaction ?? {}),
+      trigger: message.compact_metadata.trigger,
+      preTokens: message.compact_metadata.pre_tokens,
+    };
+  }
+
+  if (message.type === "system") {
+    turn.stream.writeNative({
+      kind: "progress",
+      stage: `qoder.${message.subtype}`,
+      data: message,
+    });
+  }
+}
+
+function appendPendingCompactionSummary(session: QoderNativeSession): void {
+  const pending = session.pendingCompaction;
+  if (pending?.summary === undefined || pending.preTokens === undefined) return;
+  session.messages.push({
+    role: "compactionSummary",
+    summary: pending.summary,
+    tokensBefore: pending.preTokens,
+    timestamp: Date.now(),
+  });
+  session.pendingCompaction = undefined;
+}
+
+export function mapQoderUsage(result: SDKResultMessage): AgentMessageUsage {
+  return createUsageFromTokenCounts({
+    measurement: "reported",
+    inputTokens: result.usage.input_tokens,
+    inputTokensIncludeCacheRead: false,
+    outputTokens: result.usage.output_tokens,
+    cacheReadTokens: result.usage.cache_read_input_tokens,
+    cacheWriteTokens: result.usage.cache_creation_input_tokens,
+    cacheWrite1hTokens: result.usage.cache_creation.ephemeral_1h_input_tokens,
+  });
+}
+
+async function readContextUsage(
+  q: Query,
+  session: QoderNativeSession,
+): Promise<RuntimeContextWindowUsage | undefined> {
+  const usage = await q.getContextUsage().catch(() => undefined);
+  if (usage !== undefined && usage.maxTokens > 0) {
+    return createRuntimeContextWindowUsage({
+      usedTokens: usage.totalTokens,
+      contextWindowTokens: usage.maxTokens,
+      measurement: "reported",
+    });
+  }
+  if (session.contextWindowTokens === undefined) return undefined;
+  return estimateContextUsage(session);
+}
+
+function estimateContextUsage(
+  session: QoderNativeSession,
+): RuntimeContextWindowUsage | undefined {
+  if (session.contextWindowTokens === undefined) return undefined;
+  const latestCompactionIndex = session.messages.findLastIndex(
+    (message) => message.role === "compactionSummary",
+  );
+  const activeMessages =
+    latestCompactionIndex < 0 ? session.messages : session.messages.slice(latestCompactionIndex);
+  return createRuntimeContextWindowUsage({
+    usedTokens: defaultTokenEstimator.count(
+      JSON.stringify({
+        systemPrompt: session.systemPrompt,
+        messages: activeMessages,
+        ...(latestCompactionIndex < 0 && session.compactSummary !== undefined
+          ? { compactSummary: session.compactSummary }
+          : {}),
+      }),
+    ),
+    contextWindowTokens: session.contextWindowTokens,
+    measurement: "estimated",
+  });
+}
+
+function createAssistantMessage(
+  result: SDKResultMessage,
+  usage: AgentMessageUsage,
+): AgentAssistantMessage {
+  return {
+    role: "assistant",
+    content:
+      result.subtype === "success"
+        ? [{ type: "text", text: result.result }]
+        : [{ type: "text", text: result.errors.join("\n") }],
+    api: "qoder-agent-sdk",
+    provider: "qoder",
+    model: Object.keys(result.modelUsage)[0] ?? "qoder",
+    usage,
+    stopReason: result.subtype === "success" ? "stop" : "error",
+    timestamp: Date.now(),
+  };
+}
+
+function updateSessionId(session: QoderNativeSession, message: SDKMessage): void {
+  if ("session_id" in message && typeof message.session_id === "string") {
+    session.sessionId = message.session_id;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -417,15 +417,24 @@ function createCanUseTool(
             : "Invalid approval response.",
       };
     }
-    const updatedInput = response.updatedInput;
     return {
       behavior: "allow",
-      updatedInput:
-        updatedInput !== null && typeof updatedInput === "object" && !Array.isArray(updatedInput)
-          ? (updatedInput as Record<string, unknown>)
-          : input,
+      updatedInput: resolveQoderApprovedToolInput(input, response.updatedInput),
     };
   };
+}
+
+export function resolveQoderApprovedToolInput(
+  originalInput: Record<string, unknown>,
+  updatedInput: unknown,
+): Record<string, unknown> {
+  if (updatedInput === null || typeof updatedInput !== "object" || Array.isArray(updatedInput)) {
+    return originalInput;
+  }
+  const prototype = Object.getPrototypeOf(updatedInput);
+  return prototype === Object.prototype || prototype === null
+    ? (updatedInput as Record<string, unknown>)
+    : originalInput;
 }
 
 function emitSdkMessage(

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -25,6 +25,7 @@ import {
   type Query,
   type SDKMessage,
   type SDKResultMessage,
+  type SDKResultSuccess,
 } from "@qoder-ai/qoder-agent-sdk";
 
 import { resolveQoderContextWindow } from "./models.ts";
@@ -182,6 +183,7 @@ export async function compactQoderContextWindow(
 
   session.pendingCompaction = undefined;
   const q = createQuery(session, "/compact", {
+    modelName: session.compactModelName,
     onPostCompact(input) {
       session.compactSummary = input.compact_summary;
       session.pendingCompaction = {
@@ -194,34 +196,38 @@ export async function compactQoderContextWindow(
   session.activeQuery = q;
   try {
     let result: SDKResultMessage | undefined;
+    let iterationError: unknown;
     const init = await q.initializationResult();
     if (!init.commands.some((command) => command.name === "compact")) {
       throw new Error("The installed Qoder CLI does not support the /compact command.");
     }
-    for await (const message of q) {
-      updateSessionId(session, message);
-      if (
-        message.type === "system" &&
-        message.subtype === "compact_boundary" &&
-        message.compact_metadata.trigger === "manual"
-      ) {
-        session.pendingCompaction = {
-          ...(session.pendingCompaction ?? {}),
-          trigger: "manual",
-          preTokens: message.compact_metadata.pre_tokens,
-        };
+    try {
+      for await (const message of q) {
+        updateSessionId(session, message);
+        if (
+          message.type === "system" &&
+          message.subtype === "compact_boundary" &&
+          message.compact_metadata.trigger === "manual"
+        ) {
+          session.pendingCompaction = {
+            ...(session.pendingCompaction ?? {}),
+            trigger: "manual",
+            preTokens: message.compact_metadata.pre_tokens,
+          };
+        }
+        if (message.type === "result") {
+          result = message;
+          session.contextWindowUsage = await readContextUsage(q, session, message);
+        }
       }
-      if (message.type === "result") {
-        result = message;
-        session.contextWindowUsage = await readContextUsage(q, session);
-      }
+    } catch (error) {
+      iterationError = error;
     }
-    if (result === undefined) {
-      throw new Error("Qoder CLI ended /compact without a result message.");
-    }
-    if (result.subtype !== "success") {
-      throw new Error(result.errors.join("\n") || `Qoder CLI failed: ${result.subtype}.`);
-    }
+    requireSuccessfulQoderResult(
+      result,
+      iterationError,
+      "Qoder CLI ended /compact without a result message.",
+    );
     if (
       session.pendingCompaction?.trigger !== "manual" ||
       session.pendingCompaction.preTokens === undefined
@@ -272,20 +278,25 @@ async function runQoderQuery(
 
   try {
     let result: SDKResultMessage | undefined;
-    for await (const message of q) {
-      updateSessionId(session, message);
-      emitSdkMessage(session, message, turn);
-      if (message.type === "result") {
-        result = message;
-        session.contextWindowUsage = await readContextUsage(q, session);
-        turn.stream.writeNative({ kind: "usage", usage: mapQoderUsage(message) });
+    let iterationError: unknown;
+    try {
+      for await (const message of q) {
+        updateSessionId(session, message);
+        emitSdkMessage(session, message, turn);
+        if (message.type === "result") {
+          result = message;
+          session.contextWindowUsage = await readContextUsage(q, session, message);
+          turn.stream.writeNative({ kind: "usage", usage: mapQoderUsage(message) });
+        }
       }
+    } catch (error) {
+      iterationError = error;
     }
-    if (result === undefined) throw new Error("Qoder CLI ended without a result message.");
-    if (result.subtype !== "success") {
-      throw new Error(result.errors.join("\n") || `Qoder CLI failed: ${result.subtype}.`);
-    }
-    return result;
+    return requireSuccessfulQoderResult(
+      result,
+      iterationError,
+      "Qoder CLI ended without a result message.",
+    );
   } finally {
     turn.signal.removeEventListener("abort", onAbort);
     session.activeQuery = undefined;
@@ -305,6 +316,7 @@ function createQuery(
   },
 ): Query {
   const modelName = options.modelName ?? session.defaultModelName ?? "auto";
+  const compactModelName = session.compactModelName ?? modelName;
   return query({
     prompt,
     options: {
@@ -328,6 +340,7 @@ function createQuery(
       allowedMcpServerNames: ["pragma"],
       strictMcpConfig: true,
       disallowedTools: ["AskUserQuestion"],
+      settings: { model: compactModelName },
       plugins: [{ type: "local", path: session.plugin.path }],
       skills: [...session.plugin.skills],
       permissionMode: session.permissionMode,
@@ -350,19 +363,19 @@ function createQuery(
         ],
       },
       resolveModel(context) {
+        const isCompaction =
+          context.purpose === "compact" || context.purpose === "compression";
+        const resolvedModelName = isCompaction ? compactModelName : modelName;
         const selected =
-          context.availableModels.find((model) => model.value === modelName) ??
+          context.availableModels.find((model) => model.value === resolvedModelName) ??
           context.availableModels.find((model) => model.isDefault === true);
         const contextWindow = resolveQoderContextWindow(
           selected,
           session.contextWindowOverride,
         );
-        session.contextWindowTokens = contextWindow;
+        if (!isCompaction) session.contextWindowTokens = contextWindow;
         return {
-          model:
-            context.purpose === "compact" && session.compactModelName !== undefined
-              ? session.compactModelName
-              : modelName,
+          model: resolvedModelName,
           parameters: {
             contextWindow,
             ...(options.thinkingLevel === undefined
@@ -519,10 +532,29 @@ export function mapQoderUsage(result: SDKResultMessage): AgentMessageUsage {
   });
 }
 
+export function requireSuccessfulQoderResult(
+  result: SDKResultMessage | undefined,
+  iterationError: unknown,
+  missingResultMessage: string,
+): SDKResultSuccess {
+  if (result === undefined) {
+    if (iterationError !== undefined) throw iterationError;
+    throw new Error(missingResultMessage);
+  }
+  if (result.subtype !== "success") {
+    throw new Error(result.errors.join("\n") || `Qoder CLI failed: ${result.subtype}.`);
+  }
+  if (iterationError !== undefined) throw iterationError;
+  return result;
+}
+
 async function readContextUsage(
   q: Query,
   session: QoderNativeSession,
+  result?: SDKResultMessage,
 ): Promise<RuntimeContextWindowUsage | undefined> {
+  const derived = deriveQoderContextWindowUsage(result, session.contextWindowTokens);
+  if (derived !== undefined) return derived;
   const usage = await q.getContextUsage().catch(() => undefined);
   if (usage !== undefined && usage.maxTokens > 0) {
     return createRuntimeContextWindowUsage({
@@ -533,6 +565,26 @@ async function readContextUsage(
   }
   if (session.contextWindowTokens === undefined) return undefined;
   return estimateContextUsage(session);
+}
+
+export function deriveQoderContextWindowUsage(
+  result: SDKResultMessage | undefined,
+  contextWindowTokens: number | undefined,
+): RuntimeContextWindowUsage | undefined {
+  const ratio = result?.usage.context_usage_ratio;
+  if (
+    contextWindowTokens === undefined ||
+    ratio === undefined ||
+    !Number.isFinite(ratio) ||
+    ratio < 0
+  ) {
+    return undefined;
+  }
+  return createRuntimeContextWindowUsage({
+    usedTokens: ratio * contextWindowTokens,
+    contextWindowTokens,
+    measurement: "derived",
+  });
 }
 
 function estimateContextUsage(

--- a/packages/runtime/qodercli/src/skills.ts
+++ b/packages/runtime/qodercli/src/skills.ts
@@ -1,0 +1,103 @@
+import type { Expert } from "@pragma/core";
+import { constants } from "node:fs";
+import { access, cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+
+const NON_ALPHANUMERIC = /[^a-z0-9]+/g;
+
+export interface QoderSkillPlugin {
+  readonly path: string;
+  readonly skills: readonly string[];
+}
+
+export async function materializeQoderSkillPlugin(
+  agent: Expert,
+  sessionDir: string,
+): Promise<QoderSkillPlugin> {
+  const pluginDir = join(sessionDir, "plugin");
+  const skillsDir = join(pluginDir, "skills");
+  const pluginName = `pragma-${sanitize(agent.id)}`;
+
+  await rm(pluginDir, { recursive: true, force: true });
+  await mkdir(skillsDir, { recursive: true });
+  await mkdir(join(pluginDir, ".qoder-plugin"), { recursive: true });
+  await writeFile(
+    join(pluginDir, ".qoder-plugin", "plugin.json"),
+    `${JSON.stringify(
+      {
+        name: pluginName,
+        version: "0.0.0",
+        description: `Pragma Expert skills for ${agent.name}.`,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const qualifiedSkills: string[] = [];
+  const usedSlugs = new Set<string>();
+  for (const skill of agent.skills?.skills ?? []) {
+    if (skill.path === undefined) continue;
+    const sourcePath = isAbsolute(skill.path)
+      ? skill.path
+      : resolve(skill.baseDir ?? agent.workspace, skill.path);
+    const info = await stat(sourcePath);
+    const sourceDir = info.isDirectory() ? sourcePath : dirname(sourcePath);
+    const sourceFile = info.isDirectory() ? join(sourcePath, "SKILL.md") : sourcePath;
+    await access(sourceFile, constants.R_OK);
+
+    const slug = allocateSlug(usedSlugs, sanitize(skill.name));
+    const targetDir = join(skillsDir, slug);
+    await cp(sourceDir, targetDir, {
+      recursive: true,
+      dereference: true,
+      filter: (path) => basename(path) !== "node_modules",
+    });
+    await writeFile(
+      join(targetDir, "SKILL.md"),
+      ensureFrontmatter(await readFile(sourceFile, "utf8"), slug, skill.description),
+    );
+    qualifiedSkills.push(`${pluginName}:${slug}`);
+  }
+
+  return { path: pluginDir, skills: qualifiedSkills };
+}
+
+function sanitize(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(NON_ALPHANUMERIC, "-")
+      .replace(/^-+|-+$/g, "") || "skill"
+  );
+}
+
+function allocateSlug(used: Set<string>, base: string): string {
+  let result = base;
+  let suffix = 2;
+  while (used.has(result)) result = `${base}-${suffix++}`;
+  used.add(result);
+  return result;
+}
+
+function ensureFrontmatter(content: string, name: string, description: string): string {
+  const normalized = content.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n${normalized}`;
+  }
+
+  const end = normalized.indexOf("\n---\n", 4);
+  if (end < 0) {
+    return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n${normalized}`;
+  }
+
+  const lines = normalized.slice(4, end).split("\n");
+  if (!lines.some((line) => line.trimStart().startsWith("name:"))) {
+    lines.unshift(`name: ${JSON.stringify(name)}`);
+  }
+  if (!lines.some((line) => line.trimStart().startsWith("description:"))) {
+    lines.push(`description: ${JSON.stringify(description)}`);
+  }
+  return `---\n${lines.join("\n")}\n---\n${normalized.slice(end + 5)}`;
+}

--- a/packages/runtime/qodercli/src/token-estimator.ts
+++ b/packages/runtime/qodercli/src/token-estimator.ts
@@ -1,0 +1,16 @@
+export interface TokenEstimator {
+  readonly count: (value: string) => number;
+}
+
+export const defaultTokenEstimator: TokenEstimator = {
+  count(value) {
+    if (value === "") return 0;
+    let asciiUnits = 0;
+    let nonAsciiUnits = 0;
+    for (const character of value) {
+      if (character.codePointAt(0)! <= 0x7f) asciiUnits += 1;
+      else nonAsciiUnits += 1;
+    }
+    return nonAsciiUnits + Math.ceil(asciiUnits / 4);
+  },
+};

--- a/packages/runtime/qodercli/src/types.ts
+++ b/packages/runtime/qodercli/src/types.ts
@@ -1,0 +1,35 @@
+import type {
+  RuntimeAdapterDescriptor,
+  RuntimeCanUseResult,
+  RuntimeModel,
+  RuntimeSessionRestoreHandler,
+  RuntimeSessionSyncCallback,
+} from "@pragma/core";
+
+export type QoderCliRuntimePermissionMode =
+  | "default"
+  | "auto"
+  | "bypassPermissions";
+
+export type QoderCliRuntimeAuth =
+  | { readonly type: "qodercli" }
+  | { readonly type: "access-token"; readonly token: string }
+  | { readonly type: "access-token-env"; readonly envVar?: string | undefined };
+
+export interface QoderCliRuntimeAdapterOptions {
+  readonly descriptor?: Partial<RuntimeAdapterDescriptor> | undefined;
+  readonly executablePath?: string | undefined;
+  readonly env?: NodeJS.ProcessEnv | undefined;
+  readonly auth?: QoderCliRuntimeAuth | undefined;
+  readonly defaultModelName?: string | undefined;
+  readonly defaultThinkingLevel?: string | undefined;
+  readonly contextWindowTokens?: number | undefined;
+  readonly compactModelName?: string | undefined;
+  readonly listModels?: (() => Promise<readonly RuntimeModel[]>) | undefined;
+  readonly onModelCatalogUpdated?: (() => void) | undefined;
+  readonly permissionMode?: QoderCliRuntimePermissionMode | undefined;
+  readonly canUse?: (() => Promise<RuntimeCanUseResult> | RuntimeCanUseResult) | undefined;
+  readonly outputRetryLimit?: number | undefined;
+  readonly sessionRestoreHandler?: RuntimeSessionRestoreHandler | undefined;
+  readonly sessionSyncCallback?: RuntimeSessionSyncCallback | undefined;
+}

--- a/packages/runtime/qodercli/test/adapter.test.ts
+++ b/packages/runtime/qodercli/test/adapter.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { createQoderCliRuntime } from "../src/adapter.ts";
+
+describe("Qoder CLI Runtime adapter", () => {
+  it("declares local streaming, MCP, context inspection, and compaction", () => {
+    const adapter = createQoderCliRuntime({
+      executablePath: "/opt/qodercli",
+      canUse: () => ({ usable: true }),
+      listModels: async () => [],
+    });
+
+    expect(adapter.descriptor).toMatchObject({
+      id: "qodercli-local",
+      kind: "qodercli-local",
+      capabilities: {
+        targets: ["agent"],
+        executionLocations: ["local"],
+        supportsStreaming: true,
+        supportsMcp: true,
+        supportsContextWindowInspection: true,
+        supportsManualCompaction: true,
+        supportsResume: true,
+        supportsCancel: true,
+        supportsClose: true,
+        supportsSteer: false,
+      },
+    });
+  });
+});

--- a/packages/runtime/qodercli/test/executable.test.ts
+++ b/packages/runtime/qodercli/test/executable.test.ts
@@ -1,0 +1,56 @@
+import { win32 } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveQoderCliExecutablePath } from "../src/executable.ts";
+
+describe("resolveQoderCliExecutablePath", () => {
+  it("prefers an explicit adapter path", () => {
+    expect(
+      resolveQoderCliExecutablePath({
+        executablePath: "/opt/qoder/qodercli",
+        env: { QODERCLI_PATH: "/ignored/qodercli" },
+      }),
+    ).toBe("/opt/qoder/qodercli");
+  });
+
+  it("uses QODERCLI_PATH before PATH discovery", () => {
+    expect(
+      resolveQoderCliExecutablePath({
+        env: { QODERCLI_PATH: "/managed/qodercli", PATH: "/bin" },
+        isExecutable: () => false,
+      }),
+    ).toBe("/managed/qodercli");
+  });
+
+  it("discovers the executable from PATH", () => {
+    expect(
+      resolveQoderCliExecutablePath({
+        env: { PATH: "/first:/second" },
+        platform: "linux",
+        isExecutable: (path) => path === "/second/qodercli",
+      }),
+    ).toBe("/second/qodercli");
+  });
+
+  it("resolves qodercli.exe from a case-insensitive Windows Path", () => {
+    const directory = win32.join("C:\\", "Qoder", "bin");
+    const executable = win32.join(directory, "qodercli.exe");
+    expect(
+      resolveQoderCliExecutablePath({
+        env: { Path: directory },
+        platform: "win32",
+        isExecutable: (path) => path.toLowerCase() === executable.toLowerCase(),
+      }),
+    ).toBe(executable);
+  });
+
+  it("rejects a Windows command shim instead of spawning it through a shell", () => {
+    expect(() =>
+      resolveQoderCliExecutablePath({
+        executablePath: win32.join("C:\\", "npm", "qodercli.cmd"),
+        platform: "win32",
+      }),
+    ).toThrow("not directly spawnable");
+  });
+});

--- a/packages/runtime/qodercli/test/models.test.ts
+++ b/packages/runtime/qodercli/test/models.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { mapQoderModel, resolveQoderContextWindow } from "../src/models.ts";
+
+describe("Qoder model mapping", () => {
+  it("maps model defaults, thinking efforts, and provider identity", () => {
+    expect(
+      mapQoderModel({
+        value: "performance",
+        displayName: "Performance",
+        description: "Fast",
+        isDefault: true,
+        supportsDisabled: true,
+        efforts: ["low", "high"],
+        defaultEffort: "high",
+      }),
+    ).toMatchObject({
+      id: "performance",
+      default: true,
+      provider: { id: "qoder", kind: "runtime-managed" },
+      thinking: {
+        defaultLevel: "high",
+        supportedLevels: [
+          { value: "none" },
+          { value: "low" },
+          { value: "high" },
+        ],
+      },
+    });
+  });
+
+  it("uses the model default context window and allows an explicit override", () => {
+    const model = {
+      value: "performance",
+      displayName: "Performance",
+      description: "Fast",
+      availableContextWindows: [100_000, 200_000],
+      defaultContextWindow: 200_000,
+    };
+    expect(resolveQoderContextWindow(model, undefined)).toBe(200_000);
+    expect(resolveQoderContextWindow(model, 300_000)).toBe(300_000);
+  });
+
+  it("fails closed when no context denominator is available", () => {
+    expect(() =>
+      resolveQoderContextWindow(
+        { value: "unknown", displayName: "Unknown", description: "" },
+        undefined,
+      ),
+    ).toThrow("does not report a context window");
+  });
+});

--- a/packages/runtime/qodercli/test/models.test.ts
+++ b/packages/runtime/qodercli/test/models.test.ts
@@ -1,8 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
 
-import { mapQoderModel, resolveQoderContextWindow } from "../src/models.ts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({ query: vi.fn() }));
+
+vi.mock("@qoder-ai/qoder-agent-sdk", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@qoder-ai/qoder-agent-sdk")>()),
+  query: sdk.query,
+}));
+
+import {
+  createQoderCliModelDiscovery,
+  mapQoderModel,
+  resolveQoderContextWindow,
+} from "../src/models.ts";
 
 describe("Qoder model mapping", () => {
+  beforeEach(() => {
+    sdk.query.mockReset();
+  });
+
   it("maps model defaults, thinking efforts, and provider identity", () => {
     expect(
       mapQoderModel({
@@ -20,11 +37,7 @@ describe("Qoder model mapping", () => {
       provider: { id: "qoder", kind: "runtime-managed" },
       thinking: {
         defaultLevel: "high",
-        supportedLevels: [
-          { value: "none" },
-          { value: "low" },
-          { value: "high" },
-        ],
+        supportedLevels: [{ value: "none" }, { value: "low" }, { value: "high" }],
       },
     });
   });
@@ -48,5 +61,60 @@ describe("Qoder model mapping", () => {
         undefined,
       ),
     ).toThrow("does not report a context window");
+  });
+
+  it("coalesces live discovery across adapters with the same executable, auth, and env", async () => {
+    const getAvailableModels = vi.fn().mockResolvedValue([
+      {
+        value: "performance",
+        displayName: "Performance",
+        description: "Fast",
+        isEnabled: true,
+      },
+    ]);
+    const close = vi.fn().mockResolvedValue(undefined);
+    sdk.query.mockImplementation(() => ({ getAvailableModels, close }));
+    const options = {
+      executablePath: `/opt/qodercli-${randomUUID()}`,
+      auth: { type: "qodercli" as const },
+      env: { QODER_TEST_CATALOG: "same" },
+    };
+    const first = createQoderCliModelDiscovery(options);
+    const second = createQoderCliModelDiscovery(options);
+
+    const [firstModels, secondModels] = await Promise.all([first(), second()]);
+
+    expect(firstModels).toEqual(secondModels);
+    expect(sdk.query).toHaveBeenCalledTimes(1);
+    expect(getAvailableModels).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a different catalog cache when executable configuration changes", async () => {
+    const getAvailableModels = vi.fn().mockResolvedValue([
+      {
+        value: "performance",
+        displayName: "Performance",
+        description: "Fast",
+        isEnabled: true,
+      },
+    ]);
+    sdk.query.mockImplementation(() => ({
+      getAvailableModels,
+      close: vi.fn().mockResolvedValue(undefined),
+    }));
+    const executable = `/opt/qodercli-${randomUUID()}`;
+
+    await createQoderCliModelDiscovery({
+      executablePath: executable,
+      env: { QODER_TEST_CATALOG: "first" },
+    })();
+    await createQoderCliModelDiscovery({
+      executablePath: executable,
+      env: { QODER_TEST_CATALOG: "second" },
+    })();
+
+    expect(sdk.query).toHaveBeenCalledTimes(2);
+    expect(getAvailableModels).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/runtime/qodercli/test/permissions.test.ts
+++ b/packages/runtime/qodercli/test/permissions.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveQoderApprovedToolInput } from "../src/session.ts";
+
+describe("Qoder tool approval input", () => {
+  it("accepts plain records and rejects values that cannot be Qoder tool input", () => {
+    const original = { path: "original" };
+    const updated = { path: "updated" };
+
+    expect(resolveQoderApprovedToolInput(original, updated)).toBe(updated);
+    expect(resolveQoderApprovedToolInput(original, Object.assign(new Map(), updated))).toBe(
+      original,
+    );
+    expect(resolveQoderApprovedToolInput(original, new Date())).toBe(original);
+    expect(resolveQoderApprovedToolInput(original, ["updated"])).toBe(original);
+  });
+});

--- a/packages/runtime/qodercli/test/qoder-config.test.ts
+++ b/packages/runtime/qodercli/test/qoder-config.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { prepareManagedQoderConfig } from "../src/qoder-config.ts";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map(async (root) => {
+      await rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("prepareManagedQoderConfig", () => {
+  it("snapshots local login state while keeping session state private", async () => {
+    const root = await temporaryRoot();
+    const shared = join(root, "shared");
+    const session = join(root, "session");
+    await mkdir(join(shared, ".auth"), { recursive: true });
+    await writeFile(join(shared, ".auth", "user"), "credential");
+
+    const config = await prepareManagedQoderConfig({
+      sessionDir: session,
+      env: { QODER_CONFIG_DIR: shared },
+      logger: { warn: vi.fn() },
+    });
+
+    await expect(readFile(join(config, ".auth", "user"), "utf8")).resolves.toBe(
+      "credential",
+    );
+    await expect(readFile(join(config, "projects", "missing"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not overwrite login state already owned by a restored session", async () => {
+    const root = await temporaryRoot();
+    const shared = join(root, "shared");
+    const session = join(root, "session");
+    await mkdir(join(shared, ".auth"), { recursive: true });
+    await mkdir(join(session, "config", ".auth"), { recursive: true });
+    await writeFile(join(shared, ".auth", "user"), "new-global-login");
+    await writeFile(join(session, "config", ".auth", "user"), "session-login");
+
+    const config = await prepareManagedQoderConfig({
+      sessionDir: session,
+      env: { QODER_CONFIG_DIR: shared },
+      logger: { warn: vi.fn() },
+    });
+
+    await expect(readFile(join(config, ".auth", "user"), "utf8")).resolves.toBe(
+      "session-login",
+    );
+  });
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pragma-qoder-config-"));
+  temporaryRoots.push(root);
+  return root;
+}

--- a/packages/runtime/qodercli/test/qoder-config.test.ts
+++ b/packages/runtime/qodercli/test/qoder-config.test.ts
@@ -1,10 +1,13 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { prepareManagedQoderConfig } from "../src/qoder-config.ts";
+import {
+  prepareManagedQoderConfig,
+  resolveSharedQoderConfigDir,
+} from "../src/qoder-config.ts";
 
 const temporaryRoots: string[] = [];
 
@@ -17,6 +20,15 @@ afterEach(async () => {
 });
 
 describe("prepareManagedQoderConfig", () => {
+  it("uses only the explicit Qoder config directory or the native default", () => {
+    expect(resolveSharedQoderConfigDir({ QODER_CONFIG_DIR: "/custom/qoder" })).toBe(
+      "/custom/qoder",
+    );
+    expect(resolveSharedQoderConfigDir({ QODER_CLI_HOME: "/ambiguous/home" })).toBe(
+      join(homedir(), ".qoder"),
+    );
+  });
+
   it("snapshots local login state while keeping session state private", async () => {
     const root = await temporaryRoot();
     const shared = join(root, "shared");

--- a/packages/runtime/qodercli/test/qoder-config.test.ts
+++ b/packages/runtime/qodercli/test/qoder-config.test.ts
@@ -22,7 +22,9 @@ describe("prepareManagedQoderConfig", () => {
     const shared = join(root, "shared");
     const session = join(root, "session");
     await mkdir(join(shared, ".auth"), { recursive: true });
+    await mkdir(join(shared, ".models", "user"), { recursive: true });
     await writeFile(join(shared, ".auth", "user"), "credential");
+    await writeFile(join(shared, ".models", "user", "catalog-v6"), "encrypted-catalog");
 
     const config = await prepareManagedQoderConfig({
       sessionDir: session,
@@ -33,6 +35,9 @@ describe("prepareManagedQoderConfig", () => {
     await expect(readFile(join(config, ".auth", "user"), "utf8")).resolves.toBe(
       "credential",
     );
+    await expect(
+      readFile(join(config, ".models", "user", "catalog-v6"), "utf8"),
+    ).resolves.toBe("encrypted-catalog");
     await expect(readFile(join(config, "projects", "missing"), "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });
@@ -43,9 +48,16 @@ describe("prepareManagedQoderConfig", () => {
     const shared = join(root, "shared");
     const session = join(root, "session");
     await mkdir(join(shared, ".auth"), { recursive: true });
+    await mkdir(join(shared, ".models", "user"), { recursive: true });
     await mkdir(join(session, "config", ".auth"), { recursive: true });
+    await mkdir(join(session, "config", ".models", "user"), { recursive: true });
     await writeFile(join(shared, ".auth", "user"), "new-global-login");
+    await writeFile(join(shared, ".models", "user", "catalog-v6"), "new-global-catalog");
     await writeFile(join(session, "config", ".auth", "user"), "session-login");
+    await writeFile(
+      join(session, "config", ".models", "user", "catalog-v6"),
+      "session-catalog",
+    );
 
     const config = await prepareManagedQoderConfig({
       sessionDir: session,
@@ -56,6 +68,9 @@ describe("prepareManagedQoderConfig", () => {
     await expect(readFile(join(config, ".auth", "user"), "utf8")).resolves.toBe(
       "session-login",
     );
+    await expect(
+      readFile(join(config, ".models", "user", "catalog-v6"), "utf8"),
+    ).resolves.toBe("session-catalog");
   });
 });
 

--- a/packages/runtime/qodercli/test/token-estimator.test.ts
+++ b/packages/runtime/qodercli/test/token-estimator.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultTokenEstimator } from "../src/token-estimator.ts";
+
+describe("Qoder context token estimator", () => {
+  it("uses deterministic ASCII and non-ASCII weights", () => {
+    expect(defaultTokenEstimator.count("")).toBe(0);
+    expect(defaultTokenEstimator.count("abcdefgh")).toBe(2);
+    expect(defaultTokenEstimator.count("上下文")).toBe(3);
+    expect(defaultTokenEstimator.count("test上下文")).toBe(4);
+  });
+});

--- a/packages/runtime/qodercli/test/usage.test.ts
+++ b/packages/runtime/qodercli/test/usage.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { SDKResultSuccess } from "@qoder-ai/qoder-agent-sdk";
+import type { SDKResultError, SDKResultSuccess } from "@qoder-ai/qoder-agent-sdk";
 
-import { mapQoderUsage } from "../src/session.ts";
+import {
+  deriveQoderContextWindowUsage,
+  mapQoderUsage,
+  requireSuccessfulQoderResult,
+} from "../src/session.ts";
 
 describe("Qoder usage mapping", () => {
   it("keeps reported input, output, cache-read, and cache-write categories disjoint", () => {
@@ -46,5 +50,87 @@ describe("Qoder usage mapping", () => {
       totalTokens: 155,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     });
+  });
+
+  it("derives context usage from the CLI-reported ratio", () => {
+    const result = {
+      type: "result",
+      subtype: "success",
+      duration_ms: 10,
+      duration_api_ms: 8,
+      is_error: false,
+      num_turns: 1,
+      result: "done",
+      stop_reason: "end_turn",
+      total_cost_usd: 0,
+      usage: {
+        cache_creation: {
+          ephemeral_1h_input_tokens: 0,
+          ephemeral_5m_input_tokens: 0,
+        },
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        context_usage_ratio: 0.125,
+        inference_geo: "",
+        input_tokens: 0,
+        iterations: [],
+        output_tokens: 0,
+        server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
+        service_tier: "",
+        speed: "",
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "result",
+      session_id: "session",
+    } satisfies SDKResultSuccess;
+
+    expect(deriveQoderContextWindowUsage(result, 200_000)).toMatchObject({
+      usedTokens: 25_000,
+      contextWindowTokens: 200_000,
+      percent: 12.5,
+      measurement: "derived",
+    });
+  });
+
+  it("preserves a structured Qoder failure when the process also exits unsuccessfully", () => {
+    const result = {
+      type: "result",
+      subtype: "error_during_execution",
+      duration_ms: 10,
+      duration_api_ms: 8,
+      is_error: true,
+      num_turns: 1,
+      stop_reason: null,
+      total_cost_usd: 0,
+      usage: {
+        cache_creation: {
+          ephemeral_1h_input_tokens: 0,
+          ephemeral_5m_input_tokens: 0,
+        },
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        inference_geo: "",
+        input_tokens: 0,
+        iterations: [],
+        output_tokens: 0,
+        server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
+        service_tier: "",
+        speed: "",
+      },
+      modelUsage: {},
+      permission_denials: [],
+      errors: ["Qoder quota is exhausted."],
+      uuid: "result",
+      session_id: "session",
+    } satisfies SDKResultError;
+
+    expect(() =>
+      requireSuccessfulQoderResult(
+        result,
+        new Error("Qoder CLI process exited with code 1"),
+        "missing result",
+      ),
+    ).toThrow("Qoder quota is exhausted.");
   });
 });

--- a/packages/runtime/qodercli/test/usage.test.ts
+++ b/packages/runtime/qodercli/test/usage.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { SDKResultSuccess } from "@qoder-ai/qoder-agent-sdk";
+
+import { mapQoderUsage } from "../src/session.ts";
+
+describe("Qoder usage mapping", () => {
+  it("keeps reported input, output, cache-read, and cache-write categories disjoint", () => {
+    const result = {
+      type: "result",
+      subtype: "success",
+      duration_ms: 10,
+      duration_api_ms: 8,
+      is_error: false,
+      num_turns: 1,
+      result: "done",
+      stop_reason: "end_turn",
+      total_cost_usd: 0,
+      usage: {
+        cache_creation: {
+          ephemeral_1h_input_tokens: 2,
+          ephemeral_5m_input_tokens: 3,
+        },
+        cache_creation_input_tokens: 5,
+        cache_read_input_tokens: 20,
+        inference_geo: "",
+        input_tokens: 100,
+        iterations: [],
+        output_tokens: 30,
+        server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
+        service_tier: "",
+        speed: "",
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "result",
+      session_id: "session",
+    } satisfies SDKResultSuccess;
+
+    expect(mapQoderUsage(result)).toEqual({
+      measurement: "reported",
+      input: 100,
+      output: 30,
+      cacheRead: 20,
+      cacheWrite: 5,
+      cacheWrite1h: 2,
+      totalTokens: 155,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    });
+  });
+});

--- a/packages/runtime/qodercli/test/usage.test.ts
+++ b/packages/runtime/qodercli/test/usage.test.ts
@@ -5,6 +5,7 @@ import {
   deriveQoderContextWindowUsage,
   mapQoderUsage,
   requireSuccessfulQoderResult,
+  resolveQoderUsage,
 } from "../src/session.ts";
 
 describe("Qoder usage mapping", () => {
@@ -50,6 +51,95 @@ describe("Qoder usage mapping", () => {
       totalTokens: 155,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     });
+  });
+
+  it("estimates a turn when Qoder reports an all-zero usage snapshot", () => {
+    const result = {
+      type: "result",
+      subtype: "success",
+      duration_ms: 10,
+      duration_api_ms: 8,
+      is_error: false,
+      num_turns: 1,
+      result: "done",
+      stop_reason: "end_turn",
+      total_cost_usd: 0,
+      usage: {
+        cache_creation: {
+          ephemeral_1h_input_tokens: 0,
+          ephemeral_5m_input_tokens: 0,
+        },
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        context_usage_ratio: 0.125,
+        inference_geo: "",
+        input_tokens: 0,
+        iterations: [],
+        output_tokens: 0,
+        server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
+        service_tier: "",
+        speed: "",
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "result",
+      session_id: "session",
+    } satisfies SDKResultSuccess;
+
+    expect(
+      resolveQoderUsage(result, {
+        inputText: "abcdefgh",
+        outputText: "done",
+      }),
+    ).toEqual({
+      measurement: "estimated",
+      input: 2,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 3,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    });
+  });
+
+  it("prefers Qoder's reported usage over the estimation fallback", () => {
+    const result = {
+      type: "result",
+      subtype: "success",
+      duration_ms: 10,
+      duration_api_ms: 8,
+      is_error: false,
+      num_turns: 1,
+      result: "done",
+      stop_reason: "end_turn",
+      total_cost_usd: 0,
+      usage: {
+        cache_creation: {
+          ephemeral_1h_input_tokens: 2,
+          ephemeral_5m_input_tokens: 3,
+        },
+        cache_creation_input_tokens: 5,
+        cache_read_input_tokens: 20,
+        inference_geo: "",
+        input_tokens: 100,
+        iterations: [],
+        output_tokens: 30,
+        server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
+        service_tier: "",
+        speed: "",
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "result",
+      session_id: "session",
+    } satisfies SDKResultSuccess;
+
+    expect(
+      resolveQoderUsage(result, {
+        inputText: "fallback input",
+        outputText: "fallback output",
+      }),
+    ).toEqual(mapQoderUsage(result));
   });
 
   it("derives context usage from the CLI-reported ratio", () => {

--- a/packages/runtime/qodercli/tsconfig.build.json
+++ b/packages/runtime/qodercli/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": false
+  },
+  "include": ["src"],
+  "exclude": ["test", "src/**/*.test.ts"]
+}

--- a/packages/runtime/qodercli/tsconfig.json
+++ b/packages/runtime/qodercli/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@pragma/tsconfig/node.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}

--- a/packages/runtime/qodercli/vitest.config.ts
+++ b/packages/runtime/qodercli/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+
+interface OxcTsconfigOptions {
+  readonly tsconfig: {
+    readonly compilerOptions: {
+      readonly target: string;
+      readonly verbatimModuleSyntax: boolean;
+    };
+  };
+}
+
+const oxcOptions: OxcTsconfigOptions = {
+  tsconfig: {
+    compilerOptions: {
+      target: "ES2022",
+      verbatimModuleSyntax: true,
+    },
+  },
+};
+
+export default defineConfig({
+  oxc: oxcOptions as never,
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/agent-message.schema.ts
+++ b/packages/shared/src/agent-message.schema.ts
@@ -28,6 +28,7 @@ export const AgentToolCallContentSchema = z.object({
 });
 
 export const AgentMessageUsageSchema = z.object({
+  measurement: z.enum(["reported", "derived", "estimated", "unknown"]),
   input: z.number().nonnegative(),
   output: z.number().nonnegative(),
   cacheRead: z.number().nonnegative(),
@@ -41,6 +42,10 @@ export const AgentMessageUsageSchema = z.object({
     cacheWrite: z.number().nonnegative(),
     total: z.number().nonnegative(),
   }),
+});
+
+export const AgentMessageUsageWireSchema = AgentMessageUsageSchema.extend({
+  measurement: AgentMessageUsageSchema.shape.measurement.default("unknown"),
 });
 
 export const AgentUserMessageSchema = z.object({
@@ -63,7 +68,7 @@ export const AgentAssistantMessageSchema = z.object({
   responseModel: z.string().optional(),
   responseId: z.string().optional(),
   diagnostics: z.array(z.unknown()).optional(),
-  usage: AgentMessageUsageSchema,
+  usage: AgentMessageUsageWireSchema,
   stopReason: z.enum(["stop", "length", "toolUse", "error", "aborted"]),
   errorMessage: z.string().optional(),
   timestamp: z.number(),

--- a/packages/shared/src/execution/execution.schema.ts
+++ b/packages/shared/src/execution/execution.schema.ts
@@ -205,7 +205,7 @@ export const ExecutionOutputItemSchema = z.object({
 });
 
 export const ExecutionRecordSchema = z.object({
-  schemaVersion: z.literal("pragma.execution/v7"),
+  schemaVersion: z.literal("pragma.execution/v8"),
   executionId: z.string().min(1),
   version: z.number().int().nonnegative(),
   kind: ExecutionKindSchema,

--- a/packages/shared/src/stream-event.schema.ts
+++ b/packages/shared/src/stream-event.schema.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { AgentMessageSchema, AgentMessageUsageSchema } from "./agent-message.schema.ts";
+import {
+  AgentMessageSchema,
+  AgentMessageUsageWireSchema,
+} from "./agent-message.schema.ts";
 
 export const ExpertAgentStreamSchemaVersionSchema = z.literal("pragma.stream/v1");
 
@@ -44,7 +47,7 @@ export const ExpertAgentRunStartedEventSchema = ExpertAgentStreamEventBaseSchema
 export const ExpertAgentRunCompletedEventSchema = ExpertAgentStreamEventBaseSchema.extend({
   type: z.literal("run.completed"),
   payload: z.object({
-    usage: AgentMessageUsageSchema.optional(),
+    usage: AgentMessageUsageWireSchema.optional(),
   }),
 });
 

--- a/packages/shared/test/agent-message.test.ts
+++ b/packages/shared/test/agent-message.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { AgentMessageSchema } from "../src/agent-message.schema.ts";
+
+describe("AgentMessage usage wire compatibility", () => {
+  it("marks historical assistant usage without a measurement as unknown", () => {
+    expect(
+      AgentMessageSchema.parse({
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        api: "test",
+        provider: "test",
+        model: "test",
+        usage: {
+          input: 1,
+          output: 2,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 3,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      }),
+    ).toMatchObject({
+      usage: { measurement: "unknown", totalTokens: 3 },
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
         specifier: latest
         version: 4.4.3
     devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
       '@pragma/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@pragma/runtime-pi':
         specifier: workspace:*
         version: link:../../packages/runtime/pi
+      '@pragma/runtime-qodercli':
+        specifier: workspace:*
+        version: link:../../packages/runtime/qodercli
       '@pragma/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -460,10 +463,10 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.80.10
-        version: 0.80.10(ws@8.21.0)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(ws@8.21.0)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@pragma/core':
         specifier: workspace:*
         version: link:../../core
@@ -486,6 +489,34 @@ importers:
       zod:
         specifier: latest
         version: 4.4.3
+
+  packages/runtime/qodercli:
+    dependencies:
+      '@pragma/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@pragma/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      '@qoder-ai/qoder-agent-sdk':
+        specifier: 1.0.15
+        version: 1.0.15(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      zod:
+        specifier: latest
+        version: 4.4.3
+    devDependencies:
+      '@pragma/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      '@types/node':
+        specifier: 26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: latest
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@8.1.0(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/server:
     devDependencies:
@@ -1238,6 +1269,12 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hono/node-server@2.0.12':
+    resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1512,6 +1549,16 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@modelcontextprotocol/server@2.0.0-alpha.2':
     resolution: {integrity: sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==}
     engines: {node: '>=20'}
@@ -1650,6 +1697,12 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@qoder-ai/qoder-agent-sdk@1.0.15':
+    resolution: {integrity: sha512-6WyA0wEcM3ThwVEmDJsJcuc7jmCIO02SrbYIOSz6MvDQuWY/on+3usLX7WIpeIKg7pfQQMqUeSrQLXo1DkBQ+w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -2172,6 +2225,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2277,6 +2334,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -2313,6 +2374,10 @@ packages:
     resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
     engines: {node: '>=14.0.0'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   bytestreamjs@2.0.1:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
     engines: {node: '>=6.0.0'}
@@ -2335,6 +2400,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001806:
@@ -2406,8 +2475,28 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -2415,6 +2504,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
@@ -2504,6 +2597,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2547,6 +2644,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -2588,6 +2688,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2638,6 +2742,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2693,6 +2800,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -2707,6 +2818,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.6.1:
+    resolution: {integrity: sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -2775,6 +2896,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
@@ -2797,6 +2922,14 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2938,6 +3071,10 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  hono@4.12.32:
+    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2951,6 +3088,10 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -2972,6 +3113,10 @@ packages:
       typescript:
         optional: true
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2990,6 +3135,14 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -3010,6 +3163,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -3079,6 +3235,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3231,13 +3390,29 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -3298,6 +3473,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   next@16.2.11:
     resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
     engines: {node: '>=20.9.0'}
@@ -3356,6 +3535,14 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -3367,6 +3554,10 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3403,6 +3594,10 @@ packages:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -3425,6 +3620,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3520,6 +3718,10 @@ packages:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3534,6 +3736,10 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -3543,6 +3749,14 @@ packages:
 
   quickjs-emscripten-core@0.32.0:
     resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -3643,6 +3857,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -3656,6 +3874,9 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
@@ -3700,12 +3921,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -3718,6 +3950,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3759,6 +4007,10 @@ packages:
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -3846,6 +4098,10 @@ packages:
     resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
     engines: {node: '>=20'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
@@ -3877,6 +4133,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
@@ -3916,6 +4176,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unzipper@0.12.5:
     resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
 
@@ -3938,6 +4202,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@7.3.6:
     resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
@@ -4537,9 +4805,9 @@ snapshots:
 
   '@dagrejs/graphlib@4.0.1': {}
 
-  '@earendil-works/pi-agent-core@0.80.10(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.10(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -4551,11 +4819,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.10(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
@@ -4572,10 +4840,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.80.10(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.80.10(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.80.10(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.80.10
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -4940,16 +5208,22 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.4.0
 
-  '@google/genai@1.52.0':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
       protobufjs: 7.6.4
       ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@hono/node-server@2.0.12(hono@4.12.32)':
+    dependencies:
+      hono: 4.12.32
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -5175,6 +5449,30 @@ snapshots:
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
 
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.0.12(hono@4.12.32)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.1(express@5.2.1)
+      hono: 4.12.32
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
     dependencies:
       zod: 4.4.3
@@ -5274,6 +5572,14 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@qoder-ai/qoder-agent-sdk@1.0.15(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -5779,6 +6085,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -5904,6 +6215,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -5960,6 +6285,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bytes@3.1.2: {}
+
   bytestreamjs@2.0.1: {}
 
   cac@6.7.14: {}
@@ -5982,6 +6309,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001806: {}
 
@@ -6035,11 +6367,26 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   croner@10.0.1: {}
 
@@ -6120,6 +6467,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -6165,6 +6514,8 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -6244,6 +6595,8 @@ snapshots:
       - supports-color
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6335,6 +6688,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   eslint-scope@9.1.2:
@@ -6409,6 +6764,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
@@ -6418,6 +6775,47 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.6.1(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -6510,6 +6908,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6539,6 +6948,10 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -6729,6 +7142,8 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
+  hono@4.12.32: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -6742,6 +7157,14 @@ snapshots:
       void-elements: 3.1.0
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -6768,6 +7191,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -6781,6 +7208,10 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ip-address@10.3.1: {}
+
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.4.0: {}
 
   is-extendable@0.1.1: {}
@@ -6792,6 +7223,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-promise@4.0.0: {}
 
   isarray@1.0.0: {}
 
@@ -6846,6 +7279,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6976,11 +7411,21 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -7023,6 +7468,8 @@ snapshots:
   nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   next@16.2.11(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -7088,12 +7535,20 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1:
     optional: true
 
   obug@2.1.3: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -7128,6 +7583,8 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  parseurl@1.3.3: {}
+
   partial-json@0.1.7: {}
 
   path-exists@4.0.0: {}
@@ -7142,6 +7599,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -7252,6 +7711,11 @@ snapshots:
       '@types/node': 26.1.0
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -7265,6 +7729,11 @@ snapshots:
 
   pvutils@1.1.5: {}
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
@@ -7272,6 +7741,15 @@ snapshots:
   quickjs-emscripten-core@0.32.0:
     dependencies:
       '@jitl/quickjs-ffi-types': 0.32.0
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -7403,6 +7881,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -7412,6 +7900,8 @@ snapshots:
       ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
 
   sanitize-filename@1.6.4:
     dependencies:
@@ -7441,12 +7931,39 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -7486,6 +8003,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -7517,6 +8062,8 @@ snapshots:
   stackback@0.0.2: {}
 
   stat-mode@1.0.0: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -7600,6 +8147,8 @@ snapshots:
 
   toad-cache@3.7.1: {}
 
+  toidentifier@1.0.1: {}
+
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
@@ -7634,6 +8183,12 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   typebox@1.1.38: {}
 
   typescript-eslint@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3):
@@ -7662,6 +8217,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unzipper@0.12.5:
     dependencies:
       bluebird: 3.7.2
@@ -7687,6 +8244,8 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## Summary

- add the `@pragma/runtime-qodercli` adapter with executable discovery, authentication, model discovery, native session resume, streaming events, permission mapping, skills, context compaction, and the process-shared MCP gateway
- support Qoder context-window statistics with reported, derived, estimated, and unknown measurement precision
- register Qoder CLI as a built-in Desktop runtime and preserve usage precision through persisted state migrations
- make Runtime adapter and model-catalog caches live for the Desktop Runtime service lifetime, keyed by immutable Runtime identity and discovery inputs
- skip Mission recompilation for follow-up messages when the live ExpertSession and immutable execution fingerprint still match; recompile only when the definition, revision, Runtime configuration, model override, or permissions change
- add a platform-independent compiler Blueprint cache: the interpreter owns cache keys, validation, loading, and reconstruction, while the Host supplies memory, filesystem, database, or object-storage persistence
- add a Desktop atomic filesystem-backed Blueprint store plus an in-process LRU and single-flight loading; cache only serializable immutable Blueprints, never mutable ExpertSessions
- eliminate duplicate artifact hashing and repeated resource/plugin resolution, memoize project validation, and parallelize independent Runtime, capability, context-store, and plugin work on cache misses
- replace per-request storage scans with a background-refreshed capacity guard that performs synchronous maintenance only when stale or under pressure
- share reference-counted MCP Tool Registries across compatible Codex and Qoder sessions with bounded idle eviction
- split startup timing into message acceptance, preparation phases, model request dispatch, Runtime acknowledgement, first protocol event, first reasoning/text delta, first UI projection receipt, and first painted UI token
- retain isolated Runtime processes/threads per Mission Context; shared Codex processes were evaluated but rejected because private Home, SQLite, session, configuration, log, and authentication boundaries must remain isolated
- replace Codex's full `~/.codex` shared-base copy/hash path with a minimal private Home projection that links only safe rebuildable caches
- document the compiler-cache, storage-admission, Runtime reuse, and latency-observation decisions in ADR 027

## Why

Pragma needs a first-class Qoder CLI runtime with the same governed execution and recovery boundaries as the existing local runtimes. Mission startup also repeated substantial local work before the first model token became visible:

- every follow-up recompiled an unchanged executor even when its ExpertSession was already live
- compilation repeated content hashing, resource resolution, plugin resolution, validation, and Runtime probing
- every request performed storage-capacity work that could take about one second despite recently verified state
- MCP Tool Registries were rebuilt for compatible Runtime sessions
- timing data did not distinguish local preparation, Runtime acknowledgement, protocol streaming, model TTFT, UI projection, and actual browser paint

These costs obscured the external model/network latency and made follow-ups unnecessarily pay cold-start work.

## User and developer impact

Warm follow-ups now bypass compilation when their immutable execution identity matches. Cache misses still fail closed and preserve full DSL validation; definition or execution-configuration changes invalidate the fast path and produce a freshly compiled executor.

Compiler caching remains platform independent. Hosts decide where serialized Blueprint bytes live, corrupt or incompatible entries fail open to recompilation, and cache keys include compiler version, immutable source identity, entry path, and resource-adapter registry fingerprint. Runtime sessions, ExpertSessions, credentials, and other mutable state are not cached.

Users enter the queued/preparing state immediately. Structured logs now expose each boundary from request acceptance through the first painted reasoning/text token, enabling model, thinking-level, tool-count, context-length, and prompt-cache comparisons without conflating them with compiler or UI overhead.

Permissions, sandboxing, Runtime Session ownership, restoration, model-selection validation, and Flow/Expert DSL semantics remain enforced. External native-process initialization and model/network latency remain outside the local compiler cache and are now reported independently.

## Review follow-up

The latest code review found and fixed four correctness gaps:

- definition changes now create a successor ExpertSession directly instead of trying to resume a Session that was just closed
- external MCP Registry cache keys now use canonical recursive serialization, so equivalent configurations share the same registry regardless of object or tool ordering
- Blueprint single-flight now coalesces the complete source load, parse, artifact collection, build, and cache-write path
- precomputed artifact hashes are trusted only for immutable sources; mutable projects reverify content and fail closed when an artifact changes between load and compilation

Regression tests cover each corrected path, including successor Session creation, stable MCP cache keys, concurrent Blueprint construction, and mutable artifact integrity.

## Validation

- real Qoder CLI 1.1.6 smoke: model discovery, text/thought streaming, native resume, context inspection, manual compaction, post-compaction continuation, and usage reporting
- follow-up regression tests proving unchanged live Sessions bypass compilation and changed definitions create successor Sessions
- compiler cache tests covering Host persistence, process-local cache reset, serialized Blueprint reconstruction, adapter-fingerprint keys, concurrent single-flight construction, mutable artifact verification, and corrupt/missing-entry fallback
- storage-capacity tests covering fresh-snapshot admission and stale-snapshot refresh
- MCP Registry pool tests covering compatible-session reuse, canonical cache keys, reference counting, and cleanup
- Codex and Qoder Runtime suites, including acknowledgement and first-delta instrumentation
- Desktop: 79 test files and 435 tests passed
- `git diff --check`
- lint and typecheck passed across all workspaces
- serial full test run — 19/19 workspace tasks passed
- `pnpm build` — 19/19 workspaces passed
