### PR TITLE
Fix Mission token settlement and live context-window accuracy

### DIFF
--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -14,6 +14,7 @@ import {
   readRuntimeSessionRecord,
   StoredExecutionView,
   type RuntimeDriverSessionContext,
+  type RuntimeContextWindowUsage,
   type RuntimeModelSelection,
   type RuntimeResolver,
 } from "@pragma/core";
@@ -29,6 +30,7 @@ import {
   MissionChatUpdateSchema,
   missionExecutorSnapshot,
   type DesktopToolPermissionMode,
+  type MissionChatUpdate,
 } from "../../../shared/contracts/index.ts";
 import type { CapabilityCredentialStore } from "../capabilities/capability-credential-store.ts";
 import type { CapabilityStore } from "../capabilities/capability-store.ts";
@@ -325,13 +327,27 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       measurement: "reported" as const,
       observedAt: new Date().toISOString(),
     }));
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    let finishTurn = (): void => undefined;
+    const turnCanFinish = new Promise<void>((resolve) => {
+      finishTurn = resolve;
+    });
+    const runtime = defineRuntimeDriver<RuntimeContextWindowUsage, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
-      startTurn: () => ({ outputText: "done", runtimeSessionId: "runtime" }),
-      mapEvent: () => ({ events: [] }),
+      async startTurn(_session, turn) {
+        turn.stream.writeNative({
+          usedTokens: 40_000,
+          contextWindowTokens: 200_000,
+          percent: 20,
+          measurement: "reported",
+          observedAt: new Date().toISOString(),
+        });
+        await turnCanFinish;
+        return { outputText: "done", runtimeSessionId: "runtime" };
+      },
+      mapEvent: (usage) => ({ events: [], contextWindowUsage: usage }),
       readContextWindow: () => ({
         usedTokens: 50_000,
         contextWindowTokens: 200_000,
@@ -353,12 +369,29 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         runtimes,
       });
     const runner = createRunner();
+    const chatUpdates: MissionChatUpdate[] = [];
+    const unsubscribe = runner.subscribeChat((update) => chatUpdates.push(update));
 
     await runner.run(mission.id);
+    await vi.waitFor(() => {
+      expect(
+        chatUpdates.some(
+          (update) =>
+            update.kind === "patch" &&
+            update.patches.some(
+              (patch) =>
+                patch.type === "context-window.update" && patch.usage.usedTokens === 40_000,
+            ),
+        ),
+      ).toBe(true);
+    });
+    expect((await missions.get(mission.id)).execution?.status).toBe("running");
+    finishTurn();
     await vi.waitFor(
       async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
       { timeout: settlementTimeoutMs },
     );
