### PR TITLE
Hide PI runtime implementation details

### DIFF
--- a/apps/desktop/src/main/features/experts/system-expert-runtime.ts
+++ b/apps/desktop/src/main/features/experts/system-expert-runtime.ts
@@ -41,7 +41,7 @@ export async function resolveSystemExpertRuntimeDefaults(
   const model = (await resolved.adapter.listModels?.())?.[0];
   if (model === undefined) {
     throw new Error(
-      "The default PI Runtime has no configured model. Configure a Model Provider or choose an explicit model for this mission.",
+      "The built-in runtime has no configured model. Configure a Model Provider or choose an explicit model for this mission.",
     );
   }
   return {

--- a/apps/desktop/src/main/features/model-providers/model-connectivity.test.ts
+++ b/apps/desktop/src/main/features/model-providers/model-connectivity.test.ts
@@ -15,7 +15,7 @@ describe("testProviderModel", () => {
     vi.mocked(probePiModelProvider).mockResolvedValue({
       ok: true,
       code: "success",
-      message: "Connection successful through the PI runtime.",
+      message: "Connection successful.",
     });
     const model = testModel("gpt-test");
     const provider: ResolvedModelProvider = {

--- a/apps/desktop/src/main/features/model-providers/model-provider-store.test.ts
+++ b/apps/desktop/src/main/features/model-providers/model-provider-store.test.ts
@@ -314,33 +314,6 @@ describe("model provider store", () => {
     ]);
   });
 
-  it("normalizes a legacy implementation-specific verification message for display", async () => {
-    const { configPath, store } = await createStore();
-    const provider = await store.create({
-      presetId: "ollama",
-      name: "Ollama",
-      protocol: "openai-completions",
-      baseUrl: "http://127.0.0.1:11434/v1",
-      apiKey: "",
-      requiresApiKey: false,
-      models: [model("qwen3", "qwen3", false, "openai-completions")],
-    });
-
-    await store.recordVerification(provider.id, provider.revision, {
-      ok: true,
-      code: "success",
-      message: "Connection successful through the PI runtime.",
-    });
-
-    await expect(store.list()).resolves.toEqual([
-      expect.objectContaining({
-        verification: expect.objectContaining({ message: "Connection successful." }),
-      }),
-    ]);
-    expect(await readFile(configPath, "utf8")).toContain(
-      "Connection successful through the PI runtime.",
-    );
-  });
 });
 
 function model(

--- a/apps/desktop/src/main/features/model-providers/model-provider-store.test.ts
+++ b/apps/desktop/src/main/features/model-providers/model-provider-store.test.ts
@@ -313,6 +313,34 @@ describe("model provider store", () => {
       }),
     ]);
   });
+
+  it("normalizes a legacy implementation-specific verification message for display", async () => {
+    const { configPath, store } = await createStore();
+    const provider = await store.create({
+      presetId: "ollama",
+      name: "Ollama",
+      protocol: "openai-completions",
+      baseUrl: "http://127.0.0.1:11434/v1",
+      apiKey: "",
+      requiresApiKey: false,
+      models: [model("qwen3", "qwen3", false, "openai-completions")],
+    });
+
+    await store.recordVerification(provider.id, provider.revision, {
+      ok: true,
+      code: "success",
+      message: "Connection successful through the PI runtime.",
+    });
+
+    await expect(store.list()).resolves.toEqual([
+      expect.objectContaining({
+        verification: expect.objectContaining({ message: "Connection successful." }),
+      }),
+    ]);
+    expect(await readFile(configPath, "utf8")).toContain(
+      "Connection successful through the PI runtime.",
+    );
+  });
 });
 
 function model(

--- a/apps/desktop/src/main/features/model-providers/model-provider-store.ts
+++ b/apps/desktop/src/main/features/model-providers/model-provider-store.ts
@@ -148,9 +148,27 @@ function toPublicProvider(provider: StoredModelProvider): ModelProvider {
     models: provider.models.map((model) => ({ ...model })),
     hasApiKey: provider.encryptedApiKey.length > 0,
     requiresApiKey: provider.requiresApiKey,
-    verification: provider.verification,
+    verification: normalizeVerificationForDisplay(provider.verification),
     revision: provider.revision,
   };
+}
+
+function normalizeVerificationForDisplay(
+  verification: ModelProviderVerification,
+): ModelProviderVerification {
+  const message = verification.message;
+  if (message === undefined) return verification;
+  const normalized = message
+    .replaceAll("Connection successful through the PI runtime.", "Connection successful.")
+    .replaceAll("Cloud PI Agent", "built-in runtime")
+    .replaceAll("PI Runtime", "built-in runtime")
+    .replaceAll("PI runtime", "built-in runtime")
+    .replaceAll("PI model provider", "Model provider")
+    .replaceAll("PI thinking level", "thinking level")
+    .replaceAll("PI compatibility profile", "compatibility profile")
+    .replace(/^PI does not support/u, "The built-in runtime does not support")
+    .replace(/^PI could not/u, "The built-in runtime could not");
+  return normalized === message ? verification : { ...verification, message: normalized };
 }
 
 function parseConfig(raw: string): StoredModelProviderConfig {

--- a/apps/desktop/src/main/features/model-providers/model-provider-store.ts
+++ b/apps/desktop/src/main/features/model-providers/model-provider-store.ts
@@ -148,27 +148,9 @@ function toPublicProvider(provider: StoredModelProvider): ModelProvider {
     models: provider.models.map((model) => ({ ...model })),
     hasApiKey: provider.encryptedApiKey.length > 0,
     requiresApiKey: provider.requiresApiKey,
-    verification: normalizeVerificationForDisplay(provider.verification),
+    verification: provider.verification,
     revision: provider.revision,
   };
-}
-
-function normalizeVerificationForDisplay(
-  verification: ModelProviderVerification,
-): ModelProviderVerification {
-  const message = verification.message;
-  if (message === undefined) return verification;
-  const normalized = message
-    .replaceAll("Connection successful through the PI runtime.", "Connection successful.")
-    .replaceAll("Cloud PI Agent", "built-in runtime")
-    .replaceAll("PI Runtime", "built-in runtime")
-    .replaceAll("PI runtime", "built-in runtime")
-    .replaceAll("PI model provider", "Model provider")
-    .replaceAll("PI thinking level", "thinking level")
-    .replaceAll("PI compatibility profile", "compatibility profile")
-    .replace(/^PI does not support/u, "The built-in runtime does not support")
-    .replace(/^PI could not/u, "The built-in runtime could not");
-  return normalized === message ? verification : { ...verification, message: normalized };
 }
 
 function parseConfig(raw: string): StoredModelProviderConfig {

--- a/apps/desktop/src/main/features/runtimes/runtime-availability.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-availability.test.ts
@@ -68,6 +68,47 @@ describe("getRuntimeAvailability", () => {
       }),
     ]);
   });
