### PR TITLE
feat(desktop): show models in runtime environment list

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.test.tsx
@@ -11,7 +11,7 @@ const runtime: DesktopRuntimeAvailability = {
   origin: "built-in",
   adapter: { id: "pragma.runtime.codex", version: "1.0.0" },
   isDefault: true,
-  kind: "Codex CLI",
+  kind: "codex-local",
   displayName: "Codex",
   status: "available",
   executablePath: "/usr/local/bin/codex",
@@ -30,16 +30,23 @@ const runtime: DesktopRuntimeAvailability = {
         defaultLevel: "medium",
       },
     },
+    {
+      id: "gpt-5.5-codex-mini",
+      displayName: "GPT-5.5 Codex Mini",
+      provider: { kind: "runtime-managed", id: "openai", displayName: "OpenAI" },
+    },
   ],
 };
 
 describe("Runtime Environment settings", () => {
-  it("keeps model names out of the Runtime directory card", () => {
+  it("centers model names in the Runtime directory card without internal identity", () => {
     const html = renderToStaticMarkup(<RuntimeCard runtime={runtime} onOpen={() => undefined} />);
 
-    expect(html).toContain("1 model");
-    expect(html).toContain("View details");
-    expect(html).not.toContain("GPT-5.6 Codex");
+    expect(html).toContain('class="runtime-summary-models"');
+    expect(html).toContain("GPT-5.6 Codex");
+    expect(html).toContain("GPT-5.5 Codex Mini");
+    expect(html).not.toContain("codex-local");
+    expect(html).not.toContain("built-in");
     expect(html).not.toContain("gpt-5.6-codex");
   });
 

--- a/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.tsx
@@ -1,10 +1,10 @@
-import { CaretRight, TerminalWindow } from "@phosphor-icons/react";
+import { TerminalWindow } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { DesktopRuntimeAvailability } from "../../../../shared/contracts/index.ts";
 import { errorMessage } from "../../lib/errors.ts";
-import { isBuiltInRuntime, runtimeDisplayName } from "../../lib/runtime-display.ts";
+import { runtimeDisplayName } from "../../lib/runtime-display.ts";
 import { RuntimeEnvironmentDetail } from "./RuntimeEnvironmentDetail.tsx";
 import { SettingsScreenFrame } from "./SettingsScreenFrame.tsx";
 
@@ -14,11 +14,8 @@ export function RuntimeCard(props: {
 }) {
   const { t } = useTranslation(["settings", "common"]);
   const available = props.runtime.status === "available";
-  const modelCount = props.runtime.models?.length;
   const displayName = runtimeDisplayName(t, props.runtime);
-  const runtimeType = isBuiltInRuntime(props.runtime)
-    ? t("runtimes.builtIn", { ns: "settings" })
-    : props.runtime.kind;
+  const models = props.runtime.models;
 
   return (
     <article className="runtime-card runtime-summary-card">
@@ -51,22 +48,21 @@ export function RuntimeCard(props: {
         </span>
       </header>
 
-      <div className="runtime-summary-footer">
-        <div>
-          <p>{runtimeType}</p>
-          <span>
-            {modelCount === undefined
-              ? t("runtimes.catalogUnavailable", { ns: "settings" })
-              : t("counts.model", { ns: "common", count: modelCount })}
-          </span>
-        </div>
-        <span className="runtime-open-detail" aria-hidden="true">
-          {t("actions.viewDetails", { ns: "common" })}
-          <CaretRight size={17} />
-        </span>
+      <div className="runtime-summary-models" aria-label={t("runtimes.models", { ns: "settings" })}>
+        {models === undefined ? (
+          <span>{t("runtimes.catalogUnavailable", { ns: "settings" })}</span>
+        ) : models.length === 0 ? (
+          <span>{t("runtimes.noModels", { ns: "settings" })}</span>
+        ) : (
+          models.map((model) => <span key={runtimeModelKey(model)}>{model.displayName}</span>)
+        )}
       </div>
     </article>
   );
+}
+
+function runtimeModelKey(model: NonNullable<DesktopRuntimeAvailability["models"]>[number]): string {
+  return JSON.stringify([model.provider.kind, model.provider.id, model.id]);
 }
 
 export function RuntimeEnvironmentsFragment() {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -6030,40 +6030,20 @@ p {
   outline: 0;
 }
 
-.runtime-summary-footer {
+.runtime-summary-models {
   display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 24px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px 20px;
   margin-top: 20px;
   padding-top: 17px;
   border-top: 1px solid var(--border);
-}
-
-.runtime-summary-footer > div {
-  display: grid;
-  gap: 4px;
-}
-
-.runtime-summary-footer p {
-  color: var(--text);
+  color: var(--muted);
   font-size: 13px;
   font-weight: 610;
-}
-
-.runtime-summary-footer > div > span {
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.runtime-open-detail {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  color: var(--green-dark);
-  font-size: 12px;
-  font-weight: 650;
-  white-space: nowrap;
+  line-height: 1.5;
+  text-align: center;
 }
 
 .runtime-detail-back {


### PR DESCRIPTION
## What changed

- Replace the runtime card footer's internal runtime type and model count with the runtime's model display names.
- Center model names with consistent typography and wrapping.
- Preserve localized runtime display names and empty/unavailable catalog states.
- Add coverage ensuring internal values such as `built-in`, `codex-local`, and model IDs are not exposed in the directory card.

## Why

The Runtime Environments settings list exposed implementation details instead of the information users need to choose a runtime. Showing readable model names makes the list easier to scan and keeps internal identifiers out of the primary UI.

## User impact

Runtime cards now show their available models directly in a centered summary. Cards remain clickable for full runtime details.

## Validation

- `pnpm --dir apps/desktop exec vitest run src/renderer/src/pages/settings/RuntimeEnvironmentsFragment.test.tsx`
- `pnpm --filter @pragma/desktop typecheck:web`
- `pnpm --filter @pragma/desktop lint`
- Earlier full Desktop suite: 80 test files, 436 tests passed