### PR TITLE
Move mission token usage outside composer

### DIFF
--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -2033,120 +2033,122 @@ export function MissionDetailFragment(props: {
                   onInterrupt={() => void interrupt()}
                 />
               ) : (
-                <div className="mission-chat-composer" aria-busy={clientOperationBusy}>
+                <>
                   <MissionUsageHint
                     missionId={props.mission.id}
                     executionActive={executionActive}
                   />
-                  <textarea
-                    ref={textareaRef}
-                    rows={1}
-                    value={draft}
-                    disabled={
-                      isFlow ||
-                      clientOperationBusy ||
-                      compactingContext ||
-                      executionActive ||
-                      props.mission.lifecycleStatus === "completed"
-                    }
-                    placeholder={
-                      compactingContext
-                        ? t("contextCompactionInputDisabled", { ns: "missions" })
-                        : executionActive
-                          ? interruptible
-                            ? t("executorWorking", {
-                                ns: "missions",
-                                name: props.mission.executor.name,
-                              })
-                            : t("resumeToManage", { ns: "missions" })
-                          : props.mission.lifecycleStatus === "completed"
-                            ? t("reopenToContinue", { ns: "missions" })
-                            : isFlow
-                              ? t("flowContinues", { ns: "missions" })
-                              : t("messageExecutor", {
+                  <div className="mission-chat-composer" aria-busy={clientOperationBusy}>
+                    <textarea
+                      ref={textareaRef}
+                      rows={1}
+                      value={draft}
+                      disabled={
+                        isFlow ||
+                        clientOperationBusy ||
+                        compactingContext ||
+                        executionActive ||
+                        props.mission.lifecycleStatus === "completed"
+                      }
+                      placeholder={
+                        compactingContext
+                          ? t("contextCompactionInputDisabled", { ns: "missions" })
+                          : executionActive
+                            ? interruptible
+                              ? t("executorWorking", {
                                   ns: "missions",
                                   name: props.mission.executor.name,
                                 })
-                    }
-                    aria-label={t("messageExecutor", {
-                      ns: "missions",
-                      name: props.mission.executor.name,
-                    })}
-                    aria-describedby={
-                      compactingContext ? "mission-context-compaction-status" : undefined
-                    }
-                    onChange={(event) => setDraft(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" && !event.shiftKey) {
-                        event.preventDefault();
-                        void send();
+                              : t("resumeToManage", { ns: "missions" })
+                            : props.mission.lifecycleStatus === "completed"
+                              ? t("reopenToContinue", { ns: "missions" })
+                              : isFlow
+                                ? t("flowContinues", { ns: "missions" })
+                                : t("messageExecutor", {
+                                    ns: "missions",
+                                    name: props.mission.executor.name,
+                                  })
                       }
-                    }}
-                  />
-                  <div className="mission-chat-composer-toolbar">
-                    <div className="mission-chat-options" aria-label={t("missionOptions")}>
-                      {!isFlow ? (
-                        <MissionModelOverrideControls
-                          models={models}
-                          loading={modelsLoading}
-                          disabled={controlsDisabled}
-                          value={modelOverride}
-                          defaultValue={defaultModelSelection}
-                          onChange={(value) => void saveOptions(toolPermissionMode, value)}
-                        />
-                      ) : null}
-                      <ToolPermissionSelect
-                        value={toolPermissionMode}
-                        disabled={controlsDisabled}
-                        title={
-                          executionActive
-                            ? t("optionsAvailableNextTurn", { ns: "missions" })
-                            : t("permissionOverride", { ns: "missions" })
+                      aria-label={t("messageExecutor", {
+                        ns: "missions",
+                        name: props.mission.executor.name,
+                      })}
+                      aria-describedby={
+                        compactingContext ? "mission-context-compaction-status" : undefined
+                      }
+                      onChange={(event) => setDraft(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" && !event.shiftKey) {
+                          event.preventDefault();
+                          void send();
                         }
-                        onChange={(value) => void saveOptions(value, modelOverride)}
-                      />
-                    </div>
-                    <div className="mission-chat-actions">
-                      {chat?.contextWindow === undefined ? null : (
-                        <ContextWindowControl
-                          state={chat.contextWindow}
-                          compacting={compactingContext}
-                          onCompact={() => void compactContext()}
-                        />
-                      )}
-                      {executionActive ? (
-                        <button
-                          className="is-interrupt"
-                          type="button"
-                          aria-label={t("interrupt", { ns: "missions" })}
+                      }}
+                    />
+                    <div className="mission-chat-composer-toolbar">
+                      <div className="mission-chat-options" aria-label={t("missionOptions")}>
+                        {!isFlow ? (
+                          <MissionModelOverrideControls
+                            models={models}
+                            loading={modelsLoading}
+                            disabled={controlsDisabled}
+                            value={modelOverride}
+                            defaultValue={defaultModelSelection}
+                            onChange={(value) => void saveOptions(toolPermissionMode, value)}
+                          />
+                        ) : null}
+                        <ToolPermissionSelect
+                          value={toolPermissionMode}
+                          disabled={controlsDisabled}
                           title={
-                            interruptible
-                              ? t("interrupt", { ns: "missions" })
-                              : t("resumeBeforeInterrupt", { ns: "missions" })
+                            executionActive
+                              ? t("optionsAvailableNextTurn", { ns: "missions" })
+                              : t("permissionOverride", { ns: "missions" })
                           }
-                          disabled={!interruptible || interrupting}
-                          onClick={() => void interrupt()}
-                        >
-                          <StopCircle size={19} weight="fill" aria-hidden="true" />
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          aria-label={t("send", { ns: "missions" })}
-                          disabled={
-                            isFlow ||
-                            draft.trim() === "" ||
-                            clientOperationBusy ||
-                            props.mission.lifecycleStatus === "completed"
-                          }
-                          onClick={() => void send()}
-                        >
-                          <PaperPlaneTilt size={18} aria-hidden="true" />
-                        </button>
-                      )}
+                          onChange={(value) => void saveOptions(value, modelOverride)}
+                        />
+                      </div>
+                      <div className="mission-chat-actions">
+                        {chat?.contextWindow === undefined ? null : (
+                          <ContextWindowControl
+                            state={chat.contextWindow}
+                            compacting={compactingContext}
+                            onCompact={() => void compactContext()}
+                          />
+                        )}
+                        {executionActive ? (
+                          <button
+                            className="is-interrupt"
+                            type="button"
+                            aria-label={t("interrupt", { ns: "missions" })}
+                            title={
+                              interruptible
+                                ? t("interrupt", { ns: "missions" })
+                                : t("resumeBeforeInterrupt", { ns: "missions" })
+                            }
+                            disabled={!interruptible || interrupting}
+                            onClick={() => void interrupt()}
+                          >
+                            <StopCircle size={19} weight="fill" aria-hidden="true" />
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            aria-label={t("send", { ns: "missions" })}
+                            disabled={
+                              isFlow ||
+                              draft.trim() === "" ||
+                              clientOperationBusy ||
+                              props.mission.lifecycleStatus === "completed"
+                            }
+                            onClick={() => void send()}
+                          >
+                            <PaperPlaneTilt size={18} aria-hidden="true" />
+                          </button>
+                        )}
+                      </div>
                     </div>
                   </div>
-                </div>
+                </>
               )}
             </div>
           </div>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -7298,7 +7298,7 @@ p {
 .mission-usage-hint {
   display: block;
   justify-self: end;
-  margin: 9px 14px 0;
+  margin: 0 5px;
   color: var(--faint);
   font-size: 11px;
   line-height: 1.35;


### PR DESCRIPTION
## What changed

- Moved the Mission token usage hint out of the composer container.
- Kept the hint above the composer, right-aligned, with spacing suited to the footer layout.

## Why

The usage text was rendered inside the Mission input surface, which made it look like part of the editable composer. The hint is informational metadata and should sit outside the input boundary.

## Impact

Mission users now see the accumulated token usage immediately above the input box without reducing or visually cluttering the editable area.

## Validation

- `pnpm --filter @pragma/desktop exec vitest run src/renderer/src/pages/missions/MissionsPage.test.tsx` (36 tests passed)
- `pnpm --filter @pragma/desktop exec eslint src/renderer/src/pages/missions/MissionsPage.tsx`
- `pnpm --filter @pragma/desktop typecheck:web`
- `git diff --check`