+
+  it("normalizes legacy built-in Runtime identity and diagnostics", async () => {
+    const pragmaHome = await mkdtemp(join(tmpdir(), "pragma-runtime-availability-"));
+    const store = createRuntimeEnvironmentStore({
+      pragmaHome,
+      builtIns: [definition("pi", "PI Runtime")],
+      defaultRuntimeId: "pi",
+    });
+    const runtimes = createRuntimeEnvironmentService({
+      store,
+      factories: [
+        {
+          id: "test.runtime",
+          version: "v1",
+          create: (environment) =>
+            defineRuntimeDriver({
+              descriptor: {
+                id: environment.id,
+                kind: "cloud-pi-agent",
+                displayName: environment.displayName,
+              },
+              canUse: () => ({
+                usable: false,
+                reason: "cloud-pi-agent could not load pragma.runtime.pi",
+              }),
+              createSession: () => ({}),
+              startTurn: () => ({ outputText: "" }),
+              mapEvent: () => ({ events: [] }),
+            }),
+        },
+      ],
+    });
+
+    await expect(getRuntimeAvailability(runtimes)).resolves.toEqual([
+      expect.objectContaining({
+        id: "pi",
+        displayName: "Built-in Runtime",
+        reason: "built-in runtime could not load built-in runtime adapter",
+      }),
+    ]);
+  });
 });
 
 function definition(id: string, displayName: string) {

--- a/apps/desktop/src/main/features/runtimes/runtime-availability.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-availability.test.ts
@@ -69,7 +69,7 @@ describe("getRuntimeAvailability", () => {
     ]);
   });
 
