### PR TITLE
Improve DSL resource cycle diagnostics

### DIFF
--- a/packages/interpreter/src/compiler/pragma-project.ts
+++ b/packages/interpreter/src/compiler/pragma-project.ts
@@ -72,10 +72,7 @@ import {
   type PragmaResourceInspection,
   type PragmaRuntimeProfileContribution,
 } from "../runtime/resource-adapters.ts";
-import {
-  evaluatePragmaFlowValue,
-  renderPragmaFlowPrompt,
-} from "../runtime/flow-values.ts";
+import { evaluatePragmaFlowValue, renderPragmaFlowPrompt } from "../runtime/flow-values.ts";
 
 const COMPILER_VERSION = "pragma.dsl/v2";
 const provenance = new WeakMap<object, PragmaProvenance>();
@@ -1739,95 +1736,178 @@ function validateAndReadLoopMembers(
   return new Map(analysis.loopMembers);
 }
 
-function hasCycle(
+interface ResourceDependency {
+  readonly ref: string;
+  readonly path: readonly (string | number)[];
+}
+
+interface ResourceDependencyEdge extends ResourceDependency {
+  readonly target: string;
+}
+
+interface ResourceCycle {
+  readonly refs: readonly string[];
+  readonly sourceRef: string;
+  readonly path: readonly (string | number)[];
+}
+
+function findResourceCycles(
   nodes: ReadonlySet<string>,
-  edges: ReadonlyMap<string, ReadonlySet<string>>,
-): boolean {
+  edges: ReadonlyMap<string, readonly ResourceDependencyEdge[]>,
+): readonly ResourceCycle[] {
   const visiting = new Set<string>();
   const visited = new Set<string>();
-  const visit = (node: string): boolean => {
-    if (visiting.has(node)) return true;
-    if (visited.has(node)) return false;
+  const stack: string[] = [];
+  const cycles: ResourceCycle[] = [];
+
+  const visit = (node: string): void => {
     visiting.add(node);
-    for (const target of edges.get(node) ?? []) {
-      if (visit(target)) return true;
+    stack.push(node);
+    for (const edge of edges.get(node) ?? []) {
+      if (!nodes.has(edge.target)) continue;
+      if (!visiting.has(edge.target) && !visited.has(edge.target)) {
+        visit(edge.target);
+        continue;
+      }
+      if (!visiting.has(edge.target)) continue;
+      const cycleStart = stack.indexOf(edge.target);
+      cycles.push({
+        refs: [node, ...stack.slice(cycleStart)],
+        sourceRef: node,
+        path: edge.path,
+      });
     }
+    stack.pop();
     visiting.delete(node);
     visited.add(node);
-    return false;
   };
-  return [...nodes].some(visit);
+
+  for (const node of [...nodes].sort()) {
+    if (!visited.has(node)) visit(node);
+  }
+  return cycles;
 }
 
 function validateResourceCycles(
   resources: ReadonlyMap<string, IndexedResource>,
 ): PragmaDiagnostic[] {
-  const edges = new Map<string, Set<string>>();
+  const edges = new Map<string, readonly ResourceDependencyEdge[]>();
   for (const [key, indexed] of resources) {
+    const dependencies = new Map<string, ResourceDependencyEdge>();
+    for (const dependency of resourceDependencyEntries(indexed.resource)) {
+      const parsed = parsePragmaReference(dependency.ref);
+      const target = `${parsed.kind}:${parsed.id}`;
+      if (!resources.has(target) || dependencies.has(target)) continue;
+      dependencies.set(target, { ...dependency, target });
+    }
     edges.set(
       key,
-      new Set(
-        resourceDependencies(indexed.resource)
-          .map((ref) => parsePragmaReference(ref))
-          .filter((parsed) =>
-            new Set([
-              "expert",
-              "team",
-              "flow",
-              "automation",
-              "capability",
-              "context-store",
-              "runtime-profile",
-            ]).has(parsed.kind),
-          )
-          .map((parsed) => `${parsed.kind}:${parsed.id}`),
-      ),
+      [...dependencies.values()].sort((left, right) => left.target.localeCompare(right.target)),
     );
   }
-  if (!hasCycle(new Set(resources.keys()), edges)) return [];
-  return [
-    {
+  return findResourceCycles(new Set(resources.keys()), edges).map((cycle) => {
+    const source = resources.get(cycle.sourceRef);
+    return {
       severity: "error",
       code: "resource.cycle",
-      message: "Pragma resource definitions must form an acyclic dependency graph.",
-      path: [],
-    },
-  ];
+      message: `Pragma resource definitions must form an acyclic dependency graph: ${cycle.refs.join(" -> ")}.`,
+      source: source?.source,
+      path: [...cycle.path],
+    };
+  });
 }
 
 function resourceDependencies(resource: PragmaResource): string[] {
+  return resourceDependencyEntries(resource).map((dependency) => dependency.ref);
+}
+
+function resourceDependencyEntries(resource: PragmaResource): ResourceDependency[] {
   if (resource.kind === "Expert") {
     return [
-      ...(resource.spec.runtime === undefined ? [] : [resource.spec.runtime.ref]),
-      ...resource.spec.capabilities.map((binding) => binding.ref),
-      ...resource.spec.contextStores.map((binding) => binding.ref),
-      ...resource.spec.tools.flatMap((binding) => [
+      ...(resource.spec.runtime === undefined
+        ? []
+        : [{ ref: resource.spec.runtime.ref, path: ["spec", "runtime", "ref"] }]),
+      ...resource.spec.capabilities.map((binding, index) => ({
+        ref: binding.ref,
+        path: ["spec", "capabilities", index, "ref"],
+      })),
+      ...resource.spec.contextStores.map((binding, index) => ({
+        ref: binding.ref,
+        path: ["spec", "contextStores", index, "ref"],
+      })),
+      ...resource.spec.tools.flatMap((binding, index) => [
         ...(binding.target === undefined
-          ? binding.targets!.map((target) => target.ref)
-          : [binding.target.ref]),
-        ...Object.values(binding.policy?.runtimes ?? {}),
+          ? binding.targets!.map((target, targetIndex) => ({
+              ref: target.ref,
+              path: ["spec", "tools", index, "targets", targetIndex, "ref"],
+            }))
+          : [
+              {
+                ref: binding.target.ref,
+                path: ["spec", "tools", index, "target", "ref"],
+              },
+            ]),
+        ...Object.entries(binding.policy?.runtimes ?? {}).map(([expertId, ref]) => ({
+          ref,
+          path: ["spec", "tools", index, "policy", "runtimes", expertId],
+        })),
       ]),
     ];
   }
   if (resource.kind === "ExpertTeam") {
     return [
-      resource.spec.coordinator.ref,
-      ...resource.spec.members.map((member) => member.ref),
-      ...Object.values(resource.spec.delegation.runtimes),
+      { ref: resource.spec.coordinator.ref, path: ["spec", "coordinator", "ref"] },
+      ...resource.spec.members.map((member, index) => ({
+        ref: member.ref,
+        path: ["spec", "members", index, "ref"],
+      })),
+      ...Object.entries(resource.spec.delegation.runtimes).map(([expertId, ref]) => ({
+        ref,
+        path: ["spec", "delegation", "runtimes", expertId],
+      })),
     ];
   }
   if (resource.kind === "Flow") {
-    return Object.values(resource.spec.graph.steps).flatMap((step) => {
-      const ref = step.expert?.ref ?? step.team?.ref ?? step.flow?.ref;
+    return Object.entries(resource.spec.graph.steps).flatMap(([stepId, step]) => {
+      const target =
+        step.expert === undefined
+          ? step.team === undefined
+            ? step.flow === undefined
+              ? undefined
+              : { ref: step.flow.ref, field: "flow" }
+            : { ref: step.team.ref, field: "team" }
+          : { ref: step.expert.ref, field: "expert" };
       return [
-        ...(ref === undefined ? [] : [ref]),
-        ...(step.runtime === undefined ? [] : [step.runtime.ref]),
-        ...Object.values(step.runtimes ?? {}),
+        ...(target === undefined
+          ? []
+          : [
+              {
+                ref: target.ref,
+                path: ["spec", "graph", "steps", stepId, target.field, "ref"],
+              },
+            ]),
+        ...(step.runtime === undefined
+          ? []
+          : [
+              {
+                ref: step.runtime.ref,
+                path: ["spec", "graph", "steps", stepId, "runtime", "ref"],
+              },
+            ]),
+        ...Object.entries(step.runtimes ?? {}).map(([expertId, ref]) => ({
+          ref,
+          path: ["spec", "graph", "steps", stepId, "runtimes", expertId],
+        })),
       ];
     });
   }
   if (resource.kind === "Automation") {
-    return [resource.spec.route.executor.ref];
+    return [
+      {
+        ref: resource.spec.route.executor.ref,
+        path: ["spec", "route", "executor", "ref"],
+      },
+    ];
   }
   return [];
 }

--- a/packages/interpreter/test/pragma-dsl.test.ts
+++ b/packages/interpreter/test/pragma-dsl.test.ts
@@ -814,6 +814,259 @@ describe("Pragma YAML DSL", () => {
     });
   });
 
+  it("reports the ExpertTeam reference that closes an Expert and Team cycle", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-resource-team-cycle-"));
+    const entry = join(root, "pragma.yaml");
+    const lead = expertResource("1xddvess309a6gme", "Leads delivery");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [
+          runtimeProfile(),
+          {
+            ...lead,
+            spec: {
+              ...lead.spec,
+              tools: [
+                {
+                  adapter: "pragma.tool.call@v1",
+                  target: { ref: "team:vyv9pwwzaksth2dd" },
+                  tool: {
+                    name: "call_delivery_team",
+                    description: "Call the delivery team",
+                    approval: "none",
+                  },
+                },
+              ],
+            },
+          },
+          expertResource("3sfd30h5017wd17d", "Reviews delivery"),
+          {
+            apiVersion: "pragma/v3",
+            kind: "ExpertTeam",
+            metadata: {
+              id: "vyv9pwwzaksth2dd",
+              name: "Delivery",
+              description: "Coordinates delivery",
+              tags: [],
+            },
+            spec: {
+              coordinator: { ref: "expert:1xddvess309a6gme" },
+              members: [{ ref: "expert:3sfd30h5017wd17d" }],
+              delegation: {},
+            },
+          },
+        ],
+      }),
+    );
+
+    const project = await loadPragmaProject(entry);
+    const expectedMessage =
+      "Pragma resource definitions must form an acyclic dependency graph: " +
+      "team:vyv9pwwzaksth2dd -> expert:1xddvess309a6gme -> team:vyv9pwwzaksth2dd.";
+    expect(await project.validate()).toEqual([
+      expect.objectContaining({
+        severity: "error",
+        code: "resource.cycle",
+        message: expectedMessage,
+        source: project.entryFile,
+        path: ["spec", "coordinator", "ref"],
+      }),
+    ]);
+    await expect(project.compile("expert:1xddvess309a6gme", { workspace: root })).rejects.toThrow(
+      expectedMessage,
+    );
+  });
+
+  it("reports the Flow step that closes a Flow and Expert cycle", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-resource-flow-cycle-"));
+    const entry = join(root, "pragma.yaml");
+    const expert = expertResource("1xddvess309a6gme", "Runs approval");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [
+          runtimeProfile(),
+          {
+            ...expert,
+            spec: {
+              ...expert.spec,
+              tools: [
+                {
+                  adapter: "pragma.tool.call@v1",
+                  target: { ref: "flow:ffdfk2cczgqjda7q" },
+                  tool: {
+                    name: "call_approval",
+                    description: "Call the approval flow",
+                    approval: "none",
+                  },
+                },
+              ],
+            },
+          },
+          {
+            apiVersion: "pragma/v3",
+            kind: "Flow",
+            metadata: {
+              id: "ffdfk2cczgqjda7q",
+              name: "Approval",
+              description: "Runs approval through an Expert",
+              tags: [],
+            },
+            spec: {
+              graph: {
+                start: "approve",
+                steps: {
+                  approve: {
+                    expert: { ref: "expert:1xddvess309a6gme" },
+                    prompt: { segments: [{ text: "Approve the work." }] },
+                  },
+                },
+                transitions: { approve: { end: true } },
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const project = await loadPragmaProject(entry);
+    const expectedMessage =
+      "Pragma resource definitions must form an acyclic dependency graph: " +
+      "flow:ffdfk2cczgqjda7q -> expert:1xddvess309a6gme -> flow:ffdfk2cczgqjda7q.";
+    expect(await project.validate()).toEqual([
+      expect.objectContaining({
+        severity: "error",
+        code: "resource.cycle",
+        message: expectedMessage,
+        source: project.entryFile,
+        path: ["spec", "graph", "steps", "approve", "expert", "ref"],
+      }),
+    ]);
+    await expect(project.compile("flow:ffdfk2cczgqjda7q", { workspace: root })).rejects.toThrow(
+      expectedMessage,
+    );
+  });
+
+  it("reports a self-referencing Expert tool at its target path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-resource-self-cycle-"));
+    const entry = join(root, "pragma.yaml");
+    const expert = expertResource("1xddvess309a6gme", "Calls itself");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [
+          runtimeProfile(),
+          {
+            ...expert,
+            spec: {
+              ...expert.spec,
+              tools: [
+                {
+                  adapter: "pragma.tool.call@v1",
+                  target: { ref: "expert:1xddvess309a6gme" },
+                  tool: {
+                    name: "call_self",
+                    description: "Call the same Expert",
+                    approval: "none",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+
+    const project = await loadPragmaProject(entry);
+    expect(await project.validate()).toEqual([
+      expect.objectContaining({
+        severity: "error",
+        code: "resource.cycle",
+        message:
+          "Pragma resource definitions must form an acyclic dependency graph: " +
+          "expert:1xddvess309a6gme -> expert:1xddvess309a6gme.",
+        source: project.entryFile,
+        path: ["spec", "tools", 0, "target", "ref"],
+      }),
+    ]);
+  });
+
+  it("allows multiple resources to share an acyclic dependency", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-resource-shared-dependency-"));
+    const entry = join(root, "pragma.yaml");
+    const lead = expertResource("1xddvess309a6gme", "Leads review");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [
+          runtimeProfile(),
+          {
+            ...lead,
+            spec: {
+              ...lead.spec,
+              tools: [
+                {
+                  adapter: "pragma.tool.call@v1",
+                  target: { ref: "expert:3sfd30h5017wd17d" },
+                  tool: {
+                    name: "call_reviewer",
+                    description: "Call the shared reviewer",
+                    approval: "none",
+                  },
+                },
+              ],
+            },
+          },
+          expertResource("3sfd30h5017wd17d", "Reviews work"),
+          {
+            apiVersion: "pragma/v3",
+            kind: "Flow",
+            metadata: {
+              id: "ffdfk2cczgqjda7q",
+              name: "Review",
+              description: "Uses the shared reviewer",
+              tags: [],
+            },
+            spec: {
+              graph: {
+                start: "review",
+                steps: {
+                  review: {
+                    expert: { ref: "expert:3sfd30h5017wd17d" },
+                    prompt: { segments: [{ text: "Review the work." }] },
+                  },
+                },
+                transitions: { review: { end: true } },
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const project = await loadPragmaProject(entry);
+    expect(await project.validate()).toEqual([]);
+    await expect(
+      project.compile<Expert>("expert:1xddvess309a6gme", { workspace: root }),
+    ).resolves.toMatchObject({ ref: "expert:1xddvess309a6gme" });
+    await expect(
+      project.compile<Flow>("flow:ffdfk2cczgqjda7q", { workspace: root }),
+    ).resolves.toMatchObject({ ref: "flow:ffdfk2cczgqjda7q" });
+  });
+
   it("rejects an unmarked control-flow cycle", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-dsl-cycle-"));
     await writeFile(


### PR DESCRIPTION
## What changed

- Replace the project-wide boolean cycle check with deterministic resource dependency traversal that records the concrete cycle.
- Attach each `resource.cycle` diagnostic to the source file and DSL path of the reference that closes the cycle.
- Preserve acyclic shared dependencies while reporting self-references and cross-resource cycles.
- Add regression coverage for Expert/ExpertTeam cycles, Expert/Flow cycles, Expert self-references, and shared acyclic dependencies.

## Why

The compiler already rejected cyclic resource graphs, but the diagnostic only said that the project contained a cycle. Users could not tell which resources or reference field caused the failure, and the behavior did not have dedicated cross-resource regression tests.

## Impact

Invalid projects now receive actionable diagnostics such as `team:... -> expert:... -> team:...`, with `source` and `path` pointing to the closing reference. Valid DAGs and the existing prohibition on cyclic resource definitions are unchanged.

## Validation

- `pnpm --filter @pragma/interpreter lint`
- `pnpm --filter @pragma/interpreter typecheck`
- `pnpm --filter @pragma/interpreter test` — 66 tests passed
- `pnpm --filter @pragma/interpreter build`
- Prettier check
- `git diff --check`