+    unsubscribe();
     await expect(runner.getChat({ id: mission.id, limit: 50 })).resolves.toMatchObject({
       contextWindow: {
         supportsInspection: true,

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -44,7 +44,11 @@ import type {
   RuntimeContextRecord,
   RuntimeEnvironmentBinding,
 } from "@pragma/shared";
-import { ExpertAgentStreamEventSchema, isFinalExecutionStatus } from "@pragma/shared";
+import {
+  ExpertAgentStreamEventSchema,
+  isFinalExecutionStatus,
+  RuntimeContextWindowUsageSchema,
+} from "@pragma/shared";
 
 import type {
   Mission,
@@ -231,6 +235,23 @@ export function createMissionRunner(options: {
           options.usage === undefined
             ? undefined
             : {
+                preview: async (observation) => {
+                  const currentMission = await options.missions.get(mission.id);
+                  const project = await options.project.openRevision(
+                    currentMission.project.revision,
+                  );
+                  const names = new Map(
+                    project
+                      .listResources()
+                      .map((resource) => [resource.metadata.id, resource.metadata.name] as const),
+                  );
+                  names.set(currentMission.executor.ref, currentMission.executor.name);
+                  options.usage!.preview(observation, {
+                    mission: { id: currentMission.id, title: currentMission.title },
+                    invocations: await executionStore.listInvocations(observation.executionId),
+                    names,
+                  });
+                },
                 record: async (observation) => {
                   const currentMission = await options.missions.get(mission.id);
                   const project = await options.project.openRevision(
@@ -248,6 +269,7 @@ export function createMissionRunner(options: {
                     names,
                   });
                 },
+                clearPreview: (observationId) => options.usage!.clearPreview(observationId),
               },
       }),
       setToolPermissionMode: (mode: DesktopToolPermissionMode) => {
@@ -265,6 +287,7 @@ export function createMissionRunner(options: {
   const chatListeners = new Set<(update: MissionChatUpdate) => void>();
   const chatRevisions = new Map<string, number>();
   const liveChats = new Map<string, LiveMissionChat>();
+  const liveContextWindows = new Map<string, RuntimeContextWindowUsage>();
   const workListeners = new Set<(update: MissionWorkUpdate) => void>();
   const workRevisions = new Map<string, number>();
   const liveWorkOutputs = new Map<string, Map<string, LiveMissionChat>>();
@@ -350,6 +373,7 @@ export function createMissionRunner(options: {
       liveChats.delete(id);
     }
     liveWorkOutputs.delete(id);
+    liveContextWindows.delete(id);
     invalidateChat(id);
     invalidateWork(id);
   };
@@ -596,6 +620,18 @@ export function createMissionRunner(options: {
       },
       () => invalidateChat(input.missionId),
       (item) => {
+        if (item.channel === "telemetry" && item.parentInvocationId === undefined) {
+          const payload = asRecord(item.value);
+          if (readString(payload, "type") === "context-window.updated") {
+            const usage = RuntimeContextWindowUsageSchema.safeParse(payload["usage"]);
+            if (usage.success) {
+              liveContextWindows.set(input.missionId, usage.data);
+              emitChatPatches(input.missionId, [
+                { type: "context-window.update", usage: usage.data },
+              ]);
+            }
+          }
+        }
         const sessionId = item.source.sessionId;
         if (item.source.parentSessionId !== undefined && sessionId !== undefined) {
           const recordId = `runtime-agent:${sessionId}`;
@@ -1125,7 +1161,7 @@ export function createMissionRunner(options: {
       active.has(mission.id) ||
       (mission.execution !== undefined &&
         ["queued", "running", "waiting"].includes(mission.execution.status));
-    let usage = usageOverride;
+    let usage = usageOverride ?? liveContextWindows.get(mission.id);
     if (usage === undefined && rootContext.snapshot !== undefined) {
       if (!executionBusy) {
         usage = await sessions
@@ -1551,6 +1587,7 @@ export function createMissionRunner(options: {
       chatRevisions.delete(id);
       workRevisions.delete(id);
       liveWorkOutputs.delete(id);
+      liveContextWindows.delete(id);
     },
     async listHumanInteractions(id) {
       return await listMissionPendingHumanInteractions(await options.missions.get(id));

--- a/apps/desktop/src/main/features/usage/usage-store.test.ts
+++ b/apps/desktop/src/main/features/usage/usage-store.test.ts
@@ -72,7 +72,7 @@ describe("Desktop usage store", () => {
 
     expect(store.getMissionUsage("mission-1")).toMatchObject({
       provisional: true,
-      usage: { totalTokens: 80 },
+      usage: { totalTokens: 0 },
     });
     expect(store.getOverview("all").totals.totalTokens).toBe(0);
 

--- a/apps/desktop/src/main/features/usage/usage-store.test.ts
+++ b/apps/desktop/src/main/features/usage/usage-store.test.ts
@@ -31,6 +31,60 @@ async function fixture() {
 }
 
 describe("Desktop usage store", () => {
+  it("replaces live previews and reconciles them with the final observation", async () => {
+    const { store } = await fixture();
+    const context = {
+      mission: { id: "mission-1", title: "Mission" },
+      invocations: invocationTree(),
+      names: new Map<string, string>(),
+    };
+    const updates: Array<{
+      readonly total: number;
+      readonly provisional: boolean | undefined;
+    }> = [];
+    store.subscribe((update) => {
+      if (update.missionUsage !== undefined) {
+        updates.push({
+          total: update.missionUsage.totalTokens,
+          provisional: update.provisional,
+        });
+      }
+    });
+    const firstPreview = {
+      ...observation(),
+      usage: {
+        ...observation().usage,
+        input: 40,
+        output: 10,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 50,
+      },
+    };
+    store.preview(firstPreview, context);
+    store.preview(
+      {
+        ...firstPreview,
+        usage: { ...firstPreview.usage, output: 40, totalTokens: 80 },
+      },
+      context,
+    );
+
+    expect(store.getMissionUsage("mission-1")).toMatchObject({
+      provisional: true,
+      usage: { totalTokens: 80 },
+    });
+    expect(store.getOverview("all").totals.totalTokens).toBe(0);
+
+    store.record(observation(), context);
+
+    expect(store.getMissionUsage("mission-1")).toMatchObject({
+      provisional: false,
+      usage: { totalTokens: 155 },
+    });
+    expect(updates.map((update) => update.total)).toEqual([50, 80, 155]);
+  });
+
   it("records token-only observations and attributes ancestors inclusively", async () => {
     const { store } = await fixture();
     store.record(observation(), {

--- a/apps/desktop/src/main/features/usage/usage-store.ts
+++ b/apps/desktop/src/main/features/usage/usage-store.ts
@@ -50,6 +50,7 @@ export interface DesktopUsageStore {
     readonly offset: number;
     readonly limit: number;
   }) => UsageSubjectList;
+  /** Returns persisted totals only; `provisional` indicates whether live previews exist. */
   readonly getMissionUsage: (missionId: string) => MissionUsage;
   readonly markMissionDeleted: (missionId: string) => void;
   readonly subscribe: (listener: (update: UsageUpdate) => void) => () => void;
@@ -455,7 +456,7 @@ export async function createDesktopUsageStore(input: {
       return {
         revision: currentRevision,
         trackingStartedAt,
-        usage: missionTotals(missionId),
+        usage: persistedMissionTotals(missionId),
         provisional: [...previews.values()].some(
           (preview) => preview.context.mission.id === missionId,
         ),

--- a/apps/desktop/src/main/features/usage/usage-store.ts
+++ b/apps/desktop/src/main/features/usage/usage-store.ts
@@ -33,7 +33,12 @@ export interface UsageObservationContext {
 
 export interface DesktopUsageStore {
   readonly trackingStartedAt: string;
+  readonly preview: (
+    observation: RuntimeUsageObservation,
+    context: UsageObservationContext,
+  ) => void;
   readonly record: (observation: RuntimeUsageObservation, context: UsageObservationContext) => void;
+  readonly clearPreview: (observationId: string) => void;
   readonly recordRecovered: (
     observation: Omit<RuntimeUsageObservation, "observationId" | "runId">,
     context: UsageObservationContext,
@@ -143,29 +148,88 @@ export async function createDesktopUsageStore(input: {
     throw new Error(`Unsupported Desktop usage schema: ${schemaVersion}.`);
   }
   const listeners = new Set<(update: UsageUpdate) => void>();
-  const revision = (): number => Number(metadata("revision"));
-  const publish = (missionId?: string): void => {
-    const next = revision() + 1;
-    database
-      .prepare("UPDATE usage_metadata SET value = ? WHERE key = 'revision'")
-      .run(String(next));
+  const previews = new Map<
+    string,
+    {
+      readonly observation: RuntimeUsageObservation;
+      readonly context: UsageObservationContext;
+    }
+  >();
+  let currentRevision = Number(metadata("revision"));
+  const persistedMissionTotals = (missionId: string): UsageTokenTotals =>
+    readTotals(
+      database
+        .prepare(
+          `SELECT
+            COALESCE(SUM(input_tokens), 0) AS input,
+            COALESCE(SUM(output_tokens), 0) AS output,
+            COALESCE(SUM(cache_read_tokens), 0) AS cacheRead,
+            COALESCE(SUM(cache_write_tokens), 0) AS cacheWrite,
+            COALESCE(SUM(total_tokens), 0) AS totalTokens
+           FROM usage_observations WHERE mission_id = ?`,
+        )
+        .get(missionId),
+    );
+  const missionPreviewTotals = (missionId: string): UsageTokenTotals =>
+    [...previews.values()]
+      .filter((preview) => preview.context.mission.id === missionId)
+      .reduce((total, preview) => addTotals(total, preview.observation.usage), { ...EMPTY_USAGE });
+  const missionTotals = (missionId: string): UsageTokenTotals =>
+    addTotals(persistedMissionTotals(missionId), missionPreviewTotals(missionId));
+  const publish = (missionId?: string, provisional = false, persist = true): void => {
+    currentRevision += 1;
+    if (persist) {
+      database
+        .prepare("UPDATE usage_metadata SET value = ? WHERE key = 'revision'")
+        .run(String(currentRevision));
+    }
     const update: UsageUpdate = {
-      revision: next,
-      ...(missionId === undefined ? {} : { missionId }),
+      revision: currentRevision,
+      ...(missionId === undefined
+        ? {}
+        : {
+            missionId,
+            missionUsage: missionTotals(missionId),
+            provisional,
+          }),
     };
     for (const listener of listeners) listener(update);
   };
 
   const store: DesktopUsageStore = {
     trackingStartedAt,
-    record(observation, context) {
+    preview(observation, context) {
       if (observation.occurredAt < trackingStartedAt) return;
+      const persisted = database
+        .prepare("SELECT signature FROM usage_observations WHERE observation_id = ?")
+        .get(observation.observationId);
+      if (persisted !== undefined) return;
+      const existing = previews.get(observation.observationId);
+      if (
+        existing !== undefined &&
+        observationSignature(existing.observation) === observationSignature(observation)
+      ) {
+        return;
+      }
+      previews.set(observation.observationId, { observation, context });
+      publish(context.mission.id, true, false);
+    },
+    record(observation, context) {
+      if (observation.occurredAt < trackingStartedAt) {
+        store.clearPreview(observation.observationId);
+        return;
+      }
       const signature = observationSignature(observation);
       const existing = database
         .prepare("SELECT signature FROM usage_observations WHERE observation_id = ?")
         .get(observation.observationId) as { signature?: unknown } | undefined;
       if (existing !== undefined) {
-        if (existing.signature === signature) return;
+        if (existing.signature === signature) {
+          const preview = previews.get(observation.observationId);
+          previews.delete(observation.observationId);
+          if (preview !== undefined) publish(preview.context.mission.id);
+          return;
+        }
         throw new Error(`Conflicting usage observation: ${observation.observationId}.`);
       }
       const subjects = resolveSubjects(observation, context);
@@ -222,7 +286,20 @@ export async function createDesktopUsageStore(input: {
         database.exec("ROLLBACK;");
         throw error;
       }
+      previews.delete(observation.observationId);
       publish(context.mission.id);
+    },
+    clearPreview(observationId) {
+      const preview = previews.get(observationId);
+      if (preview === undefined) return;
+      previews.delete(observationId);
+      publish(
+        preview.context.mission.id,
+        [...previews.values()].some(
+          (candidate) => candidate.context.mission.id === preview.context.mission.id,
+        ),
+        false,
+      );
     },
     recordRecovered(observation, context) {
       const recorded = readTotals(
@@ -312,7 +389,7 @@ export async function createDesktopUsageStore(input: {
         UsageTokenTotals & { date: string }
       >;
       return {
-        revision: revision(),
+        revision: currentRevision,
         trackingStartedAt,
         timezone: storedTimezone,
         totals,
@@ -362,7 +439,7 @@ export async function createDesktopUsageStore(input: {
         UsageTokenTotals & { id: string; name: string; deleted: number }
       >;
       return {
-        revision: revision(),
+        revision: currentRevision,
         total: Number(totalRow.total),
         items: rows.map((row) => ({
           kind,
@@ -376,20 +453,11 @@ export async function createDesktopUsageStore(input: {
     },
     getMissionUsage(missionId) {
       return {
-        revision: revision(),
+        revision: currentRevision,
         trackingStartedAt,
-        usage: readTotals(
-          database
-            .prepare(
-              `SELECT
-                COALESCE(SUM(input_tokens), 0) AS input,
-                COALESCE(SUM(output_tokens), 0) AS output,
-                COALESCE(SUM(cache_read_tokens), 0) AS cacheRead,
-                COALESCE(SUM(cache_write_tokens), 0) AS cacheWrite,
-                COALESCE(SUM(total_tokens), 0) AS totalTokens
-               FROM usage_observations WHERE mission_id = ?`,
-            )
-            .get(missionId),
+        usage: missionTotals(missionId),
+        provisional: [...previews.values()].some(
+          (preview) => preview.context.mission.id === missionId,
         ),
       };
     },
@@ -408,6 +476,7 @@ export async function createDesktopUsageStore(input: {
     },
     close() {
       listeners.clear();
+      previews.clear();
       database.close();
     },
   };
@@ -499,6 +568,19 @@ function readTotals(value: unknown): UsageTokenTotals {
     cacheRead: Number(row.cacheRead ?? 0),
     cacheWrite: Number(row.cacheWrite ?? 0),
     totalTokens: Number(row.totalTokens ?? 0),
+  };
+}
+
+function addTotals(
+  current: UsageTokenTotals,
+  next: Pick<UsageTokenTotals, "input" | "output" | "cacheRead" | "cacheWrite" | "totalTokens">,
+): UsageTokenTotals {
+  return {
+    input: current.input + next.input,
+    output: current.output + next.output,
+    cacheRead: current.cacheRead + next.cacheRead,
+    cacheWrite: current.cacheWrite + next.cacheWrite,
+    totalTokens: current.totalTokens + next.totalTokens,
   };
 }
 

--- a/apps/desktop/src/renderer/src/i18n/resources/en/usage.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/usage.ts
@@ -26,5 +26,5 @@ export const usage = {
   loadMore: "Load more",
   loading: "Loading usage…",
   loadError: "Usage could not be loaded.",
-  missionHint: "This Mission has used {{tokens}} tokens",
+  missionHint: "Used {{tokens}} tokens",
 } as const;

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/usage.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/usage.ts
@@ -26,5 +26,5 @@ export const usage = {
   loadMore: "加载更多",
   loading: "正在加载用量…",
   loadError: "无法加载用量。",
-  missionHint: "本 Mission 已使用 {{tokens}} tokens",
+  missionHint: "已使用 {{tokens}} tokens",
 } as const;

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/usage.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/usage.ts
@@ -26,5 +26,5 @@ export const usage = {
   loadMore: "載入更多",
   loading: "正在載入用量…",
   loadError: "無法載入用量。",
-  missionHint: "本 Mission 已使用 {{tokens}} tokens",
+  missionHint: "已使用 {{tokens}} tokens",
 } as const;

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -347,7 +347,7 @@ describe("MissionDetailFragment", () => {
     expect(html).toContain("mission-chat-footer");
     expect(html).toContain("mission-chat-composer");
     expect(html).toContain("mission-chat-composer-toolbar");
-    expect(html).not.toContain("This Mission has used 0 tokens");
+    expect(html).not.toContain("Used 0 tokens");
     expect(html).toContain('aria-label="Model"');
     expect(html).toContain('aria-label="Tool permissions"');
     expect(html).not.toContain("mission-execution-notice");

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -8,6 +8,7 @@ import type {
 } from "../../../../shared/contracts/index.ts";
 import { i18n } from "../../i18n/index.ts";
 import {
+  applyMissionUsageHintRevision,
   applyMissionChatPatches,
   claimMissionClientOperation,
   CONTEXT_POPOVER_CLOSE_DELAY_MS,
@@ -30,6 +31,22 @@ import {
 } from "./MissionsPage.tsx";
 
 describe("MissionsPage", () => {
+  it("does not let a stale initial usage query overwrite a newer streaming update", () => {
+    const live = applyMissionUsageHintRevision(
+      { revision: -1, totalTokens: 0 },
+      { revision: 8, totalTokens: 120 },
+    );
+
+    expect(applyMissionUsageHintRevision(live, { revision: 7, totalTokens: 80 })).toEqual({
+      revision: 8,
+      totalTokens: 120,
+    });
+    expect(applyMissionUsageHintRevision(live, { revision: 9, totalTokens: 155 })).toEqual({
+      revision: 9,
+      totalTokens: 155,
+    });
+  });
+
   it("keeps creation outside the missions surface", () => {
     const html = renderToStaticMarkup(<MissionsPage onCreate={() => undefined} />);
 
@@ -574,6 +591,46 @@ describe("Mission chat patches", () => {
         2,
       ),
     ).toBeNull();
+  });
+
+  it("applies a live context-window patch without replacing chat entries", () => {
+    const snapshot: MissionChatSnapshot = {
+      missionId: "00000000-0000-4000-8000-000000000000",
+      revision: 1,
+      entries: [],
+      page: {},
+      pendingInteractions: [],
+      contextWindow: {
+        supportsInspection: true,
+        supportsCompaction: true,
+        canCompact: false,
+      },
+    };
+
+    expect(
+      applyMissionChatPatches(
+        snapshot,
+        [
+          {
+            type: "context-window.update",
+            usage: {
+              usedTokens: 80_000,
+              contextWindowTokens: 200_000,
+              percent: 40,
+              measurement: "estimated",
+              observedAt: "2026-07-29T00:00:00.000Z",
+            },
+          },
+        ],
+        2,
+      ),
+    ).toMatchObject({
+      revision: 2,
+      contextWindow: {
+        canCompact: false,
+        usage: { usedTokens: 80_000, percent: 40 },
+      },
+    });
   });
 });
 

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -347,7 +347,7 @@ describe("MissionDetailFragment", () => {
     expect(html).toContain("mission-chat-footer");
     expect(html).toContain("mission-chat-composer");
     expect(html).toContain("mission-chat-composer-toolbar");
-    expect(html).toContain("This Mission has used 0 tokens");
+    expect(html).not.toContain("This Mission has used 0 tokens");
     expect(html).toContain('aria-label="Model"');
     expect(html).toContain('aria-label="Tool permissions"');
     expect(html).not.toContain("mission-execution-notice");

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -2047,7 +2047,7 @@ export function MissionDetailFragment(props: {
                   </div>
                 </div>
               )}
-              <MissionUsageHint missionId={props.mission.id} />
+              <MissionUsageHint missionId={props.mission.id} executionActive={executionActive} />
             </div>
           </div>
         ) : workError !== null && workRecords.length === 0 ? (
@@ -2151,12 +2151,21 @@ export function MissionDetailFragment(props: {
   );
 }
 
-function MissionUsageHint(props: { readonly missionId: string }) {
+function MissionUsageHint(props: {
+  readonly missionId: string;
+  readonly executionActive: boolean;
+}) {
   const { t } = useTranslation("usage");
   const [usageState, setUsageState] = useState<MissionUsageHintState>({
     revision: -1,
     totalTokens: 0,
   });
+  const executionActiveRef = useRef(props.executionActive);
+  const previousExecutionRef = useRef({
+    missionId: props.missionId,
+    active: props.executionActive,
+  });
+  executionActiveRef.current = props.executionActive;
 
   useEffect(() => {
     let active = true;
@@ -2175,6 +2184,7 @@ function MissionUsageHint(props: { readonly missionId: string }) {
     void refresh().catch(() => undefined);
     const unsubscribe = window.pragmaDesktop.subscribeUsageUpdates((update) => {
       if (update.missionId !== props.missionId) return;
+      if (executionActiveRef.current || update.provisional === true) return;
       if (update.missionUsage !== undefined) {
         setUsageState((current) =>
           applyMissionUsageHintRevision(current, {
@@ -2191,6 +2201,30 @@ function MissionUsageHint(props: { readonly missionId: string }) {
       unsubscribe();
     };
   }, [props.missionId]);
+
+  useEffect(() => {
+    const previous = previousExecutionRef.current;
+    previousExecutionRef.current = {
+      missionId: props.missionId,
+      active: props.executionActive,
+    };
+    if (previous.missionId !== props.missionId || !previous.active || props.executionActive) {
+      return;
+    }
+    void window.pragmaDesktop
+      .getMissionUsage(props.missionId)
+      .then((result) => {
+        setUsageState((current) =>
+          applyMissionUsageHintRevision(current, {
+            revision: result.revision,
+            totalTokens: result.usage.totalTokens,
+          }),
+        );
+      })
+      .catch(() => undefined);
+  }, [props.executionActive, props.missionId]);
+
+  if (usageState.totalTokens === 0) return null;
 
   return (
     <small className="mission-usage-hint" aria-live="polite">

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -1938,6 +1938,10 @@ export function MissionDetailFragment(props: {
                 />
               ) : (
                 <div className="mission-chat-composer" aria-busy={clientOperationBusy}>
+                  <MissionUsageHint
+                    missionId={props.mission.id}
+                    executionActive={executionActive}
+                  />
                   <textarea
                     ref={textareaRef}
                     rows={1}
@@ -2047,7 +2051,6 @@ export function MissionDetailFragment(props: {
                   </div>
                 </div>
               )}
-              <MissionUsageHint missionId={props.mission.id} executionActive={executionActive} />
             </div>
           </div>
         ) : workError !== null && workRecords.length === 0 ? (

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -2153,33 +2153,62 @@ export function MissionDetailFragment(props: {
 
 function MissionUsageHint(props: { readonly missionId: string }) {
   const { t } = useTranslation("usage");
-  const [totalTokens, setTotalTokens] = useState(0);
+  const [usageState, setUsageState] = useState<MissionUsageHintState>({
+    revision: -1,
+    totalTokens: 0,
+  });
 
   useEffect(() => {
     let active = true;
-    let timeout: ReturnType<typeof setTimeout> | undefined;
+    setUsageState({ revision: -1, totalTokens: 0 });
     const refresh = async (): Promise<void> => {
       const result = await window.pragmaDesktop.getMissionUsage(props.missionId);
-      if (active) setTotalTokens(result.usage.totalTokens);
+      if (active) {
+        setUsageState((current) =>
+          applyMissionUsageHintRevision(current, {
+            revision: result.revision,
+            totalTokens: result.usage.totalTokens,
+          }),
+        );
+      }
     };
     void refresh().catch(() => undefined);
     const unsubscribe = window.pragmaDesktop.subscribeUsageUpdates((update) => {
-      if (update.missionId !== undefined && update.missionId !== props.missionId) return;
-      if (timeout !== undefined) clearTimeout(timeout);
-      timeout = setTimeout(() => void refresh().catch(() => undefined), 200);
+      if (update.missionId !== props.missionId) return;
+      if (update.missionUsage !== undefined) {
+        setUsageState((current) =>
+          applyMissionUsageHintRevision(current, {
+            revision: update.revision,
+            totalTokens: update.missionUsage!.totalTokens,
+          }),
+        );
+        return;
+      }
+      void refresh().catch(() => undefined);
     });
     return () => {
       active = false;
-      if (timeout !== undefined) clearTimeout(timeout);
       unsubscribe();
     };
   }, [props.missionId]);
 
   return (
     <small className="mission-usage-hint" aria-live="polite">
-      {t("missionHint", { tokens: formatTokens(totalTokens) })}
+      {t("missionHint", { tokens: formatTokens(usageState.totalTokens) })}
     </small>
   );
+}
+
+interface MissionUsageHintState {
+  readonly revision: number;
+  readonly totalTokens: number;
+}
+
+export function applyMissionUsageHintRevision(
+  current: MissionUsageHintState,
+  next: MissionUsageHintState,
+): MissionUsageHintState {
+  return next.revision < current.revision ? current : next;
 }
 
 export function ContextWindowControl(props: {
@@ -3080,8 +3109,14 @@ export function applyMissionChatPatches(
 ): MissionChatSnapshot | null {
   const entries = [...snapshot.entries];
   for (const patch of patches) {
-    const index =
-      patch.type === "entry.upsert" ? -1 : entries.findIndex((entry) => entry.id === patch.entryId);
+    if (patch.type === "context-window.update") {
+      if (snapshot.contextWindow === undefined) return null;
+      snapshot = {
+        ...snapshot,
+        contextWindow: { ...snapshot.contextWindow, usage: patch.usage },
+      };
+      continue;
+    }
     if (patch.type === "entry.upsert") {
       const existingIndex = entries.findIndex((entry) => entry.id === patch.entry.id);
       if (existingIndex === -1) entries.push({ ...patch.entry });
@@ -3099,6 +3134,7 @@ export function applyMissionChatPatches(
       }
       continue;
     }
+    const index = entries.findIndex((entry) => entry.id === patch.entryId);
     if (index === -1) return null;
     const entry = entries[index]!;
     if (patch.type === "entry.streaming") {
@@ -3129,6 +3165,7 @@ function firstVisiblePatchExecutionId(
 ): string | undefined {
   if (update.kind !== "patch") return undefined;
   for (const patch of update.patches) {
+    if (patch.type === "context-window.update") continue;
     if (patch.type === "entry.upsert") {
       if (
         (patch.entry.kind === "assistant" || patch.entry.kind === "thinking") &&

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -5985,7 +5985,8 @@ p {
 
 .mission-usage-hint {
   display: block;
-  margin: 7px 4px 0;
+  justify-self: end;
+  margin: 9px 14px 0;
   color: var(--faint);
   font-size: 11px;
   line-height: 1.35;

--- a/apps/desktop/src/shared/contracts/contracts.test.ts
+++ b/apps/desktop/src/shared/contracts/contracts.test.ts
@@ -208,10 +208,31 @@ describe("mission chat streaming contracts", () => {
         patches: [{ type: "entry.append", entryId: "answer", field: "content", delta: "hello" }],
       }),
     ).toMatchObject({ kind: "patch", revision: 1 });
-    expect(MissionChatUpdateSchema.parse({ kind: "invalidate", missionId, revision: 2 })).toEqual({
+    expect(
+      MissionChatUpdateSchema.parse({
+        kind: "patch",
+        missionId,
+        revision: 2,
+        patches: [
+          {
+            type: "context-window.update",
+            usage: {
+              usedTokens: 64_000,
+              contextWindowTokens: 128_000,
+              percent: 50,
+              measurement: "estimated",
+              observedAt: "2026-07-29T00:00:00.000Z",
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({
+      patches: [{ type: "context-window.update", usage: { usedTokens: 64_000 } }],
+    });
+    expect(MissionChatUpdateSchema.parse({ kind: "invalidate", missionId, revision: 3 })).toEqual({
       kind: "invalidate",
       missionId,
-      revision: 2,
+      revision: 3,
     });
     expect(
       MissionChatUpdateSchema.safeParse({

--- a/apps/desktop/src/shared/contracts/missions.ts
+++ b/apps/desktop/src/shared/contracts/missions.ts
@@ -3,6 +3,7 @@ import {
   HumanInteractionResponseSchema,
   MissionExecutorRefSchema,
   MissionExecutorSchema,
+  RuntimeContextWindowUsageSchema,
   type MissionExecutor,
 } from "@pragma/shared";
 import {
@@ -347,13 +348,7 @@ export const MissionChatExecutionSchema = z.object({
   error: z.string().max(10_000).optional(),
 });
 
-export const MissionContextWindowUsageSchema = z.object({
-  usedTokens: z.number().int().nonnegative().nullable(),
-  contextWindowTokens: z.number().int().positive(),
-  percent: z.number().nonnegative().nullable(),
-  measurement: z.enum(["reported", "derived", "estimated"]),
-  observedAt: z.string().datetime(),
-});
+export const MissionContextWindowUsageSchema = RuntimeContextWindowUsageSchema;
 
 export const MissionContextWindowStateSchema = z.object({
   supportsInspection: z.boolean(),
@@ -391,6 +386,10 @@ export const MissionChatPatchSchema = z.discriminatedUnion("type", [
     type: z.literal("entry.streaming"),
     entryId: z.string().min(1),
     streaming: z.boolean(),
+  }),
+  z.object({
+    type: z.literal("context-window.update"),
+    usage: MissionContextWindowUsageSchema,
   }),
 ]);
 

--- a/apps/desktop/src/shared/contracts/usage.ts
+++ b/apps/desktop/src/shared/contracts/usage.ts
@@ -57,11 +57,14 @@ export const MissionUsageSchema = z.object({
   revision: z.number().int().nonnegative(),
   trackingStartedAt: z.string().datetime(),
   usage: UsageTokenTotalsSchema,
+  provisional: z.boolean().default(false),
 });
 
 export const UsageUpdateSchema = z.object({
   revision: z.number().int().nonnegative(),
   missionId: z.string().min(1).optional(),
+  missionUsage: UsageTokenTotalsSchema.optional(),
+  provisional: z.boolean().optional(),
 });
 
 export type UsagePeriod = z.infer<typeof UsagePeriodSchema>;

--- a/docs/adr/025-host-owned-token-usage-accounting.md
+++ b/docs/adr/025-host-owned-token-usage-accounting.md
@@ -21,6 +21,13 @@ Runtime/model selection, executing Expert, timestamp, and `AgentMessageUsage`. C
 persist Invocation and Execution usage snapshots for recovery, but does not persist or query an
 analytics ledger. Sink failures are logged and never change the execution outcome.
 
+While a Runtime turn is active, Core may also send replaceable previews through the sink. A
+Runtime-reported usage snapshot takes precedence; otherwise Core estimates prompt and streamed
+output tokens through one Runtime-neutral fallback. Desktop keeps previews in memory, replaces the
+previous preview for the same observation, and reconciles it with the final idempotent observation
+without persisting or double-counting the estimate. Preview failures follow the same best-effort
+rule as final sink writes.
+
 Pragma Desktop owns the analytics ledger at:
 
 ```text
@@ -57,8 +64,9 @@ Desktop provides a top-level Usage page with:
 - one daily trend chart;
 - ranked Mission, Expert, ExpertTeam, and Flow views.
 
-Mission chat shows a small cumulative token total below the composer. Context-window occupancy
-remains a separate Runtime/session concept.
+Mission chat shows a small cumulative token total below the composer. Both that total and the
+separate Runtime/session context-window occupancy update while a turn is streaming. The settled
+Runtime values replace any provisional estimate at the end of the turn.
 
 ## Consequences
 

--- a/docs/adr/025-host-owned-token-usage-accounting.md
+++ b/docs/adr/025-host-owned-token-usage-accounting.md
@@ -64,9 +64,14 @@ Desktop provides a top-level Usage page with:
 - one daily trend chart;
 - ranked Mission, Expert, ExpertTeam, and Flow views.
 
-Mission chat shows a small cumulative token total below the composer. Both that total and the
-separate Runtime/session context-window occupancy update while a turn is streaming. The settled
-Runtime values replace any provisional estimate at the end of the turn.
+Mission chat shows a compact cumulative token total in the composer's upper-right corner. The
+total is hidden until the first conversation round settles, remains stable while the next round is
+active, and refreshes only after that round settles.
+
+Runtime/session context-window occupancy remains live. Core only publishes a numeric fallback after
+the Runtime has supplied a non-empty baseline; before that calibration it reports the occupancy as
+unknown instead of presenting the prompt/output-only count as the full context. Runtime-reported or
+derived values replace provisional estimates whenever they arrive.
 
 ## Consequences
 

--- a/examples/src/console/execution-output-accumulator.ts
+++ b/examples/src/console/execution-output-accumulator.ts
@@ -57,6 +57,8 @@ export class ExecutionOutputAccumulator {
         const text = formatConsoleValue(item.value);
         return text === undefined ? [] : [{ kind: "answer", text, append: false }];
       }
+      case "telemetry":
+        return [];
     }
   }
 

--- a/packages/core/src/execution/execution-output.ts
+++ b/packages/core/src/execution/execution-output.ts
@@ -59,6 +59,13 @@ export function projectRuntimeOutput(options: {
         channel: "progress",
         value: event.payload,
       });
+    case "usage.updated":
+    case "context-window.updated":
+      return ExecutionOutputItemSchema.parse({
+        ...base,
+        channel: "telemetry",
+        value: { type: event.type, ...event.payload },
+      });
     case "agent.command":
       return ExecutionOutputItemSchema.parse({
         ...base,

--- a/packages/core/src/execution/expert-runner.ts
+++ b/packages/core/src/execution/expert-runner.ts
@@ -1327,6 +1327,7 @@ async function submitRuntimeTurn(options: {
   const rootMessageAccumulator = accumulatorFor(options.runId);
   let completedRootAssistant: AgentMessage | undefined;
   const liveBus = getExecutionLiveBus(options.options.store);
+  let usagePreview = Promise.resolve();
   const drain = (async () => {
     for await (const event of handle.events) {
       const output = projectRuntimeOutput({
@@ -1335,6 +1336,22 @@ async function submitRuntimeTurn(options: {
         event,
       });
       if (output !== undefined) liveBus.publish(options.options.executionId, output);
+      if (event.type === "usage.updated" && options.options.usageSink?.preview !== undefined) {
+        const observation = createRuntimeUsageObservation(
+          options,
+          event.payload.usage,
+          event.runId,
+        );
+        usagePreview = usagePreview
+          .then(async () => await options.options.usageSink!.preview!(observation))
+          .catch((error: unknown) => {
+            createUsageSinkLogger(options).warn(
+              "usage.sink_preview_failed",
+              "Host usage sink rejected a live preview.",
+              { observationId: observation.observationId, error },
+            );
+          });
+      }
       for (const message of accumulatorFor(event.runId).consume(event)) {
         if (
           event.runId === options.runId &&
@@ -1371,6 +1388,7 @@ async function submitRuntimeTurn(options: {
   try {
     const result = await handle.result;
     await drain;
+    await usagePreview;
     const output = result.result.output;
     const finalMessage =
       completedRootAssistant ?? rootMessageAccumulator.complete(output, result.result.usage);
@@ -1383,6 +1401,7 @@ async function submitRuntimeTurn(options: {
     };
   } catch (error) {
     const usage = await handle.usage?.catch(() => undefined);
+    await usagePreview;
     await settleRuntimeTurnUsage(options, usage);
     throw error;
   } finally {
@@ -1398,7 +1417,15 @@ async function settleRuntimeTurnUsage(
   options: Parameters<typeof submitRuntimeTurn>[0],
   usage: AgentMessageUsage | undefined,
 ): Promise<void> {
-  if (usage === undefined) return;
+  const observationId = runtimeUsageObservationId(
+    options.options.executionId,
+    options.options.invocationId,
+    options.runId,
+  );
+  if (usage === undefined) {
+    await clearRuntimeUsagePreview(options, observationId);
+    return;
+  }
   options.options.controller.addUsage(usage);
   const current = await options.options.store.getInvocation(
     options.options.executionId,
@@ -1418,41 +1445,85 @@ async function settleRuntimeTurnUsage(
     });
   }
   if (options.options.usageSink === undefined) return;
-  const observationId = createHash("sha256")
-    .update(
-      JSON.stringify([options.options.executionId, options.options.invocationId, options.runId]),
-    )
-    .digest("hex");
-  const executorId = options.invocation.executorId ?? options.invocation.definition.id;
   try {
-    await options.options.usageSink.record({
-      observationId,
-      occurredAt: new Date().toISOString(),
+    await options.options.usageSink.record(
+      createRuntimeUsageObservation(options, usage, options.runId),
+    );
+  } catch (error) {
+    createUsageSinkLogger(options).warn(
+      "usage.sink_write_failed",
+      "Host usage sink rejected an observation.",
+      {
+        observationId,
+        error,
+      },
+    );
+  } finally {
+    await clearRuntimeUsagePreview(options, observationId);
+  }
+}
+
+async function clearRuntimeUsagePreview(
+  options: Parameters<typeof submitRuntimeTurn>[0],
+  observationId: string,
+): Promise<void> {
+  try {
+    await options.options.usageSink?.clearPreview?.(observationId);
+  } catch (error) {
+    createUsageSinkLogger(options).warn(
+      "usage.sink_preview_clear_failed",
+      "Host usage sink failed to clear a live preview.",
+      { observationId, error },
+    );
+  }
+}
+
+function createRuntimeUsageObservation(
+  options: Parameters<typeof submitRuntimeTurn>[0],
+  usage: AgentMessageUsage,
+  runId: string,
+) {
+  const executorId = options.invocation.executorId ?? options.invocation.definition.id;
+  return {
+    observationId: runtimeUsageObservationId(
+      options.options.executionId,
+      options.options.invocationId,
+      runId,
+    ),
+    occurredAt: new Date().toISOString(),
+    executionId: options.options.executionId,
+    invocationId: options.options.invocationId,
+    contextId: options.options.context.contextId,
+    runId,
+    runtimeId: options.options.context.runtime.runtimeId,
+    ...(options.modelSelection === undefined ? {} : { modelSelection: options.modelSelection }),
+    executor: {
+      id: executorId,
+      name: readExpertName(options.options.expert, executorId),
+    },
+    usage,
+  };
+}
+
+function runtimeUsageObservationId(
+  executionId: string,
+  invocationId: string,
+  runId: string,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify([executionId, invocationId, runId]))
+    .digest("hex");
+}
+
+function createUsageSinkLogger(options: Parameters<typeof submitRuntimeTurn>[0]) {
+  return createPragmaLogger(options.options.loggerProvider, {
+    component: "usage-sink",
+    scope: {
       executionId: options.options.executionId,
       invocationId: options.options.invocationId,
       contextId: options.options.context.contextId,
-      runId: options.runId,
-      runtimeId: options.options.context.runtime.runtimeId,
-      ...(options.modelSelection === undefined ? {} : { modelSelection: options.modelSelection }),
-      executor: {
-        id: executorId,
-        name: readExpertName(options.options.expert, executorId),
-      },
-      usage,
-    });
-  } catch (error) {
-    createPragmaLogger(options.options.loggerProvider, {
-      component: "usage-sink",
-      scope: {
-        executionId: options.options.executionId,
-        invocationId: options.options.invocationId,
-        contextId: options.options.context.contextId,
-      },
-    }).warn("usage.sink_write_failed", "Host usage sink rejected an observation.", {
-      observationId,
-      error,
-    });
-  }
+    },
+  });
 }
 
 function readExpertName(expert: ExpertDefinition, executorId: string): string {
@@ -1465,7 +1536,11 @@ function readExpertName(expert: ExpertDefinition, executorId: string): string {
 
 function isLiveOnlyRuntimeEvent(event: ExpertAgentStreamEvent): boolean {
   return (
-    event.type === "message.delta" || event.type === "thought.delta" || event.type === "tool.delta"
+    event.type === "message.delta" ||
+    event.type === "thought.delta" ||
+    event.type === "tool.delta" ||
+    event.type === "usage.updated" ||
+    event.type === "context-window.updated"
   );
 }
 

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -545,6 +545,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
 
     managedSession = new ManagedRuntimeSession({
       agent,
+      agentContext,
       driver,
       nativeSession,
       descriptor,
@@ -574,6 +575,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
         });
       },
       executionBindings,
+      restored: request.runtimeSession !== undefined,
     });
     managedSession.setWatcher(
       persistenceSpec === undefined
@@ -708,10 +710,12 @@ function createRuntimeUnavailableMessage(
 class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
   private watcher: RuntimeSessionWatcher | undefined;
   private activeRunId: string | undefined;
+  private sessionSeedPending: boolean;
 
   constructor(
     private readonly options: {
       readonly agent: Expert;
+      readonly agentContext: ExpertAgentContext;
       readonly driver: RuntimeDriver<TNativeEvent, TNativeSession, TPrepared>;
       readonly nativeSession: TNativeSession;
       readonly descriptor: RuntimeAdapterDescriptor;
@@ -731,8 +735,11 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
         usage: RuntimeContextWindowUsage | null,
       ) => Promise<void>;
       readonly executionBindings: RuntimeExecutionBindings;
+      readonly restored: boolean;
     },
-  ) {}
+  ) {
+    this.sessionSeedPending = !options.restored;
+  }
 
   info(): RuntimeSessionInfo {
     return this.options.readSessionInfo();
@@ -1019,9 +1026,17 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
         attempt === 1
           ? createInitialRuntimePrompt(submission.query, submission.output)
           : createRuntimeOutputRetryPrompt(parseResult);
+      const attemptStartupMessages = attempt === 1 ? startupMessages : [];
+      const sessionSeed =
+        this.sessionSeedPending && attempt === 1
+          ? createRuntimeContextSessionSeed(this.options.agentContext, this.options.agent)
+          : undefined;
+      if (attempt === 1) this.sessionSeedPending = false;
       controller.resetCapture();
       controller.beginUsagePreview({
         prompt,
+        startupMessages: attemptStartupMessages.map((message) => message.content),
+        ...(sessionSeed === undefined ? {} : { sessionSeed }),
         ...(usage === undefined ? {} : { accumulatedUsage: usage }),
         ...(await this.refreshContextWindow(false).then((contextWindow) =>
           contextWindow === undefined ? {} : { contextWindow },
@@ -1041,7 +1056,7 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
             isRetry: attempt > 1,
             rawQuery: submission.query,
             prompt,
-            startupMessages: attempt === 1 ? startupMessages : [],
+            startupMessages: attemptStartupMessages,
             modelSelection: submission.modelSelection,
             output: submission.output,
             signal,
@@ -1103,6 +1118,27 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
     controller.updateUsage(usage);
 
     return createRuntimeRunResult(runId, parseResult.value, usage);
+  }
+}
+
+function createRuntimeContextSessionSeed(context: ExpertAgentContext, agent: Expert): string {
+  const tools = (agent.tools ?? []).map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: serializableToolSchema(tool.inputSchema),
+  }));
+  return [context.systemPrompt, ...(tools.length === 0 ? [] : [JSON.stringify({ tools })])].join(
+    "\n\n",
+  );
+}
+
+function serializableToolSchema(schema: unknown): unknown {
+  if (schema === undefined || schema === null) return {};
+  if (typeof schema !== "object") return {};
+  try {
+    return JSON.parse(JSON.stringify(schema)) as unknown;
+  } catch {
+    return {};
   }
 }
 

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -791,7 +791,6 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
       context: this.options.runContext,
       logger: this.options.logger,
       mapEvent: this.options.driver.mapEvent,
-      mergeUsage,
     });
     let enteredLifecycle = false;
     let finalized = false;
@@ -849,7 +848,8 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
         );
         observedUsage = runResult.result.usage;
         settleUsage(observedUsage);
-        await this.refreshContextWindow(false);
+        controller.updateContextWindowUsage(await this.refreshContextWindow(false));
+        controller.flushTelemetry(false);
 
         controller.writer.write({
           runId,
@@ -872,7 +872,8 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
       } catch (error) {
         observedUsage ??= controller.getUsage();
         settleUsage(observedUsage);
-        await this.refreshContextWindow(false);
+        controller.updateContextWindowUsage(await this.refreshContextWindow(false));
+        controller.flushTelemetry(false);
         const wasCancelled = signal.aborted || cancelled;
         const message = error instanceof Error ? error.message : "Runtime run failed.";
         const errorMetadata = readRuntimeErrorMetadata(error);
@@ -1019,6 +1020,13 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
           ? createInitialRuntimePrompt(submission.query, submission.output)
           : createRuntimeOutputRetryPrompt(parseResult);
       controller.resetCapture();
+      controller.beginUsagePreview({
+        prompt,
+        ...(usage === undefined ? {} : { accumulatedUsage: usage }),
+        ...(await this.refreshContextWindow(false).then((contextWindow) =>
+          contextWindow === undefined ? {} : { contextWindow },
+        )),
+      });
       const turnResult = await (async () => {
         const requestStartedAt = performance.now();
         this.options.logger.info(
@@ -1048,12 +1056,14 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
           return result;
         } catch (error) {
           usage = mergeUsage(usage, controller.getUsage());
+          controller.updateUsage(usage);
           observeUsage(usage);
           throw error;
         }
       })();
       outputText = turnResult.outputText ?? controller.getOutputText();
       usage = mergeUsage(usage, mergeUsage(controller.getUsage(), turnResult.usage));
+      controller.updateUsage(usage);
       observeUsage(usage);
 
       const runtimeSessionId = turnResult.runtimeSessionId ?? controller.getRuntimeSessionId();
@@ -1090,6 +1100,7 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
         })) ?? usage;
     }
     observeUsage(usage);
+    controller.updateUsage(usage);
 
     return createRuntimeRunResult(runId, parseResult.value, usage);
   }

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -545,7 +545,6 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
 
     managedSession = new ManagedRuntimeSession({
       agent,
-      agentContext,
       driver,
       nativeSession,
       descriptor,
@@ -575,7 +574,6 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
         });
       },
       executionBindings,
-      restored: request.runtimeSession !== undefined,
     });
     managedSession.setWatcher(
       persistenceSpec === undefined
@@ -710,12 +708,11 @@ function createRuntimeUnavailableMessage(
 class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
   private watcher: RuntimeSessionWatcher | undefined;
   private activeRunId: string | undefined;
-  private sessionSeedPending: boolean;
+  private contextWindowCalibrated = false;
 
   constructor(
     private readonly options: {
       readonly agent: Expert;
-      readonly agentContext: ExpertAgentContext;
       readonly driver: RuntimeDriver<TNativeEvent, TNativeSession, TPrepared>;
       readonly nativeSession: TNativeSession;
       readonly descriptor: RuntimeAdapterDescriptor;
@@ -735,11 +732,8 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
         usage: RuntimeContextWindowUsage | null,
       ) => Promise<void>;
       readonly executionBindings: RuntimeExecutionBindings;
-      readonly restored: boolean;
     },
-  ) {
-    this.sessionSeedPending = !options.restored;
-  }
+  ) {}
 
   info(): RuntimeSessionInfo {
     return this.options.readSessionInfo();
@@ -976,6 +970,9 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
     try {
       const usage = await read(this.options.nativeSession);
       if (usage !== undefined) {
+        if (usage.usedTokens !== null && usage.usedTokens > 0) {
+          this.contextWindowCalibrated = true;
+        }
         await this.options.persistContextWindowUsage(usage);
       }
       return usage;
@@ -1027,20 +1024,14 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
           ? createInitialRuntimePrompt(submission.query, submission.output)
           : createRuntimeOutputRetryPrompt(parseResult);
       const attemptStartupMessages = attempt === 1 ? startupMessages : [];
-      const sessionSeed =
-        this.sessionSeedPending && attempt === 1
-          ? createRuntimeContextSessionSeed(this.options.agentContext, this.options.agent)
-          : undefined;
-      if (attempt === 1) this.sessionSeedPending = false;
+      const contextWindow = await this.refreshContextWindow(false);
       controller.resetCapture();
       controller.beginUsagePreview({
         prompt,
         startupMessages: attemptStartupMessages.map((message) => message.content),
-        ...(sessionSeed === undefined ? {} : { sessionSeed }),
+        contextBaselineCalibrated: this.contextWindowCalibrated,
         ...(usage === undefined ? {} : { accumulatedUsage: usage }),
-        ...(await this.refreshContextWindow(false).then((contextWindow) =>
-          contextWindow === undefined ? {} : { contextWindow },
-        )),
+        ...(contextWindow === undefined ? {} : { contextWindow }),
       });
       const turnResult = await (async () => {
         const requestStartedAt = performance.now();
@@ -1118,27 +1109,6 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
     controller.updateUsage(usage);
 
     return createRuntimeRunResult(runId, parseResult.value, usage);
-  }
-}
-
-function createRuntimeContextSessionSeed(context: ExpertAgentContext, agent: Expert): string {
-  const tools = (agent.tools ?? []).map((tool) => ({
-    name: tool.name,
-    description: tool.description,
-    inputSchema: serializableToolSchema(tool.inputSchema),
-  }));
-  return [context.systemPrompt, ...(tools.length === 0 ? [] : [JSON.stringify({ tools })])].join(
-    "\n\n",
-  );
-}
-
-function serializableToolSchema(schema: unknown): unknown {
-  if (schema === undefined || schema === null) return {};
-  if (typeof schema !== "object") return {};
-  try {
-    return JSON.parse(JSON.stringify(schema)) as unknown;
-  } catch {
-    return {};
   }
 }
 

--- a/packages/core/src/runtime/runtime-adapter.ts
+++ b/packages/core/src/runtime/runtime-adapter.ts
@@ -3,6 +3,8 @@ import type { ContextAssemblerOptions } from "../agent/context-manager.ts";
 import type {
   AgentMessage,
   AgentMessageUsage,
+  RuntimeContextWindowMeasurement,
+  RuntimeContextWindowUsage,
   RuntimeSessionRef as SharedRuntimeSessionRef,
 } from "@pragma/shared";
 export { RuntimeSessionRefSchema } from "@pragma/shared";
@@ -185,15 +187,7 @@ export interface RuntimeSteerRequest {
   readonly targetRunId: string;
 }
 
-export type RuntimeContextWindowMeasurement = "reported" | "derived" | "estimated";
-
-export interface RuntimeContextWindowUsage {
-  readonly usedTokens: number | null;
-  readonly contextWindowTokens: number;
-  readonly percent: number | null;
-  readonly measurement: RuntimeContextWindowMeasurement;
-  readonly observedAt: string;
-}
+export type { RuntimeContextWindowMeasurement, RuntimeContextWindowUsage };
 
 export interface RuntimeSessionContextWindowController {
   readonly inspect: () => Promise<RuntimeContextWindowUsage | undefined>;

--- a/packages/core/src/runtime/stream-controller.ts
+++ b/packages/core/src/runtime/stream-controller.ts
@@ -1,10 +1,11 @@
-import type { AgentMessage, AgentMessageUsage } from "@pragma/shared";
+import type { AgentMessage, AgentMessageUsage, RuntimeContextWindowUsage } from "@pragma/shared";
 
 import type { Expert } from "../agent/expert-agent.ts";
 import type { PragmaLogger } from "../logging/logger.ts";
 import { dispatchExpertAgentHook } from "../plugins/expert-agent-plugin.ts";
 import type { RuntimeSessionInfo } from "./runtime-adapter.ts";
 import type { ExpertAgentRunContext } from "./run-context.ts";
+import { mergeUsage } from "./usage.ts";
 import {
   createRuntimeEventEmitter,
   type RuntimeEventEmitter,
@@ -28,6 +29,7 @@ export interface RuntimeEventMappingResult {
   readonly outputDelta?: string | undefined;
   readonly completedText?: string | undefined;
   readonly usage?: AgentMessageUsage | undefined;
+  readonly contextWindowUsage?: RuntimeContextWindowUsage | undefined;
   readonly runtimeSessionId?: string | undefined;
 }
 
@@ -75,6 +77,14 @@ export interface RuntimeStreamController<TNativeEvent> {
   readonly getUsage: () => AgentMessageUsage | undefined;
   readonly getRuntimeSessionId: () => string | undefined;
   readonly resetCapture: () => void;
+  readonly beginUsagePreview: (input: {
+    readonly prompt: string;
+    readonly accumulatedUsage?: AgentMessageUsage | undefined;
+    readonly contextWindow?: RuntimeContextWindowUsage | undefined;
+  }) => void;
+  readonly updateContextWindowUsage: (usage: RuntimeContextWindowUsage | undefined) => void;
+  readonly updateUsage: (usage: AgentMessageUsage | undefined) => void;
+  readonly flushTelemetry: (provisional: boolean) => void;
   readonly complete: () => Promise<void>;
 }
 
@@ -93,10 +103,6 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
     event: TNativeEvent,
     context: RuntimeEventMappingContext,
   ) => RuntimeEventMappingResult;
-  readonly mergeUsage: (
-    current: AgentMessageUsage | undefined,
-    next: AgentMessageUsage | undefined,
-  ) => AgentMessageUsage | undefined;
 }): RuntimeStreamController<TNativeEvent> {
   const emitter = createRuntimeEventEmitter(options.queue);
   const source =
@@ -110,8 +116,20 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   const eventFactory = createRuntimeStreamEventFactory(options.runId, source);
   const pendingHookCalls: Promise<void>[] = [];
   let outputText = "";
+  let thoughtText = "";
   let usage: AgentMessageUsage | undefined;
+  let accumulatedUsage: AgentMessageUsage | undefined;
+  let estimatedInputTokens = 0;
+  let contextWindowBase: RuntimeContextWindowUsage | undefined;
+  let contextWindowUsage: RuntimeContextWindowUsage | undefined;
   let runtimeSessionId: string | undefined;
+  let latestUsagePreview: AgentMessageUsage | undefined;
+  let latestContextWindowPreview: RuntimeContextWindowUsage | undefined;
+  let lastUsageSignature = "";
+  let lastContextWindowSignature = "";
+  let telemetryTimer: ReturnType<typeof setTimeout> | undefined;
+  let lastTelemetryAt = 0;
+  let telemetryFinalized = false;
   const streamStartedAt = performance.now();
   let firstNativeEventLogged = false;
   let firstReasoningDeltaLogged = false;
@@ -129,6 +147,79 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
         logger: options.logger,
       }),
     );
+  };
+
+  const emitTelemetry = (provisional: boolean): void => {
+    if (telemetryTimer !== undefined) {
+      clearTimeout(telemetryTimer);
+      telemetryTimer = undefined;
+    }
+    lastTelemetryAt = performance.now();
+    if (!provisional) telemetryFinalized = true;
+    if (latestUsagePreview !== undefined) {
+      const signature = JSON.stringify(latestUsagePreview);
+      if (signature !== lastUsageSignature || !provisional) {
+        lastUsageSignature = signature;
+        emit({
+          runId: options.runId,
+          source,
+          type: "usage.updated",
+          payload: { usage: latestUsagePreview, provisional },
+        });
+      }
+    }
+    if (latestContextWindowPreview !== undefined) {
+      const signature = JSON.stringify(latestContextWindowPreview);
+      if (signature !== lastContextWindowSignature || !provisional) {
+        lastContextWindowSignature = signature;
+        emit({
+          runId: options.runId,
+          source,
+          type: "context-window.updated",
+          payload: { usage: latestContextWindowPreview, provisional },
+        });
+      }
+    }
+  };
+
+  const scheduleTelemetry = (): void => {
+    const elapsed = performance.now() - lastTelemetryAt;
+    if (lastTelemetryAt === 0 || elapsed >= 100) {
+      emitTelemetry(true);
+      return;
+    }
+    if (telemetryTimer !== undefined) return;
+    telemetryTimer = setTimeout(() => emitTelemetry(true), Math.max(0, 100 - elapsed));
+  };
+
+  const updateUsagePreview = (): void => {
+    const estimatedOutputTokens = estimateTokenCount(`${thoughtText}${outputText}`);
+    const attemptUsage =
+      usage ??
+      createEstimatedUsage({
+        input: estimatedInputTokens,
+        output: estimatedOutputTokens,
+      });
+    latestUsagePreview = mergeUsage(accumulatedUsage, attemptUsage);
+    const contextSource = contextWindowUsage ?? contextWindowBase;
+    if (contextSource !== undefined) {
+      const usedTokens =
+        contextWindowUsage !== undefined
+          ? contextWindowUsage.usedTokens
+          : contextSource.usedTokens === null
+            ? null
+            : contextSource.usedTokens + attemptUsage.totalTokens;
+      latestContextWindowPreview = {
+        usedTokens,
+        contextWindowTokens: contextSource.contextWindowTokens,
+        percent:
+          usedTokens === null ? null : (usedTokens / contextSource.contextWindowTokens) * 100,
+        measurement:
+          contextWindowUsage === undefined ? "estimated" : contextWindowUsage.measurement,
+        observedAt: new Date().toISOString(),
+      };
+    }
+    scheduleTelemetry();
   };
 
   const applyMappingResult = (result: RuntimeEventMappingResult): void => {
@@ -159,8 +250,19 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
     if (result.completedText !== undefined) {
       outputText = result.completedText;
     }
-    usage = options.mergeUsage(usage, result.usage);
+    usage = result.usage ?? usage;
+    contextWindowUsage = result.contextWindowUsage ?? contextWindowUsage;
     runtimeSessionId = result.runtimeSessionId ?? runtimeSessionId;
+    for (const event of result.events ?? []) {
+      if (
+        event.type === "thought.delta" &&
+        "delta" in event.payload &&
+        typeof event.payload.delta === "string"
+      ) {
+        thoughtText += event.payload.delta;
+      }
+    }
+    updateUsagePreview();
   };
 
   return {
@@ -190,6 +292,26 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
       },
       write(event) {
         emit(event);
+        if (event.type === "message.delta" && "delta" in event.payload) {
+          outputText += event.payload.delta;
+          updateUsagePreview();
+        } else if (event.type === "thought.delta" && "delta" in event.payload) {
+          thoughtText += event.payload.delta;
+          updateUsagePreview();
+        } else if (event.type === "message.completed") {
+          if ("text" in event.payload && typeof event.payload.text === "string") {
+            outputText = event.payload.text;
+          }
+          if (
+            "message" in event.payload &&
+            typeof event.payload.message === "object" &&
+            event.payload.message !== null &&
+            event.payload.message.role === "assistant"
+          ) {
+            usage = event.payload.message.usage;
+          }
+          updateUsagePreview();
+        }
       },
     },
     getOutputText: () => outputText,
@@ -197,12 +319,67 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
     getRuntimeSessionId: () => runtimeSessionId,
     resetCapture() {
       outputText = "";
+      thoughtText = "";
       usage = undefined;
+      contextWindowUsage = undefined;
       runtimeSessionId = undefined;
     },
+    beginUsagePreview(input) {
+      accumulatedUsage = input.accumulatedUsage;
+      estimatedInputTokens = estimateTokenCount(input.prompt);
+      contextWindowBase = input.contextWindow;
+      contextWindowUsage = undefined;
+      updateUsagePreview();
+    },
+    updateContextWindowUsage(next) {
+      if (next === undefined) return;
+      contextWindowUsage = next;
+      updateUsagePreview();
+    },
+    updateUsage(next) {
+      if (next === undefined) return;
+      latestUsagePreview = next;
+      scheduleTelemetry();
+    },
+    flushTelemetry(provisional) {
+      emitTelemetry(provisional);
+    },
     async complete() {
+      if (!telemetryFinalized) emitTelemetry(false);
+      else if (telemetryTimer !== undefined) {
+        clearTimeout(telemetryTimer);
+        telemetryTimer = undefined;
+      }
       await Promise.allSettled(pendingHookCalls);
       emitter.complete();
+    },
+  };
+}
+
+function estimateTokenCount(value: string): number {
+  let ascii = 0;
+  let nonAscii = 0;
+  for (const character of value) {
+    if (character.codePointAt(0)! <= 0x7f) ascii += 1;
+    else nonAscii += 1;
+  }
+  return Math.ceil(ascii / 4) + nonAscii;
+}
+
+function createEstimatedUsage(input: { readonly input: number; readonly output: number }) {
+  return {
+    measurement: "estimated" as const,
+    input: input.input,
+    output: input.output,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: input.input + input.output,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
     },
   };
 }

--- a/packages/core/src/runtime/stream-controller.ts
+++ b/packages/core/src/runtime/stream-controller.ts
@@ -79,6 +79,8 @@ export interface RuntimeStreamController<TNativeEvent> {
   readonly resetCapture: () => void;
   readonly beginUsagePreview: (input: {
     readonly prompt: string;
+    readonly startupMessages?: readonly string[] | undefined;
+    readonly sessionSeed?: string | undefined;
     readonly accumulatedUsage?: AgentMessageUsage | undefined;
     readonly contextWindow?: RuntimeContextWindowUsage | undefined;
   }) => void;
@@ -120,6 +122,7 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   let usage: AgentMessageUsage | undefined;
   let accumulatedUsage: AgentMessageUsage | undefined;
   let estimatedInputTokens = 0;
+  let estimatedContextInputTokens = 0;
   let contextWindowBase: RuntimeContextWindowUsage | undefined;
   let contextWindowUsage: RuntimeContextWindowUsage | undefined;
   let runtimeSessionId: string | undefined;
@@ -208,7 +211,7 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
           ? contextWindowUsage.usedTokens
           : contextSource.usedTokens === null
             ? null
-            : contextSource.usedTokens + attemptUsage.totalTokens;
+            : contextSource.usedTokens + estimatedContextInputTokens + estimatedOutputTokens;
       latestContextWindowPreview = {
         usedTokens,
         contextWindowTokens: contextSource.contextWindowTokens,
@@ -326,7 +329,13 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
     },
     beginUsagePreview(input) {
       accumulatedUsage = input.accumulatedUsage;
-      estimatedInputTokens = estimateTokenCount(input.prompt);
+      const turnInput = [...(input.startupMessages ?? []), input.prompt].join("\n\n");
+      estimatedInputTokens = estimateTokenCount(turnInput);
+      estimatedContextInputTokens =
+        estimatedInputTokens +
+        (input.sessionSeed === undefined || input.contextWindow?.usedTokens !== 0
+          ? 0
+          : estimateTokenCount(input.sessionSeed));
       contextWindowBase = input.contextWindow;
       contextWindowUsage = undefined;
       updateUsagePreview();

--- a/packages/core/src/runtime/stream-controller.ts
+++ b/packages/core/src/runtime/stream-controller.ts
@@ -80,7 +80,7 @@ export interface RuntimeStreamController<TNativeEvent> {
   readonly beginUsagePreview: (input: {
     readonly prompt: string;
     readonly startupMessages?: readonly string[] | undefined;
-    readonly sessionSeed?: string | undefined;
+    readonly contextBaselineCalibrated?: boolean | undefined;
     readonly accumulatedUsage?: AgentMessageUsage | undefined;
     readonly contextWindow?: RuntimeContextWindowUsage | undefined;
   }) => void;
@@ -123,6 +123,7 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   let accumulatedUsage: AgentMessageUsage | undefined;
   let estimatedInputTokens = 0;
   let estimatedContextInputTokens = 0;
+  let contextBaselineCalibrated = false;
   let contextWindowBase: RuntimeContextWindowUsage | undefined;
   let contextWindowUsage: RuntimeContextWindowUsage | undefined;
   let runtimeSessionId: string | undefined;
@@ -209,7 +210,7 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
       const usedTokens =
         contextWindowUsage !== undefined
           ? contextWindowUsage.usedTokens
-          : contextSource.usedTokens === null
+          : !contextBaselineCalibrated || contextSource.usedTokens === null
             ? null
             : contextSource.usedTokens + estimatedContextInputTokens + estimatedOutputTokens;
       latestContextWindowPreview = {
@@ -331,11 +332,12 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
       accumulatedUsage = input.accumulatedUsage;
       const turnInput = [...(input.startupMessages ?? []), input.prompt].join("\n\n");
       estimatedInputTokens = estimateTokenCount(turnInput);
-      estimatedContextInputTokens =
-        estimatedInputTokens +
-        (input.sessionSeed === undefined || input.contextWindow?.usedTokens !== 0
-          ? 0
-          : estimateTokenCount(input.sessionSeed));
+      estimatedContextInputTokens = estimatedInputTokens;
+      contextBaselineCalibrated =
+        input.contextBaselineCalibrated ??
+        (input.contextWindow?.usedTokens !== null &&
+          input.contextWindow?.usedTokens !== undefined &&
+          input.contextWindow.usedTokens > 0);
       contextWindowBase = input.contextWindow;
       contextWindowUsage = undefined;
       updateUsagePreview();

--- a/packages/core/src/runtime/usage.ts
+++ b/packages/core/src/runtime/usage.ts
@@ -22,7 +22,9 @@ export interface RuntimeUsageObservation {
  * the cross-execution usage ledger.
  */
 export interface UsageSink {
+  readonly preview?: ((observation: RuntimeUsageObservation) => Promise<void> | void) | undefined;
   readonly record: (observation: RuntimeUsageObservation) => Promise<void> | void;
+  readonly clearPreview?: ((observationId: string) => Promise<void> | void) | undefined;
 }
 
 export interface RuntimeTokenUsageInput {

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -853,11 +853,19 @@ describe("ExpertSession", () => {
       cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
     };
     const observations: RuntimeUsageObservation[] = [];
+    const previews: RuntimeUsageObservation[] = [];
+    const clearedPreviews: string[] = [];
     const { app, expert } = await trackedFixture(
       { usage: perTurnUsage },
       {
+        preview: (observation) => {
+          previews.push(observation);
+        },
         record: (observation) => {
           observations.push(observation);
+        },
+        clearPreview: (observationId) => {
+          clearedPreviews.push(observationId);
         },
       },
     );
@@ -866,6 +874,10 @@ describe("ExpertSession", () => {
     await turn.result;
 
     expect(observations).toHaveLength(1);
+    expect(previews.length).toBeGreaterThanOrEqual(2);
+    expect(previews[0]?.usage.measurement).toBe("estimated");
+    expect(previews.at(-1)?.usage).toEqual(perTurnUsage);
+    expect(clearedPreviews).toEqual([observations[0]!.observationId]);
     expect(observations[0]).toMatchObject({
       executionId: turn.executionId,
       invocationId: turn.executionId,
@@ -877,6 +889,9 @@ describe("ExpertSession", () => {
     const failing = await trackedFixture(
       { usage: perTurnUsage },
       {
+        preview: () => {
+          throw new Error("host preview unavailable");
+        },
         record: () => {
           throw new Error("host unavailable");
         },
@@ -887,6 +902,44 @@ describe("ExpertSession", () => {
       (
         await failingSession.prompt("still succeeds", {
           requestId: "usage-sink-failure",
+        })
+      ).result,
+    ).resolves.toBeDefined();
+
+    const failingClear = await trackedFixture(
+      {},
+      {
+        record: () => undefined,
+        clearPreview: () => {
+          throw new Error("host clear unavailable");
+        },
+      },
+    );
+    const failingClearSession = await failingClear.app.experts.createSession(failingClear.expert);
+    await expect(
+      (
+        await failingClearSession.prompt("still succeeds without final usage", {
+          requestId: "usage-sink-clear-failure",
+        })
+      ).result,
+    ).resolves.toBeDefined();
+
+    const failingFinalClear = await trackedFixture(
+      { usage: perTurnUsage },
+      {
+        record: () => undefined,
+        clearPreview: () => {
+          throw new Error("host final clear unavailable");
+        },
+      },
+    );
+    const failingFinalClearSession = await failingFinalClear.app.experts.createSession(
+      failingFinalClear.expert,
+    );
+    await expect(
+      (
+        await failingFinalClearSession.prompt("still succeeds with final usage", {
+          requestId: "usage-sink-final-clear-failure",
         })
       ).result,
     ).resolves.toBeDefined();
@@ -1140,16 +1193,27 @@ describe("ExpertSession", () => {
   });
 
   it("cancels only the active submission and reuses its Runtime Session", async () => {
-    const { app, expert, stats } = await trackedFixture({ delayMs: 100 });
+    const clearedPreviews: string[] = [];
+    const { app, expert, stats } = await trackedFixture(
+      { delayMs: 100 },
+      {
+        record: () => undefined,
+        clearPreview: (observationId) => {
+          clearedPreviews.push(observationId);
+        },
+      },
+    );
     const session = await app.experts.createSession(expert);
     const active = await session.prompt("slow", { requestId: "slow" });
     await waitUntil(async () => stats.executionIds.length === 1);
     const cancelled = expect(active.result).rejects.toThrow();
     await active.cancel("stop current turn");
     await cancelled;
+    await waitUntil(async () => clearedPreviews.length === 1);
 
     const next = await session.prompt("next", { requestId: "next" });
     await expect(next.result).resolves.toBe("tracked:next");
+    await waitUntil(async () => clearedPreviews.length === 2);
     expect(stats.createSessionCalls).toBe(1);
     expect(stats.cancelTurnCalls).toBe(1);
     expect(stats.executionIds).toEqual([active.executionId, next.executionId]);

--- a/packages/core/test/runtime-session-environment.test.ts
+++ b/packages/core/test/runtime-session-environment.test.ts
@@ -93,6 +93,52 @@ describe("Runtime Session process environment", () => {
 });
 
 describe("Runtime Session context window", () => {
+  it("calibrates the live estimate from the refreshed Runtime baseline before a turn starts", async () => {
+    const root = await temporaryRoot();
+    const inspect = vi.fn(() =>
+      createRuntimeContextWindowUsage({
+        usedTokens: 40_000,
+        contextWindowTokens: 200_000,
+        measurement: "reported",
+      }),
+    );
+    const runtime = defineRuntimeDriver<never, Record<string, never>>({
+      descriptor: { id: "context-test", kind: "context-test", displayName: "Context Test" },
+      createSession: () => ({}),
+      startTurn: async (_session, turn) => {
+        turn.stream.write({
+          runId: turn.runId,
+          source: turn.source,
+          type: "message.delta",
+          payload: { contentType: "text", delta: "done" },
+        });
+        return { outputText: "done" };
+      },
+      mapEvent: () => ({ events: [] }),
+      readContextWindow: inspect,
+    });
+    const agent = await expert(root, "context-live-expert", "token");
+    const session = await open(agent, runtime, "context-live-session");
+    const submission = session.submit({ query: "12345678", execution: {} });
+    const eventsPromise = (async () => {
+      const events = [];
+      for await (const event of submission.events) events.push(event);
+      return events;
+    })();
+
+    await submission.result;
+    const events = await eventsPromise;
+    const contextUpdates = events.filter((event) => event.type === "context-window.updated");
+    const liveUpdate = contextUpdates.find((event) => event.payload.provisional);
+
+    expect(liveUpdate?.payload.usage).toMatchObject({
+      usedTokens: 40_002,
+      measurement: "estimated",
+    });
+    expect(inspect).toHaveBeenCalledTimes(2);
+    await session.close();
+  });
+
   it("persists inspection and compaction snapshots independently of billing usage", async () => {
     const root = await temporaryRoot();
     const inspect = vi.fn(() =>

--- a/packages/core/test/runtime-stream-controller.test.ts
+++ b/packages/core/test/runtime-stream-controller.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AsyncPushQueue,
+  createLoggerProvider,
+  createRuntimeStreamController,
+  type Expert,
+  type RuntimeStreamEvent,
+} from "../src/index.ts";
+
+describe("Runtime stream telemetry", () => {
+  it("keeps context estimates independent from full reported turn usage", async () => {
+    const { controller, queue } = createFixture();
+
+    controller.beginUsagePreview({
+      prompt: "1234",
+      startupMessages: ["1234"],
+      sessionSeed: "12345678",
+      contextWindow: {
+        usedTokens: 1_000,
+        contextWindowTokens: 100_000,
+        percent: 1,
+        measurement: "reported",
+        observedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    controller.writer.write({
+      runId: "run-1",
+      source: controller.source,
+      type: "message.delta",
+      payload: { contentType: "text", delta: "12345678" },
+    });
+    controller.writer.writeNative(50_000);
+    controller.flushTelemetry(false);
+    await controller.complete();
+
+    const events: RuntimeStreamEvent[] = [];
+    for await (const event of queue) events.push(event);
+    const contextUpdates = events.filter((event) => event.type === "context-window.updated");
+    const last = contextUpdates.at(-1);
+
+    expect(last?.payload.usage).toMatchObject({
+      usedTokens: 1_005,
+      measurement: "estimated",
+    });
+    expect(
+      events.findLast((event) => event.type === "usage.updated")?.payload.usage.totalTokens,
+    ).toBe(50_000);
+  });
+
+  it("includes the session prompt seed only for an empty context", async () => {
+    const { controller, queue } = createFixture();
+    controller.beginUsagePreview({
+      prompt: "1234",
+      startupMessages: ["1234"],
+      sessionSeed: "12345678",
+      contextWindow: {
+        usedTokens: 0,
+        contextWindowTokens: 100_000,
+        percent: 0,
+        measurement: "estimated",
+        observedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    controller.writer.write({
+      runId: "run-1",
+      source: controller.source,
+      type: "message.delta",
+      payload: { contentType: "text", delta: "12345678" },
+    });
+    controller.flushTelemetry(false);
+    await controller.complete();
+
+    const events: RuntimeStreamEvent[] = [];
+    for await (const event of queue) events.push(event);
+
+    expect(
+      events.findLast((event) => event.type === "context-window.updated")?.payload.usage,
+    ).toMatchObject({ usedTokens: 7, measurement: "estimated" });
+  });
+});
+
+function createFixture() {
+  const queue = new AsyncPushQueue<RuntimeStreamEvent>();
+  const controller = createRuntimeStreamController<number>({
+    agent: {
+      id: "telemetry-expert",
+      hooks: undefined,
+    } as unknown as Expert,
+    queue,
+    runId: "run-1",
+    session: () => ({
+      systemSessionId: "session-1",
+      runtimeSession: { type: "test", id: "native-1" },
+      agentId: "telemetry-expert",
+      runtime: { id: "test", kind: "test", displayName: "Test" },
+      sessionState: "active",
+      runState: "running",
+    }),
+    logger: createLoggerProvider({
+      minimumLevel: "silent",
+      handler: { write: () => undefined },
+    }).createLogger({ component: "test" }),
+    mapEvent: (usage) => ({
+      usage: {
+        measurement: "reported",
+        input: usage,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: usage,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+    }),
+  });
+  return { controller, queue };
+}

--- a/packages/core/test/runtime-stream-controller.test.ts
+++ b/packages/core/test/runtime-stream-controller.test.ts
@@ -15,7 +15,7 @@ describe("Runtime stream telemetry", () => {
     controller.beginUsagePreview({
       prompt: "1234",
       startupMessages: ["1234"],
-      sessionSeed: "12345678",
+      contextBaselineCalibrated: true,
       contextWindow: {
         usedTokens: 1_000,
         contextWindowTokens: 100_000,
@@ -48,12 +48,12 @@ describe("Runtime stream telemetry", () => {
     ).toBe(50_000);
   });
 
-  it("includes the session prompt seed only for an empty context", async () => {
+  it("does not publish a misleading numeric estimate before the Runtime baseline is calibrated", async () => {
     const { controller, queue } = createFixture();
     controller.beginUsagePreview({
       prompt: "1234",
       startupMessages: ["1234"],
-      sessionSeed: "12345678",
+      contextBaselineCalibrated: false,
       contextWindow: {
         usedTokens: 0,
         contextWindowTokens: 100_000,
@@ -76,7 +76,7 @@ describe("Runtime stream telemetry", () => {
 
     expect(
       events.findLast((event) => event.type === "context-window.updated")?.payload.usage,
-    ).toMatchObject({ usedTokens: 7, measurement: "estimated" });
+    ).toMatchObject({ usedTokens: null, percent: null, measurement: "estimated" });
   });
 });
 

--- a/packages/runtime/codex/src/session.ts
+++ b/packages/runtime/codex/src/session.ts
@@ -214,6 +214,7 @@ export function mapCodexNotificationToRuntimeEvent(
   let outputDelta: string | undefined;
   let completedText: string | undefined;
   let usage: AgentMessageUsage | undefined;
+  let contextWindowUsage: RuntimeContextWindowUsage | undefined;
   const threadId = readNotificationThreadId(notification) ?? rootThreadId;
   const turnId = readNotificationTurnId(notification);
   const nested = threadId !== rootThreadId;
@@ -319,7 +320,10 @@ export function mapCodexNotificationToRuntimeEvent(
     notification.method === "thread/tokenUsage/updated" ||
     notification.method === "turn/completed"
   ) {
-    if (!nested) usage = readUsage(notification.params);
+    if (!nested) {
+      usage = readUsage(notification.params);
+      contextWindowUsage = parseCodexContextWindowUsage(notification.params);
+    }
   }
 
   return {
@@ -327,6 +331,7 @@ export function mapCodexNotificationToRuntimeEvent(
     ...(outputDelta === undefined ? {} : { outputDelta }),
     ...(completedText === undefined ? {} : { completedText }),
     ...(usage === undefined ? {} : { usage }),
+    ...(contextWindowUsage === undefined ? {} : { contextWindowUsage }),
   };
 }
 

--- a/packages/runtime/codex/test/session.test.ts
+++ b/packages/runtime/codex/test/session.test.ts
@@ -63,6 +63,47 @@ describe("Codex context window", () => {
     });
   });
 
+  it("maps root token notifications to live usage and context-window snapshots", () => {
+    const result = mapCodexNotificationToRuntimeEvent(
+      {
+        rootThreadId: "thread-1",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            tokenUsage: {
+              last: {
+                inputTokens: 40_000,
+                cachedInputTokens: 10_000,
+                outputTokens: 2_000,
+                totalTokens: 42_000,
+                reasoningOutputTokens: 2_000,
+              },
+              modelContextWindow: 200_000,
+            },
+          },
+        },
+      },
+      {
+        runId: "run-1",
+        source: { kind: "runtime", runId: "run-1", path: [] },
+        events: {},
+      } as unknown as RuntimeEventMappingContext,
+    );
+
+    expect(result.usage).toMatchObject({
+      input: 30_000,
+      output: 2_000,
+      cacheRead: 10_000,
+      totalTokens: 42_000,
+    });
+    expect(result.contextWindowUsage).toMatchObject({
+      usedTokens: 40_000,
+      contextWindowTokens: 200_000,
+      percent: 20,
+    });
+  });
+
   it("waits for compact completion and returns refreshed thread usage", async () => {
     const notificationBus = createCodexNotificationBus();
     const client = {

--- a/packages/shared/src/execution/execution.schema.ts
+++ b/packages/shared/src/execution/execution.schema.ts
@@ -198,7 +198,7 @@ export const ExecutionOutputItemSchema = z.object({
   runId: z.string().min(1),
   parentRunId: z.string().min(1).optional(),
   source: ExpertAgentStreamSourceSchema,
-  channel: z.enum(["message", "thought", "tool", "progress", "result", "agent"]),
+  channel: z.enum(["message", "thought", "tool", "progress", "result", "agent", "telemetry"]),
   delta: z.string().optional(),
   value: z.unknown().optional(),
   occurredAt: z.string().datetime(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from "./logging/log.schema.ts";
 export * from "./model-provider.schema.ts";
 export * from "./mission/mission-executor.schema.ts";
 export * from "./result.ts";
+export * from "./runtime-context-window.schema.ts";
 export {
   RunStatus as ExecutionRunStatus,
   type RunStatus as ExecutionRunStatusValue,

--- a/packages/shared/src/runtime-context-window.schema.ts
+++ b/packages/shared/src/runtime-context-window.schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const RuntimeContextWindowMeasurementSchema = z.enum(["reported", "derived", "estimated"]);
+
+export const RuntimeContextWindowUsageSchema = z.object({
+  usedTokens: z.number().int().nonnegative().nullable(),
+  contextWindowTokens: z.number().int().positive(),
+  percent: z.number().nonnegative().nullable(),
+  measurement: RuntimeContextWindowMeasurementSchema,
+  observedAt: z.string().datetime(),
+});
+
+export type RuntimeContextWindowMeasurement = z.infer<typeof RuntimeContextWindowMeasurementSchema>;
+export type RuntimeContextWindowUsage = z.infer<typeof RuntimeContextWindowUsageSchema>;

--- a/packages/shared/src/stream-event.schema.ts
+++ b/packages/shared/src/stream-event.schema.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
-import {
-  AgentMessageSchema,
-  AgentMessageUsageWireSchema,
-} from "./agent-message.schema.ts";
+import { AgentMessageSchema, AgentMessageUsageWireSchema } from "./agent-message.schema.ts";
+import { RuntimeContextWindowUsageSchema } from "./runtime-context-window.schema.ts";
 
 export const ExpertAgentStreamSchemaVersionSchema = z.literal("pragma.stream/v1");
 
@@ -103,6 +101,22 @@ export const ExpertAgentProgressEventSchema = ExpertAgentStreamEventBaseSchema.e
   }),
 });
 
+export const ExpertAgentUsageUpdatedEventSchema = ExpertAgentStreamEventBaseSchema.extend({
+  type: z.literal("usage.updated"),
+  payload: z.object({
+    usage: AgentMessageUsageWireSchema,
+    provisional: z.boolean(),
+  }),
+});
+
+export const ExpertAgentContextWindowUpdatedEventSchema = ExpertAgentStreamEventBaseSchema.extend({
+  type: z.literal("context-window.updated"),
+  payload: z.object({
+    usage: RuntimeContextWindowUsageSchema,
+    provisional: z.boolean(),
+  }),
+});
+
 export const ExpertAgentToolStartedEventSchema = ExpertAgentStreamEventBaseSchema.extend({
   type: z.literal("tool.started"),
   payload: z.object({
@@ -190,6 +204,8 @@ export const ExpertAgentStreamEventSchema = z.discriminatedUnion("type", [
   ExpertAgentMessageCompletedEventSchema,
   ExpertAgentThoughtDeltaEventSchema,
   ExpertAgentProgressEventSchema,
+  ExpertAgentUsageUpdatedEventSchema,
+  ExpertAgentContextWindowUpdatedEventSchema,
   ExpertAgentToolStartedEventSchema,
   ExpertAgentToolDeltaEventSchema,
   ExpertAgentToolApprovalRequestedEventSchema,


### PR DESCRIPTION
## Summary

- stream Mission context-window occupancy while a Runtime turn is active
- keep the composer’s cumulative Mission token total stable during execution and refresh it only after the conversation round settles
- hide the Mission total before the first settled round, then show it in the composer’s upper-right corner as `已使用 xx tokens`
- avoid publishing a misleading numeric context estimate until the Runtime has supplied a non-empty context baseline
- reconcile provisional telemetry with settled accounting without persisting or double-counting estimates

## Root cause

Mission token accounting and context-window occupancy are different metrics: the former is cumulative billing usage across Runtime turns, while the latter is the current root Runtime Session context.

The composer originally exposed provisional cumulative usage directly, which made the Mission total jump during a reply. The context fallback also treated the final reported turn input as a new context increment, even though Runtime input usage can already include existing history and cache reads. On the first turn, Core cannot observe every Runtime-owned system prompt, built-in tool declaration, or other private context component; estimating only the visible prompt/output therefore showed a few thousand tokens before the authoritative Runtime snapshot reported the full value (for example, 32k).

## Implementation

- add live `usage.updated` and `context-window.updated` stream events plus a telemetry output channel
- keep usage previews replaceable and in memory, while `getMissionUsage` returns persisted totals only
- freeze the composer Mission total for the whole active execution and refresh it on active-to-idle settlement
- render no Mission token hint while the settled total is zero
- move the compact settled total into the composer’s upper-right corner
- refresh the Runtime context snapshot before each turn and calibrate live estimates only from a non-empty baseline
- report context occupancy as unknown before first calibration instead of presenting prompt/output-only counts as the full context
- estimate later context increments from only the current prompt/startup/output text, never from full reported billing usage
- prefer Runtime-reported or Runtime-derived context snapshots whenever available
- project root Mission context-window telemetry as live chat patches
- isolate preview, record, and clear failures so analytics never change execution outcomes
- document the Host-owned preview lifecycle in ADR 025

## Code review

Claude Code review completed with no blocking findings. One low-severity cross-Mission execution-state ref issue was accepted and fixed. Two informational findings were verified as intentional behavior: persisted-only direct Mission totals versus provisional subscriber updates, and requiring a context-window baseline before emitting estimates. The follow-up calibration change was additionally reviewed against the driver/controller event ordering and covered by an integration regression test.

## Validation

- Core and Desktop typechecks passed
- focused Core telemetry tests passed: 6/6
- focused Desktop Mission and i18n tests passed: 44/44
- Core and Desktop lint passed
- Core and Desktop production builds passed
- Desktop preload self-containment and `pragmaDesktop` bridge verification passed
- Prettier and `git diff --check` passed
- earlier repository-wide lint, typecheck, test, and production build checks passed for all 19 workspaces