-  it("normalizes legacy built-in Runtime identity and diagnostics", async () => {
+  it("projects the built-in Runtime identity without rewriting diagnostics", async () => {
     const pragmaHome = await mkdtemp(join(tmpdir(), "pragma-runtime-availability-"));
     const store = createRuntimeEnvironmentStore({
       pragmaHome,
@@ -91,7 +91,7 @@ describe("getRuntimeAvailability", () => {
               },
               canUse: () => ({
                 usable: false,
-                reason: "cloud-pi-agent could not load pragma.runtime.pi",
+                reason: "The built-in runtime is not configured.",
               }),
               createSession: () => ({}),
               startTurn: () => ({ outputText: "" }),
@@ -105,7 +105,7 @@ describe("getRuntimeAvailability", () => {
       expect.objectContaining({
         id: "pi",
         displayName: "Built-in Runtime",
-        reason: "built-in runtime could not load built-in runtime adapter",
+        reason: "The built-in runtime is not configured.",
       }),
     ]);
   });

--- a/apps/desktop/src/main/features/runtimes/runtime-availability.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-availability.ts
@@ -25,10 +25,7 @@ export async function getRuntimeAvailability(
                   : (definition?.displayName ?? inspection.head.entry.runtimeId),
               kind: definition?.adapter.id ?? "unknown",
               status: "unavailable",
-              reason: normalizeRuntimeMessage(
-                inspection.head.entry.runtimeId,
-                inspection.error ?? "Runtime Environment revision is unavailable.",
-              ),
+              reason: inspection.error ?? "Runtime Environment revision is unavailable.",
               ...(revision === undefined ? {} : { revision: revision.revision }),
               ...(definition === undefined
                 ? {}
@@ -80,18 +77,9 @@ export async function getRuntimeAvailability(
             ...(version === undefined ? {} : { version }),
             ...(availability.usable || availability.reason === undefined
               ? {}
-              : {
-                  reason: normalizeRuntimeMessage(adapter.descriptor.id, availability.reason),
-                }),
+              : { reason: availability.reason }),
             ...(models === undefined ? {} : { models }),
-            ...(modelDiscoveryError === undefined
-              ? {}
-              : {
-                  modelDiscoveryError: normalizeRuntimeMessage(
-                    adapter.descriptor.id,
-                    modelDiscoveryError,
-                  ),
-                }),
+            ...(modelDiscoveryError === undefined ? {} : { modelDiscoveryError }),
           };
         })(),
       ];
@@ -109,14 +97,4 @@ function stringDetail(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Runtime inspection failed.";
-}
-
-function normalizeRuntimeMessage(runtimeId: string, message: string): string {
-  if (runtimeId !== "pi") return message;
-  return message
-    .replaceAll("pragma.runtime.pi", "built-in runtime adapter")
-    .replaceAll("cloud-pi-agent", "built-in runtime")
-    .replaceAll("Cloud PI Agent", "built-in runtime")
-    .replaceAll("PI Runtime", "built-in runtime")
-    .replaceAll("PI runtime", "built-in runtime");
 }

--- a/apps/desktop/src/main/features/runtimes/runtime-availability.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-availability.ts
@@ -1,5 +1,6 @@
 import type { DesktopRuntimeAvailability } from "../../../shared/contracts/index.ts";
 import type { RuntimeEnvironmentService } from "./runtime-environment-service.ts";
+import { BUILT_IN_RUNTIME_DISPLAY_NAME } from "./runtime-environment-store.ts";
 
 export async function getRuntimeAvailability(
   runtimes: RuntimeEnvironmentService,
@@ -18,10 +19,16 @@ export async function getRuntimeAvailability(
             return {
               id: inspection.head.entry.runtimeId,
               isDefault: inspection.head.entry.runtimeId === defaultRuntimeId,
-              displayName: definition?.displayName ?? inspection.head.entry.runtimeId,
+              displayName:
+                inspection.head.entry.runtimeId === "pi"
+                  ? BUILT_IN_RUNTIME_DISPLAY_NAME
+                  : (definition?.displayName ?? inspection.head.entry.runtimeId),
               kind: definition?.adapter.id ?? "unknown",
               status: "unavailable",
-              reason: inspection.error ?? "Runtime Environment revision is unavailable.",
+              reason: normalizeRuntimeMessage(
+                inspection.head.entry.runtimeId,
+                inspection.error ?? "Runtime Environment revision is unavailable.",
+              ),
               ...(revision === undefined ? {} : { revision: revision.revision }),
               ...(definition === undefined
                 ? {}
@@ -64,15 +71,27 @@ export async function getRuntimeAvailability(
             adapter: definition!.adapter,
             isDefault: adapter.descriptor.id === defaultRuntimeId,
             kind: adapter.descriptor.kind,
-            displayName: adapter.descriptor.displayName,
+            displayName:
+              adapter.descriptor.id === "pi"
+                ? BUILT_IN_RUNTIME_DISPLAY_NAME
+                : adapter.descriptor.displayName,
             status: availability.usable ? "available" : "unavailable",
             ...(executablePath === undefined ? {} : { executablePath }),
             ...(version === undefined ? {} : { version }),
             ...(availability.usable || availability.reason === undefined
               ? {}
-              : { reason: availability.reason }),
+              : {
+                  reason: normalizeRuntimeMessage(adapter.descriptor.id, availability.reason),
+                }),
             ...(models === undefined ? {} : { models }),
-            ...(modelDiscoveryError === undefined ? {} : { modelDiscoveryError }),
+            ...(modelDiscoveryError === undefined
+              ? {}
+              : {
+                  modelDiscoveryError: normalizeRuntimeMessage(
+                    adapter.descriptor.id,
+                    modelDiscoveryError,
+                  ),
+                }),
           };
         })(),
       ];
@@ -90,4 +109,14 @@ function stringDetail(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Runtime inspection failed.";
+}
+
+function normalizeRuntimeMessage(runtimeId: string, message: string): string {
+  if (runtimeId !== "pi") return message;
+  return message
+    .replaceAll("pragma.runtime.pi", "built-in runtime adapter")
+    .replaceAll("cloud-pi-agent", "built-in runtime")
+    .replaceAll("Cloud PI Agent", "built-in runtime")
+    .replaceAll("PI Runtime", "built-in runtime")
+    .replaceAll("PI runtime", "built-in runtime");
 }

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
@@ -21,9 +21,10 @@ import type {
   RuntimeEnvironmentRevision,
 } from "../../../shared/contracts/index.ts";
 import type { ModelProviderStore } from "../model-providers/model-provider-store.ts";
-import type {
-  RuntimeEnvironmentHead,
-  RuntimeEnvironmentStore,
+import {
+  BUILT_IN_RUNTIME_DISPLAY_NAME,
+  type RuntimeEnvironmentHead,
+  type RuntimeEnvironmentStore,
 } from "./runtime-environment-store.ts";
 
 export interface RuntimeEnvironmentAdapterFactory {
@@ -324,7 +325,7 @@ export function createBuiltInRuntimeFactories(
       create: (environment) => {
         assertEmptyRuntimeConfig(environment);
         return createPiRuntime({
-          descriptor: { id: environment.id, displayName: environment.displayName },
+          descriptor: { id: environment.id, displayName: BUILT_IN_RUNTIME_DISPLAY_NAME },
           modelProviders,
         });
       },

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-store.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-store.test.ts
@@ -26,7 +26,7 @@ describe("RuntimeEnvironmentStore", () => {
       definition: { ...original.definition, displayName: "PI Updated" },
     });
     expect(updated.revision).toBe(2);
-    expect((await store.getRevision("pi", 1))?.definition.displayName).toBe("PI Runtime");
+    expect((await store.getRevision("pi", 1))?.definition.displayName).toBe("Built-in Runtime");
     expect((await store.getRevision("pi"))?.definition.displayName).toBe("PI Updated");
 
     await store.setDefaultRuntimeId("codex");

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-store.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-store.ts
@@ -15,9 +15,10 @@ import {
 } from "../../../shared/contracts/index.ts";
 
 export const DEFAULT_RUNTIME_ID = "pi";
+export const BUILT_IN_RUNTIME_DISPLAY_NAME = "Built-in Runtime";
 
 export const DEFAULT_RUNTIME_ENVIRONMENTS: readonly RuntimeEnvironmentDefinition[] = [
-  environment("pi", "PI Runtime", "pragma.runtime.pi"),
+  environment("pi", BUILT_IN_RUNTIME_DISPLAY_NAME, "pragma.runtime.pi"),
   environment("codex", "Codex", "pragma.runtime.codex"),
   environment("claude-code", "Claude Code", "pragma.runtime.claude-code"),
   environment("qodercli", "Qoder CLI", "pragma.runtime.qodercli"),

--- a/apps/desktop/src/renderer/src/i18n/resources/en/common.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/common.ts
@@ -71,6 +71,9 @@ export const common = {
     model_one: "{{count}} model",
     model_other: "{{count}} models",
   },
+  runtimeNames: {
+    builtIn: "Built-in Runtime",
+  },
   builtInExperts: {
     pragma: {
       name: "Pragma",

--- a/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
@@ -47,7 +47,7 @@ export const settings = {
     compatibilityProfile: "Compatibility profile",
     automaticCompatibility: "Automatic (recommended)",
     automaticCompatibilityDescription:
-      "Use the PI built-in model metadata when available, otherwise choose a conservative provider profile.",
+      "Use built-in model metadata when available, otherwise choose a conservative provider profile.",
     modelCompatibilityOverride: "Model compatibility",
     inheritCompatibility: "Inherit provider setting",
     baseUrl: "API base URL",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/common.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/common.ts
@@ -70,6 +70,9 @@ export const common = {
     model_one: "{{count}} 个模型",
     model_other: "{{count}} 个模型",
   },
+  runtimeNames: {
+    builtIn: "内置运行时",
+  },
   builtInExperts: {
     pragma: {
       name: "Pragma",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
@@ -45,7 +45,7 @@ export const settings = {
     compatibilityProfile: "兼容配置",
     automaticCompatibility: "自动（推荐）",
     automaticCompatibilityDescription:
-      "优先使用 PI 内置模型元数据；没有精确元数据时，自动选择保守的供应商兼容配置。",
+      "优先使用内置模型元数据；没有精确元数据时，自动选择保守的供应商兼容配置。",
     modelCompatibilityOverride: "模型兼容配置",
     inheritCompatibility: "继承供应商设置",
     baseUrl: "API 基础 URL",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/common.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/common.ts
@@ -70,6 +70,9 @@ export const common = {
     model_one: "{{count}} 個模型",
     model_other: "{{count}} 個模型",
   },
+  runtimeNames: {
+    builtIn: "內建執行階段",
+  },
   builtInExperts: {
     pragma: {
       name: "Pragma",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
@@ -45,7 +45,7 @@ export const settings = {
     compatibilityProfile: "相容設定檔",
     automaticCompatibility: "自動（建議）",
     automaticCompatibilityDescription:
-      "優先使用 PI 內建模型中繼資料；沒有精確資料時，自動選擇保守的供應商相容設定。",
+      "優先使用內建模型中繼資料；沒有精確資料時，自動選擇保守的供應商相容設定。",
     modelCompatibilityOverride: "模型相容設定",
     inheritCompatibility: "繼承供應商設定",
     baseUrl: "API 基礎 URL",

--- a/apps/desktop/src/renderer/src/lib/runtime-display.test.ts
+++ b/apps/desktop/src/renderer/src/lib/runtime-display.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { i18n } from "../i18n/index.ts";
+import {
+  canonicalRuntimeDisplayName,
+  runtimeDisplayName,
+} from "./runtime-display.ts";
+
+const legacyBuiltInRuntime = { id: "pi", displayName: "PI Runtime" };
+
+afterEach(async () => {
+  await i18n.changeLanguage("en");
+});
+
+describe("runtime display names", () => {
+  it("replaces a legacy built-in Runtime name in every supported locale", async () => {
+    expect(runtimeDisplayName(i18n.t, legacyBuiltInRuntime)).toBe("Built-in Runtime");
+
+    await i18n.changeLanguage("zh-Hans");
+    expect(runtimeDisplayName(i18n.t, legacyBuiltInRuntime)).toBe("内置运行时");
+
+    await i18n.changeLanguage("zh-Hant");
+    expect(runtimeDisplayName(i18n.t, legacyBuiltInRuntime)).toBe("內建執行階段");
+  });
+
+  it("uses a locale-neutral canonical name for generated resources", () => {
+    expect(canonicalRuntimeDisplayName(legacyBuiltInRuntime)).toBe("Built-in Runtime");
+    expect(canonicalRuntimeDisplayName({ id: "codex", displayName: "Codex" })).toBe("Codex");
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/runtime-display.ts
+++ b/apps/desktop/src/renderer/src/lib/runtime-display.ts
@@ -1,0 +1,28 @@
+import type { TFunction } from "i18next";
+
+export const BUILT_IN_RUNTIME_ID = "pi";
+export const BUILT_IN_RUNTIME_CANONICAL_NAME = "Built-in Runtime";
+
+export interface RuntimeDisplayIdentity {
+  readonly id: string;
+  readonly displayName: string;
+}
+
+export function isBuiltInRuntime(runtime: Pick<RuntimeDisplayIdentity, "id">): boolean {
+  return runtime.id === BUILT_IN_RUNTIME_ID;
+}
+
+export function runtimeDisplayName(
+  t: TFunction,
+  runtime: RuntimeDisplayIdentity,
+): string {
+  return isBuiltInRuntime(runtime)
+    ? t("runtimeNames.builtIn", { ns: "common" })
+    : runtime.displayName;
+}
+
+export function canonicalRuntimeDisplayName(runtime: RuntimeDisplayIdentity): string {
+  return isBuiltInRuntime(runtime)
+    ? BUILT_IN_RUNTIME_CANONICAL_NAME
+    : runtime.displayName;
+}

--- a/apps/desktop/src/renderer/src/pages/home/HomePage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/home/HomePage.test.tsx
@@ -12,7 +12,7 @@ describe("MissionModelOverrideControls", () => {
         models={[
           {
             id: "deepseek",
-            displayName: "PI Runtime",
+            displayName: "DeepSeek Model",
             provider: {
               kind: "registered",
               id: "provider",
@@ -32,7 +32,7 @@ describe("MissionModelOverrideControls", () => {
       />,
     );
 
-    expect(html).toContain("DeepSeek · PI Runtime");
+    expect(html).toContain("DeepSeek · DeepSeek Model");
     expect(html).toContain('<option value="high" selected="">High</option>');
     expect(html).toContain("Default model");
     expect(html).toContain("Default thinking depth");

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -53,6 +53,7 @@ import {
 import { errorMessage } from "../../lib/errors.ts";
 import { i18n } from "../../i18n/index.ts";
 import { formatMissionDateTime, formatMissionTime } from "../../lib/mission-time.ts";
+import { runtimeDisplayName, type RuntimeDisplayIdentity } from "../../lib/runtime-display.ts";
 import { formatTokens } from "../../lib/usage-format.ts";
 import { ToolPermissionSelect } from "../../components/ToolPermissionSelect.tsx";
 import { MissionModelOverrideControls } from "../../components/MissionModelOverrideControls.tsx";
@@ -969,7 +970,7 @@ export function MissionDetailFragment(props: {
     kind: "idle",
   });
   const [models, setModels] = useState<readonly DesktopRuntimeModel[]>([]);
-  const [runtimeName, setRuntimeName] = useState<string>();
+  const [runtimeIdentity, setRuntimeIdentity] = useState<RuntimeDisplayIdentity>();
   const [modelsLoading, setModelsLoading] = useState(false);
   const [defaultModelSelection, setDefaultModelSelection] = useState<MissionModelOverride>();
   const [modelResetRequired, setModelResetRequired] = useState(false);
@@ -1093,7 +1094,7 @@ export function MissionDetailFragment(props: {
   useEffect(() => {
     const api = desktopApi();
     setModels([]);
-    setRuntimeName(undefined);
+    setRuntimeIdentity(undefined);
     setDefaultModelSelection(undefined);
     setOptionsError(null);
     setModelResetRequired(false);
@@ -1107,7 +1108,7 @@ export function MissionDetailFragment(props: {
         .then((result) => {
           if (cancelled) return;
           modelRuntimeIdRef.current = result.runtime.id;
-          setRuntimeName(result.runtime.displayName);
+          setRuntimeIdentity(result.runtime);
           setModels(result.models);
           setDefaultModelSelection(result.defaultSelection);
           setModelResetRequired(result.status === "reset_required");
@@ -1717,11 +1718,11 @@ export function MissionDetailFragment(props: {
               <User size={17} aria-hidden="true" />
             )}
             {props.mission.executor.name}
-            {runtimeName === undefined ? null : (
+            {runtimeIdentity === undefined ? null : (
               <>
                 <span aria-hidden="true">·</span>
                 <TerminalWindow size={17} aria-hidden="true" />
-                {runtimeName}
+                {runtimeDisplayName(t, runtimeIdentity)}
               </>
             )}
           </p>

--- a/apps/desktop/src/renderer/src/pages/settings/GeneralSettingsFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/GeneralSettingsFragment.tsx
@@ -9,6 +9,7 @@ import type {
   DesktopToolPermissionMode,
 } from "../../../../shared/contracts/index.ts";
 import { localeDisplayNames, setDesktopLocale } from "../../i18n/index.ts";
+import { runtimeDisplayName } from "../../lib/runtime-display.ts";
 import { SettingsScreenFrame } from "./SettingsScreenFrame.tsx";
 
 const languageOptions: readonly {
@@ -183,7 +184,7 @@ export function GeneralSettingsFragment() {
                   value={runtime.id}
                   disabled={runtime.status !== "available"}
                 >
-                  {runtime.displayName}
+                  {runtimeDisplayName(t, runtime)}
                   {runtime.status === "available"
                     ? ""
                     : ` · ${t("status.unavailable", { ns: "common" })}`}

--- a/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentDetail.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentDetail.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { DesktopRuntimeAvailability } from "../../../../shared/contracts/index.ts";
+import { isBuiltInRuntime, runtimeDisplayName } from "../../lib/runtime-display.ts";
 import { SettingsScreenFrame } from "./SettingsScreenFrame.tsx";
 
 export function RuntimeEnvironmentDetail(props: {
@@ -16,6 +17,9 @@ export function RuntimeEnvironmentDetail(props: {
   const { runtime } = props;
   const available = runtime.status === "available";
   const models = runtime.models ?? [];
+  const builtIn = isBuiltInRuntime(runtime);
+  const displayName = runtimeDisplayName(t, runtime);
+  const runtimeType = builtIn ? t("runtimes.builtIn", { ns: "settings" }) : runtime.kind;
 
   return (
     <SettingsScreenFrame
@@ -35,14 +39,14 @@ export function RuntimeEnvironmentDetail(props: {
             </span>
             <div>
               <div className="runtime-detail-title-line">
-                <h2 id="runtime-detail-name">{runtime.displayName}</h2>
+                <h2 id="runtime-detail-name">{displayName}</h2>
                 {runtime.isDefault ? (
                   <span className="status-badge is-ready">
                     {t("status.default", { ns: "common" })}
                   </span>
                 ) : null}
               </div>
-              <p>{runtime.kind}</p>
+              <p>{runtimeType}</p>
             </div>
             <button
               className="secondary-button"
@@ -71,9 +75,11 @@ export function RuntimeEnvironmentDetail(props: {
               : t("status.unavailable", { ns: "common" })}
           </span>
         </RuntimeFact>
-        <RuntimeFact label={t("runtimes.runtimeId", { ns: "settings" })}>
-          <code>{runtime.id}</code>
-        </RuntimeFact>
+        {builtIn ? null : (
+          <RuntimeFact label={t("runtimes.runtimeId", { ns: "settings" })}>
+            <code>{runtime.id}</code>
+          </RuntimeFact>
+        )}
         <RuntimeFact label={t("runtimes.origin", { ns: "settings" })}>
           {runtime.origin
             ? runtime.origin === "built-in"
@@ -94,15 +100,17 @@ export function RuntimeEnvironmentDetail(props: {
         <RuntimeFact label={t("runtimes.runtimeVersion", { ns: "settings" })}>
           {runtime.version ?? "—"}
         </RuntimeFact>
-        <RuntimeFact label={t("runtimes.adapter", { ns: "settings" })}>
-          {runtime.adapter ? (
-            <code>
-              {runtime.adapter.id}@{runtime.adapter.version}
-            </code>
-          ) : (
-            "—"
-          )}
-        </RuntimeFact>
+        {builtIn ? null : (
+          <RuntimeFact label={t("runtimes.adapter", { ns: "settings" })}>
+            {runtime.adapter ? (
+              <code>
+                {runtime.adapter.id}@{runtime.adapter.version}
+              </code>
+            ) : (
+              "—"
+            )}
+          </RuntimeFact>
+        )}
       </section>
 
       {runtime.reason ? (

--- a/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.test.tsx
@@ -61,4 +61,32 @@ describe("Runtime Environment settings", () => {
     expect(html).toContain("gpt-5.6-codex");
     expect(html).toContain("Medium, High");
   });
+
+  it("does not expose implementation identity for the built-in Runtime", () => {
+    const builtInRuntime: DesktopRuntimeAvailability = {
+      ...runtime,
+      id: "pi",
+      adapter: { id: "pragma.runtime.pi", version: "v1" },
+      kind: "cloud-pi-agent",
+      displayName: "PI Runtime",
+    };
+    const html = [
+      renderToStaticMarkup(<RuntimeCard runtime={builtInRuntime} onOpen={() => undefined} />),
+      renderToStaticMarkup(
+        <RuntimeEnvironmentDetail
+          runtime={builtInRuntime}
+          refreshing={false}
+          error={null}
+          onBack={() => undefined}
+          onRefresh={() => undefined}
+        />,
+      ),
+    ].join("");
+
+    expect(html).toContain("Built-in Runtime");
+    expect(html).not.toContain("PI Runtime");
+    expect(html).not.toContain("cloud-pi-agent");
+    expect(html).not.toContain("pragma.runtime.pi");
+    expect(html).not.toMatch(/>pi</u);
+  });
 });

--- a/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import type { DesktopRuntimeAvailability } from "../../../../shared/contracts/index.ts";
 import { errorMessage } from "../../lib/errors.ts";
+import { isBuiltInRuntime, runtimeDisplayName } from "../../lib/runtime-display.ts";
 import { RuntimeEnvironmentDetail } from "./RuntimeEnvironmentDetail.tsx";
 import { SettingsScreenFrame } from "./SettingsScreenFrame.tsx";
 
@@ -14,6 +15,10 @@ export function RuntimeCard(props: {
   const { t } = useTranslation(["settings", "common"]);
   const available = props.runtime.status === "available";
   const modelCount = props.runtime.models?.length;
+  const displayName = runtimeDisplayName(t, props.runtime);
+  const runtimeType = isBuiltInRuntime(props.runtime)
+    ? t("runtimes.builtIn", { ns: "settings" })
+    : props.runtime.kind;
 
   return (
     <article className="runtime-card runtime-summary-card">
@@ -22,7 +27,7 @@ export function RuntimeCard(props: {
         type="button"
         aria-label={t("runtimes.viewDetails", {
           ns: "settings",
-          name: props.runtime.displayName,
+          name: displayName,
         })}
         onClick={props.onOpen}
       />
@@ -31,7 +36,7 @@ export function RuntimeCard(props: {
           <TerminalWindow size={24} />
         </span>
         <div className="card-title-group">
-          <h3>{props.runtime.displayName}</h3>
+          <h3>{displayName}</h3>
           <p className={available ? "status-copy is-active" : "status-copy"}>
             <span className="status-dot" aria-hidden="true" />
             {available
@@ -48,7 +53,7 @@ export function RuntimeCard(props: {
 
       <div className="runtime-summary-footer">
         <div>
-          <p>{props.runtime.kind}</p>
+          <p>{runtimeType}</p>
           <span>
             {modelCount === undefined
               ? t("runtimes.catalogUnavailable", { ns: "settings" })

--- a/apps/desktop/src/renderer/src/pages/studio/ExpertEditorFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/ExpertEditorFragment.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { PragmaResource } from "@pragma/interpreter/ast";
 
 import { errorMessage } from "../../lib/errors.ts";
+import { runtimeDisplayName } from "../../lib/runtime-display.ts";
 import {
   EXPERT_DESCRIPTION_MAX_LENGTH,
   EXPERT_INSTRUCTIONS_MAX_LENGTH,
@@ -450,7 +451,7 @@ export function ExpertEditorFragment(props: {
                         value={runtime.id}
                         disabled={runtime.status !== "available"}
                       >
-                        {runtime.displayName}
+                        {runtimeDisplayName(t, runtime)}
                         {runtime.status === "available"
                           ? ""
                           : ` (${t("unavailable", { ns: "studio" })})`}

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-editor-fields.test.ts
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-editor-fields.test.ts
@@ -115,4 +115,31 @@ describe("flow-editor-fields", () => {
     };
     expect(validateFlowRuntimeSelections(flow, [...resources, generated])).toEqual([]);
   });
+
+  it("normalizes the built-in Runtime name in selections and generated profiles", () => {
+    const runtime = {
+      id: "pi",
+      isDefault: true,
+      kind: "cloud-pi-agent",
+      displayName: "PI Runtime",
+      status: "available" as const,
+      models: [],
+    };
+    const html = renderToStaticMarkup(
+      createElement(RuntimeBindingEditor, {
+        value: undefined,
+        allowModel: true,
+        targetKind: "expert",
+        targetRef: "expert:1xddvess309a6gme",
+        resources: runtimeResources(),
+        runtimes: [runtime],
+        onSupportingResource: () => undefined,
+        onChange: () => undefined,
+      }),
+    );
+
+    expect(html).toContain("Built-in Runtime");
+    expect(html).not.toContain("PI Runtime");
+    expect(flowRuntimeProfile(runtime).metadata.name).toBe("Built-in Runtime Flow Runtime");
+  });
 });

--- a/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-editor-fields.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/flow-editor/flow-editor-fields.tsx
@@ -17,6 +17,7 @@ import type {
   DesktopRuntimeAvailability,
   DesktopRuntimeModel,
 } from "../../../../../shared/contracts/index.ts";
+import { canonicalRuntimeDisplayName, runtimeDisplayName } from "../../../lib/runtime-display.ts";
 import {
   SchemaFieldsEditor,
   fieldsToObjectSchema,
@@ -393,12 +394,16 @@ export function RuntimeBindingEditor(props: {
           {selectedRuntimeId !== "" &&
           !props.runtimes.some((runtime) => runtime.id === selectedRuntimeId) ? (
             <option value={selectedRuntimeId}>
-              {selectedRuntimeId} · {t("unavailable")}
+              {runtimeDisplayName(t, {
+                id: selectedRuntimeId,
+                displayName: selectedRuntimeId,
+              })}{" "}
+              · {t("unavailable")}
             </option>
           ) : null}
           {props.runtimes.map((runtime) => (
             <option key={runtime.id} value={runtime.id} disabled={runtime.status !== "available"}>
-              {runtime.displayName}
+              {runtimeDisplayName(t, runtime)}
               {runtime.status === "available" ? "" : ` · ${t("unavailable")}`}
             </option>
           ))}
@@ -510,13 +515,14 @@ function targetRuntimeProfileRef(
 }
 
 export function flowRuntimeProfile(runtime: DesktopRuntimeAvailability) {
+  const displayName = canonicalRuntimeDisplayName(runtime);
   return PragmaRuntimeProfileResourceSchema.parse({
     apiVersion: "pragma/v3",
     kind: "RuntimeProfile",
     metadata: {
       id: stableRuntimeKey(runtime.id),
-      name: `${runtime.displayName} Flow Runtime`,
-      description: `Desktop-managed Runtime profile for Flow node overrides using ${runtime.displayName}.`,
+      name: `${displayName} Flow Runtime`,
+      description: `Desktop-managed Runtime profile for Flow node overrides using ${displayName}.`,
       tags: ["desktop-managed", "flow-runtime-override"],
     },
     spec: {

--- a/packages/runtime/pi/src/adapter.ts
+++ b/packages/runtime/pi/src/adapter.ts
@@ -204,7 +204,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             if (cleanupError !== undefined) {
               throw new AggregateError(
                 [error, cleanupError],
-                "PI preparation and cleanup failed.",
+                "Runtime preparation and cleanup failed.",
                 { cause: error },
               );
             }
@@ -273,7 +273,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
           if (!piSessionManagerResult.resumedExistingSession) {
             appendStartupMessages(session, ctx.agentContext.startupMessages);
           }
-          ctx.logger.info("runtime.pi_session_ready", "PI Session preparation completed", {
+          ctx.logger.info("runtime.pi_session_ready", "Runtime session preparation completed", {
             elapsedMs: piElapsedMs(sessionStartedAt),
             toolCount: sessionOptions.customTools?.length ?? 0,
             systemPromptCharacters: ctx.agentContext.systemPrompt.length,
@@ -302,7 +302,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
           if (cleanupErrors.length > 0) {
             throw new AggregateError(
               [error, ...cleanupErrors],
-              "PI runtime initialization and cleanup failed.",
+              "Runtime initialization and cleanup failed.",
               { cause: error },
             );
           }
@@ -372,7 +372,7 @@ function logPiPhase(
   sessionStartedAt: number,
   attributes: Record<string, unknown> = {},
 ): void {
-  logger.info("runtime.pi_prepare_phase", `PI preparation phase completed: ${phase}`, {
+  logger.info("runtime.pi_prepare_phase", `Runtime preparation phase completed: ${phase}`, {
     phase,
     durationMs: piElapsedMs(phaseStartedAt),
     elapsedMs: piElapsedMs(sessionStartedAt),

--- a/packages/runtime/pi/src/adapter.ts
+++ b/packages/runtime/pi/src/adapter.ts
@@ -43,7 +43,7 @@ import { defaultOutputParser } from "./types.ts";
 const CLOUD_PI_RUNTIME_DESCRIPTOR = {
   id: "cloud-pi-agent",
   kind: "cloud-pi-agent" as const,
-  displayName: "Cloud PI Agent",
+  displayName: "Built-in Runtime",
   capabilities: {
     targets: ["agent"],
     executionLocations: ["cloud"],
@@ -149,7 +149,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             if (cleanupError !== undefined) {
               throw new AggregateError(
                 [error, cleanupError],
-                "PI model provider resolution and cleanup failed.",
+                "Model provider resolution and cleanup failed.",
                 { cause: error },
               );
             }
@@ -157,9 +157,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
           throw error;
         }
         if (selectedProviderId !== undefined && registeredProvider === undefined) {
-          const providerError = new Error(
-            `PI model provider is not registered: ${selectedProviderId}`,
-          );
+          const providerError = new Error(`Model provider is not registered: ${selectedProviderId}`);
           const preparation = await Promise.allSettled([
             resourceReloadPromise,
             mcpRegistryPromise,
@@ -171,7 +169,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             if (cleanupError !== undefined) {
               throw new AggregateError(
                 [providerError, cleanupError],
-                "PI model provider validation and cleanup failed.",
+                "Model provider validation and cleanup failed.",
                 { cause: providerError },
               );
             }
@@ -322,7 +320,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
         if (selectedModel !== undefined) {
           const provider = await options.modelProviders?.resolveProvider(selectedModel.providerId);
           if (provider === undefined) {
-            throw new Error(`PI model provider is not registered: ${selectedModel.providerId}`);
+            throw new Error(`Model provider is not registered: ${selectedModel.providerId}`);
           }
           registerPiModelProvider(
             session.models.modelRuntime,

--- a/packages/runtime/pi/src/models.ts
+++ b/packages/runtime/pi/src/models.ts
@@ -134,7 +134,7 @@ export function resolvePiThinkingLevel(
     case "max":
       return thinkingLevel;
     default:
-      throw new Error(`Unsupported PI thinking level: ${thinkingLevel}`);
+      throw new Error(`Unsupported thinking level: ${thinkingLevel}`);
   }
 }
 
@@ -180,11 +180,11 @@ export function createPiModelProviderConverter(): RuntimeModelProviderConverter<
         .map(toPiProviderModel);
       if (models.length === 0) {
         throw new Error(
-          `PI does not support any configured models for provider "${provider.displayName}".`,
+          `No configured models are supported for provider "${provider.displayName}".`,
         );
       }
       if (!SUPPORTED_APIS.has(provider.api) && models.every((model) => model.api === undefined)) {
-        throw new Error(`PI does not support provider API protocol "${provider.api}".`);
+        throw new Error(`Provider API protocol "${provider.api}" is not supported.`);
       }
       return {
         id: provider.id,

--- a/packages/runtime/pi/src/probe.ts
+++ b/packages/runtime/pi/src/probe.ts
@@ -40,7 +40,7 @@ export async function probePiModelProvider(options: {
     return {
       ok: false,
       code: "model_unavailable",
-      message: "PI could not register the configured model.",
+      message: "The configured model could not be registered.",
     };
   }
 
@@ -77,7 +77,7 @@ export async function probePiModelProvider(options: {
     return {
       ok: true,
       code: "success",
-      message: "Connection successful through the PI runtime.",
+      message: "Connection successful.",
       latencyMs: Date.now() - startedAt,
       ...(responseStatus === undefined ? {} : { status: responseStatus }),
     };

--- a/packages/runtime/pi/src/profiles.ts
+++ b/packages/runtime/pi/src/profiles.ts
@@ -183,10 +183,10 @@ export function resolvePiCompatibilityProfile(
   if (id === undefined) return undefined;
   const resolved = PROFILES_BY_ID.get(id);
   if (resolved === undefined) {
-    throw new Error(`Unknown PI compatibility profile: ${id}`);
+    throw new Error("The selected compatibility profile is unknown.");
   }
   if (resolved.api !== api) {
-    throw new Error(`PI compatibility profile "${id}" does not support API "${api}".`);
+    throw new Error(`The selected compatibility profile does not support API "${api}".`);
   }
   return resolved;
 }

--- a/packages/runtime/pi/src/session-events.ts
+++ b/packages/runtime/pi/src/session-events.ts
@@ -49,7 +49,7 @@ export function assertAssistantTurnCompleted(messages: readonly unknown[]): void
     (message) => isRecord(message) && message["role"] === "assistant",
   );
   if (!isRecord(assistant)) {
-    throw new Error("PI Runtime completed without an assistant response.");
+    throw new Error("The runtime completed without an assistant response.");
   }
 
   const stopReason = assistant["stopReason"];
@@ -58,12 +58,12 @@ export function assertAssistantTurnCompleted(messages: readonly unknown[]): void
     throw new Error(
       typeof errorMessage === "string" && errorMessage.trim() !== ""
         ? errorMessage
-        : `PI Runtime assistant stopped with reason: ${stopReason}.`,
+        : `The runtime assistant stopped with reason: ${stopReason}.`,
     );
   }
 
   if (readMessageText(assistant) === undefined) {
-    throw new Error("PI Runtime completed with an empty assistant response.");
+    throw new Error("The runtime completed with an empty assistant response.");
   }
 }
 

--- a/packages/runtime/pi/src/session-manager.ts
+++ b/packages/runtime/pi/src/session-manager.ts
@@ -30,7 +30,7 @@ export async function createPiSessionManager(
     };
   }
 
-  throw new Error(`PI runtime session was not found: ${runtimeSessionId}.`);
+  throw new Error(`Runtime session was not found: ${runtimeSessionId}.`);
 }
 
 async function findLocalSessionByExactId(

--- a/packages/runtime/pi/src/session-messages.ts
+++ b/packages/runtime/pi/src/session-messages.ts
@@ -48,7 +48,7 @@ function createUnknownRuntimeMessage(role: string, details: unknown): AgentMessa
   return {
     role: "custom",
     customType: `pi.${role}`,
-    content: `Unsupported PI runtime message role: ${role}`,
+    content: `Unsupported runtime message role: ${role}`,
     display: false,
     details,
     timestamp,

--- a/packages/runtime/pi/test/models.test.ts
+++ b/packages/runtime/pi/test/models.test.ts
@@ -81,9 +81,7 @@ describe("PI runtime model resolution", () => {
 
   it("validates thinking levels before passing them to PI", () => {
     expect(resolvePiThinkingLevel("xhigh")).toBe("xhigh");
-    expect(() => resolvePiThinkingLevel("extreme")).toThrow(
-      "Unsupported PI thinking level: extreme",
-    );
+    expect(() => resolvePiThinkingLevel("extreme")).toThrow("Unsupported thinking level: extreme");
   });
 
   it("converts neutral providers inside the PI adapter boundary", () => {
@@ -159,7 +157,7 @@ describe("PI runtime model resolution", () => {
         apiKey: "secret",
         credentialFingerprint: "fingerprint",
       }),
-    ).toThrow("does not support any configured models");
+    ).toThrow("No configured models are supported");
   });
 });
 

--- a/packages/runtime/pi/test/profiles.test.ts
+++ b/packages/runtime/pi/test/profiles.test.ts
@@ -25,7 +25,7 @@ describe("PI compatibility profiles", () => {
 
   it("rejects unknown profiles and protocol mismatches", () => {
     expect(() => resolvePiCompatibilityProfile("pi.missing@v1", "openai-completions")).toThrow(
-      "Unknown PI compatibility profile",
+      "The selected compatibility profile is unknown.",
     );
     expect(() => resolvePiCompatibilityProfile("pi.openai-modern@v1", "openai-responses")).toThrow(
       "does not support API",


### PR DESCRIPTION
## What changed

- Present the PI-backed Desktop runtime as the built-in/default runtime instead of exposing implementation-specific PI naming.
- Use the built-in runtime product label across Settings, Expert configuration, Flow configuration, Mission history, and runtime availability views.
- Update English, Simplified Chinese, and Traditional Chinese copy.
- Change first-party runtime, model-provider, session initialization, and diagnostic messages at their source so newly generated content does not mention PI.
- Keep persisted historical messages untouched and remove PI-specific `replace`/`replaceAll` sanitization.
- Preserve stable internal runtime IDs and package/protocol names.

## Why

Desktop surfaces were rendering implementation-specific runtime metadata and first-party adapter messages directly. The product UI should describe this implementation as the built-in runtime, while internal identifiers remain stable and are not presented as product terminology.

## Impact

New Desktop sessions, runtime checks, and model-provider verification results use neutral built-in runtime copy. Existing messages already persisted on disk are not migrated or rewritten.

## Validation

- `pnpm --filter @pragma/desktop test` — 441 tests passed.
- `pnpm --filter @pragma/desktop lint` — passed.
- `pnpm --filter @pragma/desktop typecheck` — passed.
- `pnpm --filter @pragma/desktop build` — passed.
- `pnpm --filter @pragma/runtime-pi test` — 20 tests passed.
- `pnpm --filter @pragma/runtime-pi lint` — passed.
- `pnpm --filter @pragma/runtime-pi typecheck` — passed.
- `pnpm --filter @pragma/runtime-pi build` — passed.