### PR TITLE
fix: reuse MCP connections during cold start

### DIFF
--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import type { BrowserWindow } from "electron";
 import {
+  createMcpToolRegistryPool,
   createRuntimeTokenCounter,
   createStorageCapacityGuard,
   PragmaPaths,
@@ -111,6 +112,7 @@ export async function createDesktopApplicationContainer(
   }
   const maintenance = await runStorageMaintenance({ paths: pragmaPaths });
   const tokenCounter = createRuntimeTokenCounter({ logger: mainLogger });
+  const mcpToolRegistryPool = createMcpToolRegistryPool();
   const storageCapacityGuard = createStorageCapacityGuard({
     paths: pragmaPaths,
     initialOverview: maintenance.after,
@@ -205,6 +207,7 @@ export async function createDesktopApplicationContainer(
         options.sendRuntimeModelCatalogUpdate(runtimeId);
       },
       tokenCounter,
+      mcpToolRegistryPool,
     ),
   });
   const missionExecutors = createMissionExecutorCatalog({
@@ -277,7 +280,8 @@ export async function createDesktopApplicationContainer(
   const capabilityStore = createCapabilityStore({
     capabilitiesPath,
     credentials: capabilityCredentials,
-    verify: createCapabilityVerifier(capabilityCredentials),
+    mcpToolRegistryPool,
+    verify: createCapabilityVerifier(capabilityCredentials, mcpToolRegistryPool),
     isReferenced: async (capabilityId) => {
       const definitions = await Promise.all(
         (await expertStore.list()).map((summary) => expertStore.get(summary.ref)),
@@ -319,6 +323,7 @@ export async function createDesktopApplicationContainer(
     capabilityStore,
     capabilityCredentials,
     capabilitiesPath,
+    mcpToolRegistryPool,
     pragmaHome: pragmaPaths.root,
     contextStores,
     plugins: pluginStore,
@@ -374,6 +379,7 @@ export async function createDesktopApplicationContainer(
             capabilityStore,
             capabilityCredentials,
             capabilitiesPath,
+            mcpToolRegistryPool,
             contextStores,
           },
           mission.workspace.path,
@@ -487,6 +493,13 @@ export async function createDesktopApplicationContainer(
       automationService.stop();
       storageCapacityGuard.close();
       tokenCounter.dispose();
+      void mcpToolRegistryPool.close().catch((error: unknown) => {
+        mainLogger.warn(
+          "desktop.mcp_pool_close_failed",
+          "Desktop MCP connections could not be closed cleanly.",
+          { error },
+        );
+      });
       usageStore.close();
     },
   };

--- a/apps/desktop/src/main/features/capabilities/capability-store.test.ts
+++ b/apps/desktop/src/main/features/capabilities/capability-store.test.ts
@@ -20,7 +20,9 @@ async function createStore(
   options: {
     readonly referenced?: boolean;
     readonly realVerifier?: boolean;
-    readonly createMcpRegistry?: Parameters<typeof createCapabilityStore>[0]["createMcpRegistry"];
+    readonly mcpToolRegistryPool?: Parameters<
+      typeof createCapabilityStore
+    >[0]["mcpToolRegistryPool"];
   } = {},
 ) {
   const directory = await mkdtemp(join(tmpdir(), "pragma-capabilities-"));
@@ -45,9 +47,9 @@ async function createStore(
     store: createCapabilityStore({
       capabilitiesPath: join(directory, "capabilities"),
       credentials,
-      ...(options.createMcpRegistry === undefined
+      ...(options.mcpToolRegistryPool === undefined
         ? {}
-        : { createMcpRegistry: options.createMcpRegistry }),
+        : { mcpToolRegistryPool: options.mcpToolRegistryPool }),
       verify:
         options.realVerifier === true
           ? createCapabilityVerifier(credentials)
@@ -270,19 +272,29 @@ describe("capability store", () => {
     const call = vi.fn(async (input: unknown) => ({ structuredContent: { echoed: input } }));
     const dispose = vi.fn(async () => undefined);
     const { store } = await createStore({
-      createMcpRegistry: async () => ({
-        tools: [
-          {
-            serverId: "capability",
-            serverName: "Echo server",
-            name: "echo",
-            description: "Echo input.",
-            inputSchema: { type: "object" },
-            call,
+      mcpToolRegistryPool: {
+        acquire: async () => ({
+          registry: {
+            tools: [
+              {
+                serverId: "capability",
+                serverName: "Echo server",
+                name: "echo",
+                description: "Echo input.",
+                inputSchema: { type: "object" },
+                call,
+              },
+            ],
           },
-        ],
-        dispose,
-      }),
+          stats: {
+            openedConnections: 1,
+            reusedConnections: 0,
+            coalescedConnections: 0,
+          },
+          release: dispose,
+        }),
+        close: async () => undefined,
+      },
     });
     const capability = await store.create({
       definition: {

--- a/apps/desktop/src/main/features/capabilities/capability-store.ts
+++ b/apps/desktop/src/main/features/capabilities/capability-store.ts
@@ -6,8 +6,9 @@ import { unzipSync } from "fflate";
 import {
   createCodeServiceMcpServer,
   createHttpServiceMcpServer,
-  createMcpToolRegistry,
+  createMcpToolRegistryPool,
   type HttpServiceAuth,
+  type McpToolRegistryPool,
 } from "@pragma/core";
 
 import {
@@ -70,7 +71,7 @@ export class CapabilityStoreError extends Error {
 export function createCapabilityStore(options: {
   readonly capabilitiesPath: string;
   readonly credentials: CapabilityCredentialStore;
-  readonly createMcpRegistry?: typeof createMcpToolRegistry;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
   readonly verify: CapabilityVerifier;
   readonly isReferenced: (capabilityId: string) => Promise<boolean>;
 }): CapabilityStore {
@@ -345,41 +346,52 @@ export function createCapabilityStore(options: {
             options.credentials,
             [input.toolName],
           );
-          const registry = await (options.createMcpRegistry ?? createMcpToolRegistry)({
-            mcpServers: { capability: server },
-          });
-          try {
-            const tool = registry.tools.find((candidate) => candidate.name === input.toolName);
-            if (tool === undefined) {
-              throw new Error(`MCP tool ${input.toolName} is not currently available.`);
-            }
-            const result = await tool.call(input.input ?? {}, undefined);
-            const failure = readToolFailure(result, "The MCP tool test failed.");
-            const health = CapabilityHealthSchema.parse({
-              revision: current.manifest.latestRevision,
-              status: failure === undefined ? "ready" : "needs_attention",
-              checkedAt: new Date().toISOString(),
-              ...(failure === undefined
-                ? {}
-                : {
-                    diagnostic: {
-                      code: failure.code,
-                      message: failure.message,
-                      retryable: true,
-                    },
-                  }),
+          const ownsPool = options.mcpToolRegistryPool === undefined;
+          const pool =
+            options.mcpToolRegistryPool ??
+            createMcpToolRegistryPool({
+              idleTtlMs: 0,
+              maxIdleEntries: 0,
             });
-            await writeJson(healthPath(input.id), health);
-            const output = readToolOutput(result);
-            return {
-              ok: failure === undefined,
-              code: failure?.code ?? "success",
-              message: failure?.message ?? "The MCP tool test succeeded.",
-              capability: await readCapability(input.id),
-              ...(output === undefined ? {} : { output }),
-            };
+          try {
+            const lease = await pool.acquire({ mcpServers: { capability: server } });
+            try {
+              const tool = lease.registry.tools.find(
+                (candidate) => candidate.name === input.toolName,
+              );
+              if (tool === undefined) {
+                throw new Error(`MCP tool ${input.toolName} is not currently available.`);
+              }
+              const result = await tool.call(input.input ?? {}, undefined);
+              const failure = readToolFailure(result, "The MCP tool test failed.");
+              const health = CapabilityHealthSchema.parse({
+                revision: current.manifest.latestRevision,
+                status: failure === undefined ? "ready" : "needs_attention",
+                checkedAt: new Date().toISOString(),
+                ...(failure === undefined
+                  ? {}
+                  : {
+                      diagnostic: {
+                        code: failure.code,
+                        message: failure.message,
+                        retryable: true,
+                      },
+                    }),
+              });
+              await writeJson(healthPath(input.id), health);
+              const output = readToolOutput(result);
+              return {
+                ok: failure === undefined,
+                code: failure?.code ?? "success",
+                message: failure?.message ?? "The MCP tool test succeeded.",
+                capability: await readCapability(input.id),
+                ...(output === undefined ? {} : { output }),
+              };
+            } finally {
+              await lease.release();
+            }
           } finally {
-            await registry.dispose();
+            if (ownsPool) await pool.close();
           }
         } catch (error) {
           const diagnostic = classifyMcpError(error);

--- a/apps/desktop/src/main/features/capabilities/capability-verifier.ts
+++ b/apps/desktop/src/main/features/capabilities/capability-verifier.ts
@@ -1,9 +1,10 @@
 import { createHash } from "node:crypto";
 
 import {
-  createMcpToolRegistry,
+  createMcpToolRegistryPool,
   verifyCodeServiceDefinition,
   type IExpertAgentMcpServer,
+  type McpToolRegistryPool,
 } from "@pragma/core";
 
 import {
@@ -16,6 +17,7 @@ import type { CapabilityVerifier } from "./capability-verification.ts";
 
 export function createCapabilityVerifier(
   credentials: CapabilityCredentialStore,
+  mcpToolRegistryPool?: McpToolRegistryPool,
 ): CapabilityVerifier {
   return async (definition, capabilityId) => {
     const checkedAt = new Date().toISOString();
@@ -42,22 +44,33 @@ export function createCapabilityVerifier(
 
     try {
       const server = await toCoreMcpServer(definition, capabilityId, credentials);
-      const registry = await createMcpToolRegistry({ mcpServers: { capability: server } });
+      const ownsPool = mcpToolRegistryPool === undefined;
+      const pool =
+        mcpToolRegistryPool ??
+        createMcpToolRegistryPool({
+          idleTtlMs: 0,
+          maxIdleEntries: 0,
+        });
       try {
-        const tools = registry.tools.map((tool) =>
-          CapabilityToolSnapshotSchema.parse({
-            name: tool.name,
-            description: tool.description,
-            inputSchema: tool.inputSchema,
-            schemaHash: hashSchema(tool.inputSchema),
-          }),
-        );
-        return {
-          definition: CapabilityDefinitionSchema.parse({ ...definition, tools }),
-          health: { status: "ready", checkedAt },
-        };
+        const lease = await pool.acquire({ mcpServers: { capability: server } });
+        try {
+          const tools = lease.registry.tools.map((tool) =>
+            CapabilityToolSnapshotSchema.parse({
+              name: tool.name,
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+              schemaHash: hashSchema(tool.inputSchema),
+            }),
+          );
+          return {
+            definition: CapabilityDefinitionSchema.parse({ ...definition, tools }),
+            health: { status: "ready", checkedAt },
+          };
+        } finally {
+          await lease.release();
+        }
       } finally {
-        await registry.dispose();
+        if (ownsPool) await pool.close();
       }
     } catch (error) {
       return {

--- a/apps/desktop/src/main/features/experts/desktop-expert-factory.ts
+++ b/apps/desktop/src/main/features/experts/desktop-expert-factory.ts
@@ -5,11 +5,13 @@ import {
   Expert,
   createCodeServiceMcpServer,
   createHttpServiceMcpServer,
-  createMcpToolRegistry,
+  createMcpToolRegistryPool,
+  sanitizeExecutionToolName,
   type DefineExpertOptions,
   type IExpertAgentMcpConfig,
   type IExpertAgentMcpServer,
   type IExpertAgentSkillsConfig,
+  type McpToolRegistryPool,
 } from "@pragma/core";
 
 import type { CapabilityDefinition, ExpertDefinition } from "../../../shared/contracts/index.ts";
@@ -45,6 +47,7 @@ interface McpAvailabilityRetryOptions {
   readonly maxDelayMs?: number | undefined;
   readonly random?: (() => number) | undefined;
   readonly sleep?: ((delayMs: number) => Promise<void>) | undefined;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
 }
 
 class McpAvailabilityCheckError extends Error {
@@ -67,6 +70,7 @@ export async function resolveExpertCapabilities(options: {
   readonly store: CapabilityStore;
   readonly credentials: CapabilityCredentialStore;
   readonly capabilitiesPath: string;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
 }): Promise<ResolvedExpertCapabilities> {
   const skills: NonNullable<IExpertAgentSkillsConfig["skills"]>[number][] = [];
   const mcpServers: Record<string, IExpertAgentMcpServer> = {};
@@ -127,7 +131,11 @@ export async function resolveExpertCapabilities(options: {
         );
       });
       try {
-        await assertSelectedMcpToolsAvailable(server, reference.toolNames);
+        await assertSelectedMcpToolsAvailable(server, reference.toolNames, {
+          ...(options.mcpToolRegistryPool === undefined
+            ? {}
+            : { mcpToolRegistryPool: options.mcpToolRegistryPool }),
+        });
       } catch (error) {
         if (error instanceof ExpertCapabilityResolutionError) throw error;
         if (!(error instanceof McpAvailabilityCheckError)) throw error;
@@ -216,6 +224,7 @@ export async function createDesktopExpertAgent(options: {
   readonly store: CapabilityStore;
   readonly credentials: CapabilityCredentialStore;
   readonly capabilitiesPath: string;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
   readonly plugins?: PluginStore | undefined;
   readonly overrides?: Pick<
     DefineExpertOptions,
@@ -227,6 +236,9 @@ export async function createDesktopExpertAgent(options: {
     store: options.store,
     credentials: options.credentials,
     capabilitiesPath: options.capabilitiesPath,
+    ...(options.mcpToolRegistryPool === undefined
+      ? {}
+      : { mcpToolRegistryPool: options.mcpToolRegistryPool }),
   });
   if (options.definition.plugins.length > 0 && options.plugins === undefined) {
     throw new Error("Desktop plugin resolution is required for this expert.");
@@ -295,33 +307,44 @@ export async function assertSelectedMcpToolsAvailable(
   const maxDelayMs = retry.maxDelayMs ?? 1_000;
   const random = retry.random ?? Math.random;
   const sleep = retry.sleep ?? wait;
+  const ownsPool = retry.mcpToolRegistryPool === undefined;
+  const pool =
+    retry.mcpToolRegistryPool ??
+    createMcpToolRegistryPool({
+      idleTtlMs: 0,
+      maxIdleEntries: 0,
+    });
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    try {
-      const registry = await createMcpToolRegistry({ mcpServers: { verify: server } });
+  try {
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
-        for (const name of selected) {
-          const current = registry.tools.find((tool) => tool.name === name);
-          if (current === undefined) {
-            throw new ExpertCapabilityResolutionError(
-              "tool_unavailable",
-              `MCP tool ${name} is not currently available.`,
-            );
+        const lease = await pool.acquire({ mcpServers: { verify: server } });
+        try {
+          for (const name of selected) {
+            const current = lease.registry.tools.find((tool) => tool.name === name);
+            if (current === undefined) {
+              throw new ExpertCapabilityResolutionError(
+                "tool_unavailable",
+                `MCP tool ${name} is not currently available.`,
+              );
+            }
           }
+        } finally {
+          await lease.release();
         }
-      } finally {
-        await registry.dispose();
+        return;
+      } catch (error) {
+        if (error instanceof ExpertCapabilityResolutionError) throw error;
+        const diagnostic = classifyMcpError(error);
+        const transient = isTransientMcpAvailabilityError(error, diagnostic);
+        if (!transient || attempt === maxAttempts) {
+          throw new McpAvailabilityCheckError(diagnostic, attempt, transient, { cause: error });
+        }
+        await sleep(retryDelayMs(attempt, baseDelayMs, maxDelayMs, random));
       }
-      return;
-    } catch (error) {
-      if (error instanceof ExpertCapabilityResolutionError) throw error;
-      const diagnostic = classifyMcpError(error);
-      const transient = isTransientMcpAvailabilityError(error, diagnostic);
-      if (!transient || attempt === maxAttempts) {
-        throw new McpAvailabilityCheckError(diagnostic, attempt, transient, { cause: error });
-      }
-      await sleep(retryDelayMs(attempt, baseDelayMs, maxDelayMs, random));
     }
+  } finally {
+    if (ownsPool) await pool.close();
   }
 }
 
@@ -382,7 +405,8 @@ function createApprovals(
 ) {
   return Object.fromEntries(
     tools.map((tool) => {
-      const mode = expert.toolApprovals[`mcp_${runtimeKey}_${sanitizeToolName(tool)}`] ?? "ask";
+      const mode =
+        expert.toolApprovals[`mcp_${runtimeKey}_${sanitizeExecutionToolName(tool)}`] ?? "ask";
       return [tool, { mode }];
     }),
   );
@@ -395,15 +419,12 @@ function createHttpApprovals(
 ) {
   return Object.fromEntries(
     tools.map((tool) => {
-      const configured = expert.toolApprovals[`mcp_${runtimeKey}_${sanitizeToolName(tool.name)}`];
+      const configured =
+        expert.toolApprovals[`mcp_${runtimeKey}_${sanitizeExecutionToolName(tool.name)}`];
       const mode = configured ?? (tool.method === "POST" ? "required" : "ask");
       return [tool.name, { mode }];
     }),
   );
-}
-
-function sanitizeToolName(value: string): string {
-  return value.replace(/[^a-zA-Z0-9_]/g, "_").replace(/_+/g, "_") || "tool";
 }
 
 function revisionDirectory(revision: number): string {

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -147,20 +147,20 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
       { timeout: settlementTimeoutMs },
     );
-    const followUpStartedAt = performance.now();
+    compile.mockImplementation(async () => {
+      throw new Error("A follow-up on a live Mission Session must not recompile.");
+    });
     await runner.sendMessage({
       id: mission.id,
       content: "Continue without recompiling",
       requestId: "00000000-0000-4000-8000-000000000099",
     });
-    const followUpAdmissionMs = performance.now() - followUpStartedAt;
     await vi.waitFor(
       async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
       { timeout: settlementTimeoutMs },
     );
 
     expect(compile).toHaveBeenCalledTimes(1);
-    expect(followUpAdmissionMs).toBeLessThan(250);
   });
 
   it("creates a successor Session when the live execution definition changes", async () => {

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -29,6 +29,7 @@ import {
   type ExpertDefinition,
   type ExpertSession,
   type MutableExecution,
+  type McpToolRegistryPool,
   type PragmaLogger,
   type RuntimeResolver,
   type RuntimeContextWindowUsage,
@@ -187,6 +188,7 @@ export function createMissionRunner(options: {
   readonly capabilityStore: CapabilityStore;
   readonly capabilityCredentials: CapabilityCredentialStore;
   readonly capabilitiesPath: string;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
   readonly pragmaHome: string;
   readonly contextStores?: ContextStoreStore | undefined;
   readonly plugins?: PluginStore | undefined;
@@ -1747,6 +1749,7 @@ export function createDesktopAdapterHost(
     readonly capabilityStore: CapabilityStore;
     readonly capabilityCredentials: CapabilityCredentialStore;
     readonly capabilitiesPath: string;
+    readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
     readonly contextStores?: ContextStoreStore | undefined;
   },
   projectRoot: string,
@@ -1778,6 +1781,9 @@ export function createDesktopAdapterHost(
           store: options.capabilityStore,
           credentials: options.capabilityCredentials,
           capabilitiesPath: options.capabilitiesPath,
+          ...(options.mcpToolRegistryPool === undefined
+            ? {}
+            : { mcpToolRegistryPool: options.mcpToolRegistryPool }),
         });
         const fingerprint = createHash("sha256")
           .update(

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeResolver,
   PragmaLogger,
   RuntimeTokenCounter,
+  McpToolRegistryPool,
 } from "@pragma/core";
 import { createClaudeCodeRuntime } from "@pragma/runtime-claude-code";
 import {
@@ -268,6 +269,7 @@ export function createBuiltInRuntimeFactories(
     | Promise<DesktopToolPermissionMode> = () => "request-approval",
   onModelCatalogUpdated?: ((runtimeId: string) => void) | undefined,
   tokenCounter?: RuntimeTokenCounter | undefined,
+  mcpToolRegistryPool?: McpToolRegistryPool | undefined,
 ): readonly RuntimeEnvironmentAdapterFactory[] {
   return [
     {
@@ -284,6 +286,7 @@ export function createBuiltInRuntimeFactories(
             : { onModelCatalogUpdated: () => onModelCatalogUpdated(environment.id) }),
           ...permissions,
           tokenCounter,
+          ...(mcpToolRegistryPool === undefined ? {} : { mcpToolRegistryPool }),
         });
       },
     },
@@ -305,6 +308,7 @@ export function createBuiltInRuntimeFactories(
                 ? "auto"
                 : "bypassPermissions",
           tokenCounter,
+          ...(mcpToolRegistryPool === undefined ? {} : { mcpToolRegistryPool }),
         });
       },
     },
@@ -321,6 +325,7 @@ export function createBuiltInRuntimeFactories(
             : { onModelCatalogUpdated: () => onModelCatalogUpdated(environment.id) }),
           permissionMode: qoderRuntimePermissionForMode(permissionMode),
           tokenCounter,
+          ...(mcpToolRegistryPool === undefined ? {} : { mcpToolRegistryPool }),
         });
       },
     },
@@ -333,6 +338,7 @@ export function createBuiltInRuntimeFactories(
           descriptor: { id: environment.id, displayName: BUILT_IN_RUNTIME_DISPLAY_NAME },
           modelProviders,
           tokenCounter,
+          ...(mcpToolRegistryPool === undefined ? {} : { mcpToolRegistryPool }),
         });
       },
     },

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -915,11 +915,15 @@ describe("Mission thinking entry", () => {
 
   it("shows streaming thinking in full without a collapse control", () => {
     const html = renderToStaticMarkup(
-      <MissionThinkingEntry entry={{ ...entry, streaming: true }} />,
+      <MissionThinkingEntry
+        entry={{ ...entry, streaming: true }}
+        paintExecutionId="execution-visible"
+      />,
     );
 
     expect(html).toContain("mission-thinking-entry is-expanded is-streaming");
     expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('data-mission-execution-id="execution-visible"');
     expect(html).not.toContain("<button");
   });
 

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -1,7 +1,9 @@
 import {
+  memo,
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -9,6 +11,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
+import { flushSync } from "react-dom";
 
 import {
   ArrowCounterClockwise,
@@ -1010,6 +1013,10 @@ export function MissionDetailFragment(props: {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const draftMissionIdRef = useRef<string | null>(props.mission.id);
   const chatRef = useRef<MissionChatSnapshot | null>(null);
+  const receivedFirstTokensRef = useRef(new Set<string>());
+  const paintedFirstTokensRef = useRef(new Set<string>());
+  const pendingFirstTokenPaintsRef = useRef(new Map<string, { readonly receivedAt: number }>());
+  const firstTokenPaintFramesRef = useRef(new Map<string, number[]>());
   const clientOperationRef = useRef<MissionClientOperationState>({ kind: "idle" });
   const autoRestoreExecutionRef = useRef<string | null>(null);
   const followLatestRef = useRef(true);
@@ -1180,11 +1187,15 @@ export function MissionDetailFragment(props: {
     let refreshing = false;
     let refreshQueued = false;
     let frame: number | undefined;
-    let paintFrame: number | undefined;
-    let paintConfirmationFrame: number | undefined;
     let hiddenTimer: ReturnType<typeof setTimeout> | undefined;
     let pending: MissionChatUpdate[] = [];
-    const paintedExecutions = new Set<string>();
+    receivedFirstTokensRef.current.clear();
+    paintedFirstTokensRef.current.clear();
+    pendingFirstTokenPaintsRef.current.clear();
+    for (const frames of firstTokenPaintFramesRef.current.values()) {
+      for (const paintFrame of frames) cancelAnimationFrame(paintFrame);
+    }
+    firstTokenPaintFramesRef.current.clear();
 
     const drainPending = (
       base: MissionChatSnapshot,
@@ -1230,6 +1241,18 @@ export function MissionDetailFragment(props: {
       }
     };
 
+    const flushVisibleFirstPatch = (): void => {
+      if (frame !== undefined) {
+        cancelAnimationFrame(frame);
+        frame = undefined;
+      }
+      if (hiddenTimer !== undefined) {
+        clearTimeout(hiddenTimer);
+        hiddenTimer = undefined;
+      }
+      flushSync(flush);
+    };
+
     const refresh = async (): Promise<void> => {
       if (refreshing) {
         refreshQueued = true;
@@ -1257,41 +1280,86 @@ export function MissionDetailFragment(props: {
     };
     const unsubscribe = api.subscribeMissionChat(props.mission.id, (update) => {
       pending.push(update);
-      scheduleFlush();
       const executionId = firstVisiblePatchExecutionId(update, chatRef.current);
-      if (executionId === undefined || paintedExecutions.has(executionId)) return;
-      paintedExecutions.add(executionId);
-      const receivedAt = performance.now();
-      api.reportRendererLog({
-        level: "info",
-        event: "mission.first_ui_token_received",
-        message: "Renderer received the first UI-visible Mission token",
-        missionId: props.mission.id,
-        executionId,
-      });
-      paintFrame = requestAnimationFrame(() => {
-        paintConfirmationFrame = requestAnimationFrame(() => {
+      if (executionId !== undefined && !receivedFirstTokensRef.current.has(executionId)) {
+        receivedFirstTokensRef.current.add(executionId);
+        const receivedAt = performance.now();
+        pendingFirstTokenPaintsRef.current.set(executionId, { receivedAt });
+        api.reportRendererLog({
+          level: "info",
+          event: "mission.first_ui_token_received",
+          message: "Renderer received the first UI-visible Mission token",
+          missionId: props.mission.id,
+          executionId,
+        });
+        if (document.visibilityState !== "hidden" && chatRef.current !== null) {
+          flushVisibleFirstPatch();
+          return;
+        }
+      }
+      scheduleFlush();
+    });
+    void refresh().catch(() => undefined);
+    return () => {
+      cancelled = true;
+      if (frame !== undefined) cancelAnimationFrame(frame);
+      if (hiddenTimer !== undefined) clearTimeout(hiddenTimer);
+      pendingFirstTokenPaintsRef.current.clear();
+      for (const frames of firstTokenPaintFramesRef.current.values()) {
+        for (const paintFrame of frames) cancelAnimationFrame(paintFrame);
+      }
+      firstTokenPaintFramesRef.current.clear();
+      unsubscribe();
+    };
+  }, [props.mission.id, updateChat]);
+
+  useLayoutEffect(() => {
+    const api = desktopApi();
+    const container = scrollRef.current;
+    if (api === undefined || container === null || document.visibilityState === "hidden") return;
+    const renderedExecutions = new Set(
+      [...container.querySelectorAll<HTMLElement>("[data-mission-execution-id]")]
+        .map((element) => element.dataset.missionExecutionId)
+        .filter((executionId): executionId is string => executionId !== undefined),
+    );
+    for (const [executionId, pendingPaint] of pendingFirstTokenPaintsRef.current) {
+      if (
+        paintedFirstTokensRef.current.has(executionId) ||
+        firstTokenPaintFramesRef.current.has(executionId) ||
+        !renderedExecutions.has(executionId)
+      ) {
+        continue;
+      }
+      const frames: number[] = [];
+      const paintFrame = requestAnimationFrame(() => {
+        const confirmationFrame = requestAnimationFrame(() => {
+          if (
+            document.visibilityState === "hidden" ||
+            ![...container.querySelectorAll<HTMLElement>("[data-mission-execution-id]")].some(
+              (element) => element.dataset.missionExecutionId === executionId,
+            )
+          ) {
+            firstTokenPaintFramesRef.current.delete(executionId);
+            return;
+          }
+          paintedFirstTokensRef.current.add(executionId);
+          pendingFirstTokenPaintsRef.current.delete(executionId);
+          firstTokenPaintFramesRef.current.delete(executionId);
           api.reportRendererLog({
             level: "info",
             event: "mission.first_ui_token_painted",
             message: "Renderer painted the first UI-visible Mission token",
             missionId: props.mission.id,
             executionId,
-            elapsedMs: Math.round((performance.now() - receivedAt) * 100) / 100,
+            elapsedMs: Math.round((performance.now() - pendingPaint.receivedAt) * 100) / 100,
           });
         });
+        frames.push(confirmationFrame);
       });
-    });
-    void refresh().catch(() => undefined);
-    return () => {
-      cancelled = true;
-      if (frame !== undefined) cancelAnimationFrame(frame);
-      if (paintFrame !== undefined) cancelAnimationFrame(paintFrame);
-      if (paintConfirmationFrame !== undefined) cancelAnimationFrame(paintConfirmationFrame);
-      if (hiddenTimer !== undefined) clearTimeout(hiddenTimer);
-      unsubscribe();
-    };
-  }, [props.mission.id, updateChat]);
+      frames.push(paintFrame);
+      firstTokenPaintFramesRef.current.set(executionId, frames);
+    }
+  }, [chat?.revision, props.mission.id]);
 
   useEffect(() => {
     const api = desktopApi();
@@ -1880,7 +1948,11 @@ export function MissionDetailFragment(props: {
                       onRetry={() => void compactContext(block.item.entry.id)}
                     />
                   ) : (
-                    <MissionChatEntryView entry={block.item.entry} key={block.item.entry.id} />
+                    <MissionChatEntryView
+                      entry={block.item.entry}
+                      key={block.item.entry.id}
+                      paintExecutionId={block.item.entry.executionId ?? chat?.execution?.id}
+                    />
                   );
                 })}
                 {showThinkingPlaceholder ? (
@@ -2545,9 +2617,10 @@ function MissionThinkingPlaceholder(props: { readonly executorName: string }) {
   );
 }
 
-function MissionChatEntryView(props: {
+const MissionChatEntryView = memo(function MissionChatEntryView(props: {
   readonly entry: MissionChatEntry;
   readonly userLabel?: string | undefined;
+  readonly paintExecutionId?: string | undefined;
 }) {
   if (props.entry.kind === "user") {
     return (
@@ -2562,7 +2635,7 @@ function MissionChatEntryView(props: {
     );
   }
   if (props.entry.kind === "thinking") {
-    return <MissionThinkingEntry entry={props.entry} />;
+    return <MissionThinkingEntry entry={props.entry} paintExecutionId={props.paintExecutionId} />;
   }
   if (props.entry.kind === "tool") {
     return <MissionToolCallEntry entry={props.entry} />;
@@ -2574,11 +2647,11 @@ function MissionChatEntryView(props: {
     return <MissionContextOperationEntry operation={props.entry} retryDisabled={false} />;
   }
   return (
-    <div className="mission-assistant-message">
+    <div className="mission-assistant-message" data-mission-execution-id={props.paintExecutionId}>
       <MissionMessageContent source={props.entry.content} />
     </div>
   );
-}
+});
 
 function MissionAgentActivityEntry(props: {
   readonly entry: Extract<MissionChatEntry, { kind: "agent_activity" }>;
@@ -2606,6 +2679,7 @@ function MissionAgentActivityEntry(props: {
 
 export function MissionThinkingEntry(props: {
   readonly entry: Extract<MissionChatEntry, { kind: "thinking" }>;
+  readonly paintExecutionId?: string | undefined;
 }) {
   const { t } = useTranslation("missions");
   const [expanded, setExpanded] = useState(false);
@@ -2618,6 +2692,7 @@ export function MissionThinkingEntry(props: {
       className={`mission-thinking-entry${showsFullContent ? " is-expanded" : ""}${
         streaming ? " is-streaming" : ""
       }`}
+      data-mission-execution-id={props.paintExecutionId ?? props.entry.executionId}
       aria-live={streaming ? "polite" : undefined}
     >
       <p id={contentId}>{props.entry.content}</p>
@@ -2896,13 +2971,15 @@ export function MissionWorkDrawer(props: {
   );
 }
 
-function MissionMessageContent(props: { readonly source: string }) {
+const MissionMessageContent = memo(function MissionMessageContent(props: {
+  readonly source: string;
+}) {
   return (
     <div className="mission-markdown">
       <MarkdownContent source={props.source} codeBlockControls />
     </div>
   );
-}
+});
 
 type MissionHumanQuestion = NonNullable<MissionHumanInteraction["request"]["questions"]>[number];
 

--- a/docs/adr/008-process-shared-execution-mcp-gateway.md
+++ b/docs/adr/008-process-shared-execution-mcp-gateway.md
@@ -28,6 +28,10 @@ stable, short MCP configuration key `pragma`; a restored Session receives a new 
 may receive a new listener port. Exposed tool names are deterministically bounded so the fully
 qualified `mcp__pragma__<tool>` name stays within the Runtime limit. PI does not use the Gateway.
 
+ADR 028 defines the shared semantic layer above these transports. Core resolves and invokes one
+execution tool set; PI projects it to native tools, while this Gateway projects it to MCP. The
+Gateway does not independently implement Agent tool policy, approval, hooks, or result semantics.
+
 ## Consequences
 
 - Concurrent Codex, Claude Code, and Qoder CLI Sessions share one HTTP listener without sharing tools or state.

--- a/docs/adr/027-mission-latency-cache-and-runtime-warmup.md
+++ b/docs/adr/027-mission-latency-cache-and-runtime-warmup.md
@@ -60,16 +60,19 @@ and preserves the hard-limit cleanup behavior.
 
 ### Runtime reuse
 
-Codex and QoderCLI use a reference-counted MCP Tool Registry pool. External MCP configurations use
-a stable, redacted fingerprint; in-process configurations use object identity because functions
-must not be merged by serialization. Idle registries are bounded and expire.
+Superseded in detail by ADR 028. Desktop owns one reference-counted MCP connection pool shared by
+compiler live checks, Capability workflows, and all four Runtime adapters. Pooling is per server
+connection so consumer-specific server IDs, tool projections, and approval policies do not prevent
+reuse. External connections use a stable, redacted fingerprint; in-process connections use object
+identity because functions must not be merged by serialization. Idle connections are bounded and
+expire.
 
 Sharing one Codex app-server process across Missions is not adopted. ADR 026 and the storage rules
 require each Runtime Context to have a private `CODEX_HOME`, `CODEX_SQLITE_HOME`, session tree,
 configuration, and logs. A single process has process-wide environment and configuration and would
 therefore weaken isolation, complicate ownership and cancellation, and risk cross-Context state.
 Each Mission continues to own an independent Codex thread and private process. Only explicitly
-rebuildable caches and the MCP Registry pool are shared. A future multiplexed Runtime protocol may
+rebuildable caches and upstream MCP connections are shared. A future multiplexed Runtime protocol may
 revisit this if it can bind home, credentials, tools, cancellation, and accounting per thread.
 
 ### Latency observations

--- a/docs/adr/028-host-scoped-mcp-connections-and-tool-projections.md
+++ b/docs/adr/028-host-scoped-mcp-connections-and-tool-projections.md
@@ -1,0 +1,75 @@
+# ADR 028: Host-scoped MCP connections and Runtime tool projections
+
+- Status: Accepted
+- Date: 2026-07-30
+
+## Context
+
+Pragma has four Runtime adapters with two delivery mechanisms. PI runs in the Host process and
+accepts native `ToolDefinition` objects. Codex, Claude Code, and Qoder CLI run in child processes
+and discover the same execution tools through the process-shared Execution MCP Gateway from ADR 008.
+
+The delivery mechanisms are necessarily different, but their implementation had also duplicated
+tool resolution, approval, hooks, result conversion, logging, and upstream MCP connection setup.
+Compiler live validation and Capability checks opened another short-lived MCP connection before a
+Runtime immediately opened the same server again. This increased new-Mission initialization time
+and made behavioral drift likely.
+
+## Decision
+
+### One semantic execution tool set
+
+Core resolves default tools, managed tools, and upstream MCP tools into
+`ResolvedExecutionToolSet`. Core also owns invocation behavior: approval, lifecycle hooks, logging,
+event emission, and normalized results.
+
+Runtime adapters only project that semantic set:
+
+- PI converts each resolved tool to a native PI `ToolDefinition`.
+- Codex, Claude Code, and Qoder CLI register the resolved tools on the Execution MCP Gateway.
+
+The Gateway remains a transport boundary, not a second tool semantics implementation. Its
+runtime-permission prompt remains Gateway-specific because it mediates child-process permission
+requests rather than an Agent-declared execution tool.
+
+### One Host-scoped connection pool
+
+Each application Host creates one `McpToolRegistryPool` and injects it into compilation and
+validation workflows and all Runtime factories. A lease is acquired per consumer and released
+when validation or the Runtime Session ends. Host shutdown closes the pool.
+
+Pooling occurs per upstream MCP server connection, not per complete Agent MCP configuration:
+
+- external transports use a stable fingerprint of connection-relevant configuration and a hashed
+  credential;
+- in-process servers use object identity;
+- server IDs, tool allow/deny projections, and approval policies are excluded from connection
+  identity and applied independently to every lease.
+
+Concurrent opens for the same connection are single-flight. Idle connections have a bounded count
+and TTL. A failed open is evicted so retries do not inherit a rejected promise.
+
+`McpToolRegistryPool.close()` is a final Host-shutdown operation, not a graceful per-lease drain.
+It rejects new acquisitions and hard-stops every pooled connection even if a lease remains active.
+Hosts must stop normal execution dispatch before closing the pool; a late lease release is a safe
+no-op. Runtime Session cleanup continues to use lease release rather than pool close.
+
+### Initialization and UI observations
+
+Runtime preparation logs distinguish opened, reused, and coalesced MCP connections. The renderer
+flushes the first visible streaming patch immediately when a current chat snapshot exists; later
+patches retain frame batching. `mission.first_ui_token_painted` is emitted only after React commits
+a matching execution element and two animation frames confirm an opportunity to paint. Hidden
+documents do not emit the paint milestone.
+
+## Consequences
+
+- Compiler live checks and Runtime startup can reuse one authenticated upstream connection.
+- Four Runtime adapters share tool policy and invocation semantics without pretending that their
+  delivery transports are identical.
+- A lease may expose a different server ID, tool subset, or approval policy while sharing the same
+  physical connection.
+- Host construction and shutdown must explicitly own the pool.
+- Connection keys must never log or persist raw credentials.
+- PI avoids loopback MCP serialization, while child-process Runtimes retain the isolation and
+  discoverability guarantees of ADR 008.

--- a/packages/core/src/expert-tools-mcp-server.ts
+++ b/packages/core/src/expert-tools-mcp-server.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { Readable } from "node:stream";
@@ -16,28 +16,25 @@ import type {
 } from "@modelcontextprotocol/server";
 
 import type { Expert } from "./agent/expert-agent.ts";
-import type { ExpertAgentDefaultTool } from "./context-system/context-tools.ts";
 import type { PragmaLogger } from "./logging/logger.ts";
 import type { McpManagedTool } from "./mcp-tools.ts";
-import { dispatchExpertAgentHook } from "./plugins/expert-agent-plugin.ts";
-import type { RuntimeEventEmitter } from "./runtime/runtime-event-emitter.ts";
-import type { RuntimeStreamEvent } from "./runtime/stream-events.ts";
 import type { ExpertAgentRunContext } from "./runtime/run-context.ts";
-import { resolveToolPolicy, type ResolvedTool } from "./tools/tool-resolver.ts";
 import type {
   ExpertAgentHumanInteractionHandler,
-  ExpertAgentManagedTool,
-  ExpertAgentToolApproval,
   ExpertAgentToolCallResult,
   ExpertToolExecutionContext,
 } from "./tools/managed-tool.ts";
-import { resolveExpertAgentToolApprovalRequirement } from "./tools/managed-tool.ts";
+import {
+  emitExecutionToolApprovalRequested,
+  executeExecutionTool,
+  resolveExecutionTools,
+  sanitizeExecutionToolName,
+  type ExecutionTool,
+  type ExecutionToolRuntimeState,
+  type ResolvedExecutionTool,
+} from "./tools/execution-tools.ts";
 
-export interface ExpertToolRuntimeState {
-  runId?: string | undefined;
-  source?: RuntimeStreamEvent["source"] | undefined;
-  emitter?: RuntimeEventEmitter | undefined;
-}
+export type ExpertToolRuntimeState = ExecutionToolRuntimeState;
 
 export interface ExpertToolsMcpSessionRegistration {
   readonly id: string;
@@ -56,7 +53,7 @@ export interface RegisterExpertToolsMcpSessionOptions {
   readonly executionContext?: ExpertToolExecutionContext | undefined;
 }
 
-type LocalTool = ExpertAgentManagedTool<string, ExpertAgentToolCallResult>;
+type LocalTool = ExecutionTool;
 const RUNTIME_PERMISSION_APPROVAL_REASON = "Runtime requested tool approval.";
 const SESSION_MCP_PATH_PATTERN = /^\/sessions\/([A-Za-z0-9_-]{43})\/mcp$/;
 const MCP_CONFIG_ID = "pragma";
@@ -256,26 +253,21 @@ function createSessionMcpServer(
 
 function createExecutionLocalTools(
   options: RegisterExpertToolsMcpSessionOptions,
-): readonly ResolvedTool<LocalTool>[] {
-  const defaultTools = options.agent.createDefaultTools({
+): readonly ResolvedExecutionTool[] {
+  const resolved = resolveExecutionTools({
+    agent: options.agent,
     getContext: options.getContext,
-  });
-  const resolved = resolveToolPolicy<LocalTool>({
-    context: options.getContext(),
-    tools: [
-      ...defaultTools.map((tool) => createResolvedLocalTool("default", fromDefaultTool(tool))),
-      ...(options.agent.tools ?? []).map((tool) => createResolvedLocalTool("managed", tool)),
-      ...createExecutionMcpTools(options.mcpTools ?? []).map((tool) =>
-        createResolvedLocalTool("mcp", tool),
-      ),
-    ],
+    mcpTools: options.mcpTools,
   });
   const permissionTool = createPermissionPromptTool(
     options,
     new Set(resolved.tools.flatMap((tool) => [tool.name, createRuntimeToolName(tool.name)])),
   );
 
-  return [createResolvedLocalTool("default", permissionTool), ...resolved.tools];
+  return [
+    { name: permissionTool.name, source: "default", tool: permissionTool },
+    ...resolved.tools,
+  ];
 }
 
 function createPermissionPromptTool(
@@ -284,6 +276,7 @@ function createPermissionPromptTool(
 ): LocalTool {
   return {
     name: "request_tool_approval",
+    label: "Request tool approval",
     description:
       "Ask the Pragma host whether a runtime tool call should be allowed. Use only for runtime permission prompts.",
     inputSchema: {
@@ -317,7 +310,7 @@ function createPermissionPromptTool(
         };
       }
 
-      emitApprovalRequested({
+      emitExecutionToolApprovalRequested({
         approval: {
           mode: "required",
           reason: RUNTIME_PERMISSION_APPROVAL_REASON,
@@ -425,68 +418,6 @@ function normalizePermissionPromptInput(args: unknown): {
   return { toolName, toolCallId, input };
 }
 
-function createExecutionMcpTools(
-  mcpTools: readonly McpManagedTool[],
-): readonly ExpertAgentManagedTool<string, ExpertAgentToolCallResult>[] {
-  return mcpTools.map((mcpTool) => {
-    const toolName = `mcp_${sanitizeToolName(mcpTool.serverId)}_${sanitizeToolName(mcpTool.name)}`;
-
-    return {
-      name: toolName,
-      description: [
-        mcpTool.description ?? `Call MCP tool ${mcpTool.name}.`,
-        `Original MCP server: ${mcpTool.serverName}. Original tool: ${mcpTool.name}.`,
-      ].join("\n"),
-      inputSchema: mcpTool.inputSchema,
-      ...(mcpTool.outputSchema === undefined ? {} : { outputSchema: mcpTool.outputSchema }),
-      async call(args, signal, context) {
-        const result = await mcpTool.call(args, signal, {
-          toolCallId: context?.toolCallId,
-        });
-
-        return {
-          text: formatMcpToolResult(result),
-          ...(isRecord(result) && result["isError"] === true ? { isError: true } : {}),
-          details:
-            isRecord(result) && isJsonObject(result["structuredContent"])
-              ? result["structuredContent"]
-              : {
-                  server: mcpTool.serverName,
-                  tool: mcpTool.name,
-                  result,
-                },
-        };
-      },
-    };
-  });
-}
-
-function createResolvedLocalTool(
-  source: ResolvedTool<LocalTool>["source"],
-  tool: LocalTool,
-): ResolvedTool<LocalTool> {
-  return {
-    name: tool.name,
-    source,
-    tool,
-  };
-}
-
-function fromDefaultTool(tool: ExpertAgentDefaultTool): LocalTool {
-  return {
-    name: tool.name,
-    description: tool.description,
-    inputSchema: tool.inputSchema,
-    approval: tool.approval,
-    async call(args, signal, context) {
-      return await tool.call(args, signal, {
-        toolCallId: context?.toolCallId,
-        humanInteraction: context?.humanInteraction,
-      });
-    },
-  };
-}
-
 function registerLocalTool(
   server: McpServer,
   runtimeName: string,
@@ -506,13 +437,12 @@ function registerLocalTool(
       const toolCallId = String(context.mcpReq.id);
 
       try {
-        const result = await executeWithToolHooks({
+        const result = await executeExecutionTool({
           agent: options.agent,
           tool,
           toolCallId,
           args: input,
           signal: context.mcpReq.signal,
-          approval: tool.approval,
           humanInteractionHandler: options.humanInteractionHandler,
           runContext: options.getContext(),
           executionContext: options.executionContext,
@@ -529,216 +459,6 @@ function registerLocalTool(
       }
     },
   );
-}
-
-async function executeWithToolHooks(options: {
-  readonly agent: Expert;
-  readonly tool: LocalTool;
-  readonly toolCallId: string | undefined;
-  readonly args: unknown;
-  readonly signal: AbortSignal | undefined;
-  readonly approval: ExpertAgentToolApproval | undefined;
-  readonly humanInteractionHandler: ExpertAgentHumanInteractionHandler | undefined;
-  readonly runContext: ExpertAgentRunContext | undefined;
-  readonly executionContext: ExpertToolExecutionContext | undefined;
-  readonly logger: PragmaLogger;
-  readonly state: ExpertToolRuntimeState;
-}): Promise<ExpertAgentToolCallResult> {
-  const startedAt = Date.now();
-  const runId = options.state.runId;
-
-  options.logger.info("tool.call_started", "Tool call started", {
-    runId,
-    toolName: options.tool.name,
-    toolCallId: options.toolCallId,
-  });
-  await dispatchExpertAgentHook(options.agent.hooks, "beforeToolCall", {
-    agent: options.agent,
-    toolName: options.tool.name,
-    toolCallId: options.toolCallId,
-    args: options.args,
-    runId,
-    logger: options.logger,
-  });
-
-  try {
-    const resolvedArgs = await maybeRequestToolApproval({
-      approval: options.approval,
-      humanInteractionHandler: options.humanInteractionHandler,
-      toolName: options.tool.name,
-      toolCallId: options.toolCallId,
-      args: options.args,
-      state: options.state,
-    });
-
-    if (!resolvedArgs.approved) {
-      const durationMs = Date.now() - startedAt;
-      await dispatchExpertAgentHook(options.agent.hooks, "afterToolCall", {
-        agent: options.agent,
-        toolName: options.tool.name,
-        toolCallId: options.toolCallId,
-        args: options.args,
-        runId,
-        durationMs,
-        result: resolvedArgs.result,
-        logger: options.logger,
-      });
-      return resolvedArgs.result;
-    }
-
-    const executeArgs = resolvedArgs.updatedInput ?? options.args;
-    const result = await options.tool.call(executeArgs, options.signal, {
-      toolCallId: options.toolCallId,
-      humanInteraction: options.humanInteractionHandler,
-      runContext: options.runContext,
-      execution: options.executionContext,
-    });
-    const durationMs = Date.now() - startedAt;
-
-    await dispatchExpertAgentHook(options.agent.hooks, "afterToolCall", {
-      agent: options.agent,
-      toolName: options.tool.name,
-      toolCallId: options.toolCallId,
-      args: executeArgs,
-      runId,
-      durationMs,
-      result,
-      logger: options.logger,
-    });
-    options.logger.info("tool.call_completed", "Tool call completed", {
-      runId,
-      toolName: options.tool.name,
-      toolCallId: options.toolCallId,
-      durationMs,
-      isError: result.isError ?? false,
-    });
-
-    return result;
-  } catch (error) {
-    const durationMs = Date.now() - startedAt;
-    await dispatchExpertAgentHook(options.agent.hooks, "afterToolCall", {
-      agent: options.agent,
-      toolName: options.tool.name,
-      toolCallId: options.toolCallId,
-      args: options.args,
-      runId,
-      durationMs,
-      error,
-      logger: options.logger,
-    });
-    options.logger.error("tool.call_failed", "Tool call failed", error, {
-      runId,
-      toolName: options.tool.name,
-      toolCallId: options.toolCallId,
-      durationMs,
-    });
-    throw error;
-  }
-}
-
-async function maybeRequestToolApproval(options: {
-  readonly approval: ExpertAgentToolApproval | undefined;
-  readonly humanInteractionHandler: ExpertAgentHumanInteractionHandler | undefined;
-  readonly toolName: string;
-  readonly toolCallId: string | undefined;
-  readonly args: unknown;
-  readonly state: ExpertToolRuntimeState;
-}): Promise<
-  | { readonly approved: true; readonly updatedInput: unknown | undefined }
-  | { readonly approved: false; readonly result: ExpertAgentToolCallResult }
-> {
-  const approval = options.approval;
-
-  if (approval === undefined) {
-    return { approved: true, updatedInput: undefined };
-  }
-
-  const approvalRequest = {
-    kind: "tool_approval" as const,
-    toolName: options.toolName,
-    toolCallId: options.toolCallId,
-    reason: approval.reason,
-    input: options.args,
-  };
-  const requirement = await resolveExpertAgentToolApprovalRequirement(approval, approvalRequest);
-
-  if (requirement === "none") {
-    return { approved: true, updatedInput: undefined };
-  }
-
-  if (requirement === "ask" && options.humanInteractionHandler === undefined) {
-    return { approved: true, updatedInput: undefined };
-  }
-
-  emitApprovalRequested({
-    approval,
-    toolName: options.toolName,
-    toolCallId: options.toolCallId,
-    args: options.args,
-    state: options.state,
-  });
-
-  if (options.humanInteractionHandler === undefined) {
-    return {
-      approved: false,
-      result: {
-        text: approval.reason ?? `Tool approval required for ${options.toolName}.`,
-        isError: true,
-      },
-    };
-  }
-
-  const response = await options.humanInteractionHandler(approvalRequest);
-
-  if (response.kind !== "tool_approval" || !response.approved) {
-    return {
-      approved: false,
-      result: {
-        text:
-          response.kind === "tool_approval" && response.reason !== undefined
-            ? response.reason
-            : `User declined ${options.toolName}.`,
-        isError: true,
-      },
-    };
-  }
-
-  return { approved: true, updatedInput: response.updatedInput };
-}
-
-function emitApprovalRequested(options: {
-  readonly approval: ExpertAgentToolApproval;
-  readonly toolName: string;
-  readonly toolCallId: string | undefined;
-  readonly args: unknown;
-  readonly state: ExpertToolRuntimeState;
-}): void {
-  const approvalId = `approval-${randomUUID()}`;
-  const runId = options.state.runId ?? approvalId;
-  const toolCallId = options.toolCallId ?? approvalId;
-
-  options.state.emitter?.emit({
-    runId,
-    source: {
-      ...(options.state.source ?? {
-        kind: "tool",
-        runId,
-        path: [],
-      }),
-      kind: "tool",
-      runId,
-      toolCallId,
-    },
-    type: "tool.approval_requested",
-    payload: {
-      approvalId,
-      toolCallId,
-      toolName: options.toolName,
-      kind: "tool",
-      ...(options.approval.reason === undefined ? {} : { reason: options.approval.reason }),
-      inputPreview: options.args,
-    },
-  });
 }
 
 function toMcpInputSchema(schema: unknown): StandardSchemaWithJSON | undefined {
@@ -939,31 +659,12 @@ function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<void
   });
 }
 
-function sanitizeToolName(value: string): string {
-  const sanitized = value.replace(/[^a-zA-Z0-9_]/g, "_").replace(/_+/g, "_");
-  return sanitized.length === 0 ? "tool" : sanitized;
-}
-
 function createRuntimeToolName(value: string): string {
-  const sanitized = sanitizeToolName(value);
+  const sanitized = sanitizeExecutionToolName(value);
   if (sanitized === value && sanitized.length <= MCP_LOCAL_TOOL_NAME_LIMIT) return sanitized;
   const digest = createHash("sha256").update(value).digest("hex").slice(0, 10);
   const prefixLength = MCP_LOCAL_TOOL_NAME_LIMIT - digest.length - 1;
   return `${sanitized.slice(0, prefixLength)}_${digest}`;
-}
-
-function formatMcpToolResult(result: unknown): string {
-  if (isRecord(result) && Array.isArray(result.content)) {
-    const textParts = result.content
-      .map((entry) => (isRecord(entry) && typeof entry.text === "string" ? entry.text : undefined))
-      .filter((entry): entry is string => entry !== undefined);
-
-    if (textParts.length > 0) {
-      return textParts.join("\n");
-    }
-  }
-
-  return typeof result === "string" ? result : JSON.stringify(result, null, 2);
 }
 
 function isAddressInfo(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export * from "./runtime-resolver.ts";
 export * from "./resource-id.ts";
 export * from "./sdk-mcp-server.ts";
 export * from "./tools/managed-tool.ts";
+export * from "./tools/execution-tools.ts";
 export * from "./tools/tool-resolver.ts";
 export * from "./storage/pragma-paths.ts";
 export * from "./storage/file-lock.ts";

--- a/packages/core/src/mcp-tool-registry-cache-key.ts
+++ b/packages/core/src/mcp-tool-registry-cache-key.ts
@@ -1,42 +1,36 @@
 import { createHash } from "node:crypto";
 
-import type { IExpertAgentMcpConfig, IExpertAgentMcpServer } from "./agent/expert-agent.ts";
+import type { IExpertAgentMcpServer } from "./agent/expert-agent.ts";
 
-export function mcpToolRegistryCacheKey(
-  config: IExpertAgentMcpConfig | undefined,
-): string | IExpertAgentMcpConfig {
-  if (config === undefined) return "empty";
-  if (Object.values(config.mcpServers).some((server) => server.transport === "in-process")) {
-    return config;
-  }
-  const normalized = Object.entries(config.mcpServers)
-    .toSorted(([left], [right]) => left.localeCompare(right))
-    .map(([id, server]) => [id, normalizeExternalMcpServer(server)]);
-  return createHash("sha256").update(stableStringify(normalized)).digest("hex");
+export function mcpServerConnectionCacheKey(server: IExpertAgentMcpServer): string | object {
+  if (server.transport === "in-process") return server.inProcess;
+  return createHash("sha256")
+    .update(stableStringify(normalizeExternalMcpServer(server)))
+    .digest("hex");
 }
 
 function normalizeExternalMcpServer(server: IExpertAgentMcpServer): unknown {
   if (server.transport === "in-process") {
     throw new Error("In-process MCP Servers use object-identity cache keys.");
   }
+  const connection = Object.fromEntries(
+    Object.entries(server).filter(
+      ([key]) => key !== "allowTools" && key !== "disallowTools" && key !== "toolApprovals",
+    ),
+  );
   return {
-    ...server,
+    ...connection,
     ...(server.transport === "stdio"
       ? {
-          env: Object.entries(server.env ?? {}).toSorted(([left], [right]) =>
-            left.localeCompare(right),
-          ),
+          env: Object.entries(server.env ?? {})
+            .toSorted(([left], [right]) => left.localeCompare(right))
+            .map(([key, value]) => [key, createHash("sha256").update(value).digest("hex")]),
         }
       : server.token === undefined
         ? {}
         : {
             token: createHash("sha256").update(server.token).digest("hex"),
           }),
-    allowTools: [...(server.allowTools ?? [])].toSorted(),
-    disallowTools: [...(server.disallowTools ?? [])].toSorted(),
-    toolApprovals: Object.entries(server.toolApprovals ?? {}).toSorted(([left], [right]) =>
-      left.localeCompare(right),
-    ),
   };
 }
 

--- a/packages/core/src/mcp-tools.ts
+++ b/packages/core/src/mcp-tools.ts
@@ -5,26 +5,34 @@ import {
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/client";
 import type { AuthProvider, Transport } from "@modelcontextprotocol/client";
-import type {
-  ExpertAgentManagedTool,
-  IExpertAgentMcpConfig,
-  IExpertAgentMcpServer,
-} from "@pragma/core";
+import type { IExpertAgentMcpConfig, IExpertAgentMcpServer } from "./agent/expert-agent.ts";
+import type { ExpertAgentManagedTool } from "./tools/managed-tool.ts";
 
-import { mcpToolRegistryCacheKey } from "./mcp-tool-registry-cache-key.ts";
+import { mcpServerConnectionCacheKey } from "./mcp-tool-registry-cache-key.ts";
 
 export interface McpToolRegistry {
   readonly tools: readonly McpManagedTool[];
-  readonly dispose: () => Promise<void>;
+}
+
+export interface McpToolRegistryLeaseStats {
+  readonly openedConnections: number;
+  readonly reusedConnections: number;
+  readonly coalescedConnections: number;
 }
 
 export interface McpToolRegistryLease {
   readonly registry: McpToolRegistry;
+  readonly stats: McpToolRegistryLeaseStats;
   readonly release: () => Promise<void>;
 }
 
 export interface McpToolRegistryPool {
   readonly acquire: (config: IExpertAgentMcpConfig | undefined) => Promise<McpToolRegistryLease>;
+  /**
+   * Hard-stops every pooled connection, including connections referenced by active leases.
+   * Hosts must call this only during final shutdown, after stopping normal execution dispatch.
+   * Releasing a lease after close is safe and has no effect.
+   */
   readonly close: () => Promise<void>;
 }
 
@@ -46,36 +54,9 @@ interface McpClient {
   readonly dispose: () => Promise<void>;
 }
 
-export async function createMcpToolRegistry(
-  config: IExpertAgentMcpConfig | undefined,
-): Promise<McpToolRegistry> {
-  if (config === undefined) {
-    return emptyMcpToolRegistry();
-  }
-
-  const clients: McpClient[] = [];
-  const tools: McpManagedTool[] = [];
-
-  try {
-    for (const [serverId, server] of Object.entries(config.mcpServers)) {
-      const client = await createOfficialMcpClient(server);
-      clients.push(client);
-
-      const mcpTools = filterMcpTools(await client.listTools(), server);
-
-      for (const mcpTool of mcpTools) {
-        tools.push(createManagedMcpTool(serverId, server, client, mcpTool));
-      }
-    }
-  } catch (error) {
-    await disposeMcpClients(clients);
-    throw error;
-  }
-
-  return {
-    tools,
-    dispose: () => disposeMcpClients(clients),
-  };
+interface McpConnection {
+  readonly client: McpClient;
+  readonly tools: readonly McpToolInfo[];
 }
 
 export function createMcpToolRegistryPool(
@@ -87,23 +68,24 @@ export function createMcpToolRegistryPool(
   const idleTtlMs = options.idleTtlMs ?? 5 * 60_000;
   const maxIdleEntries = options.maxIdleEntries ?? 32;
   const entries = new Map<
-    string | IExpertAgentMcpConfig,
+    string | object,
     {
-      readonly opening: Promise<McpToolRegistry>;
+      readonly opening: Promise<McpConnection>;
       references: number;
+      ready: boolean;
       releasedAt?: number | undefined;
       timer?: ReturnType<typeof setTimeout> | undefined;
     }
   >();
   let closed = false;
 
-  const disposeEntry = async (key: string | IExpertAgentMcpConfig): Promise<void> => {
+  const disposeEntry = async (key: string | object): Promise<void> => {
     const entry = entries.get(key);
     if (entry === undefined || entry.references > 0) return;
     entries.delete(key);
     if (entry.timer !== undefined) clearTimeout(entry.timer);
-    const registry = await entry.opening.catch(() => undefined);
-    await registry?.dispose();
+    const connection = await entry.opening.catch(() => undefined);
+    await connection?.client.dispose();
   };
 
   const trimIdle = async (): Promise<void> => {
@@ -114,40 +96,128 @@ export function createMcpToolRegistryPool(
     await Promise.all(idle.slice(0, excess).map(async ([key]) => await disposeEntry(key)));
   };
 
-  return {
-    async acquire(config) {
-      if (closed) throw new Error("MCP Tool Registry pool is closed.");
-      const key = mcpToolRegistryCacheKey(config);
-      let entry = entries.get(key);
-      if (entry === undefined) {
-        const opening = createMcpToolRegistry(config);
-        entry = { opening, references: 0 };
-        entries.set(key, entry);
-        void opening.catch(() => {
+  const releaseConnection = async (key: string | object): Promise<void> => {
+    const current = entries.get(key);
+    if (current === undefined) return;
+    current.references = Math.max(0, current.references - 1);
+    if (current.references > 0) return;
+    current.releasedAt = Date.now();
+    if (idleTtlMs === 0) {
+      await disposeEntry(key);
+      return;
+    }
+    current.timer = setTimeout(() => {
+      void disposeEntry(key).catch(() => undefined);
+    }, idleTtlMs);
+    current.timer.unref();
+    await trimIdle();
+  };
+
+  const acquireConnection = async (
+    server: IExpertAgentMcpServer,
+  ): Promise<{
+    readonly connection: McpConnection;
+    readonly disposition: "opened" | "reused" | "coalesced";
+    readonly release: () => Promise<void>;
+  }> => {
+    const key = mcpServerConnectionCacheKey(server);
+    let entry = entries.get(key);
+    let disposition: "opened" | "reused" | "coalesced";
+    if (entry === undefined) {
+      const opening = openMcpConnection(server);
+      entry = { opening, references: 0, ready: false };
+      entries.set(key, entry);
+      disposition = "opened";
+      void opening.then(
+        () => {
+          const current = entries.get(key);
+          if (current?.opening === opening) current.ready = true;
+        },
+        () => {
           if (entries.get(key)?.opening === opening) entries.delete(key);
-        });
-      }
-      if (entry.timer !== undefined) clearTimeout(entry.timer);
-      entry.timer = undefined;
-      entry.releasedAt = undefined;
-      entry.references += 1;
-      let released = false;
-      const registry = await entry.opening;
+        },
+      );
+    } else {
+      disposition = entry.ready ? "reused" : "coalesced";
+    }
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    entry.timer = undefined;
+    entry.releasedAt = undefined;
+    entry.references += 1;
+    let released = false;
+    try {
+      const connection = await entry.opening;
       return {
-        registry,
+        connection,
+        disposition,
         async release() {
           if (released) return;
           released = true;
-          const current = entries.get(key);
-          if (current === undefined) return;
-          current.references = Math.max(0, current.references - 1);
-          if (current.references > 0) return;
-          current.releasedAt = Date.now();
-          current.timer = setTimeout(() => {
-            void disposeEntry(key).catch(() => undefined);
-          }, idleTtlMs);
-          current.timer.unref();
-          await trimIdle();
+          await releaseConnection(key);
+        },
+      };
+    } catch (error) {
+      released = true;
+      await releaseConnection(key);
+      throw error;
+    }
+  };
+
+  return {
+    async acquire(config) {
+      if (closed) throw new Error("MCP Tool Registry pool is closed.");
+      if (config === undefined || Object.keys(config.mcpServers).length === 0) {
+        return emptyMcpToolRegistryLease();
+      }
+      const servers = Object.entries(config.mcpServers);
+      const acquisitions = await Promise.allSettled(
+        servers.map(async ([serverId, server]) => ({
+          serverId,
+          server,
+          acquired: await acquireConnection(server),
+        })),
+      );
+      const acquired = acquisitions.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : [],
+      );
+      const errors = acquisitions.flatMap((result) =>
+        result.status === "rejected" ? [result.reason as unknown] : [],
+      );
+      if (errors.length > 0) {
+        await Promise.allSettled(acquired.map(async (item) => await item.acquired.release()));
+        if (errors.length === 1) throw errors[0];
+        throw new AggregateError(errors, "Multiple MCP Server connections failed.");
+      }
+
+      const tools = acquired.flatMap(({ serverId, server, acquired: current }) =>
+        filterMcpTools(current.connection.tools, server).map((tool) =>
+          createManagedMcpTool(serverId, server, current.connection.client, tool),
+        ),
+      );
+      let released = false;
+      return {
+        registry: { tools },
+        stats: {
+          openedConnections: acquired.filter((item) => item.acquired.disposition === "opened")
+            .length,
+          reusedConnections: acquired.filter((item) => item.acquired.disposition === "reused")
+            .length,
+          coalescedConnections: acquired.filter((item) => item.acquired.disposition === "coalesced")
+            .length,
+        },
+        async release() {
+          if (released) return;
+          released = true;
+          const results = await Promise.allSettled(
+            acquired.map(async (item) => await item.acquired.release()),
+          );
+          const releaseErrors = results.flatMap((result) =>
+            result.status === "rejected" ? [result.reason as unknown] : [],
+          );
+          if (releaseErrors.length === 1) throw releaseErrors[0];
+          if (releaseErrors.length > 1) {
+            throw new AggregateError(releaseErrors, "MCP Tool Registry lease release failed.");
+          }
         },
       };
     },
@@ -159,23 +229,45 @@ export function createMcpToolRegistryPool(
       for (const entry of values) {
         if (entry.timer !== undefined) clearTimeout(entry.timer);
       }
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         values.map(async (entry) => {
-          const registry = await entry.opening;
-          await registry.dispose();
+          const connection = await entry.opening;
+          await connection.client.dispose();
         }),
       );
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason as unknown] : [],
+      );
+      if (errors.length === 1) throw errors[0];
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "MCP Tool Registry pool close failed.");
+      }
     },
   };
 }
 
-function emptyMcpToolRegistry(): McpToolRegistry {
+function emptyMcpToolRegistryLease(): McpToolRegistryLease {
   return {
-    tools: [],
-    async dispose() {
+    registry: { tools: [] },
+    stats: {
+      openedConnections: 0,
+      reusedConnections: 0,
+      coalescedConnections: 0,
+    },
+    async release() {
       return undefined;
     },
   };
+}
+
+async function openMcpConnection(server: IExpertAgentMcpServer): Promise<McpConnection> {
+  const client = await createOfficialMcpClient(server);
+  try {
+    return { client, tools: await client.listTools() };
+  } catch (error) {
+    await client.dispose().catch(() => undefined);
+    throw error;
+  }
 }
 
 function createManagedMcpTool(
@@ -354,10 +446,6 @@ function normalizeMcpToolInfo(tool: McpToolInfo): McpToolInfo {
     ...(tool.inputSchema === undefined ? {} : { inputSchema: tool.inputSchema }),
     ...(tool.outputSchema === undefined ? {} : { outputSchema: tool.outputSchema }),
   };
-}
-
-async function disposeMcpClients(clients: readonly McpClient[]): Promise<void> {
-  await Promise.allSettled(clients.map((client) => client.dispose()));
 }
 
 async function withTimeout<TResult>(

--- a/packages/core/src/tools/execution-tools.ts
+++ b/packages/core/src/tools/execution-tools.ts
@@ -1,0 +1,318 @@
+import { randomUUID } from "node:crypto";
+
+import type { Expert } from "../agent/expert-agent.ts";
+import type { ExpertAgentDefaultTool } from "../context-system/context-tools.ts";
+import type { PragmaLogger } from "../logging/logger.ts";
+import type { McpManagedTool } from "../mcp-tools.ts";
+import { dispatchExpertAgentHook } from "../plugins/expert-agent-plugin.ts";
+import type { RuntimeEventEmitter } from "../runtime/runtime-event-emitter.ts";
+import type { ExpertAgentRunContext } from "../runtime/run-context.ts";
+import type { RuntimeStreamEvent } from "../runtime/stream-events.ts";
+import type {
+  ExpertAgentHumanInteractionHandler,
+  ExpertAgentManagedTool,
+  ExpertAgentToolApproval,
+  ExpertAgentToolCallResult,
+  ExpertToolExecutionContext,
+} from "./managed-tool.ts";
+import { resolveExpertAgentToolApprovalRequirement } from "./managed-tool.ts";
+import { resolveToolPolicy, type ResolvedTool, type ResolvedToolSet } from "./tool-resolver.ts";
+
+export interface ExecutionToolRuntimeState {
+  runId?: string | undefined;
+  source?: RuntimeStreamEvent["source"] | undefined;
+  emitter?: RuntimeEventEmitter | undefined;
+}
+
+export interface ExecutionTool extends ExpertAgentManagedTool<string, ExpertAgentToolCallResult> {
+  readonly label: string;
+}
+export type ResolvedExecutionTool = ResolvedTool<ExecutionTool>;
+export type ResolvedExecutionToolSet = ResolvedToolSet<ExecutionTool>;
+
+export function resolveExecutionTools(options: {
+  readonly agent: Expert;
+  readonly context?: ExpertAgentRunContext | undefined;
+  readonly getContext: () => ExpertAgentRunContext | undefined;
+  readonly mcpTools?: readonly McpManagedTool[] | undefined;
+}): ResolvedExecutionToolSet {
+  const defaultTools = options.agent.createDefaultTools({ getContext: options.getContext });
+  return resolveToolPolicy({
+    context: options.context ?? options.getContext(),
+    tools: [
+      ...defaultTools.map((tool) => resolvedTool("default", fromDefaultTool(tool))),
+      ...(options.agent.tools ?? []).map((tool) => resolvedTool("managed", fromManagedTool(tool))),
+      ...createExecutionMcpTools(options.mcpTools ?? []).map((tool) => resolvedTool("mcp", tool)),
+    ],
+  });
+}
+
+export async function executeExecutionTool(options: {
+  readonly agent: Expert;
+  readonly tool: ExecutionTool;
+  readonly toolCallId: string | undefined;
+  readonly args: unknown;
+  readonly signal: AbortSignal | undefined;
+  readonly humanInteractionHandler?: ExpertAgentHumanInteractionHandler | undefined;
+  readonly runContext?: ExpertAgentRunContext | undefined;
+  readonly executionContext?: ExpertToolExecutionContext | undefined;
+  readonly logger: PragmaLogger;
+  readonly state: ExecutionToolRuntimeState;
+}): Promise<ExpertAgentToolCallResult> {
+  const startedAt = Date.now();
+  const runId = options.state.runId;
+
+  options.logger.info("tool.call_started", "Tool call started", {
+    runId,
+    toolName: options.tool.name,
+    toolCallId: options.toolCallId,
+  });
+  await dispatchExpertAgentHook(options.agent.hooks, "beforeToolCall", {
+    agent: options.agent,
+    toolName: options.tool.name,
+    toolCallId: options.toolCallId,
+    args: options.args,
+    runId,
+    logger: options.logger,
+  });
+
+  try {
+    const resolvedArgs = await maybeRequestToolApproval({
+      approval: options.tool.approval,
+      humanInteractionHandler: options.humanInteractionHandler,
+      toolName: options.tool.name,
+      toolCallId: options.toolCallId,
+      args: options.args,
+      state: options.state,
+    });
+    if (!resolvedArgs.approved) {
+      const durationMs = Date.now() - startedAt;
+      await dispatchExpertAgentHook(options.agent.hooks, "afterToolCall", {
+        agent: options.agent,
+        toolName: options.tool.name,
+        toolCallId: options.toolCallId,
+        args: options.args,
+        runId,
+        durationMs,
+        result: resolvedArgs.result,
+        logger: options.logger,
+      });
+      return resolvedArgs.result;
+    }
+
+    const executeArgs = resolvedArgs.updatedInput ?? options.args;
+    const result = await options.tool.call(executeArgs, options.signal, {
+      toolCallId: options.toolCallId,
+      humanInteraction: options.humanInteractionHandler,
+      runContext: options.runContext,
+      execution: options.executionContext,
+    });
+    const durationMs = Date.now() - startedAt;
+    await dispatchExpertAgentHook(options.agent.hooks, "afterToolCall", {
+      agent: options.agent,
+      toolName: options.tool.name,
+      toolCallId: options.toolCallId,
+      args: executeArgs,
+      runId,
+      durationMs,
+      result,
+      logger: options.logger,
+    });
+    options.logger.info("tool.call_completed", "Tool call completed", {
+      runId,
+      toolName: options.tool.name,
+      toolCallId: options.toolCallId,
+      durationMs,
+      isError: result.isError ?? false,
+    });
+    return result;
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    await dispatchExpertAgentHook(options.agent.hooks, "afterToolCall", {
+      agent: options.agent,
+      toolName: options.tool.name,
+      toolCallId: options.toolCallId,
+      args: options.args,
+      runId,
+      durationMs,
+      error,
+      logger: options.logger,
+    });
+    options.logger.error("tool.call_failed", "Tool call failed", error, {
+      runId,
+      toolName: options.tool.name,
+      toolCallId: options.toolCallId,
+      durationMs,
+    });
+    throw error;
+  }
+}
+
+function resolvedTool(
+  source: ResolvedExecutionTool["source"],
+  tool: ExecutionTool,
+): ResolvedExecutionTool {
+  return { name: tool.name, source, tool };
+}
+
+function fromDefaultTool(tool: ExpertAgentDefaultTool): ExecutionTool {
+  return {
+    name: tool.name,
+    label: tool.label,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    approval: tool.approval,
+    async call(args, signal, context) {
+      return await tool.call(args, signal, {
+        toolCallId: context?.toolCallId,
+        humanInteraction: context?.humanInteraction,
+      });
+    },
+  };
+}
+
+function fromManagedTool(
+  tool: ExpertAgentManagedTool<string, ExpertAgentToolCallResult>,
+): ExecutionTool {
+  return {
+    name: tool.name,
+    label: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    ...(tool.outputSchema === undefined ? {} : { outputSchema: tool.outputSchema }),
+    approval: tool.approval,
+    async call(args, signal, context) {
+      return await tool.call(args, signal, context);
+    },
+  };
+}
+
+function createExecutionMcpTools(mcpTools: readonly McpManagedTool[]): ExecutionTool[] {
+  return mcpTools.map((mcpTool) => ({
+    name: `mcp_${sanitizeExecutionToolName(mcpTool.serverId)}_${sanitizeExecutionToolName(mcpTool.name)}`,
+    label: `MCP ${mcpTool.serverName}:${mcpTool.name}`,
+    description: [
+      mcpTool.description ?? `Call MCP tool ${mcpTool.name}.`,
+      `Original MCP server: ${mcpTool.serverName}. Original tool: ${mcpTool.name}.`,
+    ].join("\n"),
+    inputSchema: mcpTool.inputSchema,
+    ...(mcpTool.outputSchema === undefined ? {} : { outputSchema: mcpTool.outputSchema }),
+    approval: mcpTool.approval,
+    async call(args, signal, context) {
+      const result = await mcpTool.call(args, signal, { toolCallId: context?.toolCallId });
+      return {
+        text: formatMcpToolResult(result),
+        ...(isRecord(result) && result["isError"] === true ? { isError: true } : {}),
+        details:
+          isRecord(result) && isJsonObject(result["structuredContent"])
+            ? result["structuredContent"]
+            : { server: mcpTool.serverName, tool: mcpTool.name, result },
+      };
+    },
+  }));
+}
+
+export function sanitizeExecutionToolName(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9_]/g, "_").replace(/_+/g, "_");
+  return sanitized.length === 0 ? "tool" : sanitized;
+}
+
+function formatMcpToolResult(result: unknown): string {
+  if (isRecord(result) && Array.isArray(result["content"])) {
+    const text = result["content"]
+      .map((entry) => (isRecord(entry) && typeof entry["text"] === "string" ? entry["text"] : null))
+      .filter((entry): entry is string => entry !== null);
+    if (text.length > 0) return text.join("\n");
+  }
+  if (typeof result === "string") return result;
+  return JSON.stringify(result, null, 2) ?? String(result);
+}
+
+async function maybeRequestToolApproval(options: {
+  readonly approval: ExpertAgentToolApproval | undefined;
+  readonly humanInteractionHandler?: ExpertAgentHumanInteractionHandler | undefined;
+  readonly toolName: string;
+  readonly toolCallId: string | undefined;
+  readonly args: unknown;
+  readonly state: ExecutionToolRuntimeState;
+}): Promise<
+  | { readonly approved: true; readonly updatedInput: unknown | undefined }
+  | { readonly approved: false; readonly result: ExpertAgentToolCallResult }
+> {
+  const approval = options.approval;
+  if (approval === undefined) return { approved: true, updatedInput: undefined };
+  const request = {
+    kind: "tool_approval" as const,
+    toolName: options.toolName,
+    toolCallId: options.toolCallId,
+    reason: approval.reason,
+    input: options.args,
+  };
+  const requirement = await resolveExpertAgentToolApprovalRequirement(approval, request);
+  if (requirement === "none") return { approved: true, updatedInput: undefined };
+  if (requirement === "ask" && options.humanInteractionHandler === undefined) {
+    return { approved: true, updatedInput: undefined };
+  }
+  emitExecutionToolApprovalRequested({ ...options, approval });
+  if (options.humanInteractionHandler === undefined) {
+    return {
+      approved: false,
+      result: {
+        text: approval.reason ?? `Tool approval required for ${options.toolName}.`,
+        isError: true,
+      },
+    };
+  }
+  const response = await options.humanInteractionHandler(request);
+  if (response.kind !== "tool_approval" || !response.approved) {
+    return {
+      approved: false,
+      result: {
+        text:
+          response.kind === "tool_approval" && response.reason !== undefined
+            ? response.reason
+            : `User declined ${options.toolName}.`,
+        isError: true,
+      },
+    };
+  }
+  return { approved: true, updatedInput: response.updatedInput };
+}
+
+export function emitExecutionToolApprovalRequested(options: {
+  readonly approval: ExpertAgentToolApproval;
+  readonly toolName: string;
+  readonly toolCallId: string | undefined;
+  readonly args: unknown;
+  readonly state: ExecutionToolRuntimeState;
+}): void {
+  const approvalId = `approval-${randomUUID()}`;
+  const runId = options.state.runId ?? approvalId;
+  const toolCallId = options.toolCallId ?? approvalId;
+  options.state.emitter?.emit({
+    runId,
+    source: {
+      ...(options.state.source ?? { kind: "tool", runId, path: [] }),
+      kind: "tool",
+      runId,
+      toolCallId,
+    },
+    type: "tool.approval_requested",
+    payload: {
+      approvalId,
+      toolCallId,
+      toolName: options.toolName,
+      kind: "tool",
+      ...(options.approval.reason === undefined ? {} : { reason: options.approval.reason }),
+      inputPreview: options.args,
+    },
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && !Array.isArray(value);
+}

--- a/packages/core/test/mcp-tool-registry-pool.test.ts
+++ b/packages/core/test/mcp-tool-registry-pool.test.ts
@@ -1,38 +1,47 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { mcpToolRegistryCacheKey } from "../src/mcp-tool-registry-cache-key.ts";
+import { mcpServerConnectionCacheKey } from "../src/mcp-tool-registry-cache-key.ts";
 import { createMcpToolRegistryPool } from "../src/mcp-tools.ts";
 import type { IExpertAgentMcpConfig } from "../src/agent/expert-agent.ts";
 
 describe("McpToolRegistryPool", () => {
-  it("shares one Registry while leases use the same MCP configuration", async () => {
-    const listTools = vi.fn(async () => [
-      { name: "search", description: "Search", inputSchema: { type: "object" } },
-    ]);
+  it("shares one server connection across concurrent leases", async () => {
+    let resolveTools: ((tools: readonly { name: string }[]) => void) | undefined;
+    const listTools = vi.fn(
+      async () =>
+        await new Promise<readonly { name: string }[]>((resolve) => {
+          resolveTools = resolve;
+        }),
+    );
     const dispose = vi.fn(async () => undefined);
-    const config: IExpertAgentMcpConfig = {
-      mcpServers: {
-        docs: {
-          name: "Docs",
-          transport: "in-process",
-          timeout: 1_000,
-          inProcess: {
-            listTools,
-            async callTool() {
-              return { content: [] };
-            },
-            dispose,
-          },
-        },
+    const inProcess = {
+      listTools,
+      async callTool() {
+        return { content: [] };
       },
+      dispose,
     };
     const pool = createMcpToolRegistryPool({ maxIdleEntries: 0 });
 
-    const first = await pool.acquire(config);
-    const second = await pool.acquire(config);
+    const firstPromise = pool.acquire({
+      mcpServers: {
+        compile: { name: "Docs", transport: "in-process", inProcess },
+      },
+    });
+    const secondPromise = pool.acquire({
+      mcpServers: {
+        runtime: { name: "Docs", transport: "in-process", inProcess },
+      },
+    });
+    while (resolveTools === undefined) await Promise.resolve();
+    resolveTools?.([{ name: "search" }]);
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
 
-    expect(first.registry).toBe(second.registry);
     expect(listTools).toHaveBeenCalledOnce();
+    expect(first.stats.openedConnections).toBe(1);
+    expect(second.stats.coalescedConnections).toBe(1);
+    expect(first.registry.tools[0]?.serverId).toBe("compile");
+    expect(second.registry.tools[0]?.serverId).toBe("runtime");
     await first.release();
     expect(dispose).not.toHaveBeenCalled();
     await second.release();
@@ -40,13 +49,57 @@ describe("McpToolRegistryPool", () => {
     await pool.close();
   });
 
-  it("does not merge distinct in-process MCP configurations", async () => {
+  it("applies allowlists and approvals per lease without reopening the server", async () => {
+    const listTools = vi.fn(async () => [
+      { name: "read", description: "Read" },
+      { name: "search", description: "Search" },
+    ]);
+    const inProcess = {
+      listTools,
+      async callTool() {
+        return { content: [] };
+      },
+    };
+    const pool = createMcpToolRegistryPool({ idleTtlMs: 1_000, maxIdleEntries: 32 });
+
+    const compile = await pool.acquire({
+      mcpServers: {
+        verify: {
+          name: "Docs",
+          transport: "in-process",
+          inProcess,
+          allowTools: ["read"],
+        },
+      },
+    });
+    await compile.release();
+    const runtime = await pool.acquire({
+      mcpServers: {
+        docs: {
+          name: "Docs",
+          transport: "in-process",
+          inProcess,
+          allowTools: ["search"],
+          toolApprovals: { search: { mode: "ask" } },
+        },
+      },
+    });
+
+    expect(listTools).toHaveBeenCalledOnce();
+    expect(compile.registry.tools.map((tool) => tool.name)).toEqual(["read"]);
+    expect(runtime.registry.tools.map((tool) => tool.name)).toEqual(["search"]);
+    expect(runtime.registry.tools[0]?.approval).toEqual({ mode: "ask" });
+    expect(runtime.stats.reusedConnections).toBe(1);
+    await runtime.release();
+    await pool.close();
+  });
+
+  it("does not merge distinct in-process servers", async () => {
     const configuration = (): IExpertAgentMcpConfig => ({
       mcpServers: {
         local: {
           name: "Local",
           transport: "in-process",
-          timeout: 1_000,
           inProcess: {
             async listTools() {
               return [];
@@ -63,43 +116,57 @@ describe("McpToolRegistryPool", () => {
     const first = await pool.acquire(configuration());
     const second = await pool.acquire(configuration());
 
-    expect(first.registry).not.toBe(second.registry);
+    expect(first.stats.openedConnections).toBe(1);
+    expect(second.stats.openedConnections).toBe(1);
     await Promise.all([first.release(), second.release()]);
     await pool.close();
   });
 
-  it("uses the same cache key for equivalent external configurations", () => {
-    const first = {
+  it("hard-closes active connections during final Host shutdown", async () => {
+    const dispose = vi.fn(async () => undefined);
+    const pool = createMcpToolRegistryPool();
+    const lease = await pool.acquire({
       mcpServers: {
-        docs: {
-          name: "Docs",
-          transport: "streamable-http",
-          url: "https://docs.example.test/mcp",
-          token: "secret",
-          allowTools: ["read", "search"],
-          toolApprovals: {
-            search: { mode: "ask" },
-            read: { mode: "none" },
+        local: {
+          name: "Local",
+          transport: "in-process",
+          inProcess: {
+            async listTools() {
+              return [];
+            },
+            async callTool() {
+              return { content: [] };
+            },
+            dispose,
           },
         },
       },
-    } satisfies IExpertAgentMcpConfig;
-    const second = {
-      mcpServers: {
-        docs: {
-          toolApprovals: {
-            read: { mode: "none" },
-            search: { mode: "ask" },
-          },
-          allowTools: ["search", "read"],
-          token: "secret",
-          url: "https://docs.example.test/mcp",
-          transport: "streamable-http",
-          name: "Docs",
-        },
-      },
-    } satisfies IExpertAgentMcpConfig;
+    });
 
-    expect(mcpToolRegistryCacheKey(first)).toBe(mcpToolRegistryCacheKey(second));
+    await pool.close();
+    expect(dispose).toHaveBeenCalledOnce();
+    await expect(lease.release()).resolves.toBeUndefined();
+    await expect(pool.acquire(undefined)).rejects.toThrow("pool is closed");
+  });
+
+  it("uses one connection key for equivalent external servers regardless of projections", () => {
+    const first = {
+      name: "Docs",
+      transport: "streamable-http",
+      url: "https://docs.example.test/mcp",
+      token: "secret",
+      allowTools: ["read"],
+      toolApprovals: { read: { mode: "none" } },
+    } as const;
+    const second = {
+      toolApprovals: { search: { mode: "ask" } },
+      allowTools: ["search"],
+      token: "secret",
+      url: "https://docs.example.test/mcp",
+      transport: "streamable-http",
+      name: "Docs",
+    } as const;
+
+    expect(mcpServerConnectionCacheKey(first)).toBe(mcpServerConnectionCacheKey(second));
   });
 });

--- a/packages/interpreter/src/compiler/pragma-project.ts
+++ b/packages/interpreter/src/compiler/pragma-project.ts
@@ -8,6 +8,7 @@ import {
   defineExpertTeam,
   defineFlow,
   mergeExpertAgentToolApprovals,
+  sanitizeExecutionToolName,
   type Expert,
   type ExpertAgentManagedTool,
   type ExpertAgentToolCallResult,
@@ -2250,7 +2251,9 @@ function filterMcpContribution(
               toolName,
               mergeExpertAgentToolApprovals(server.toolApprovals?.[toolName], {
                 mode:
-                  resource.spec.toolApprovals[`mcp_${key}_${sanitizeToolName(toolName)}`] ??
+                  resource.spec.toolApprovals[
+                    `mcp_${key}_${sanitizeExecutionToolName(toolName)}`
+                  ] ??
                   resource.spec.toolApprovals[toolName] ??
                   "ask",
               })!,
@@ -2260,10 +2263,6 @@ function filterMcpContribution(
       ]),
     ),
   };
-}
-
-function sanitizeToolName(value: string): string {
-  return value.replace(/[^a-zA-Z0-9_]/g, "_").replace(/_+/g, "_") || "tool";
 }
 
 function mergeSkills(

--- a/packages/runtime/claude-code/src/adapter.ts
+++ b/packages/runtime/claude-code/src/adapter.ts
@@ -3,12 +3,13 @@ import { join } from "node:path";
 
 import type {
   McpToolRegistry,
+  McpToolRegistryLease,
   RuntimeAdapter,
   RuntimeCanUseResult,
   ExpertToolsMcpSessionRegistration,
 } from "@pragma/core";
 import {
-  createMcpToolRegistry,
+  createMcpToolRegistryPool,
   defineRuntimeDriver,
   registerExpertToolsMcpSession,
   type PragmaLogger,
@@ -54,13 +55,14 @@ const CLAUDE_CODE_LOCAL_RUNTIME_DESCRIPTOR = {
 const DEFAULT_CLAUDE_CODE_PERMISSION_MODE = "bypassPermissions" as const;
 
 interface ClaudeCodeDriverSession extends ClaudeCodeNativeSession {
-  readonly mcpToolRegistry: McpToolRegistry;
+  readonly mcpToolRegistryLease: McpToolRegistryLease;
   readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
 }
 
 export function createClaudeCodeRuntime(
   options: ClaudeCodeRuntimeAdapterOptions = {},
 ): RuntimeAdapter {
+  const mcpToolRegistries = options.mcpToolRegistryPool ?? createMcpToolRegistryPool();
   const command =
     options.spawn === undefined
       ? resolveClaudeCodeCommand(options)
@@ -129,6 +131,7 @@ export function createClaudeCodeRuntime(
         const toolRuntimeState: ExpertToolRuntimeState = {};
         const compactionHookRelay = await createClaudeCompactionHookRelay();
         let mcpToolRegistry: McpToolRegistry | undefined;
+        let mcpToolRegistryLease: McpToolRegistryLease | undefined;
         let expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined;
 
         try {
@@ -140,7 +143,8 @@ export function createClaudeCodeRuntime(
               authorization: compactionHookRelay.authorization,
             },
           });
-          mcpToolRegistry = await createMcpToolRegistry(ctx.agent.mcp);
+          mcpToolRegistryLease = await mcpToolRegistries.acquire(ctx.agent.mcp);
+          mcpToolRegistry = mcpToolRegistryLease.registry;
           expertToolsMcpRegistration = await registerExpertToolsMcpSession({
             agent: ctx.agent,
             getContext: () => ctx.lifecycle.currentContext,
@@ -166,6 +170,17 @@ export function createClaudeCodeRuntime(
               );
             }
           }
+          ctx.logger.info(
+            "runtime.claude_code_session_ready",
+            "Claude Code Session preparation completed",
+            {
+              systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+              toolCount: mcpToolRegistry.tools.length,
+              mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
+              mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
+              mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
+            },
+          );
 
           return {
             ...createClaudeCodeNativeSession({
@@ -190,12 +205,16 @@ export function createClaudeCodeRuntime(
               systemPrompt: ctx.agentContext.systemPrompt,
               tokenCounter: options.tokenCounter,
             }),
-            mcpToolRegistry,
+            mcpToolRegistryLease,
             expertToolsMcpRegistration,
           };
         } catch (error) {
           const cleanup = await Promise.allSettled([
-            disposeClaudeRuntimeResources(expertToolsMcpRegistration, mcpToolRegistry, ctx.logger),
+            disposeClaudeRuntimeResources(
+              expertToolsMcpRegistration,
+              mcpToolRegistryLease,
+              ctx.logger,
+            ),
             compactionHookRelay.close(),
           ]);
           const cleanupErrors = cleanup.flatMap((result) =>
@@ -251,7 +270,7 @@ export function createClaudeCodeRuntime(
         const cleanup = await Promise.allSettled([
           disposeClaudeRuntimeResources(
             session.expertToolsMcpRegistration,
-            session.mcpToolRegistry,
+            session.mcpToolRegistryLease,
             ctx.logger,
           ),
           session.compactionHookRelay.close(),
@@ -326,12 +345,12 @@ function createClaudeCodeRuntimeCanUse(
 
 async function disposeClaudeRuntimeResources(
   expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined,
-  mcpToolRegistry: McpToolRegistry | undefined,
+  mcpToolRegistryLease: McpToolRegistryLease | undefined,
   logger: PragmaLogger,
 ): Promise<void> {
   const results = await Promise.allSettled([
     expertToolsMcpRegistration?.dispose() ?? Promise.resolve(),
-    mcpToolRegistry?.dispose() ?? Promise.resolve(),
+    mcpToolRegistryLease?.release() ?? Promise.resolve(),
   ]);
   const errors = results.flatMap((result) =>
     result.status === "rejected" ? [result.reason as unknown] : [],

--- a/packages/runtime/claude-code/src/types.ts
+++ b/packages/runtime/claude-code/src/types.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeSessionRestoreHandler,
   RuntimeSessionSyncCallback,
   RuntimeTokenCounter,
+  McpToolRegistryPool,
 } from "@pragma/core";
 
 export type ClaudeCodeRuntimePermissionMode =
@@ -34,6 +35,7 @@ export interface ClaudeCodeRuntimeAdapterOptions {
   readonly sessionRestoreHandler?: RuntimeSessionRestoreHandler | undefined;
   readonly sessionSyncCallback?: RuntimeSessionSyncCallback | undefined;
   readonly tokenCounter?: RuntimeTokenCounter | undefined;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
 }
 
 export interface ClaudeCodeRuntimeMessage {

--- a/packages/runtime/codex/src/adapter.ts
+++ b/packages/runtime/codex/src/adapter.ts
@@ -63,13 +63,12 @@ const DEFAULT_CODEX_CLIENT_INFO = {
 
 interface CodexDriverSession extends CodexNativeSession {
   readonly logger: PragmaLogger;
-  readonly mcpToolRegistry: McpToolRegistry;
   readonly mcpToolRegistryLease: McpToolRegistryLease;
   readonly expertToolsMcpRegistration: CodexExpertToolsMcpSessionRegistration;
 }
 
 export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): RuntimeAdapter {
-  const mcpToolRegistries = createMcpToolRegistryPool();
+  const mcpToolRegistries = options.mcpToolRegistryPool ?? createMcpToolRegistryPool();
   const executablePath =
     options.executablePath ??
     (options.spawn === undefined ? resolveCodexExecutablePath(options) : "codex");
@@ -241,6 +240,9 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
             elapsedMs: codexElapsedMs(sessionStartedAt),
             systemPromptCharacters: ctx.agentContext.systemPrompt.length,
             toolCount: mcpToolRegistry.tools.length,
+            mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
+            mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
+            mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
           });
 
           return {
@@ -257,7 +259,6 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
                 : [],
             }),
             logger: ctx.logger,
-            mcpToolRegistry,
             mcpToolRegistryLease,
             expertToolsMcpRegistration,
           };

--- a/packages/runtime/codex/src/types.ts
+++ b/packages/runtime/codex/src/types.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeSessionRestoreHandler,
   RuntimeSessionSyncCallback,
   RuntimeTokenCounter,
+  McpToolRegistryPool,
 } from "@pragma/core";
 
 export type CodexRuntimeSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
@@ -43,6 +44,7 @@ export interface CodexRuntimeAdapterOptions {
   readonly sessionRestoreHandler?: RuntimeSessionRestoreHandler | undefined;
   readonly sessionSyncCallback?: RuntimeSessionSyncCallback | undefined;
   readonly tokenCounter?: RuntimeTokenCounter | undefined;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
 }
 
 export interface CodexRuntimeMessage {

--- a/packages/runtime/pi/src/adapter.ts
+++ b/packages/runtime/pi/src/adapter.ts
@@ -11,6 +11,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type {
   McpToolRegistry,
+  McpToolRegistryLease,
   PragmaLogger,
   ResolvedModelProvider,
   RuntimeAdapter,
@@ -18,7 +19,7 @@ import type {
   RuntimeTokenModelIdentity,
 } from "@pragma/core";
 import {
-  createMcpToolRegistry,
+  createMcpToolRegistryPool,
   defineRuntimeDriver,
   type RuntimeSessionPersistenceSpec,
 } from "@pragma/core";
@@ -64,11 +65,12 @@ const CLOUD_PI_RUNTIME_DESCRIPTOR = {
 };
 
 interface PiDriverSession extends PiNativeSession {
-  readonly mcpToolRegistry: McpToolRegistry;
+  readonly mcpToolRegistryLease: McpToolRegistryLease;
 }
 
 export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): RuntimeAdapter {
   const modelProviderConverter = createPiModelProviderConverter();
+  const mcpToolRegistries = options.mcpToolRegistryPool ?? createMcpToolRegistryPool();
   const descriptor = {
     ...CLOUD_PI_RUNTIME_DESCRIPTOR,
     ...options.descriptor,
@@ -137,7 +139,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
           ctx.logger,
           "mcp_tool_registry",
           sessionStartedAt,
-          async () => await createMcpToolRegistry(ctx.agent.mcp),
+          async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
         );
         const sessionManagerPromise = timedPiPhase(
           ctx.logger,
@@ -159,9 +161,9 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             mcpRegistryPromise,
             sessionManagerPromise,
           ]);
-          const registry = preparation[1];
-          if (registry?.status === "fulfilled") {
-            const cleanupError = await piRegistryCleanupError(registry.value);
+          const lease = preparation[1];
+          if (lease?.status === "fulfilled") {
+            const cleanupError = await piRegistryCleanupError(lease.value);
             if (cleanupError !== undefined) {
               throw new AggregateError(
                 [error, cleanupError],
@@ -181,9 +183,9 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             mcpRegistryPromise,
             sessionManagerPromise,
           ]);
-          const registry = preparation[1];
-          if (registry?.status === "fulfilled") {
-            const cleanupError = await piRegistryCleanupError(registry.value);
+          const lease = preparation[1];
+          if (lease?.status === "fulfilled") {
+            const cleanupError = await piRegistryCleanupError(lease.value);
             if (cleanupError !== undefined) {
               throw new AggregateError(
                 [providerError, cleanupError],
@@ -206,19 +208,24 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             ),
         );
         let modelRuntimeResult: Awaited<ReturnType<typeof createPiModelRuntime>>;
+        let mcpToolRegistryLease: McpToolRegistryLease;
         let mcpToolRegistry: McpToolRegistry;
         let piSessionManagerResult: Awaited<ReturnType<typeof createPiSessionManager>>;
         try {
-          [modelRuntimeResult, mcpToolRegistry, piSessionManagerResult] = await Promise.all([
+          const preparation = await Promise.all([
             modelRuntimePromise,
             mcpRegistryPromise,
             sessionManagerPromise,
             resourceReloadPromise,
           ]);
+          modelRuntimeResult = preparation[0];
+          mcpToolRegistryLease = preparation[1];
+          mcpToolRegistry = mcpToolRegistryLease.registry;
+          piSessionManagerResult = preparation[2];
         } catch (error) {
-          const registry = await Promise.allSettled([mcpRegistryPromise]);
-          if (registry[0]?.status === "fulfilled") {
-            const cleanupError = await piRegistryCleanupError(registry[0].value);
+          const lease = await Promise.allSettled([mcpRegistryPromise]);
+          if (lease[0]?.status === "fulfilled") {
+            const cleanupError = await piRegistryCleanupError(lease[0].value);
             if (cleanupError !== undefined) {
               throw new AggregateError(
                 [error, cleanupError],
@@ -295,6 +302,9 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             elapsedMs: piElapsedMs(sessionStartedAt),
             toolCount: sessionOptions.customTools?.length ?? 0,
             systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+            mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
+            mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
+            mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
           });
 
           return {
@@ -311,13 +321,13 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
               tokenCounter: options.tokenCounter,
               tokenModelIdentity: piTokenModelIdentity(registeredProvider, selectedModel),
             }),
-            mcpToolRegistry,
+            mcpToolRegistryLease,
           };
         } catch (error) {
           const cleanupErrors = (
             await Promise.allSettled([
               Promise.resolve().then(() => session?.dispose()),
-              mcpToolRegistry.dispose(),
+              mcpToolRegistryLease.release(),
             ])
           ).flatMap((result) => (result.status === "rejected" ? [result.reason as unknown] : []));
           if (cleanupErrors.length > 0) {
@@ -366,7 +376,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
       },
       async closeSession(session) {
         session.session.dispose();
-        await session.mcpToolRegistry.dispose();
+        await session.mcpToolRegistryLease.release();
       },
     },
     {
@@ -422,8 +432,8 @@ function piElapsedMs(startedAt: number): number {
   return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
-async function piRegistryCleanupError(registry: McpToolRegistry): Promise<unknown | undefined> {
-  const [result] = await Promise.allSettled([registry.dispose()]);
+async function piRegistryCleanupError(lease: McpToolRegistryLease): Promise<unknown | undefined> {
+  const [result] = await Promise.allSettled([lease.release()]);
   return result?.status === "rejected" ? result.reason : undefined;
 }
 

--- a/packages/runtime/pi/src/tool-schema.ts
+++ b/packages/runtime/pi/src/tool-schema.ts
@@ -12,25 +12,6 @@ export function normalizeInputSchema(schema: unknown): ToolDefinition["parameter
   } as ToolDefinition["parameters"];
 }
 
-export function formatMcpToolResult(result: unknown): string {
-  if (isRecord(result) && Array.isArray(result.content)) {
-    const textParts = result.content
-      .map((entry) => (isRecord(entry) && typeof entry.text === "string" ? entry.text : undefined))
-      .filter((entry): entry is string => entry !== undefined);
-
-    if (textParts.length > 0) {
-      return textParts.join("\n");
-    }
-  }
-
-  return typeof result === "string" ? result : JSON.stringify(result, null, 2);
-}
-
-export function sanitizeToolName(value: string): string {
-  const sanitized = value.replace(/[^a-zA-Z0-9_]/g, "_").replace(/_+/g, "_");
-  return sanitized.length === 0 ? "tool" : sanitized;
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }

--- a/packages/runtime/pi/src/tools.ts
+++ b/packages/runtime/pi/src/tools.ts
@@ -1,26 +1,17 @@
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
-import type {
-  AgentLifecycle,
-  Expert,
-  ExpertAgentDefaultTool,
-  ExpertAgentHumanInteractionHandler,
-  ExpertAgentManagedTool,
-  ExpertAgentToolApproval,
-  ExpertAgentToolCallResult,
-  ExpertAgentRunContext,
-  ExpertToolExecutionContext,
-  ResolvedTool,
-  ResolvedToolSet,
-} from "@pragma/core";
 import {
-  dispatchExpertAgentHook,
-  resolveExpertAgentToolApprovalRequirement,
-  resolveToolPolicy,
+  executeExecutionTool,
+  resolveExecutionTools,
+  type AgentLifecycle,
+  type Expert,
+  type ExpertAgentHumanInteractionHandler,
+  type ExpertAgentRunContext,
+  type ExpertToolExecutionContext,
+  type McpManagedTool,
+  type ResolvedToolSet,
 } from "@pragma/core";
-import { randomUUID } from "node:crypto";
 
-import type { McpManagedTool } from "@pragma/core";
-import { formatMcpToolResult, normalizeInputSchema, sanitizeToolName } from "./tool-schema.ts";
+import { normalizeInputSchema } from "./tool-schema.ts";
 import type { PiRuntimeStreamState } from "./types.ts";
 
 export function createResolvedPiTools(options: {
@@ -34,35 +25,20 @@ export function createResolvedPiTools(options: {
   readonly executionContext?: ExpertToolExecutionContext | undefined;
   readonly humanInteractionHandler?: ExpertAgentHumanInteractionHandler | undefined;
 }): ResolvedToolSet<ToolDefinition> {
-  const contextTools = options.agent.createDefaultTools({
-    getContext: () => options.lifecycle.currentContext,
-  });
-  const humanInteractionHandler = options.humanInteractionHandler;
-
-  const parentResolvedTools = resolveToolPolicy({
+  const resolved = resolveExecutionTools({
+    agent: options.agent,
     context: options.context,
-    tools: [
-      ...createPiDefaultTools(
-        options.agent,
-        contextTools,
-        options.streamState,
-        humanInteractionHandler,
-      ).map((tool) => createResolvedTool("default", tool)),
-      ...createPiManagedTools(
-        options.agent,
-        options.agent.tools ?? [],
-        options.streamState,
-        humanInteractionHandler,
-        options.lifecycle.currentContext,
-        options.executionContext,
-      ).map((tool) => createResolvedTool("managed", tool)),
-      ...createPiMcpTools(options.agent, options.mcpTools, options.streamState).map((tool) =>
-        createResolvedTool("mcp", tool),
-      ),
-    ],
+    getContext: () => options.lifecycle.currentContext,
+    mcpTools: options.mcpTools,
   });
-
-  return parentResolvedTools;
+  return {
+    policy: resolved.policy,
+    tools: resolved.tools.map((item) => ({
+      name: item.name,
+      source: item.source,
+      tool: toPiTool(item.tool, options),
+    })),
+  };
 }
 
 export function createCustomTools(
@@ -71,24 +47,11 @@ export function createCustomTools(
   return createResolvedPiTools(options).tools.map((resolvedTool) => resolvedTool.tool);
 }
 
-function createResolvedTool(
-  source: ResolvedTool<ToolDefinition>["source"],
-  tool: ToolDefinition,
-): ResolvedTool<ToolDefinition> {
+function toPiTool(
+  tool: ReturnType<typeof resolveExecutionTools>["tools"][number]["tool"],
+  options: Parameters<typeof createResolvedPiTools>[0],
+): ToolDefinition {
   return {
-    name: tool.name,
-    source,
-    tool,
-  };
-}
-
-function createPiDefaultTools(
-  agent: Expert,
-  tools: readonly ExpertAgentDefaultTool[],
-  streamState: PiRuntimeStreamState,
-  humanInteractionHandler: ExpertAgentHumanInteractionHandler | undefined,
-): ToolDefinition[] {
-  return tools.map((tool) => ({
     name: tool.name,
     label: tool.label,
     description: tool.description,
@@ -96,353 +59,23 @@ function createPiDefaultTools(
     parameters: normalizeInputSchema(tool.inputSchema),
     executionMode: "parallel",
     async execute(toolCallId, params, signal) {
-      const result = await executeWithToolHooks(
-        agent,
-        tool.name,
+      const result = await executeExecutionTool({
+        agent: options.agent,
+        tool,
         toolCallId,
-        params,
-        tool.approval,
-        humanInteractionHandler,
-        streamState,
-        async (resolvedParams) =>
-          await tool.call(resolvedParams, signal, {
-            toolCallId,
-            humanInteraction: humanInteractionHandler,
-          }),
-      );
-
+        args: params,
+        signal,
+        humanInteractionHandler: options.humanInteractionHandler,
+        runContext: options.lifecycle.currentContext,
+        executionContext: options.executionContext,
+        logger: options.streamState.logger ?? options.agent.logger,
+        state: options.streamState,
+      });
       return {
-        content: [
-          {
-            type: "text",
-            text: result.text,
-          },
-        ],
+        content: [{ type: "text", text: result.text }],
         isError: result.isError ?? false,
         details: result.details,
       };
     },
-  }));
-}
-
-function createPiManagedTools(
-  agent: Expert,
-  tools: readonly ExpertAgentManagedTool<string, ExpertAgentToolCallResult>[],
-  streamState: PiRuntimeStreamState,
-  humanInteractionHandler: ExpertAgentHumanInteractionHandler | undefined,
-  runContext: ExpertAgentRunContext | undefined,
-  executionContext: ExpertToolExecutionContext | undefined,
-): ToolDefinition[] {
-  return tools.map((tool) => ({
-    name: tool.name,
-    label: tool.name,
-    description: tool.description,
-    promptSnippet: `${tool.name}: ${tool.description}`,
-    parameters: normalizeInputSchema(tool.inputSchema),
-    executionMode: "parallel",
-    async execute(toolCallId, params, signal) {
-      const result = await executeWithToolHooks(
-        agent,
-        tool.name,
-        toolCallId,
-        params,
-        tool.approval,
-        humanInteractionHandler,
-        streamState,
-        async (resolvedParams) =>
-          await tool.call(resolvedParams, signal, {
-            toolCallId,
-            humanInteraction: humanInteractionHandler,
-            runContext,
-            execution: executionContext,
-          }),
-      );
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: result.text,
-          },
-        ],
-        isError: result.isError ?? false,
-        details: result.details,
-      };
-    },
-  }));
-}
-
-function createPiMcpTools(
-  agent: Expert,
-  mcpTools: readonly McpManagedTool[],
-  streamState: PiRuntimeStreamState,
-): ToolDefinition[] {
-  return mcpTools.map((mcpTool) => {
-    const toolName = `mcp_${sanitizeToolName(mcpTool.serverId)}_${sanitizeToolName(mcpTool.name)}`;
-
-    return {
-      name: toolName,
-      label: `MCP ${mcpTool.serverName}:${mcpTool.name}`,
-      description: [
-        mcpTool.description ?? `Call MCP tool ${mcpTool.name}.`,
-        `Original MCP server: ${mcpTool.serverName}. Original tool: ${mcpTool.name}.`,
-      ].join("\n"),
-      promptSnippet: `${toolName}: call ${mcpTool.name} from MCP server ${mcpTool.serverName}`,
-      parameters: normalizeInputSchema(mcpTool.inputSchema),
-      executionMode: "parallel",
-      async execute(toolCallId, params) {
-        const result = await executeWithToolHooks(
-          agent,
-          toolName,
-          toolCallId,
-          params,
-          undefined,
-          undefined,
-          streamState,
-          async (resolvedParams) => {
-            const rawResult = await mcpTool.call(resolvedParams, undefined, { toolCallId });
-            return {
-              text: formatMcpToolResult(rawResult),
-              ...(isRecord(rawResult) && rawResult["isError"] === true ? { isError: true } : {}),
-              details: rawResult,
-            };
-          },
-        );
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: result.text,
-            },
-          ],
-          isError: result.isError ?? false,
-          details: {
-            server: mcpTool.serverName,
-            tool: mcpTool.name,
-            result,
-          },
-        };
-      },
-    };
-  });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-async function executeWithToolHooks<
-  TResult extends { text: string; isError?: boolean; details?: unknown },
->(
-  agent: Expert,
-  toolName: string,
-  toolCallId: string | undefined,
-  args: unknown,
-  approval: ExpertAgentToolApproval | undefined,
-  humanInteractionHandler: ExpertAgentHumanInteractionHandler | undefined,
-  streamState: PiRuntimeStreamState,
-  execute: (args: unknown) => Promise<TResult>,
-): Promise<TResult> {
-  const startedAt = Date.now();
-  const logger = streamState.logger ?? agent.logger;
-
-  logger.info("tool.call_started", "Tool call started", {
-    runId: streamState.runId,
-    toolName,
-    toolCallId,
-  });
-  await dispatchExpertAgentHook(agent.hooks, "beforeToolCall", {
-    agent,
-    toolName,
-    toolCallId,
-    args,
-    runId: streamState.runId,
-    logger,
-  });
-
-  try {
-    const resolvedArgs = await maybeRequestToolApproval<TResult>({
-      approval,
-      humanInteractionHandler,
-      toolName,
-      toolCallId,
-      runId: streamState.runId,
-      source: streamState.source,
-      args,
-      emitApprovalRequested: (request) => {
-        streamState.emitter?.emit(request);
-      },
-    });
-    if (resolvedArgs.approved === false) {
-      const durationMs = Date.now() - startedAt;
-      await dispatchExpertAgentHook(agent.hooks, "afterToolCall", {
-        agent,
-        toolName,
-        toolCallId,
-        args,
-        runId: streamState.runId,
-        durationMs,
-        result: resolvedArgs.result,
-        logger,
-      });
-      logger.warn("tool.call_rejected", "Tool call rejected by approval policy", {
-        runId: streamState.runId,
-        toolName,
-        toolCallId,
-        durationMs,
-      });
-      return resolvedArgs.result;
-    }
-
-    const executeArgs = resolvedArgs.updatedInput ?? args;
-    const result = await execute(executeArgs);
-    const durationMs = Date.now() - startedAt;
-
-    await dispatchExpertAgentHook(agent.hooks, "afterToolCall", {
-      agent,
-      toolName,
-      toolCallId,
-      args: executeArgs,
-      runId: streamState.runId,
-      durationMs,
-      result,
-      logger,
-    });
-    logger.info("tool.call_completed", "Tool call completed", {
-      runId: streamState.runId,
-      toolName,
-      toolCallId,
-      durationMs,
-      isError: result.isError ?? false,
-    });
-
-    return result;
-  } catch (error) {
-    const durationMs = Date.now() - startedAt;
-    await dispatchExpertAgentHook(agent.hooks, "afterToolCall", {
-      agent,
-      toolName,
-      toolCallId,
-      args,
-      runId: streamState.runId,
-      durationMs,
-      error,
-      logger,
-    });
-    logger.error("tool.call_failed", "Tool call failed", error, {
-      runId: streamState.runId,
-      toolName,
-      toolCallId,
-      durationMs,
-    });
-    throw error;
-  }
-}
-
-async function maybeRequestToolApproval<
-  TResult extends { text: string; isError?: boolean; details?: unknown },
->(options: {
-  readonly approval: ExpertAgentToolApproval | undefined;
-  readonly humanInteractionHandler: ExpertAgentHumanInteractionHandler | undefined;
-  readonly toolName: string;
-  readonly toolCallId: string | undefined;
-  readonly runId: string | undefined;
-  readonly source: PiRuntimeStreamState["source"];
-  readonly args: unknown;
-  readonly emitApprovalRequested: (event: {
-    readonly runId: string;
-    readonly source: NonNullable<PiRuntimeStreamState["source"]>;
-    readonly type: "tool.approval_requested";
-    readonly payload: {
-      readonly approvalId: string;
-      readonly toolCallId: string;
-      readonly toolName: string;
-      readonly kind: "tool";
-      readonly reason?: string | undefined;
-      readonly inputPreview?: unknown;
-    };
-  }) => void;
-}): Promise<
-  | { readonly approved: true; readonly updatedInput: unknown | undefined }
-  | {
-      readonly approved: false;
-      readonly result: TResult;
-    }
-> {
-  const approval = options.approval;
-
-  if (approval === undefined) {
-    return { approved: true, updatedInput: undefined };
-  }
-
-  const approvalRequest = {
-    kind: "tool_approval" as const,
-    toolName: options.toolName,
-    toolCallId: options.toolCallId,
-    reason: approval.reason,
-    input: options.args,
   };
-  const requirement = await resolveExpertAgentToolApprovalRequirement(approval, approvalRequest);
-
-  if (requirement === "none") {
-    return { approved: true, updatedInput: undefined };
-  }
-
-  if (requirement === "ask" && options.humanInteractionHandler === undefined) {
-    return { approved: true, updatedInput: undefined };
-  }
-
-  const approvalId = `approval-${randomUUID()}`;
-  const runId = options.runId ?? approvalId;
-  const toolCallId = options.toolCallId ?? approvalId;
-  options.emitApprovalRequested({
-    runId,
-    source: {
-      ...(options.source ?? {
-        kind: "tool",
-        runId,
-        path: [],
-      }),
-      kind: "tool",
-      runId,
-      toolCallId,
-    },
-    type: "tool.approval_requested",
-    payload: {
-      approvalId,
-      toolCallId,
-      toolName: options.toolName,
-      kind: "tool",
-      ...(approval.reason === undefined ? {} : { reason: approval.reason }),
-      inputPreview: options.args,
-    },
-  });
-
-  if (options.humanInteractionHandler === undefined) {
-    return {
-      approved: false,
-      result: {
-        text: approval.reason ?? `Tool approval required for ${options.toolName}.`,
-        isError: true,
-      } as TResult,
-    };
-  }
-
-  const response = await options.humanInteractionHandler(approvalRequest);
-
-  if (response.kind !== "tool_approval" || !response.approved) {
-    return {
-      approved: false,
-      result: {
-        text:
-          response.kind === "tool_approval" && response.reason !== undefined
-            ? response.reason
-            : `User declined ${options.toolName}.`,
-        isError: true,
-      } as TResult,
-    };
-  }
-
-  return { approved: true, updatedInput: response.updatedInput };
 }

--- a/packages/runtime/pi/src/types.ts
+++ b/packages/runtime/pi/src/types.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeSessionSyncCallback,
   RuntimeEventEmitter,
   RuntimeStreamEvent,
+  McpToolRegistryPool,
   ModelProviderRegistry,
   RuntimeTokenCounter,
 } from "@pragma/core";
@@ -49,6 +50,7 @@ export interface CloudPiRuntimeAdapterOptions {
   readonly sessionSyncCallback?: RuntimeSessionSyncCallback | undefined;
   readonly sessionSyncDebounceMs?: number | undefined;
   readonly tokenCounter?: RuntimeTokenCounter | undefined;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
 }
 
 export interface PiRuntimeStreamState {

--- a/packages/runtime/pi/test/tools.test.ts
+++ b/packages/runtime/pi/test/tools.test.ts
@@ -1,0 +1,44 @@
+import { createQueuedAgentLifecycle, defineExpert, type McpManagedTool } from "@pragma/core";
+import { describe, expect, it } from "vitest";
+
+import { createResolvedPiTools } from "../src/tools.ts";
+
+describe("PI tool projection", () => {
+  it("preserves human-readable labels for default and MCP tools", async () => {
+    const expert = await defineExpert({
+      id: "pi-tool-labels",
+      name: "PI tool labels",
+      description: "PI tool projection test",
+      tags: [],
+      scope: "test",
+      workspace: process.cwd(),
+    });
+    const mcpTool: McpManagedTool = {
+      serverId: "docs-server",
+      serverName: "Documentation",
+      name: "search",
+      description: "Search documentation.",
+      inputSchema: { type: "object" },
+      async call() {
+        return { content: [] };
+      },
+    };
+
+    const resolved = createResolvedPiTools({
+      agent: expert,
+      cwd: process.cwd(),
+      mcpTools: [mcpTool],
+      parentSystemPrompt: "",
+      streamState: {},
+      lifecycle: createQueuedAgentLifecycle(undefined),
+    });
+
+    expect(resolved.tools.find((tool) => tool.name === "list_expert_context")?.tool.label).toBe(
+      "List expert context",
+    );
+    expect(resolved.tools.find((tool) => tool.source === "mcp")?.tool).toMatchObject({
+      name: "mcp_docs_server_search",
+      label: "MCP Documentation:search",
+    });
+  });
+});

--- a/packages/runtime/qodercli/src/adapter.ts
+++ b/packages/runtime/qodercli/src/adapter.ts
@@ -50,13 +50,12 @@ const QODER_DESCRIPTOR = {
 };
 
 interface QoderDriverSession extends QoderNativeSession {
-  readonly mcpToolRegistry: McpToolRegistry;
   readonly mcpToolRegistryLease: McpToolRegistryLease;
   readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
 }
 
 export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {}): RuntimeAdapter {
-  const mcpToolRegistries = createMcpToolRegistryPool();
+  const mcpToolRegistries = options.mcpToolRegistryPool ?? createMcpToolRegistryPool();
   const descriptor = {
     ...QODER_DESCRIPTOR,
     ...options.descriptor,
@@ -171,6 +170,9 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
             elapsedMs: qoderElapsedMs(sessionStartedAt),
             systemPromptCharacters: ctx.agentContext.systemPrompt.length,
             toolCount: mcpToolRegistry.tools.length,
+            mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
+            mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
+            mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
           });
           return {
             agent: ctx.agent,
@@ -194,7 +196,6 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
             messages: [],
             toolNames: new Map(),
             sessionId: restoredRuntimeSessionId,
-            mcpToolRegistry,
             mcpToolRegistryLease,
             expertToolsMcpRegistration,
           };

--- a/packages/runtime/qodercli/src/types.ts
+++ b/packages/runtime/qodercli/src/types.ts
@@ -5,12 +5,10 @@ import type {
   RuntimeSessionRestoreHandler,
   RuntimeSessionSyncCallback,
   RuntimeTokenCounter,
+  McpToolRegistryPool,
 } from "@pragma/core";
 
-export type QoderCliRuntimePermissionMode =
-  | "default"
-  | "auto"
-  | "bypassPermissions";
+export type QoderCliRuntimePermissionMode = "default" | "auto" | "bypassPermissions";
 
 export type QoderCliRuntimeAuth =
   | { readonly type: "qodercli" }
@@ -34,4 +32,5 @@ export interface QoderCliRuntimeAdapterOptions {
   readonly sessionRestoreHandler?: RuntimeSessionRestoreHandler | undefined;
   readonly sessionSyncCallback?: RuntimeSessionSyncCallback | undefined;
   readonly tokenCounter?: RuntimeTokenCounter | undefined;
+  readonly mcpToolRegistryPool?: McpToolRegistryPool | undefined;
 }


### PR DESCRIPTION
## Summary

- 将四种 Runtime 的工具行为收敛到 Core 的统一执行语义层：PI 保留原生工具投影，Codex / Claude Code / Qoder CLI 通过进程共享的 Execution MCP Gateway 投影
- 引入 Host 级、按 MCP Server 复用的 `McpToolRegistryPool`，让编译、能力校验和 Runtime 启动共享连接与工具注册结果
- 优化 Mission 首个可见增量的渲染路径，并分别记录 received / painted 遥测
- 补充 ADR、连接池生命周期测试、PI 标签回归测试和无重复编译的确定性回归测试

## Root cause

四种 Runtime 在工具注册形式上有原生 SDK 与 MCP Gateway 两种投影，但此前各自复制了工具策略和执行逻辑；同时，Agent 编译/能力校验与 Runtime 启动分别打开同一个 MCP Server，导致 GitHub MCP 在冷启动阶段重复连接和验证。Renderer 对首个增量也沿用了后续批量帧调度，放大了首次可见输出延迟。

## Architecture

- Core 负责唯一的工具发现、审批、Hook、日志、事件和结果转换语义
- Runtime Adapter 只负责协议投影，不再维护第二套业务语义
- Desktop 持有并注入一个 Host-scoped MCP 连接池；连接身份排除工具策略，敏感配置只参与哈希
- 连接池支持 single-flight、引用计数、TTL / idle 上限、失败驱逐与最终关闭
- `close()` 明确定义为 Host 最终停机的 hard shutdown，不用于普通 lease 释放

## Review fixes

- 保留 PI 默认工具与 MCP 工具的人类可读标签
- 将工具名清洗逻辑统一到 Core，移除 Desktop / Interpreter / Gateway 的重复实现
- 用确定性“不得二次编译”断言替换脆弱的墙钟耗时断言
- 增加活跃 lease 下 hard-close 的契约测试

## Validation

- `pnpm check`
- `pnpm build`
- Core: 31 files / 205 tests
- Desktop: 83 files / 463 tests
- Interpreter: 9 files / 69 tests
- Runtime PI: 8 files / 30 tests
- `git diff --check`
- 两轮 Claude Code CR，所有可执行问题已独立复核并修复

Closes #63