### PR TITLE
Fix DSL compiler version upgrade regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,27 @@ import { HealthResponseSchema } from "../../../shared/contracts/src/index.ts";
 
 禁止对内部依赖使用 `"*"`、固定 semver 或 npm registry 版本。
 
+## 协议与版本升级治理
+
+以下规则适用于所有持久化和跨进程协议，包括 DSL `apiVersion`、状态 `schemaVersion`、
+Interpreter `compilerVersion`、manifest、lock、IPC、Bridge 和 Runtime capability：
+
+- 任何会让新代码拒绝或改变既有合法数据语义的改动，必须在同一个 Pull Request 中提交明确的版本升级、
+  可执行升级机制和完整测试；禁止先升级 Schema 或版本号、再留待后续补迁移。缺少升级机制时不得合入。
+- Capability 必须区分“当前代码可直接读取的版本”和“可通过迁移升级的来源版本”。只有当前 parser
+  能完整接受真实历史 fixture 时才能声明直接可读；禁止只放行旧版本号后把旧数据交给当前严格 Schema。
+- 支持窗口内的旧版本必须提供静态注册的相邻迁移、协议协商或等价升级链。`fail closed` 只是损坏数据、
+  未来版本和缺失迁移的安全兜底，不是升级策略。
+- 业务 parser 只处理当前 Schema；历史 Schema 和字段转换放在迁移模块。废弃或错误字段可以由迁移显式
+  删除，但必须记录决策、保留升级前备份并验证结果，不得静默丢弃，也不得为此保留长期业务兼容分支。
+- Host 必须在正常启动和业务读取前，在最小 owner 边界内执行升级。持久化升级使用锁、稳定 journal、
+  备份、原子替换和可重放恢复；失败时保留原数据并提供可操作诊断。除非共享全局状态无法安全初始化，
+  单个 owner 升级失败不得阻断无关项目、对象或能力启动。
+- 升级测试必须使用由真实历史代码写出的 fixture，不得用当前对象只改版本号伪造。Pull Request 至少
+  覆盖历史 fixture、当前版本 no-op、相邻和链式升级、崩溃恢复、未来版本拒绝以及升级后的启动/执行；
+  缺少任一适用场景时不得合入。
+- 删除仍在支持窗口内的升级链属于兼容性 cutover，必须另写 ADR，并提供导出、备份或离线升级方案。
+
 ## 运行环境边界
 
 `shared` package 必须同时支持浏览器和 Node，不允许引入运行环境专属依赖。
@@ -604,9 +625,11 @@ Expert API 设计要求：
 - Interpreter 普通 parser/compiler 只接受当前 DSL；旧版本必须先经过静态注册的相邻迁移链。
 - 删除仍在支持窗口内的旧 DSL 迁移步骤属于兼容性 cutover，必须另写 ADR，并提供导出、备份或离线升级路径。
 - Project Revision 的 Interpreter 兼容能力统一由 `@pragma/interpreter/ast` 导出的 compiler capability
-  声明；写入、读取、Lock、Blueprint cache、Desktop IPC 和 Mission 编译不得各自维护版本常量。
+  声明，并分别列出 write version、direct-read versions 和 upgrade-from versions；Lock、Blueprint
+  cache、Desktop IPC 和 Mission 编译不得各自维护版本常量。
 - 修改闭合资源联合、严格资源 Schema，或新增会拒绝既有 Revision 的 portable validator 时，必须
-  明确升级 compiler write version 或提供旧版本读取路径，并提交新旧版本 fixture 和 fail-closed 测试。
+  升级 compiler write version，并在同一改动中提供历史 Schema、相邻升级步骤、Host 事务迁移和真实
+  新旧版本 fixture；不得把“可迁移”版本声明成“可直接读取”。
 - `PragmaProject.validate()` 是全项目健康检查；执行入口使用目标资源及其传递依赖闭包校验。无关资源
   诊断不得阻断独立执行器，compiler、lock、source topology 和资源身份歧义仍然全局 fail closed。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,6 +603,12 @@ Expert API 设计要求：
   `revision` 专指不可变项目内容序号。三者不得共用迁移开关。
 - Interpreter 普通 parser/compiler 只接受当前 DSL；旧版本必须先经过静态注册的相邻迁移链。
 - 删除仍在支持窗口内的旧 DSL 迁移步骤属于兼容性 cutover，必须另写 ADR，并提供导出、备份或离线升级路径。
+- Project Revision 的 Interpreter 兼容能力统一由 `@pragma/interpreter/ast` 导出的 compiler capability
+  声明；写入、读取、Lock、Blueprint cache、Desktop IPC 和 Mission 编译不得各自维护版本常量。
+- 修改闭合资源联合、严格资源 Schema，或新增会拒绝既有 Revision 的 portable validator 时，必须
+  明确升级 compiler write version 或提供旧版本读取路径，并提交新旧版本 fixture 和 fail-closed 测试。
+- `PragmaProject.validate()` 是全项目健康检查；执行入口使用目标资源及其传递依赖闭包校验。无关资源
+  诊断不得阻断独立执行器，compiler、lock、source topology 和资源身份歧义仍然全局 fail closed。
 
 禁止引入具体 Runtime Adapter、Desktop UI、Server 应用层、数据库实现或 Client SDK。
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,7 +10,7 @@
     "prepare:electron": "install-electron",
     "prepare:plugins": "node ./scripts/package-built-in-plugins.mjs",
     "predev": "pnpm run prepare:electron && pnpm run prepare:plugins",
-    "dev": "electron-vite dev",
+    "dev": "electron-vite dev --watch",
     "prebuild": "pnpm run prepare:plugins",
     "build": "electron-vite build && pnpm run verify:preload",
     "verify:preload": "node ./scripts/verify-preload-bundle.mjs",

--- a/apps/desktop/src/main/features/projects/pragma-project-store.test.ts
+++ b/apps/desktop/src/main/features/projects/pragma-project-store.test.ts
@@ -113,7 +113,7 @@ describe("PragmaProjectStore", () => {
       { kind: "Flow", sourceId: "release", targetId: expectedId },
     ]);
     expect(await readFile(join(directory, "studio", "project.json"), "utf8")).toContain(
-      "pragma.desktop-project/v4",
+      "pragma.desktop-project/v5",
     );
   });
 
@@ -294,8 +294,145 @@ describe("PragmaProjectStore", () => {
 
     expect(migrated.revision).toBe(1);
     expect(await readFile(join(directory, "studio", "project.json"), "utf8")).toContain(
+      "pragma.desktop-project/v5",
+    );
+  });
+
+  it("upgrades compiler v2 project revisions to storage v5 and removes historical runDry", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pragma-project-v4-compiler-migration-"));
+    directories.push(directory);
+    await seedCompilerV2ProjectRevisions(directory, 2);
+
+    const project = createPragmaProjectStore({ projectsPath: directory });
+    const head = await project.get();
+    const first = await project.openRevision(1);
+
+    expect(head.revision).toBe(2);
+    expect(first.listResources()).toEqual([
+      expect.objectContaining({
+        kind: "Flow",
+        spec: expect.not.objectContaining({ runDry: expect.anything() }),
+      }),
+    ]);
+    expect(await readFile(join(directory, "studio", "project.json"), "utf8")).toContain(
+      "pragma.desktop-project/v5",
+    );
+    expect(await readFile(join(directory, "studio", "revisions", "1.json"), "utf8")).toContain(
+      '"revision": 1',
+    );
+    expect(await projectRevisionFile(directory, 1, "pragma.lock.yaml")).toContain(
+      "compilerVersion: pragma.dsl/v3",
+    );
+    expect((await readdir(directory)).some((name) => name.startsWith("studio.v4-backup-"))).toBe(
+      true,
+    );
+  });
+
+  it("upgrades an already-current compiler v3 storage manifest without changing its revision", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pragma-project-v4-current-compiler-"));
+    directories.push(directory);
+    const original = createPragmaProjectStore({ projectsPath: directory });
+    await original.publish({
+      expectedRevision: 0,
+      resources: [exampleRuntime(), exampleExpert()],
+    });
+    const projectManifestPath = join(directory, "studio", "project.json");
+    const revisionManifestPath = join(directory, "studio", "revisions", "1.json");
+    const projectManifest = JSON.parse(await readFile(projectManifestPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const revisionManifest = JSON.parse(await readFile(revisionManifestPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    await writeFile(
+      projectManifestPath,
+      `${JSON.stringify({ ...projectManifest, schemaVersion: "pragma.desktop-project/v4" })}\n`,
+    );
+    await writeFile(
+      revisionManifestPath,
+      `${JSON.stringify({ ...revisionManifest, schemaVersion: "pragma.project-revision/v4" })}\n`,
+    );
+
+    const migrated = await createPragmaProjectStore({ projectsPath: directory }).get();
+
+    expect(migrated).toMatchObject({ revision: 1 });
+    expect(await readFile(projectManifestPath, "utf8")).toContain("pragma.desktop-project/v5");
+    expect(await projectRevisionFile(directory, 1, "pragma.lock.yaml")).toContain(
+      "compilerVersion: pragma.dsl/v3",
+    );
+  });
+
+  it("reports an invalid current revision manifest as an unsupported storage format", async () => {
+    const { directory, project } = await stores();
+    await project.publish({
+      expectedRevision: 0,
+      resources: [exampleRuntime(), exampleExpert()],
+    });
+    await writeFile(
+      join(directory, "studio", "revisions", "1.json"),
+      `${JSON.stringify({
+        schemaVersion: "pragma.project-revision/v5",
+        projectId: "studio",
+        revision: 1,
+      })}\n`,
+    );
+
+    await expect(project.openRevision(1)).rejects.toMatchObject({
+      code: "unsupported_format",
+      message: "Project revision manifest is invalid: studio@1.",
+    });
+  });
+
+  it("restores an interrupted compiler v2 migration and retries it idempotently", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pragma-project-v4-recovery-"));
+    directories.push(directory);
+    await seedCompilerV2ProjectRevisions(directory, 1);
+    const projectPath = join(directory, "studio");
+    const backupPath = `${projectPath}.v4-backup-interrupted`;
+    await rename(projectPath, backupPath);
+    await writeFile(
+      join(directory, ".studio.v4-to-v5.json"),
+      `${JSON.stringify({
+        schemaVersion: "pragma.desktop-project-migration/v1",
+        projectId: "studio",
+        sourceSchema: "pragma.desktop-project/v4",
+        targetSchema: "pragma.desktop-project/v5",
+        backupPath,
+      })}\n`,
+    );
+
+    const migrated = await createPragmaProjectStore({ projectsPath: directory }).get();
+
+    expect(migrated.revision).toBe(1);
+    await expect(readFile(join(directory, ".studio.v4-to-v5.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(await readFile(join(directory, "studio", "project.json"), "utf8")).toContain(
+      "pragma.desktop-project/v5",
+    );
+  });
+
+  it("keeps the compiler v2 project untouched when its historical lock is invalid", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pragma-project-v4-invalid-lock-"));
+    directories.push(directory);
+    await seedCompilerV2ProjectRevisions(directory, 1, {
+      flowSource: COMPILER_V2_FLOW_SOURCE.replace("Historical Run Dry", "Tampered"),
+    });
+
+    await expect(createPragmaProjectStore({ projectsPath: directory }).get()).rejects.toMatchObject(
+      {
+        code: "unsupported_format",
+        message: expect.stringContaining("does not match its lock"),
+      },
+    );
+    expect(await readFile(join(directory, "studio", "project.json"), "utf8")).toContain(
       "pragma.desktop-project/v4",
     );
+    await expect(readFile(join(directory, ".studio.v4-to-v5.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("materializes one cold snapshot view across concurrent project stores", async () => {
@@ -1159,6 +1296,92 @@ function expertUpdate(definition: ExpertDefinition, description: string): Update
 
 async function seedLegacyProject(directory: string, sources: readonly string[]): Promise<void> {
   await seedLegacyProjectRevisions(directory, [sources]);
+}
+
+const COMPILER_V2_FLOW_SOURCE = `apiVersion: pragma/v3
+kind: Flow
+metadata:
+  id: 8h9j0k1m2n3p4q5r
+  name: Historical Run Dry
+  description: Compiler v2 fixture with the removed runDry branch.
+  tags: []
+spec:
+  limits:
+    maxNodeVisits: 1000
+  graph:
+    start: finish
+    steps:
+      finish:
+        action:
+          ref: action:finish@v1
+    loops: {}
+    transitions:
+      finish:
+        end: true
+  runDry:
+    cases: []
+`;
+
+const COMPILER_V2_ENTRY_SOURCE = `apiVersion: pragma/v3
+kind: Bundle
+imports:
+  - ./flows/8h9j0k1m2n3p4q5r.pragma.yaml
+resources: []
+`;
+
+const COMPILER_V2_LOCK_SOURCE = `apiVersion: pragma/v3
+kind: Lock
+compilerVersion: pragma.dsl/v2
+projectFingerprint: 33e69dc432c7d321b1a0280144bdab0105b82a8f9270bf7067871dfc7f966ff8
+resources:
+  - ref: flow:8h9j0k1m2n3p4q5r
+    contentHash: eec635492a253e33328ae04586548877b5e4631d56b8723d950aa4db0b7aaa4c
+    source: flows/8h9j0k1m2n3p4q5r.pragma.yaml
+artifacts: []
+`;
+
+async function seedCompilerV2ProjectRevisions(
+  directory: string,
+  revisionCount: number,
+  overrides: { readonly flowSource?: string } = {},
+): Promise<void> {
+  const objects = new ContentAddressedStore(join(directory, ".storage", "objects"));
+  const createdAt = "2026-07-29T00:00:00.000Z";
+  await mkdir(join(directory, "studio", "revisions"), { recursive: true });
+  await writeFile(
+    join(directory, "studio", "project.json"),
+    `${JSON.stringify({
+      schemaVersion: "pragma.desktop-project/v4",
+      projectId: "studio",
+      headRevision: revisionCount,
+      updatedAt: createdAt,
+    })}\n`,
+  );
+  for (let revision = 1; revision <= revisionCount; revision += 1) {
+    const snapshot = await objects.putSnapshot(
+      new Map([
+        ["pragma.yaml", Buffer.from(COMPILER_V2_ENTRY_SOURCE, "utf8")],
+        ["pragma.lock.yaml", Buffer.from(COMPILER_V2_LOCK_SOURCE, "utf8")],
+        [
+          "flows/8h9j0k1m2n3p4q5r.pragma.yaml",
+          Buffer.from(overrides.flowSource ?? COMPILER_V2_FLOW_SOURCE, "utf8"),
+        ],
+      ]),
+    );
+    await writeFile(
+      join(directory, "studio", "revisions", `${revision}.json`),
+      `${JSON.stringify({
+        schemaVersion: "pragma.project-revision/v4",
+        projectId: "studio",
+        revision,
+        ...(revision === 1 ? {} : { parentRevision: revision - 1 }),
+        snapshotHash: snapshot.root.hash,
+        projectFingerprint: "33e69dc432c7d321b1a0280144bdab0105b82a8f9270bf7067871dfc7f966ff8",
+        compilerVersion: "pragma.dsl/v2",
+        createdAt,
+      })}\n`,
+    );
+  }
 }
 
 async function seedLegacyProjectRevisions(

--- a/apps/desktop/src/main/features/projects/pragma-project-store.ts
+++ b/apps/desktop/src/main/features/projects/pragma-project-store.ts
@@ -441,6 +441,9 @@ export function createPragmaProjectStore(options: {
       return await loadPragmaProject(location.entryFile, {
         rootDir: location.rootDir,
         requireLock: true,
+        ...(location.compilerVersion === undefined
+          ? {}
+          : { revisionCompilerVersion: location.compilerVersion }),
         sourceIdentity: location.snapshotHash ?? location.projectFingerprint,
         blueprintCache: options.blueprintCache,
       });

--- a/apps/desktop/src/main/features/projects/pragma-project-store.ts
+++ b/apps/desktop/src/main/features/projects/pragma-project-store.ts
@@ -14,10 +14,12 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import {
   PragmaDslMigrationError,
+  PragmaCompilerMigrationError,
   PragmaProjectRevisionConflictError,
   PragmaProjectService,
   PragmaProjectValidationError,
   loadPragmaProject,
+  migratePragmaCompilerProjectToCurrent,
   migratePragmaDslProjectToCurrent,
   parsePragmaYaml,
   type PragmaProject,
@@ -55,7 +57,7 @@ import { referencingPragmaResources } from "./pragma-resource-references.ts";
 
 const ProjectManifestSchema = z
   .object({
-    schemaVersion: z.literal("pragma.desktop-project/v4"),
+    schemaVersion: z.literal("pragma.desktop-project/v5"),
     projectId: z.string().min(1),
     headRevision: z.number().int().positive(),
     updatedAt: z.string().datetime(),
@@ -64,7 +66,7 @@ const ProjectManifestSchema = z
 
 const ProjectRevisionManifestSchema = z
   .object({
-    schemaVersion: z.literal("pragma.project-revision/v4"),
+    schemaVersion: z.literal("pragma.project-revision/v5"),
     projectId: z.string().min(1),
     revision: z.number().int().positive(),
     parentRevision: z.number().int().positive().optional(),
@@ -174,10 +176,13 @@ export function createPragmaProjectStore(options: {
   readonly blueprintCache?: PragmaBlueprintCacheStore | undefined;
 }): PragmaProjectStore {
   const projectId = options.projectId ?? "studio";
+  const objectsPath = options.objectsPath ?? join(options.projectsPath, ".storage", "objects");
+  const projectViewsPath =
+    options.projectViewsPath ?? join(options.projectsPath, ".cache", "views");
   const repository = createDesktopProjectSourceRepository({
     projectsPath: options.projectsPath,
-    objectsPath: options.objectsPath ?? join(options.projectsPath, ".storage", "objects"),
-    projectViewsPath: options.projectViewsPath ?? join(options.projectsPath, ".cache", "views"),
+    objectsPath,
+    projectViewsPath,
   });
   const service = new PragmaProjectService({
     repository,
@@ -185,10 +190,35 @@ export function createPragmaProjectStore(options: {
     externalResourceRefs: options.reservedResourceRefs,
     loggerProvider: options.loggerProvider,
   });
-  const ensureMigrated = async (): Promise<void> =>
+  const legacyV4Repository = createDesktopProjectSourceRepository({
+    projectsPath: options.projectsPath,
+    objectsPath,
+    projectViewsPath,
+    storageVersion: 4,
+  });
+  const legacyV4Service = new PragmaProjectService({
+    repository: legacyV4Repository,
+    externalResourceRefs: options.reservedResourceRefs,
+    loggerProvider: options.loggerProvider,
+  });
+  const ensureMigrated = async (): Promise<void> => {
     await migrateDesktopProjectStorageV3ToV4({
       projectsPath: options.projectsPath,
-      objectsPath: options.objectsPath ?? join(options.projectsPath, ".storage", "objects"),
+      objectsPath,
+      projectId,
+      publish: async (expectedRevision, resources, artifacts) => {
+        await legacyV4Service.publish({
+          projectId,
+          expectedRevision,
+          resources,
+          artifacts,
+          forceRevision: true,
+        });
+      },
+    });
+    await migrateDesktopProjectStorageV4ToV5({
+      projectsPath: options.projectsPath,
+      objectsPath,
       projectId,
       publish: async (expectedRevision, resources, artifacts) => {
         await service.publish({
@@ -200,6 +230,7 @@ export function createPragmaProjectStore(options: {
         });
       },
     });
+  };
 
   const get = async (): Promise<PragmaProjectSnapshot> => {
     await ensureMigrated();
@@ -527,7 +558,9 @@ function createDesktopProjectSourceRepository(options: {
   readonly projectsPath: string;
   readonly objectsPath: string;
   readonly projectViewsPath: string;
+  readonly storageVersion?: 4 | 5;
 }): PragmaProjectSourceRepository {
+  const storageVersion = options.storageVersion ?? 5;
   const projectPath = (projectId: string) => join(options.projectsPath, projectId);
   const manifestPath = (projectId: string) => join(projectPath(projectId), "project.json");
   const revisionManifestPath = (projectId: string, revision: number) =>
@@ -541,7 +574,10 @@ function createDesktopProjectSourceRepository(options: {
   const readManifest = async (projectId: string) => {
     try {
       const raw = JSON.parse(await readFile(manifestPath(projectId), "utf8")) as unknown;
-      const parsed = ProjectManifestSchema.safeParse(raw);
+      const parsed =
+        storageVersion === 4
+          ? LegacyProjectV4ManifestSchema.safeParse(raw)
+          : ProjectManifestSchema.safeParse(raw);
       if (!parsed.success) {
         throw new PragmaProjectStoreError(
           "unsupported_format",
@@ -557,9 +593,20 @@ function createDesktopProjectSourceRepository(options: {
 
   const readRevisionManifest = async (projectId: string, revision: number) => {
     try {
-      return ProjectRevisionManifestSchema.parse(
-        JSON.parse(await readFile(revisionManifestPath(projectId, revision), "utf8")) as unknown,
-      );
+      const raw = JSON.parse(
+        await readFile(revisionManifestPath(projectId, revision), "utf8"),
+      ) as unknown;
+      const parsed =
+        storageVersion === 4
+          ? LegacyProjectRevisionV4ManifestSchema.safeParse(raw)
+          : ProjectRevisionManifestSchema.safeParse(raw);
+      if (!parsed.success) {
+        throw new PragmaProjectStoreError(
+          "unsupported_format",
+          `Project revision manifest is invalid: ${projectId}@${revision}.`,
+        );
+      }
+      return parsed.data;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
       throw error;
@@ -696,7 +743,7 @@ function createDesktopProjectSourceRepository(options: {
           const revision = actualRevision + 1;
           const createdAt = new Date().toISOString();
           const revisionManifest = ProjectRevisionManifestSchema.parse({
-            schemaVersion: "pragma.project-revision/v4",
+            schemaVersion: "pragma.project-revision/v5",
             projectId: input.projectId,
             revision,
             ...(actualRevision === 0 ? {} : { parentRevision: actualRevision }),
@@ -705,19 +752,33 @@ function createDesktopProjectSourceRepository(options: {
             compilerVersion: lock.compilerVersion,
             createdAt,
           });
+          const storedRevisionManifest =
+            storageVersion === 4
+              ? LegacyProjectRevisionV4ManifestSchema.parse({
+                  ...revisionManifest,
+                  schemaVersion: "pragma.project-revision/v4",
+                })
+              : revisionManifest;
           await writeAtomically(
             revisionManifestPath(input.projectId, revision),
-            `${JSON.stringify(revisionManifest, undefined, 2)}\n`,
+            `${JSON.stringify(storedRevisionManifest, undefined, 2)}\n`,
           );
           await writeAtomically(
             manifestPath(input.projectId),
             `${JSON.stringify(
-              ProjectManifestSchema.parse({
-                schemaVersion: "pragma.desktop-project/v4",
-                projectId: input.projectId,
-                headRevision: revision,
-                updatedAt: createdAt,
-              }),
+              storageVersion === 4
+                ? LegacyProjectV4ManifestSchema.parse({
+                    schemaVersion: "pragma.desktop-project/v4",
+                    projectId: input.projectId,
+                    headRevision: revision,
+                    updatedAt: createdAt,
+                  })
+                : ProjectManifestSchema.parse({
+                    schemaVersion: "pragma.desktop-project/v5",
+                    projectId: input.projectId,
+                    headRevision: revision,
+                    updatedAt: createdAt,
+                  }),
               undefined,
               2,
             )}\n`,
@@ -808,7 +869,30 @@ const LegacyProjectRevisionManifestSchema = z
   })
   .passthrough();
 
+const LegacyProjectV4ManifestSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.desktop-project/v4"),
+    projectId: z.string().min(1),
+    headRevision: z.number().int().positive(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+const LegacyProjectRevisionV4ManifestSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.project-revision/v4"),
+    projectId: z.string().min(1),
+    revision: z.number().int().positive(),
+    parentRevision: z.number().int().positive().optional(),
+    snapshotHash: z.string().regex(/^[a-f0-9]{64}$/),
+    projectFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    compilerVersion: z.string().min(1),
+    createdAt: z.string().datetime(),
+  })
+  .strict();
+
 type LegacyProjectRevision = ReturnType<typeof migratePragmaDslProjectToCurrent>;
+type CompilerMigratedProjectRevision = ReturnType<typeof migratePragmaCompilerProjectToCurrent>;
 
 async function migrateDesktopProjectStorageV3ToV4(input: {
   readonly projectsPath: string;
@@ -824,7 +908,7 @@ async function migrateDesktopProjectStorageV3ToV4(input: {
   const manifestPath = join(projectPath, "project.json");
   const journalPath = join(input.projectsPath, `.${input.projectId}.v3-to-v4.json`);
   await withFileLock(`${projectPath}.v3-to-v4.lock`, async () => {
-    const pending = await readProjectMigrationJournal(journalPath, input.projectId);
+    const pending = await readV3ProjectMigrationJournal(journalPath, input.projectId);
     if (pending !== undefined) {
       if (!(await pathExists(pending.backupPath))) {
         throw new PragmaProjectStoreError(
@@ -847,7 +931,8 @@ async function migrateDesktopProjectStorageV3ToV4(input: {
       typeof rawManifest === "object" &&
       rawManifest !== null &&
       "schemaVersion" in rawManifest &&
-      rawManifest.schemaVersion === "pragma.desktop-project/v4"
+      (rawManifest.schemaVersion === "pragma.desktop-project/v4" ||
+        rawManifest.schemaVersion === "pragma.desktop-project/v5")
     ) {
       await rm(journalPath, { force: true });
       return;
@@ -924,6 +1009,141 @@ async function migrateDesktopProjectStorageV3ToV4(input: {
   });
 }
 
+async function migrateDesktopProjectStorageV4ToV5(input: {
+  readonly projectsPath: string;
+  readonly objectsPath: string;
+  readonly projectId: string;
+  readonly publish: (
+    expectedRevision: number,
+    resources: readonly PragmaResource[],
+    artifacts: ReadonlyMap<string, string>,
+  ) => Promise<void>;
+}): Promise<void> {
+  const projectPath = join(input.projectsPath, input.projectId);
+  const manifestPath = join(projectPath, "project.json");
+  const journalPath = join(input.projectsPath, `.${input.projectId}.v4-to-v5.json`);
+  await withFileLock(`${projectPath}.v4-to-v5.lock`, async () => {
+    const pending = await readV4ProjectMigrationJournal(journalPath, input.projectId);
+    if (pending !== undefined) {
+      if (!(await pathExists(pending.backupPath))) {
+        throw new PragmaProjectStoreError(
+          "unsupported_format",
+          `Cannot recover project compiler migration because its backup is missing: ${pending.backupPath}`,
+        );
+      }
+      await rm(projectPath, { recursive: true, force: true });
+      await rename(pending.backupPath, projectPath);
+      await rm(journalPath, { force: true });
+    }
+
+    let rawManifest: unknown;
+    try {
+      rawManifest = JSON.parse(await readFile(manifestPath, "utf8")) as unknown;
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") return;
+      throw error;
+    }
+    if (
+      typeof rawManifest === "object" &&
+      rawManifest !== null &&
+      "schemaVersion" in rawManifest &&
+      rawManifest.schemaVersion === "pragma.desktop-project/v5"
+    ) {
+      await rm(journalPath, { force: true });
+      return;
+    }
+
+    const legacyManifest = LegacyProjectV4ManifestSchema.parse(rawManifest);
+    const objects = new ContentAddressedStore(input.objectsPath);
+    const revisions: CompilerMigratedProjectRevision[] = [];
+    for (let revision = 1; revision <= legacyManifest.headRevision; revision += 1) {
+      const parsedRevisionManifest = LegacyProjectRevisionV4ManifestSchema.safeParse(
+        JSON.parse(
+          await readFile(join(projectPath, "revisions", `${revision}.json`), "utf8"),
+        ) as unknown,
+      );
+      if (!parsedRevisionManifest.success) {
+        throw new PragmaProjectStoreError(
+          "unsupported_format",
+          `Project revision manifest is invalid: ${input.projectId}@${revision}.`,
+        );
+      }
+      const revisionManifest = parsedRevisionManifest.data;
+      if (
+        revisionManifest.projectId !== input.projectId ||
+        revisionManifest.revision !== revision
+      ) {
+        throw new PragmaProjectStoreError(
+          "unsupported_format",
+          `Project revision metadata is inconsistent: ${input.projectId}@${revision}.`,
+        );
+      }
+      const temporary = await mkdtemp(join(input.projectsPath, ".project-v4-view-"));
+      try {
+        await objects.materializeTree(revisionManifest.snapshotHash, temporary);
+        try {
+          revisions.push(
+            migratePragmaCompilerProjectToCurrent({
+              files: await readTextFiles(temporary),
+              revisionCompilerVersion: revisionManifest.compilerVersion,
+            }),
+          );
+        } catch (error) {
+          if (error instanceof PragmaCompilerMigrationError) {
+            throw new PragmaProjectStoreError(
+              "unsupported_format",
+              `Cannot upgrade ${input.projectId}@${revision}: ${error.message}`,
+            );
+          }
+          throw error;
+        }
+      } finally {
+        await rm(temporary, { recursive: true, force: true });
+      }
+    }
+    // Identity migration metadata and Flow layouts have independent schema versions.
+    // Carry them byte-for-byte; their owning stores validate and migrate them on access.
+    const auxiliaryFiles = new Map(
+      [...(await readTextFiles(projectPath))].filter(
+        ([path]) =>
+          path !== "project.json" && !path.startsWith("revisions/") && path !== ".commit.lock",
+      ),
+    );
+
+    const backupPath = `${projectPath}.v4-backup-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+    await writeAtomically(
+      journalPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: "pragma.desktop-project-migration/v1",
+          projectId: input.projectId,
+          sourceSchema: "pragma.desktop-project/v4",
+          targetSchema: "pragma.desktop-project/v5",
+          backupPath,
+        },
+        undefined,
+        2,
+      )}\n`,
+    );
+    await rename(projectPath, backupPath);
+    try {
+      for (let revision = 0; revision < revisions.length; revision += 1) {
+        const migrated = revisions[revision]!;
+        await input.publish(revision, migrated.resources, migrated.artifacts);
+      }
+      for (const [path, contents] of auxiliaryFiles) {
+        await writeAtomically(join(projectPath, path), contents);
+      }
+      await rm(journalPath, { force: true });
+    } catch (error) {
+      await rm(projectPath, { recursive: true, force: true });
+      await rename(backupPath, projectPath);
+      await rm(journalPath, { force: true });
+      throw error;
+    }
+  });
+}
+
 async function writeLegacyProjectIdentityMigrationIndex(
   projectPath: string,
   projectId: string,
@@ -952,7 +1172,7 @@ async function writeLegacyProjectIdentityMigrationIndex(
   );
 }
 
-async function readProjectMigrationJournal(
+async function readV3ProjectMigrationJournal(
   journalPath: string,
   projectId: string,
 ): Promise<{ readonly backupPath: string } | undefined> {
@@ -969,6 +1189,29 @@ async function readProjectMigrationJournal(
       projectId: z.literal(projectId),
       sourceSchema: z.literal("pragma.desktop-project/v3"),
       targetSchema: z.literal("pragma.desktop-project/v4"),
+      backupPath: z.string().min(1),
+    })
+    .parse(value);
+  return { backupPath: parsed.backupPath };
+}
+
+async function readV4ProjectMigrationJournal(
+  journalPath: string,
+  projectId: string,
+): Promise<{ readonly backupPath: string } | undefined> {
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(journalPath, "utf8")) as unknown;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return undefined;
+    throw error;
+  }
+  const parsed = z
+    .object({
+      schemaVersion: z.literal("pragma.desktop-project-migration/v1"),
+      projectId: z.literal(projectId),
+      sourceSchema: z.literal("pragma.desktop-project/v4"),
+      targetSchema: z.literal("pragma.desktop-project/v5"),
       backupPath: z.string().min(1),
     })
     .parse(value);

--- a/apps/desktop/src/main/platform/ipc/bridge-snapshot.ts
+++ b/apps/desktop/src/main/platform/ipc/bridge-snapshot.ts
@@ -1,6 +1,7 @@
 import { app } from "electron";
 import {
-  PRAGMA_COMPILER_READ_VERSIONS,
+  PRAGMA_COMPILER_DIRECT_READ_VERSIONS,
+  PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS,
   PRAGMA_COMPILER_WRITE_VERSION,
 } from "@pragma/interpreter/ast";
 
@@ -22,7 +23,8 @@ export function createBridgeSnapshot(): DesktopBridgeSnapshot {
     },
     interpreter: {
       writeVersion: PRAGMA_COMPILER_WRITE_VERSION,
-      readVersions: [...PRAGMA_COMPILER_READ_VERSIONS],
+      directReadVersions: [...PRAGMA_COMPILER_DIRECT_READ_VERSIONS],
+      upgradeFromVersions: [...PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS],
     },
     gateway: {
       schemaVersion: 1,

--- a/apps/desktop/src/main/platform/ipc/bridge-snapshot.ts
+++ b/apps/desktop/src/main/platform/ipc/bridge-snapshot.ts
@@ -1,4 +1,8 @@
 import { app } from "electron";
+import {
+  PRAGMA_COMPILER_READ_VERSIONS,
+  PRAGMA_COMPILER_WRITE_VERSION,
+} from "@pragma/interpreter/ast";
 
 import type { DesktopBridgeSnapshot } from "../../../shared/contracts/index.ts";
 
@@ -15,6 +19,10 @@ export function createBridgeSnapshot(): DesktopBridgeSnapshot {
       name: "Pragma Desktop",
       version: app.getVersion(),
       os: normalizeOs(),
+    },
+    interpreter: {
+      writeVersion: PRAGMA_COMPILER_WRITE_VERSION,
+      readVersions: [...PRAGMA_COMPILER_READ_VERSIONS],
     },
     gateway: {
       schemaVersion: 1,

--- a/apps/desktop/src/renderer/src/components/DesktopFatalError.test.tsx
+++ b/apps/desktop/src/renderer/src/components/DesktopFatalError.test.tsx
@@ -30,6 +30,15 @@ describe("DesktopFatalError", () => {
     expect(html).toContain("Pragma 未能完成启动");
     expect(html).toContain("诊断代码：RENDERER_STARTUP_FAILURE");
   });
+
+  it("explains that mismatched Desktop components must be reloaded", () => {
+    const html = renderToStaticMarkup(
+      <DesktopFatalError code="DESKTOP_COMPONENT_VERSION_MISMATCH" onReload={() => undefined} />,
+    );
+
+    expect(html).toContain("Pragma components are out of sync");
+    expect(html).toContain("Diagnostic code: DESKTOP_COMPONENT_VERSION_MISMATCH");
+  });
 });
 
 describe("DesktopErrorBoundary", () => {

--- a/apps/desktop/src/renderer/src/components/DesktopFatalError.tsx
+++ b/apps/desktop/src/renderer/src/components/DesktopFatalError.tsx
@@ -3,17 +3,21 @@ import { useTranslation } from "react-i18next";
 
 import { serializeRendererError } from "../lib/renderer-log.ts";
 
-export type DesktopFatalErrorCode = "DESKTOP_BRIDGE_UNAVAILABLE" | "RENDERER_STARTUP_FAILURE";
+export type DesktopFatalErrorCode =
+  | "DESKTOP_BRIDGE_UNAVAILABLE"
+  | "DESKTOP_COMPONENT_VERSION_MISMATCH"
+  | "RENDERER_STARTUP_FAILURE";
 
 export function DesktopFatalError(props: {
   readonly code: DesktopFatalErrorCode;
   readonly onReload?: (() => void) | undefined;
 }) {
   const { t } = useTranslation();
-  const copyKey =
-    props.code === "DESKTOP_BRIDGE_UNAVAILABLE"
-      ? "startupFailure.bridge"
-      : "startupFailure.renderer";
+  const copyKey = {
+    DESKTOP_BRIDGE_UNAVAILABLE: "startupFailure.bridge",
+    DESKTOP_COMPONENT_VERSION_MISMATCH: "startupFailure.version",
+    RENDERER_STARTUP_FAILURE: "startupFailure.renderer",
+  }[props.code];
   const reload = props.onReload ?? (() => window.location.reload());
 
   return (

--- a/apps/desktop/src/renderer/src/i18n/resources/en/common.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/common.ts
@@ -60,6 +60,11 @@ export const common = {
       description:
         "Pragma could not connect the interface to its local Desktop services. Your data has not been changed.",
     },
+    version: {
+      title: "Pragma components are out of sync",
+      description:
+        "The Desktop interface and local compiler use different protocol versions. Reload Pragma before editing a project or starting a Mission.",
+    },
     renderer: {
       title: "Pragma could not finish starting",
       description: "The Desktop interface encountered an unexpected problem while it was starting.",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/common.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/common.ts
@@ -59,6 +59,11 @@ export const common = {
       title: "无法加载 Desktop 桥接服务",
       description: "Pragma 无法连接界面与本地 Desktop 服务。你的数据没有被更改。",
     },
+    version: {
+      title: "Pragma 组件版本不一致",
+      description:
+        "Desktop 界面与本地编译器正在使用不同的协议版本。请先重新加载 Pragma，再编辑项目或启动任务。",
+    },
     renderer: {
       title: "Pragma 未能完成启动",
       description: "Desktop 界面在启动过程中遇到了意外问题。",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/common.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/common.ts
@@ -59,6 +59,11 @@ export const common = {
       title: "無法載入 Desktop 橋接服務",
       description: "Pragma 無法連接介面與本機 Desktop 服務。你的資料沒有被變更。",
     },
+    version: {
+      title: "Pragma 元件版本不一致",
+      description:
+        "Desktop 介面與本機編譯器正在使用不同的協定版本。請先重新載入 Pragma，再編輯專案或啟動任務。",
+    },
     renderer: {
       title: "Pragma 未能完成啟動",
       description: "Desktop 介面在啟動過程中遇到了非預期問題。",

--- a/apps/desktop/src/renderer/src/lib/desktop-startup.test.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-startup.test.ts
@@ -5,7 +5,8 @@ import { resolveDesktopStartup } from "./desktop-startup.ts";
 const currentBridgeSnapshot = {
   interpreter: {
     writeVersion: "pragma.dsl/v3",
-    readVersions: ["pragma.dsl/v2", "pragma.dsl/v3"],
+    directReadVersions: ["pragma.dsl/v3"],
+    upgradeFromVersions: ["pragma.dsl/v2"],
   },
 } as const;
 
@@ -69,7 +70,8 @@ describe("resolveDesktopStartup", () => {
           getBridgeSnapshot: async () => ({
             interpreter: {
               writeVersion: "pragma.dsl/v2",
-              readVersions: ["pragma.dsl/v2"],
+              directReadVersions: ["pragma.dsl/v2"],
+              upgradeFromVersions: [],
             },
           }),
           getDesktopSettings: async () => ({ resolvedLocale: "en" }),
@@ -89,7 +91,8 @@ describe("resolveDesktopStartup", () => {
           getBridgeSnapshot: async () => ({
             interpreter: {
               writeVersion: "pragma.dsl/v3",
-              readVersions: ["pragma.dsl/v2\u0000pragma.dsl/v3"],
+              directReadVersions: ["pragma.dsl/v3\u0000pragma.dsl/v4"],
+              upgradeFromVersions: ["pragma.dsl/v2"],
             },
           }),
           getDesktopSettings: async () => ({ resolvedLocale: "en" }),

--- a/apps/desktop/src/renderer/src/lib/desktop-startup.test.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-startup.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { resolveDesktopStartup } from "./desktop-startup.ts";
 
+const currentBridgeSnapshot = {
+  interpreter: {
+    writeVersion: "pragma.dsl/v3",
+    readVersions: ["pragma.dsl/v2", "pragma.dsl/v3"],
+  },
+} as const;
+
 describe("resolveDesktopStartup", () => {
   it("reports a missing preload bridge using the system locale", async () => {
     await expect(resolveDesktopStartup(undefined, ["zh-TW"])).resolves.toEqual({
@@ -10,10 +17,25 @@ describe("resolveDesktopStartup", () => {
     });
   });
 
+  it("reports an older preload bridge as a component version mismatch", async () => {
+    await expect(
+      resolveDesktopStartup(
+        {
+          getDesktopSettings: async () => ({ resolvedLocale: "en" }),
+        },
+        ["zh-CN"],
+      ),
+    ).resolves.toEqual({
+      locale: "zh-Hans",
+      errorCode: "DESKTOP_COMPONENT_VERSION_MISMATCH",
+    });
+  });
+
   it("uses the locale stored by Desktop settings", async () => {
     await expect(
       resolveDesktopStartup(
         {
+          getBridgeSnapshot: async () => currentBridgeSnapshot,
           getDesktopSettings: async () => ({ resolvedLocale: "zh-Hans" }),
         },
         ["en-US"],
@@ -27,6 +49,7 @@ describe("resolveDesktopStartup", () => {
     await expect(
       resolveDesktopStartup(
         {
+          getBridgeSnapshot: async () => currentBridgeSnapshot,
           getDesktopSettings: async () => {
             throw settingsError;
           },
@@ -36,6 +59,63 @@ describe("resolveDesktopStartup", () => {
     ).resolves.toEqual({
       locale: "zh-Hant",
       settingsError,
+    });
+  });
+
+  it("blocks startup when the main and preload Interpreter capabilities differ", async () => {
+    await expect(
+      resolveDesktopStartup(
+        {
+          getBridgeSnapshot: async () => ({
+            interpreter: {
+              writeVersion: "pragma.dsl/v2",
+              readVersions: ["pragma.dsl/v2"],
+            },
+          }),
+          getDesktopSettings: async () => ({ resolvedLocale: "en" }),
+        },
+        ["zh-CN"],
+      ),
+    ).resolves.toEqual({
+      locale: "zh-Hans",
+      errorCode: "DESKTOP_COMPONENT_VERSION_MISMATCH",
+    });
+  });
+
+  it("compares Interpreter readable versions without delimiter collisions", async () => {
+    await expect(
+      resolveDesktopStartup(
+        {
+          getBridgeSnapshot: async () => ({
+            interpreter: {
+              writeVersion: "pragma.dsl/v3",
+              readVersions: ["pragma.dsl/v2\u0000pragma.dsl/v3"],
+            },
+          }),
+          getDesktopSettings: async () => ({ resolvedLocale: "en" }),
+        },
+        ["en-US"],
+      ),
+    ).resolves.toEqual({
+      locale: "en",
+      errorCode: "DESKTOP_COMPONENT_VERSION_MISMATCH",
+    });
+  });
+
+  it("reports bridge snapshot failures as unavailable instead of a version mismatch", async () => {
+    await expect(
+      resolveDesktopStartup(
+        {
+          getBridgeSnapshot: async () => {
+            throw new Error("IPC unavailable");
+          },
+          getDesktopSettings: async () => ({ resolvedLocale: "en" }),
+        },
+        ["zh-HK"],
+      ),
+    ).resolves.toEqual({
+      locale: "zh-Hant",
+      errorCode: "DESKTOP_BRIDGE_UNAVAILABLE",
     });
   });
 });

--- a/apps/desktop/src/renderer/src/lib/desktop-startup.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-startup.ts
@@ -1,7 +1,14 @@
+import {
+  PRAGMA_COMPILER_READ_VERSIONS,
+  PRAGMA_COMPILER_WRITE_VERSION,
+} from "@pragma/interpreter/ast";
+
 import type { DesktopResolvedLocale } from "../../../shared/contracts/index.ts";
 import { resolveDesktopLocale } from "../../../shared/desktop-locale.ts";
 
-export type DesktopStartupErrorCode = "DESKTOP_BRIDGE_UNAVAILABLE";
+export type DesktopStartupErrorCode =
+  | "DESKTOP_BRIDGE_UNAVAILABLE"
+  | "DESKTOP_COMPONENT_VERSION_MISMATCH";
 
 export type DesktopStartupResult =
   | {
@@ -16,6 +23,14 @@ export type DesktopStartupResult =
 export async function resolveDesktopStartup(
   bridge:
     | {
+        getBridgeSnapshot?(): Promise<{
+          readonly interpreter?:
+            | {
+                readonly writeVersion: string;
+                readonly readVersions: readonly string[];
+              }
+            | undefined;
+        }>;
         getDesktopSettings(): Promise<{ readonly resolvedLocale: DesktopResolvedLocale }>;
       }
     | undefined,
@@ -23,6 +38,35 @@ export async function resolveDesktopStartup(
 ): Promise<DesktopStartupResult> {
   const fallbackLocale = resolveDesktopLocale(preferredSystemLanguages);
   if (bridge === undefined) {
+    return {
+      locale: fallbackLocale,
+      errorCode: "DESKTOP_BRIDGE_UNAVAILABLE",
+    };
+  }
+  if (typeof bridge.getBridgeSnapshot !== "function") {
+    return {
+      locale: fallbackLocale,
+      errorCode: "DESKTOP_COMPONENT_VERSION_MISMATCH",
+    };
+  }
+
+  try {
+    const snapshot = await bridge.getBridgeSnapshot();
+    const interpreter = snapshot.interpreter;
+    if (
+      interpreter === undefined ||
+      interpreter.writeVersion !== PRAGMA_COMPILER_WRITE_VERSION ||
+      interpreter.readVersions.length !== PRAGMA_COMPILER_READ_VERSIONS.length ||
+      interpreter.readVersions.some(
+        (version, index) => version !== PRAGMA_COMPILER_READ_VERSIONS[index],
+      )
+    ) {
+      return {
+        locale: fallbackLocale,
+        errorCode: "DESKTOP_COMPONENT_VERSION_MISMATCH",
+      };
+    }
+  } catch {
     return {
       locale: fallbackLocale,
       errorCode: "DESKTOP_BRIDGE_UNAVAILABLE",

--- a/apps/desktop/src/renderer/src/lib/desktop-startup.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-startup.ts
@@ -1,5 +1,6 @@
 import {
-  PRAGMA_COMPILER_READ_VERSIONS,
+  PRAGMA_COMPILER_DIRECT_READ_VERSIONS,
+  PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS,
   PRAGMA_COMPILER_WRITE_VERSION,
 } from "@pragma/interpreter/ast";
 
@@ -27,7 +28,8 @@ export async function resolveDesktopStartup(
           readonly interpreter?:
             | {
                 readonly writeVersion: string;
-                readonly readVersions: readonly string[];
+                readonly directReadVersions: readonly string[];
+                readonly upgradeFromVersions: readonly string[];
               }
             | undefined;
         }>;
@@ -56,9 +58,13 @@ export async function resolveDesktopStartup(
     if (
       interpreter === undefined ||
       interpreter.writeVersion !== PRAGMA_COMPILER_WRITE_VERSION ||
-      interpreter.readVersions.length !== PRAGMA_COMPILER_READ_VERSIONS.length ||
-      interpreter.readVersions.some(
-        (version, index) => version !== PRAGMA_COMPILER_READ_VERSIONS[index],
+      interpreter.directReadVersions.length !== PRAGMA_COMPILER_DIRECT_READ_VERSIONS.length ||
+      interpreter.directReadVersions.some(
+        (version, index) => version !== PRAGMA_COMPILER_DIRECT_READ_VERSIONS[index],
+      ) ||
+      interpreter.upgradeFromVersions.length !== PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS.length ||
+      interpreter.upgradeFromVersions.some(
+        (version, index) => version !== PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS[index],
       )
     ) {
       return {

--- a/apps/desktop/src/shared/contracts/bundles.ts
+++ b/apps/desktop/src/shared/contracts/bundles.ts
@@ -83,6 +83,7 @@ export const PragmaBundleConflictSchema = z
       "Capability",
       "ContextStore",
       "RuntimeProfile",
+      "Evaluation",
     ]),
     importedName: z.string().trim().min(1).max(200),
     matches: z.array(PragmaBundleConflictMatchSchema).min(1).max(2),

--- a/apps/desktop/src/shared/contracts/contracts.test.ts
+++ b/apps/desktop/src/shared/contracts/contracts.test.ts
@@ -82,7 +82,8 @@ describe("runtime settings contracts", () => {
       },
       interpreter: {
         writeVersion: "pragma.dsl/v4",
-        readVersions: ["pragma.dsl/v2", "pragma.dsl/v3", "pragma.dsl/v4"],
+        directReadVersions: ["pragma.dsl/v4"],
+        upgradeFromVersions: ["pragma.dsl/v2", "pragma.dsl/v3"],
       },
       gateway: {
         schemaVersion: 1,
@@ -101,6 +102,16 @@ describe("runtime settings contracts", () => {
     } as const;
 
     expect(DesktopBridgeSnapshotSchema.parse(snapshot).interpreter).toEqual(snapshot.interpreter);
+    expect(
+      DesktopBridgeSnapshotSchema.safeParse({
+        ...snapshot,
+        interpreter: {
+          writeVersion: "pragma.dsl/v4",
+          directReadVersions: ["pragma.dsl/v4"],
+          upgradeFromVersions: [],
+        },
+      }).success,
+    ).toBe(true);
     expect(
       DesktopBridgeSnapshotSchema.parse({ ...snapshot, interpreter: undefined }),
     ).toMatchObject({

--- a/apps/desktop/src/shared/contracts/contracts.test.ts
+++ b/apps/desktop/src/shared/contracts/contracts.test.ts
@@ -25,6 +25,7 @@ import {
   MissionUpdateSchema,
   PragmaProjectChangesSchema,
   SetDefaultRuntimeSchema,
+  DesktopBridgeSnapshotSchema,
   DesktopSettingsSnapshotSchema,
   UpdateDesktopSettingsSchema,
   UpdateExpertDefinitionSchema,
@@ -70,6 +71,41 @@ describe("runtime settings contracts", () => {
       runtimeId: "codex",
     });
     expect(SetDefaultRuntimeSchema.safeParse({ runtimeId: "" }).success).toBe(false);
+  });
+
+  it("preserves arbitrary Interpreter capability lists for renderer compatibility checks", () => {
+    const snapshot = {
+      app: {
+        name: "Pragma Desktop",
+        version: "1.0.0",
+        os: "macos",
+      },
+      interpreter: {
+        writeVersion: "pragma.dsl/v4",
+        readVersions: ["pragma.dsl/v2", "pragma.dsl/v3", "pragma.dsl/v4"],
+      },
+      gateway: {
+        schemaVersion: 1,
+        endpoint: "ws://localhost:3001/runtime-gateway",
+        transport: "websocket",
+      },
+      device: {
+        status: "offline",
+        label: "Local Desktop",
+      },
+      workspace: {
+        path: null,
+        status: "unset",
+      },
+      capabilities: [],
+    } as const;
+
+    expect(DesktopBridgeSnapshotSchema.parse(snapshot).interpreter).toEqual(snapshot.interpreter);
+    expect(
+      DesktopBridgeSnapshotSchema.parse({ ...snapshot, interpreter: undefined }),
+    ).toMatchObject({
+      app: snapshot.app,
+    });
   });
 });
 

--- a/apps/desktop/src/shared/contracts/projects.ts
+++ b/apps/desktop/src/shared/contracts/projects.ts
@@ -13,6 +13,7 @@ export const PragmaProjectSnapshotSchema = z.object({
   schemaVersion: z.literal("pragma.project-snapshot/v3"),
   projectId: z.string().trim().min(1).max(120),
   revision: z.number().int().nonnegative(),
+  compilerVersion: z.string().trim().min(1).optional(),
   resources: z.array(PragmaResourceSchema),
   diagnostics: z.array(PragmaDiagnosticSchema),
   lock: PragmaLockSchema.optional(),

--- a/apps/desktop/src/shared/contracts/runtime.ts
+++ b/apps/desktop/src/shared/contracts/runtime.ts
@@ -114,7 +114,8 @@ export const DesktopBridgeSnapshotSchema = z.object({
   interpreter: z
     .object({
       writeVersion: z.string().min(1),
-      readVersions: z.array(z.string().min(1)).min(1),
+      directReadVersions: z.array(z.string().min(1)).min(1),
+      upgradeFromVersions: z.array(z.string().min(1)),
     })
     .strict()
     .optional(),

--- a/apps/desktop/src/shared/contracts/runtime.ts
+++ b/apps/desktop/src/shared/contracts/runtime.ts
@@ -111,6 +111,13 @@ export const SetDefaultRuntimeSchema = z.object({
 
 export const DesktopBridgeSnapshotSchema = z.object({
   app: DesktopAppInfoSchema,
+  interpreter: z
+    .object({
+      writeVersion: z.string().min(1),
+      readVersions: z.array(z.string().min(1)).min(1),
+    })
+    .strict()
+    .optional(),
   gateway: RuntimeGatewayConfigSchema,
   device: z.object({
     status: z.literal("offline"),

--- a/docs/adr/029-interpreter-compiler-compatibility-and-scoped-validation.md
+++ b/docs/adr/029-interpreter-compiler-compatibility-and-scoped-validation.md
@@ -1,0 +1,46 @@
+# ADR 029: Interpreter compiler compatibility and scoped execution validation
+
+## Status
+
+Accepted.
+
+## Context
+
+Project revisions persist a `compilerVersion`, but the Interpreter previously treated it only as
+part of a generic lock comparison. The independent Evaluation change extended the closed resource
+union without changing that version. A long-running older Desktop process therefore reported the
+new resource as both an invalid schema and a stale lock.
+
+Compilation also ran complete-project validation before resolving the requested executor. A new
+validator finding in one unrelated Flow could consequently disable every project Expert and Team.
+
+## Decision
+
+- The Interpreter exports one browser-safe compiler capability declaration. Project publication,
+  lock generation, revision loading, Blueprint caching, Desktop IPC, and Mission compilation use
+  that declaration.
+- New revisions write `pragma.dsl/v3`. The current Interpreter reads both `pragma.dsl/v2` and
+  `pragma.dsl/v3`; immutable v2 revisions are not rewritten.
+- Revision metadata and the persisted lock must agree. Unsupported versions and metadata
+  disagreement are compiler diagnostics evaluated before resource parsing. They are not lock
+  mismatches.
+- `PragmaProject.validate()` remains the complete-project health check used by authoring and
+  publication. `PragmaProject.validateFor(ref)` validates only an executor and its transitive
+  project-resource dependency closure.
+- Compiler, lock, unreadable source topology, and resource identity ambiguity remain project-wide
+  blockers. Reference, cycle, Flow contract, portable semantic, and adapter diagnostics block only
+  an executor whose dependency closure contains the affected resource.
+- Desktop main and preload expose and compare the compiler capability during startup. Development
+  runs electron-vite in watch mode so changes to bundled workspace dependencies rebuild and restart
+  the Electron process.
+
+## Consequences
+
+Studio can continue to show complete project diagnostics while independent executors remain usable.
+Executors that directly or indirectly depend on damaged resources still fail closed. A rollback to
+an Interpreter that cannot read a newer revision remains safe because the compiler version blocks
+execution before resources are trusted.
+
+Changes to the closed DSL resource union, strict resource schemas, or portable validators that can
+reject a previously published revision require an explicit compiler compatibility decision,
+cross-version fixtures, and an update to the compiler capability declaration.

--- a/docs/adr/029-interpreter-compiler-compatibility-and-scoped-validation.md
+++ b/docs/adr/029-interpreter-compiler-compatibility-and-scoped-validation.md
@@ -19,8 +19,14 @@ validator finding in one unrelated Flow could consequently disable every project
 - The Interpreter exports one browser-safe compiler capability declaration. Project publication,
   lock generation, revision loading, Blueprint caching, Desktop IPC, and Mission compilation use
   that declaration.
-- New revisions write `pragma.dsl/v3`. The current Interpreter reads both `pragma.dsl/v2` and
-  `pragma.dsl/v3`; immutable v2 revisions are not rewritten.
+- New revisions write and directly read `pragma.dsl/v3`. `pragma.dsl/v2` is an upgrade source, not
+  a directly readable version.
+- The Interpreter owns the pure v2-to-v3 compiler migration. It validates the historical v2 lock
+  and the exact historical `Flow.spec.runDry` shape, removes that abandoned field, and emits
+  current resources. It does not create an `Evaluation` or retain a runtime compatibility branch.
+- Desktop owns the transaction that upgrades project storage v4 to v5 before normal reads. It
+  preserves project and revision identities, republishes every revision with a v3 lock, and uses a
+  file lock, stable journal, backup, atomic replacement, and replayable recovery.
 - Revision metadata and the persisted lock must agree. Unsupported versions and metadata
   disagreement are compiler diagnostics evaluated before resource parsing. They are not lock
   mismatches.
@@ -42,5 +48,6 @@ an Interpreter that cannot read a newer revision remains safe because the compil
 execution before resources are trusted.
 
 Changes to the closed DSL resource union, strict resource schemas, or portable validators that can
-reject a previously published revision require an explicit compiler compatibility decision,
-cross-version fixtures, and an update to the compiler capability declaration.
+reject a previously published revision require a compiler version bump, a same-change adjacent
+migration, real historical fixtures, Host transaction coverage, and an update to the compiler
+capability declaration. Declaring an upgrade source as directly readable is invalid.

--- a/docs/architecture/pragma-yaml-dsl.md
+++ b/docs/architecture/pragma-yaml-dsl.md
@@ -33,6 +33,13 @@ Applications also own migration transactions, but not DSL transformation rules. 
 revision, calls the Interpreter's in-memory adjacent migration chain, republishes the canonical
 current resources, and uses the returned identity mapping for Host-specific dependent records.
 
+Compiler compatibility is declared on a separate axis from DSL `apiVersion`. The current
+Interpreter writes and directly reads `pragma.dsl/v3`, while `pragma.dsl/v2` is only an upgrade
+source. Desktop upgrades v2 revisions transactionally before normal parsing; the compiler migration
+validates the historical lock and removes the abandoned `Flow.spec.runDry` field without creating
+an Evaluation. A version may be advertised as directly readable only when the current parser accepts
+real revisions written by that version.
+
 ## Project layout and identity
 
 Every semantic reference contains one Host-generated opaque ID. Project revisions, rather than

--- a/docs/architecture/pragma-yaml-dsl.md
+++ b/docs/architecture/pragma-yaml-dsl.md
@@ -211,6 +211,17 @@ Published revisions must contain their actual lock. A missing, malformed, stale,
 incompatible lock removes trust in the project fingerprint and blocks apply, compile, and recover;
 the service never synthesizes a replacement lock while reading a snapshot.
 
+The browser-safe Interpreter compiler capability declares one write version and the bounded set of
+readable versions. Revision metadata and `pragma.lock.yaml` must agree before resource parsing.
+Unsupported versions use `compiler.version_unsupported`; metadata disagreement uses
+`compiler.version_metadata_mismatch`. Neither condition is reported as a stale lock.
+
+Complete-project validation remains the authoring and publication health gate. Runtime compilation
+validates only the selected Expert, Team, or Flow and its transitive project-resource dependencies.
+Compiler, lock, unreadable source topology, and resource identity ambiguity are project-wide
+blockers; unrelated resource-reference or Flow-contract diagnostics remain visible in project
+health without disabling independent executors.
+
 Compilation separately returns an environment fingerprint containing:
 
 - the environment ID;

--- a/packages/interpreter/src/application/project-service.ts
+++ b/packages/interpreter/src/application/project-service.ts
@@ -81,6 +81,7 @@ export interface PragmaProjectSnapshot {
   readonly schemaVersion: "pragma.project-snapshot/v3";
   readonly projectId: string;
   readonly revision: number;
+  readonly compilerVersion?: string | undefined;
   readonly resources: readonly PragmaResource[];
   readonly diagnostics: readonly PragmaDiagnostic[];
   readonly lock?: PragmaLock | undefined;
@@ -139,11 +140,16 @@ export class PragmaProjectService {
       } catch {
         lock = undefined;
       }
-      const lockValid = !diagnostics.some((diagnostic) => diagnostic.code.startsWith("lock."));
+      const lockValid = !diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code.startsWith("lock.") || diagnostic.code.startsWith("compiler."),
+      );
+      const compilerVersion = lock?.compilerVersion ?? checkedOut.compilerVersion;
       return {
         schemaVersion: "pragma.project-snapshot/v3",
         projectId,
         revision: checkedOut.revision,
+        ...(compilerVersion === undefined ? {} : { compilerVersion }),
         resources: project.listResources(),
         diagnostics,
         ...(lock === undefined ? {} : { lock }),
@@ -385,16 +391,24 @@ export class PragmaProjectService {
       return await loadPragmaProject(location.entryFile, {
         rootDir: location.rootDir,
         requireLock,
+        ...(location.compilerVersion === undefined
+          ? {}
+          : { revisionCompilerVersion: location.compilerVersion }),
         resourceAdapters: this.adapters,
         externalResourceRefs: this.options.externalResourceRefs,
       });
     }
-    const key = `${sourceIdentity}\0${requireLock ? "locked" : "unlocked"}`;
+    const key =
+      `${sourceIdentity}\0${location.compilerVersion ?? "unknown"}\0` +
+      `${requireLock ? "locked" : "unlocked"}`;
     let project = this.openedProjects.get(key);
     if (project === undefined) {
       project = loadPragmaProject(location.entryFile, {
         rootDir: location.rootDir,
         requireLock,
+        ...(location.compilerVersion === undefined
+          ? {}
+          : { revisionCompilerVersion: location.compilerVersion }),
         sourceIdentity,
         blueprintCache: this.options.blueprintCache,
         onBlueprintCacheLookup: (observation) => {
@@ -450,7 +464,9 @@ export class PragmaProjectService {
       throw new PragmaProjectRevisionConflictError(input.baseRevision, current.revision, [], false);
     }
     const currentErrors = current.diagnostics.filter(
-      (diagnostic) => diagnostic.severity === "error" && diagnostic.code.startsWith("lock."),
+      (diagnostic) =>
+        diagnostic.severity === "error" &&
+        (diagnostic.code.startsWith("lock.") || diagnostic.code.startsWith("compiler.")),
     );
     if (currentErrors.length > 0) throw new PragmaProjectValidationError(currentErrors);
 

--- a/packages/interpreter/src/ast/compiler-compatibility.ts
+++ b/packages/interpreter/src/ast/compiler-compatibility.ts
@@ -1,0 +1,10 @@
+export const PRAGMA_COMPILER_WRITE_VERSION = "pragma.dsl/v3";
+
+export const PRAGMA_COMPILER_READ_VERSIONS = [
+  "pragma.dsl/v2",
+  PRAGMA_COMPILER_WRITE_VERSION,
+] as const;
+
+export function isPragmaCompilerVersionReadable(version: string): boolean {
+  return (PRAGMA_COMPILER_READ_VERSIONS as readonly string[]).includes(version);
+}

--- a/packages/interpreter/src/ast/compiler-compatibility.ts
+++ b/packages/interpreter/src/ast/compiler-compatibility.ts
@@ -1,10 +1,13 @@
 export const PRAGMA_COMPILER_WRITE_VERSION = "pragma.dsl/v3";
 
-export const PRAGMA_COMPILER_READ_VERSIONS = [
-  "pragma.dsl/v2",
-  PRAGMA_COMPILER_WRITE_VERSION,
-] as const;
+export const PRAGMA_COMPILER_DIRECT_READ_VERSIONS = [PRAGMA_COMPILER_WRITE_VERSION] as const;
 
-export function isPragmaCompilerVersionReadable(version: string): boolean {
-  return (PRAGMA_COMPILER_READ_VERSIONS as readonly string[]).includes(version);
+export const PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS = ["pragma.dsl/v2"] as const;
+
+export function isPragmaCompilerVersionDirectlyReadable(version: string): boolean {
+  return (PRAGMA_COMPILER_DIRECT_READ_VERSIONS as readonly string[]).includes(version);
+}
+
+export function isPragmaCompilerVersionUpgradeable(version: string): boolean {
+  return (PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS as readonly string[]).includes(version);
 }

--- a/packages/interpreter/src/ast/index.ts
+++ b/packages/interpreter/src/ast/index.ts
@@ -1,3 +1,4 @@
+export * from "./compiler-compatibility.ts";
 export * from "./flow-data-contracts.ts";
 export * from "./flow-graph.ts";
 export * from "./flow-run-dry.schema.ts";

--- a/packages/interpreter/src/ast/pragma-dsl.schema.ts
+++ b/packages/interpreter/src/ast/pragma-dsl.schema.ts
@@ -905,6 +905,7 @@ export const PragmaDiagnosticSchema = z
     severity: z.enum(["error", "warning"]),
     code: z.string().min(1),
     message: z.string().min(1),
+    resourceRef: PragmaSemanticResourceRefSchema.optional(),
     source: z.string().optional(),
     path: z.array(z.union([z.string(), z.number()])).default([]),
   })

--- a/packages/interpreter/src/compiler-migrations/index.ts
+++ b/packages/interpreter/src/compiler-migrations/index.ts
@@ -1,0 +1,171 @@
+import {
+  PRAGMA_COMPILER_WRITE_VERSION,
+  isPragmaCompilerVersionDirectlyReadable,
+  isPragmaCompilerVersionUpgradeable,
+} from "../ast/compiler-compatibility.ts";
+import {
+  PragmaBundleSchema,
+  PragmaLockSchema,
+  PragmaResourceSchema,
+  canonicalPragmaResourceRef,
+  type PragmaResource,
+} from "../ast/index.ts";
+import { parsePragmaYaml } from "../compiler/pragma-project.ts";
+import { sha256, stableStringify } from "../compiler/compiler-hash.ts";
+import { migratePragmaCompilerV2Project } from "./steps/v2-to-v3.ts";
+import {
+  PragmaCompilerMigrationError,
+  type PragmaCompilerProjectMigrationResult,
+  type PragmaCompilerVersion,
+} from "./types.ts";
+
+export {
+  PragmaCompilerMigrationError,
+  type PragmaCompilerMigrationErrorCode,
+  type PragmaCompilerProjectMigrationResult,
+  type PragmaCompilerVersion,
+} from "./types.ts";
+
+export function migratePragmaCompilerProjectToCurrent(input: {
+  readonly files: ReadonlyMap<string, string>;
+  readonly revisionCompilerVersion: string;
+}): PragmaCompilerProjectMigrationResult {
+  const sourceCompilerVersion = parseCompilerVersion(input.revisionCompilerVersion);
+  if (isPragmaCompilerVersionUpgradeable(sourceCompilerVersion)) {
+    const migrated = migratePragmaCompilerV2Project(input);
+    return {
+      sourceCompilerVersion,
+      targetCompilerVersion: PRAGMA_COMPILER_WRITE_VERSION,
+      migrated: true,
+      ...migrated,
+    };
+  }
+  if (!isPragmaCompilerVersionDirectlyReadable(sourceCompilerVersion)) {
+    const source = compilerVersionNumber(sourceCompilerVersion);
+    const target = compilerVersionNumber(PRAGMA_COMPILER_WRITE_VERSION);
+    throw new PragmaCompilerMigrationError(
+      source > target ? "future_compiler_version" : "missing_migration_step",
+      `Pragma compiler ${sourceCompilerVersion} cannot be upgraded to ${PRAGMA_COMPILER_WRITE_VERSION}.`,
+    );
+  }
+  return {
+    sourceCompilerVersion,
+    targetCompilerVersion: PRAGMA_COMPILER_WRITE_VERSION,
+    migrated: false,
+    ...parseCurrentProject(input.files, sourceCompilerVersion),
+  };
+}
+
+function parseCurrentProject(
+  files: ReadonlyMap<string, string>,
+  revisionCompilerVersion: PragmaCompilerVersion,
+): {
+  readonly resources: readonly PragmaResource[];
+  readonly artifacts: ReadonlyMap<string, string>;
+} {
+  const lockSource = files.get("pragma.lock.yaml");
+  if (lockSource === undefined) {
+    throw new PragmaCompilerMigrationError(
+      "lock_missing",
+      "Current compiler project revision is missing pragma.lock.yaml.",
+    );
+  }
+  let lock;
+  try {
+    lock = PragmaLockSchema.parse(parsePragmaYaml(lockSource));
+  } catch (error) {
+    throw new PragmaCompilerMigrationError(
+      "invalid_legacy_project",
+      "Current compiler project revision has an invalid pragma.lock.yaml.",
+      { cause: error },
+    );
+  }
+  if (lock.compilerVersion !== revisionCompilerVersion) {
+    throw new PragmaCompilerMigrationError(
+      "compiler_metadata_mismatch",
+      `Project revision metadata declares ${revisionCompilerVersion}, but pragma.lock.yaml declares ${lock.compilerVersion}.`,
+    );
+  }
+
+  const indexed: { readonly resource: PragmaResource; readonly source: string }[] = [];
+  const managed = new Set(["pragma.yaml", "pragma.lock.yaml"]);
+  for (const [source, contents] of files) {
+    if (source !== "pragma.yaml" && !source.endsWith(".pragma.yaml")) continue;
+    try {
+      const value = parsePragmaYaml(contents);
+      if (isRecord(value) && value["kind"] === "Bundle") {
+        const bundle = PragmaBundleSchema.parse(value);
+        for (const resource of bundle.resources) {
+          indexed.push({ resource, source });
+        }
+        managed.add(source);
+        continue;
+      }
+      if (isRecord(value) && typeof value["kind"] === "string" && value["kind"] !== "Lock") {
+        indexed.push({ resource: PragmaResourceSchema.parse(value), source });
+        managed.add(source);
+      }
+    } catch (error) {
+      throw new PragmaCompilerMigrationError(
+        "invalid_legacy_project",
+        `Current compiler project source is invalid: ${source}.`,
+        { cause: error },
+      );
+    }
+  }
+  const expectedResources = indexed
+    .map(({ resource, source }) => ({
+      ref: canonicalPragmaResourceRef(resource),
+      contentHash: sha256(stableStringify(resource)),
+      source,
+    }))
+    .toSorted((left, right) => left.ref.localeCompare(right.ref));
+  const actualByRef = new Map(lock.resources.map((resource) => [resource.ref, resource]));
+  const mismatches = expectedResources
+    .filter((expected) => {
+      const actual = actualByRef.get(expected.ref);
+      return (
+        actual === undefined ||
+        actual.contentHash !== expected.contentHash ||
+        actual.source !== expected.source
+      );
+    })
+    .map((resource) => resource.ref);
+  if (actualByRef.size !== expectedResources.length) mismatches.push("resource set");
+  const expectedProjectFingerprint = sha256(
+    stableStringify({
+      resources: expectedResources.map(({ ref, contentHash }) => ({ ref, contentHash })),
+      artifacts: [...lock.artifacts].toSorted((left, right) =>
+        left.source.localeCompare(right.source),
+      ),
+    }),
+  );
+  if (mismatches.length > 0 || expectedProjectFingerprint !== lock.projectFingerprint) {
+    throw new PragmaCompilerMigrationError(
+      "lock_mismatch",
+      `Current compiler project revision does not match its lock: ${mismatches.join(", ") || "project fingerprint"}.`,
+    );
+  }
+  return {
+    resources: indexed.map(({ resource }) => resource),
+    artifacts: new Map([...files].filter(([path]) => !managed.has(path))),
+  };
+}
+
+function parseCompilerVersion(value: string): PragmaCompilerVersion {
+  if (!/^pragma\.dsl\/v[1-9][0-9]*$/u.test(value)) {
+    throw new PragmaCompilerMigrationError(
+      "missing_migration_step",
+      `Unsupported Pragma compiler version: ${value}.`,
+    );
+  }
+  return value as PragmaCompilerVersion;
+}
+
+function compilerVersionNumber(value: PragmaCompilerVersion): number {
+  return Number(value.slice("pragma.dsl/v".length));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/interpreter/src/compiler-migrations/schemas/v2.ts
+++ b/packages/interpreter/src/compiler-migrations/schemas/v2.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+import { PragmaFlowNodeIdSchema } from "../../ast/pragma-dsl.schema.ts";
+
+const PragmaCompilerV2FlowRunDryMockOutcomeSchema = z.union([
+  z
+    .object({
+      expectInput: z.unknown(),
+      expectPrompt: z.string().max(20_000).optional(),
+      output: z.unknown(),
+    })
+    .strict(),
+  z
+    .object({
+      expectInput: z.unknown(),
+      expectPrompt: z.string().max(20_000).optional(),
+      error: z.string().trim().min(1).max(4_000),
+    })
+    .strict(),
+]);
+
+const PragmaCompilerV2FlowRunDryMockSequenceSchema = z.union([
+  PragmaCompilerV2FlowRunDryMockOutcomeSchema,
+  z.array(PragmaCompilerV2FlowRunDryMockOutcomeSchema).min(1).max(1_000),
+]);
+
+const PragmaCompilerV2FlowRunDryCaseSchema = z
+  .object({
+    id: PragmaFlowNodeIdSchema,
+    name: z.string().trim().min(1).max(200),
+    input: z.unknown(),
+    mocks: z.record(PragmaFlowNodeIdSchema, PragmaCompilerV2FlowRunDryMockSequenceSchema),
+    expect: z
+      .object({
+        status: z.enum(["succeeded", "failed"]),
+        path: z.array(PragmaFlowNodeIdSchema).max(1_000),
+        output: z.unknown().optional(),
+        errorContains: z.string().trim().min(1).max(4_000).optional(),
+      })
+      .strict()
+      .superRefine((value, context) => {
+        if (value.status === "succeeded" && value.errorContains !== undefined) {
+          context.addIssue({
+            code: "custom",
+            path: ["errorContains"],
+            message: "A successful run dry case cannot expect an error.",
+          });
+        }
+        if (value.status === "failed" && value.output !== undefined) {
+          context.addIssue({
+            code: "custom",
+            path: ["output"],
+            message: "A failed run dry case cannot expect an output.",
+          });
+        }
+        if (value.status === "failed" && value.errorContains === undefined) {
+          context.addIssue({
+            code: "custom",
+            path: ["errorContains"],
+            message: "A failed run dry case must assert an error fragment.",
+          });
+        }
+      }),
+  })
+  .strict();
+
+/**
+ * Exact snapshot of the runDry branch written by compiler v2 before commit 4f3f96c.
+ * Unchanged Flow fields are parsed by the current schema only after this historical
+ * field has been validated and removed by the migration step.
+ */
+export const PragmaCompilerV2FlowRunDrySuiteSchema = z
+  .object({
+    cases: z.array(PragmaCompilerV2FlowRunDryCaseSchema).max(500),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const ids = new Set<string>();
+    value.cases.forEach((testCase, index) => {
+      if (ids.has(testCase.id)) {
+        context.addIssue({
+          code: "custom",
+          path: ["cases", index, "id"],
+          message: "Run dry case IDs must be unique.",
+        });
+      }
+      ids.add(testCase.id);
+    });
+  });

--- a/packages/interpreter/src/compiler-migrations/steps/v2-to-v3.ts
+++ b/packages/interpreter/src/compiler-migrations/steps/v2-to-v3.ts
@@ -1,0 +1,194 @@
+import {
+  PragmaLockSchema,
+  PragmaResourceSchema,
+  canonicalPragmaResourceRef,
+  type PragmaResource,
+} from "../../ast/index.ts";
+import { parsePragmaYaml } from "../../compiler/pragma-project.ts";
+import { sha256, stableStringify } from "../../compiler/compiler-hash.ts";
+import { PragmaCompilerV2FlowRunDrySuiteSchema } from "../schemas/v2.ts";
+import { PragmaCompilerMigrationError } from "../types.ts";
+
+interface ParsedCompilerV2Resource {
+  readonly source: string;
+  readonly historical: PragmaResource | Record<string, unknown>;
+  readonly current: PragmaResource;
+}
+
+export function migratePragmaCompilerV2Project(input: {
+  readonly files: ReadonlyMap<string, string>;
+  readonly revisionCompilerVersion: string;
+}): {
+  readonly resources: readonly PragmaResource[];
+  readonly artifacts: ReadonlyMap<string, string>;
+} {
+  const lockSource = input.files.get("pragma.lock.yaml");
+  if (lockSource === undefined) {
+    throw new PragmaCompilerMigrationError(
+      "lock_missing",
+      "Compiler v2 project revision is missing pragma.lock.yaml.",
+    );
+  }
+  let lock;
+  try {
+    lock = PragmaLockSchema.parse(parsePragmaYaml(lockSource));
+  } catch (error) {
+    throw new PragmaCompilerMigrationError(
+      "invalid_legacy_project",
+      "Compiler v2 project revision has an invalid pragma.lock.yaml.",
+      { cause: error },
+    );
+  }
+  if (
+    input.revisionCompilerVersion !== "pragma.dsl/v2" ||
+    lock.compilerVersion !== input.revisionCompilerVersion
+  ) {
+    throw new PragmaCompilerMigrationError(
+      "compiler_metadata_mismatch",
+      `Project revision metadata declares ${input.revisionCompilerVersion}, but pragma.lock.yaml declares ${lock.compilerVersion}.`,
+    );
+  }
+
+  const parsedResources = extractCompilerV2Resources(input.files);
+  const actualByRef = new Map(
+    parsedResources.map((parsed) => {
+      const ref = canonicalPragmaResourceRef(parsed.current);
+      return [
+        ref,
+        {
+          ref,
+          source: parsed.source,
+          contentHash: sha256(stableStringify(parsed.historical)),
+        },
+      ] as const;
+    }),
+  );
+  const expectedByRef = new Map(lock.resources.map((resource) => [resource.ref, resource]));
+  const mismatches = [...new Set([...actualByRef.keys(), ...expectedByRef.keys()])].filter(
+    (ref) => {
+      const actual = actualByRef.get(ref);
+      const expected = expectedByRef.get(ref);
+      return (
+        actual === undefined ||
+        expected === undefined ||
+        actual.source !== expected.source ||
+        actual.contentHash !== expected.contentHash
+      );
+    },
+  );
+  const expectedProjectFingerprint = sha256(
+    stableStringify({
+      resources: lock.resources
+        .map(({ ref, contentHash }) => ({ ref, contentHash }))
+        .toSorted((left, right) => left.ref.localeCompare(right.ref)),
+      artifacts: [...lock.artifacts].toSorted((left, right) =>
+        left.source.localeCompare(right.source),
+      ),
+    }),
+  );
+  if (mismatches.length > 0 || expectedProjectFingerprint !== lock.projectFingerprint) {
+    throw new PragmaCompilerMigrationError(
+      "lock_mismatch",
+      `Compiler v2 project revision does not match its lock: ${mismatches.join(", ") || "project fingerprint"}.`,
+    );
+  }
+
+  const managed = new Set([
+    "pragma.yaml",
+    "pragma.lock.yaml",
+    ...parsedResources.map((resource) => resource.source),
+  ]);
+  return {
+    resources: parsedResources.map((resource) => resource.current),
+    artifacts: new Map([...input.files].filter(([path]) => !managed.has(path))),
+  };
+}
+
+function extractCompilerV2Resources(
+  files: ReadonlyMap<string, string>,
+): readonly ParsedCompilerV2Resource[] {
+  const resources: ParsedCompilerV2Resource[] = [];
+  let sawBundle = false;
+  for (const [source, contents] of files) {
+    if (source !== "pragma.yaml" && !source.endsWith(".pragma.yaml")) continue;
+    let value: unknown;
+    try {
+      value = parsePragmaYaml(contents);
+    } catch (error) {
+      throw new PragmaCompilerMigrationError(
+        "invalid_legacy_project",
+        `Cannot parse compiler v2 source: ${source}.`,
+        { cause: error },
+      );
+    }
+    if (isRecord(value) && value["kind"] === "Bundle") {
+      sawBundle = true;
+      if (value["apiVersion"] !== "pragma/v3" || !Array.isArray(value["resources"])) {
+        throw new PragmaCompilerMigrationError(
+          "invalid_legacy_project",
+          `Compiler v2 Bundle is invalid: ${source}.`,
+        );
+      }
+      for (const resource of value["resources"])
+        resources.push(parseCompilerV2Resource(resource, source));
+      continue;
+    }
+    if (isRecord(value) && typeof value["kind"] === "string" && value["kind"] !== "Lock") {
+      resources.push(parseCompilerV2Resource(value, source));
+    }
+  }
+  if (resources.length === 0 && !sawBundle) {
+    throw new PragmaCompilerMigrationError(
+      "invalid_legacy_project",
+      "Compiler v2 project revision does not contain a semantic resource.",
+    );
+  }
+  return resources;
+}
+
+function parseCompilerV2Resource(value: unknown, source: string): ParsedCompilerV2Resource {
+  const historical = structuredClone(value);
+  const candidate = structuredClone(value);
+  if (
+    isRecord(historical) &&
+    historical["kind"] === "Flow" &&
+    isRecord(historical["spec"]) &&
+    "runDry" in historical["spec"]
+  ) {
+    try {
+      historical["spec"]["runDry"] = PragmaCompilerV2FlowRunDrySuiteSchema.parse(
+        historical["spec"]["runDry"],
+      );
+    } catch (error) {
+      throw new PragmaCompilerMigrationError(
+        "invalid_legacy_project",
+        `Compiler v2 Flow has an invalid spec.runDry: ${source}.`,
+        { cause: error },
+      );
+    }
+    if (isRecord(candidate) && isRecord(candidate["spec"])) delete candidate["spec"]["runDry"];
+  }
+  const current = PragmaResourceSchema.safeParse(candidate);
+  if (!current.success) {
+    throw new PragmaCompilerMigrationError(
+      "invalid_legacy_project",
+      `Compiler v2 resource cannot be upgraded: ${source}.`,
+      { cause: current.error },
+    );
+  }
+  const normalizedHistorical =
+    current.data.kind === "Flow" &&
+    isRecord(historical) &&
+    isRecord(historical["spec"]) &&
+    "runDry" in historical["spec"]
+      ? {
+          ...current.data,
+          spec: { ...current.data.spec, runDry: historical["spec"]["runDry"] },
+        }
+      : current.data;
+  return { source, historical: normalizedHistorical, current: current.data };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/interpreter/src/compiler-migrations/types.ts
+++ b/packages/interpreter/src/compiler-migrations/types.ts
@@ -1,0 +1,30 @@
+import type { PragmaResource } from "../ast/pragma-dsl.schema.ts";
+
+export type PragmaCompilerVersion = `pragma.dsl/v${number}`;
+
+export interface PragmaCompilerProjectMigrationResult {
+  readonly sourceCompilerVersion: PragmaCompilerVersion;
+  readonly targetCompilerVersion: PragmaCompilerVersion;
+  readonly migrated: boolean;
+  readonly resources: readonly PragmaResource[];
+  readonly artifacts: ReadonlyMap<string, string>;
+}
+
+export type PragmaCompilerMigrationErrorCode =
+  | "compiler_metadata_mismatch"
+  | "future_compiler_version"
+  | "invalid_legacy_project"
+  | "lock_mismatch"
+  | "lock_missing"
+  | "missing_migration_step";
+
+export class PragmaCompilerMigrationError extends Error {
+  constructor(
+    readonly code: PragmaCompilerMigrationErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "PragmaCompilerMigrationError";
+  }
+}

--- a/packages/interpreter/src/compiler/compiler-hash.ts
+++ b/packages/interpreter/src/compiler/compiler-hash.ts
@@ -1,0 +1,16 @@
+import { createHash } from "node:crypto";
+
+export function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (typeof value === "object" && value !== null) {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/packages/interpreter/src/compiler/pragma-project.ts
+++ b/packages/interpreter/src/compiler/pragma-project.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { lstat, readFile, readdir, realpath } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 
@@ -74,10 +73,13 @@ import {
   type PragmaRuntimeProfileContribution,
 } from "../runtime/resource-adapters.ts";
 import { evaluatePragmaFlowValue, renderPragmaFlowPrompt } from "../runtime/flow-values.ts";
+import { sha256, stableStringify } from "./compiler-hash.ts";
 import {
-  PRAGMA_COMPILER_READ_VERSIONS,
+  PRAGMA_COMPILER_DIRECT_READ_VERSIONS,
+  PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS,
   PRAGMA_COMPILER_WRITE_VERSION,
-  isPragmaCompilerVersionReadable,
+  isPragmaCompilerVersionDirectlyReadable,
+  isPragmaCompilerVersionUpgradeable,
 } from "../ast/compiler-compatibility.ts";
 
 const provenance = new WeakMap<object, PragmaProvenance>();
@@ -217,36 +219,36 @@ async function readCompilerCompatibilityDiagnostic(
   options: LoadPragmaProjectOptions,
 ): Promise<PragmaDiagnostic | undefined> {
   if (options.requireLock !== true) return undefined;
-  if (
-    options.revisionCompilerVersion !== undefined &&
-    !isPragmaCompilerVersionReadable(options.revisionCompilerVersion)
-  ) {
+  const versionDiagnostic = (
+    version: string,
+    source: "revision metadata" | "pragma.lock.yaml",
+    path?: string,
+  ): PragmaDiagnostic | undefined => {
+    if (isPragmaCompilerVersionDirectlyReadable(version)) return undefined;
+    const upgradeable = isPragmaCompilerVersionUpgradeable(version);
     return PragmaDiagnosticSchema.parse({
       severity: "error",
-      code: "compiler.version_unsupported",
+      code: upgradeable ? "compiler.version_upgrade_required" : "compiler.version_unsupported",
       message:
-        `Project revision metadata requires compiler ${options.revisionCompilerVersion}; ` +
-        `this Interpreter reads ${PRAGMA_COMPILER_READ_VERSIONS.join(", ")}.`,
+        `Project ${source} requires compiler ${version}; ` +
+        (upgradeable
+          ? `upgrade it to ${PRAGMA_COMPILER_WRITE_VERSION} before loading.`
+          : `this Interpreter directly reads ${PRAGMA_COMPILER_DIRECT_READ_VERSIONS.join(", ")}` +
+            ((PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS as readonly string[]).length === 0
+              ? "."
+              : ` and upgrades ${PRAGMA_COMPILER_UPGRADE_FROM_VERSIONS.join(", ")}.`)),
+      ...(path === undefined ? {} : { source: path }),
       path: ["compilerVersion"],
     });
-  }
+  };
   const lockPath = resolve(dirname(entryFile), "pragma.lock.yaml");
   let lock: PragmaLock;
   try {
     lock = PragmaLockSchema.parse(parsePragmaYaml(await readFile(lockPath, "utf8")));
   } catch {
-    return undefined;
-  }
-  if (!isPragmaCompilerVersionReadable(lock.compilerVersion)) {
-    return PragmaDiagnosticSchema.parse({
-      severity: "error",
-      code: "compiler.version_unsupported",
-      message:
-        `Project revision requires compiler ${lock.compilerVersion}; this Interpreter reads ` +
-        `${PRAGMA_COMPILER_READ_VERSIONS.join(", ")}.`,
-      source: lockPath,
-      path: ["compilerVersion"],
-    });
+    return options.revisionCompilerVersion === undefined
+      ? undefined
+      : versionDiagnostic(options.revisionCompilerVersion, "revision metadata");
   }
   if (
     options.revisionCompilerVersion !== undefined &&
@@ -262,7 +264,7 @@ async function readCompilerCompatibilityDiagnostic(
       path: ["compilerVersion"],
     });
   }
-  return undefined;
+  return versionDiagnostic(lock.compilerVersion, "pragma.lock.yaml", lockPath);
 }
 
 export async function loadPragmaProject(
@@ -2664,19 +2666,4 @@ function requireStepReference(
 
 function canonicalRef(resource: PragmaResource): PragmaSemanticResourceRef {
   return canonicalPragmaResourceRef(resource);
-}
-
-function sha256(value: string | Uint8Array): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
-  if (typeof value === "object" && value !== null) {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
 }

--- a/packages/interpreter/src/compiler/pragma-project.ts
+++ b/packages/interpreter/src/compiler/pragma-project.ts
@@ -74,8 +74,12 @@ import {
   type PragmaRuntimeProfileContribution,
 } from "../runtime/resource-adapters.ts";
 import { evaluatePragmaFlowValue, renderPragmaFlowPrompt } from "../runtime/flow-values.ts";
+import {
+  PRAGMA_COMPILER_READ_VERSIONS,
+  PRAGMA_COMPILER_WRITE_VERSION,
+  isPragmaCompilerVersionReadable,
+} from "../ast/compiler-compatibility.ts";
 
-const COMPILER_VERSION = "pragma.dsl/v2";
 const provenance = new WeakMap<object, PragmaProvenance>();
 
 export interface LoadPragmaProjectOptions {
@@ -84,6 +88,7 @@ export interface LoadPragmaProjectOptions {
   readonly serializers?: DefinitionSerializerRegistry | undefined;
   readonly resourceAdapters?: PragmaResourceAdapterRegistry | undefined;
   readonly externalResourceRefs?: ReadonlySet<PragmaResourceRef> | undefined;
+  readonly revisionCompilerVersion?: string | undefined;
   readonly sourceIdentity?: string | undefined;
   readonly blueprintCache?: PragmaBlueprintCacheStore | undefined;
   readonly onBlueprintCacheLookup?:
@@ -134,6 +139,7 @@ export interface PragmaProject {
   readonly entryFile: string;
   listResources(): readonly PragmaResource[];
   validate(): Promise<readonly PragmaDiagnostic[]>;
+  validateFor(ref: PragmaResourceRef): Promise<readonly PragmaDiagnostic[]>;
   validateEnvironment(host: PragmaCompileOptions): Promise<readonly PragmaDiagnostic[]>;
   inspectEnvironment(host: PragmaCompileOptions): Promise<PragmaEnvironmentInspection>;
   compile<T extends InvocableResource>(
@@ -175,7 +181,7 @@ interface PragmaProvenance {
 const PragmaProjectBlueprintSchema = z
   .object({
     schemaVersion: z.literal("pragma.project-blueprint/v1"),
-    compilerVersion: z.literal(COMPILER_VERSION),
+    compilerVersion: z.literal(PRAGMA_COMPILER_WRITE_VERSION),
     sourceIdentity: z.string().min(1),
     entry: z.string().min(1),
     resources: z.array(
@@ -206,6 +212,59 @@ const projectBlueprintLoads = new Map<string, Promise<PragmaProjectBlueprint | u
 const projectBlueprintBuilds = new Map<string, Promise<PragmaProjectBlueprint>>();
 const PROJECT_BLUEPRINT_MEMORY_LIMIT = 128;
 
+async function readCompilerCompatibilityDiagnostic(
+  entryFile: string,
+  options: LoadPragmaProjectOptions,
+): Promise<PragmaDiagnostic | undefined> {
+  if (options.requireLock !== true) return undefined;
+  if (
+    options.revisionCompilerVersion !== undefined &&
+    !isPragmaCompilerVersionReadable(options.revisionCompilerVersion)
+  ) {
+    return PragmaDiagnosticSchema.parse({
+      severity: "error",
+      code: "compiler.version_unsupported",
+      message:
+        `Project revision metadata requires compiler ${options.revisionCompilerVersion}; ` +
+        `this Interpreter reads ${PRAGMA_COMPILER_READ_VERSIONS.join(", ")}.`,
+      path: ["compilerVersion"],
+    });
+  }
+  const lockPath = resolve(dirname(entryFile), "pragma.lock.yaml");
+  let lock: PragmaLock;
+  try {
+    lock = PragmaLockSchema.parse(parsePragmaYaml(await readFile(lockPath, "utf8")));
+  } catch {
+    return undefined;
+  }
+  if (!isPragmaCompilerVersionReadable(lock.compilerVersion)) {
+    return PragmaDiagnosticSchema.parse({
+      severity: "error",
+      code: "compiler.version_unsupported",
+      message:
+        `Project revision requires compiler ${lock.compilerVersion}; this Interpreter reads ` +
+        `${PRAGMA_COMPILER_READ_VERSIONS.join(", ")}.`,
+      source: lockPath,
+      path: ["compilerVersion"],
+    });
+  }
+  if (
+    options.revisionCompilerVersion !== undefined &&
+    options.revisionCompilerVersion !== lock.compilerVersion
+  ) {
+    return PragmaDiagnosticSchema.parse({
+      severity: "error",
+      code: "compiler.version_metadata_mismatch",
+      message:
+        `Project revision metadata declares compiler ${options.revisionCompilerVersion}, ` +
+        `but pragma.lock.yaml declares ${lock.compilerVersion}.`,
+      source: lockPath,
+      path: ["compilerVersion"],
+    });
+  }
+  return undefined;
+}
+
 export async function loadPragmaProject(
   entryFile: string,
   options: LoadPragmaProjectOptions = {},
@@ -214,6 +273,16 @@ export async function loadPragmaProject(
   const configuredRoot = resolve(options.rootDir ?? dirname(absoluteEntry));
   const rootDir = await realpath(configuredRoot);
   const canonicalEntry = await realpath(absoluteEntry);
+  const compatibilityDiagnostic = await readCompilerCompatibilityDiagnostic(
+    canonicalEntry,
+    options,
+  );
+  if (compatibilityDiagnostic !== undefined) {
+    return new PragmaProjectImpl(canonicalEntry, new Map(), new Map(), [compatibilityDiagnostic], {
+      ...options,
+      requireLock: false,
+    });
+  }
   const adapters = options.resourceAdapters ?? createDefaultPragmaResourceAdapterRegistry();
   const sourceIdentity = options.sourceIdentity;
   const blueprintKey =
@@ -221,7 +290,7 @@ export async function loadPragmaProject(
       ? undefined
       : sha256(
           stableStringify({
-            compilerVersion: COMPILER_VERSION,
+            compilerVersion: PRAGMA_COMPILER_WRITE_VERSION,
             sourceIdentity,
             entry: relative(rootDir, canonicalEntry),
             resourceAdapters: adapters.fingerprint(),
@@ -380,7 +449,7 @@ function createProjectBlueprint(
   };
   return PragmaProjectBlueprintSchema.parse({
     schemaVersion: "pragma.project-blueprint/v1",
-    compilerVersion: COMPILER_VERSION,
+    compilerVersion: PRAGMA_COMPILER_WRITE_VERSION,
     sourceIdentity,
     entry: relativeSource(entryFile),
     resources: [...loader.resources.values()].map((indexed) => ({
@@ -645,6 +714,11 @@ class SourceLoader {
 
 class PragmaProjectImpl implements PragmaProject {
   private validation: Promise<readonly PragmaDiagnostic[]> | undefined;
+  private lockValidation: Promise<PragmaDiagnostic[]> | undefined;
+  private readonly targetedValidations = new Map<
+    PragmaSemanticResourceRef,
+    Promise<readonly PragmaDiagnostic[]>
+  >();
 
   constructor(
     readonly entryFile: string,
@@ -661,31 +735,72 @@ class PragmaProjectImpl implements PragmaProject {
   }
 
   async validate(): Promise<readonly PragmaDiagnostic[]> {
-    this.validation ??= this.validateOnce();
+    this.validation ??= this.validateResources(this.resources);
     return await this.validation;
   }
 
-  private async validateOnce(): Promise<readonly PragmaDiagnostic[]> {
+  async validateFor(ref: PragmaResourceRef): Promise<readonly PragmaDiagnostic[]> {
+    const root = this.resolveResource(ref);
+    const rootRef = canonicalRef(root.resource);
+    let validation = this.targetedValidations.get(rootRef);
+    if (validation === undefined) {
+      validation = this.validateResources(this.collectDependencyClosure(root));
+      this.targetedValidations.set(rootRef, validation);
+    }
+    return await validation;
+  }
+
+  private async validateResources(
+    resources: ReadonlyMap<string, IndexedResource>,
+  ): Promise<readonly PragmaDiagnostic[]> {
     const diagnostics = [...this.sourceDiagnostics];
     const adapters = this.options.resourceAdapters ?? createDefaultPragmaResourceAdapterRegistry();
-    for (const indexed of this.resources.values()) {
+    for (const indexed of resources.values()) {
+      const resourceRef = canonicalRef(indexed.resource);
       diagnostics.push(...this.validateReferences(indexed));
-      diagnostics.push(...validatePortableSemantics(indexed, this.resources));
+      diagnostics.push(
+        ...validatePortableSemantics(indexed, this.resources).map((diagnostic) => ({
+          ...diagnostic,
+          resourceRef,
+        })),
+      );
       if (indexed.resource.kind === "Flow") {
-        diagnostics.push(...validateFlowGraph(indexed, this.resources));
+        diagnostics.push(
+          ...validateFlowGraph(indexed, this.resources).map((diagnostic) => ({
+            ...diagnostic,
+            resourceRef,
+          })),
+        );
       }
       if (isDeclarativeResource(indexed.resource)) {
         diagnostics.push(
           ...adapters.validate(indexed.resource).map((diagnostic) => ({
             ...diagnostic,
+            resourceRef,
             source: indexed.source,
           })),
         );
       }
     }
-    diagnostics.push(...validateResourceCycles(this.resources));
+    diagnostics.push(...validateResourceCycles(resources));
     if (this.options.requireLock === true) diagnostics.push(...(await this.validateLock()));
     return diagnostics;
+  }
+
+  private collectDependencyClosure(root: IndexedResource): ReadonlyMap<string, IndexedResource> {
+    const closure = new Map<string, IndexedResource>();
+    const visit = (indexed: IndexedResource): void => {
+      const ref = canonicalRef(indexed.resource);
+      if (closure.has(ref)) return;
+      closure.set(ref, indexed);
+      for (const dependencyRef of resourceDependencies(indexed.resource)) {
+        const parsed = parsePragmaReference(dependencyRef);
+        const dependency = this.resources.get(`${parsed.kind}:${parsed.id}`);
+        if (dependency !== undefined) visit(dependency);
+      }
+    };
+    visit(root);
+    return closure;
   }
 
   async validateEnvironment(host: PragmaCompileOptions): Promise<readonly PragmaDiagnostic[]> {
@@ -778,7 +893,22 @@ class PragmaProjectImpl implements PragmaProject {
     ref: PragmaResourceRef,
     host: PragmaCompileOptions,
   ): Promise<CompiledResource<T>> {
-    const diagnostics = await this.validate();
+    const compilerErrors = this.sourceDiagnostics.filter(
+      (diagnostic) => diagnostic.severity === "error" && diagnostic.code.startsWith("compiler."),
+    );
+    if (compilerErrors.length > 0) {
+      throw new PragmaDslError(
+        `Pragma project compiler compatibility check failed: ${compilerErrors
+          .map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`)
+          .join("; ")}`,
+        compilerErrors,
+      );
+    }
+    const indexed = this.resolveResource(ref);
+    if (!isInvocableResource(indexed.resource)) {
+      throw new PragmaDslError(`Resource is not invocable: ${ref}`);
+    }
+    const diagnostics = await this.validateFor(ref);
     const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error");
     if (errors.length > 0) {
       throw new PragmaDslError(
@@ -879,10 +1009,6 @@ class PragmaProjectImpl implements PragmaProject {
       (await resolveDeclarative<PragmaRuntimeProfileContribution>(runtimeRef, "RuntimeProfile"))
         .contribution;
 
-    const indexed = this.resolveResource(ref);
-    if (!isInvocableResource(indexed.resource)) {
-      throw new PragmaDslError(`Resource is not invocable: ${ref}`);
-    }
     const rootExpertRefs = new Set<string>();
     if (indexed.resource.kind === "Expert") {
       rootExpertRefs.add(canonicalRef(indexed.resource));
@@ -1165,7 +1291,7 @@ class PragmaProjectImpl implements PragmaProject {
     return {
       apiVersion: "pragma/v3",
       kind: "Lock",
-      compilerVersion: COMPILER_VERSION,
+      compilerVersion: PRAGMA_COMPILER_WRITE_VERSION,
       projectFingerprint: sha256(
         stableStringify({
           resources: resources.map(({ ref, contentHash }) => ({ ref, contentHash })),
@@ -1184,6 +1310,11 @@ class PragmaProjectImpl implements PragmaProject {
   }
 
   private async validateLock(): Promise<PragmaDiagnostic[]> {
+    this.lockValidation ??= this.validateLockOnce();
+    return await this.lockValidation;
+  }
+
+  private async validateLockOnce(): Promise<PragmaDiagnostic[]> {
     const lockPath = resolve(dirname(this.entryFile), "pragma.lock.yaml");
     let lock: PragmaLock;
     try {
@@ -1214,9 +1345,6 @@ class PragmaProjectImpl implements PragmaProject {
         return left === undefined || right === undefined || left.contentHash !== right.contentHash;
       },
     );
-    if (lock.compilerVersion !== expected.compilerVersion) {
-      mismatches.push(`compiler:${lock.compilerVersion}`);
-    }
     if (lock.projectFingerprint !== expected.projectFingerprint) {
       mismatches.push(`project:${lock.projectFingerprint}`);
     }
@@ -1242,6 +1370,7 @@ class PragmaProjectImpl implements PragmaProject {
 
   private validateReferences(indexed: IndexedResource): PragmaDiagnostic[] {
     const diagnostics: PragmaDiagnostic[] = [];
+    const resourceRef = canonicalRef(indexed.resource);
     for (const ref of resourceDependencies(indexed.resource)) {
       if (this.options.externalResourceRefs?.has(ref)) continue;
       try {
@@ -1251,6 +1380,7 @@ class PragmaProjectImpl implements PragmaProject {
           severity: "error",
           code: "reference.invalid",
           message: error instanceof Error ? error.message : String(error),
+          resourceRef,
           source: indexed.source,
           path: [],
         });
@@ -2111,6 +2241,7 @@ function validateResourceCycles(
       severity: "error",
       code: "resource.cycle",
       message: `Pragma resource definitions must form an acyclic dependency graph: ${cycle.refs.join(" -> ")}.`,
+      resourceRef: cycle.sourceRef as PragmaSemanticResourceRef,
       source: source?.source,
       path: [...cycle.path],
     };

--- a/packages/interpreter/src/index.ts
+++ b/packages/interpreter/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./ast/index.ts";
 export * from "./application/project-service.ts";
 export * from "./compiler/pragma-project.ts";
+export * from "./compiler-migrations/index.ts";
 export * from "./migrations/index.ts";
 export * from "./run-dry/flow-run-dry.ts";
 export * from "./runtime/registries.ts";

--- a/packages/interpreter/test/fixtures/compiler-v2-run-dry/flows/8h9j0k1m2n3p4q5r.pragma.yaml
+++ b/packages/interpreter/test/fixtures/compiler-v2-run-dry/flows/8h9j0k1m2n3p4q5r.pragma.yaml
@@ -1,0 +1,22 @@
+apiVersion: pragma/v3
+kind: Flow
+metadata:
+  id: 8h9j0k1m2n3p4q5r
+  name: Historical Run Dry
+  description: Compiler v2 fixture with the removed runDry branch.
+  tags: []
+spec:
+  limits:
+    maxNodeVisits: 1000
+  graph:
+    start: finish
+    steps:
+      finish:
+        action:
+          ref: action:finish@v1
+    loops: {}
+    transitions:
+      finish:
+        end: true
+  runDry:
+    cases: []

--- a/packages/interpreter/test/fixtures/compiler-v2-run-dry/pragma.lock.yaml
+++ b/packages/interpreter/test/fixtures/compiler-v2-run-dry/pragma.lock.yaml
@@ -1,0 +1,9 @@
+apiVersion: pragma/v3
+kind: Lock
+compilerVersion: pragma.dsl/v2
+projectFingerprint: 33e69dc432c7d321b1a0280144bdab0105b82a8f9270bf7067871dfc7f966ff8
+resources:
+  - ref: flow:8h9j0k1m2n3p4q5r
+    contentHash: eec635492a253e33328ae04586548877b5e4631d56b8723d950aa4db0b7aaa4c
+    source: flows/8h9j0k1m2n3p4q5r.pragma.yaml
+artifacts: []

--- a/packages/interpreter/test/fixtures/compiler-v2-run-dry/pragma.yaml
+++ b/packages/interpreter/test/fixtures/compiler-v2-run-dry/pragma.yaml
@@ -1,0 +1,5 @@
+apiVersion: pragma/v3
+kind: Bundle
+imports:
+  - ./flows/8h9j0k1m2n3p4q5r.pragma.yaml
+resources: []

--- a/packages/interpreter/test/pragma-dsl.test.ts
+++ b/packages/interpreter/test/pragma-dsl.test.ts
@@ -26,6 +26,7 @@ import {
   PragmaSemanticResourceIdSchema,
   formatPragmaYaml,
   loadPragmaProject,
+  migratePragmaCompilerProjectToCurrent,
   type PragmaExpertResource,
 } from "../src/index.ts";
 
@@ -739,7 +740,7 @@ describe("Pragma YAML DSL", () => {
     });
   });
 
-  it("continues to read compatible pragma.dsl/v2 locks", async () => {
+  it("requires pragma.dsl/v2 revisions to be upgraded before normal loading", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-dsl-compiler-v2-"));
     const entry = join(root, "pragma.yaml");
     await writeFile(
@@ -764,10 +765,72 @@ describe("Pragma YAML DSL", () => {
       requireLock: true,
       revisionCompilerVersion: "pragma.dsl/v2",
     });
-    expect(await project.validate()).toEqual([]);
+    expect(await project.validate()).toEqual([
+      expect.objectContaining({ code: "compiler.version_upgrade_required" }),
+    ]);
     await expect(
       project.compile("expert:1xddvess309a6gme", { workspace: root }),
-    ).resolves.toMatchObject({ ref: "expert:1xddvess309a6gme" });
+    ).rejects.toMatchObject({
+      diagnostics: [expect.objectContaining({ code: "compiler.version_upgrade_required" })],
+    });
+  });
+
+  it("upgrades a real compiler v2 runDry fixture without preserving the rejected branch", async () => {
+    const fixture = join(import.meta.dirname, "fixtures", "compiler-v2-run-dry");
+    const files = new Map([
+      ["pragma.yaml", await readFile(join(fixture, "pragma.yaml"), "utf8")],
+      ["pragma.lock.yaml", await readFile(join(fixture, "pragma.lock.yaml"), "utf8")],
+      [
+        "flows/8h9j0k1m2n3p4q5r.pragma.yaml",
+        await readFile(join(fixture, "flows", "8h9j0k1m2n3p4q5r.pragma.yaml"), "utf8"),
+      ],
+    ]);
+
+    const migrated = migratePragmaCompilerProjectToCurrent({
+      files,
+      revisionCompilerVersion: "pragma.dsl/v2",
+    });
+
+    expect(migrated).toMatchObject({
+      sourceCompilerVersion: "pragma.dsl/v2",
+      targetCompilerVersion: "pragma.dsl/v3",
+      migrated: true,
+    });
+    expect(migrated.resources).toEqual([
+      expect.objectContaining({
+        kind: "Flow",
+        spec: expect.not.objectContaining({ runDry: expect.anything() }),
+      }),
+    ]);
+  });
+
+  it("rejects compiler migration when a historical v2 source no longer matches its lock", async () => {
+    const fixture = join(import.meta.dirname, "fixtures", "compiler-v2-run-dry");
+    const flowPath = join(fixture, "flows", "8h9j0k1m2n3p4q5r.pragma.yaml");
+    const files = new Map([
+      ["pragma.yaml", await readFile(join(fixture, "pragma.yaml"), "utf8")],
+      ["pragma.lock.yaml", await readFile(join(fixture, "pragma.lock.yaml"), "utf8")],
+      [
+        "flows/8h9j0k1m2n3p4q5r.pragma.yaml",
+        (await readFile(flowPath, "utf8")).replace("Historical Run Dry", "Tampered"),
+      ],
+    ]);
+
+    expect(() =>
+      migratePragmaCompilerProjectToCurrent({
+        files,
+        revisionCompilerVersion: "pragma.dsl/v2",
+      }),
+    ).toThrow(expect.objectContaining({ code: "lock_mismatch" }));
+  });
+
+  it("rejects future compiler revisions instead of guessing an upgrade path", () => {
+    expect(() =>
+      migratePragmaCompilerProjectToCurrent({
+        files: new Map(),
+        revisionCompilerVersion: "pragma.dsl/v99",
+      }),
+    ).toThrow(expect.objectContaining({ code: "future_compiler_version" }));
   });
 
   it("compiles only the target dependency closure while preserving full project diagnostics", async () => {

--- a/packages/interpreter/test/pragma-dsl.test.ts
+++ b/packages/interpreter/test/pragma-dsl.test.ts
@@ -490,7 +490,7 @@ describe("Pragma YAML DSL", () => {
     });
     const dumped = await project.dump(compiled.value, { split: "by-resource" });
     expect(dumped.files.get("flows/t9ne4d8njvvxv2ea.pragma.yaml")).toContain("kind: Flow");
-    expect(dumped.files.get("pragma.lock.yaml")).toContain("compilerVersion: pragma.dsl/v2");
+    expect(dumped.files.get("pragma.lock.yaml")).toContain("compilerVersion: pragma.dsl/v3");
     const single = await project.dump(compiled.value, { split: "single" });
     await writeFile(join(root, "single.yaml"), single.files.get("pragma.yaml")!);
     expect((await loadPragmaProject(join(root, "single.yaml"))).listResources()).toHaveLength(1);
@@ -639,6 +639,224 @@ describe("Pragma YAML DSL", () => {
     expect(await (await loadPragmaProject(entry, { requireLock: true })).validate()).toEqual(
       expect.arrayContaining([expect.objectContaining({ code: "lock.mismatch" })]),
     );
+  });
+
+  it("rejects an unsupported compiler before reporting schema or lock mismatches", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-dsl-compiler-version-"));
+    const entry = join(root, "pragma.yaml");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [runtimeProfile(), expertResource("1xddvess309a6gme", "Writes")],
+      }),
+    );
+    const unlocked = await loadPragmaProject(entry);
+    await writeFile(
+      join(root, "pragma.lock.yaml"),
+      formatPragmaYaml({
+        ...unlocked.createLock(),
+        compilerVersion: "pragma.dsl/v99",
+      }),
+    );
+
+    const project = await loadPragmaProject(entry, { requireLock: true });
+    expect(await project.validate()).toEqual([
+      expect.objectContaining({
+        code: "compiler.version_unsupported",
+        path: ["compilerVersion"],
+      }),
+    ]);
+    await expect(
+      project.compile("expert:1xddvess309a6gme", { workspace: root }),
+    ).rejects.toMatchObject({
+      diagnostics: [
+        expect.objectContaining({
+          code: "compiler.version_unsupported",
+        }),
+      ],
+    });
+  });
+
+  it("reports revision metadata and lock compiler disagreement explicitly", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-dsl-compiler-metadata-"));
+    const entry = join(root, "pragma.yaml");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [runtimeProfile(), expertResource("1xddvess309a6gme", "Writes")],
+      }),
+    );
+    const unlocked = await loadPragmaProject(entry);
+    await writeFile(join(root, "pragma.lock.yaml"), formatPragmaYaml(unlocked.createLock()));
+
+    const project = await loadPragmaProject(entry, {
+      requireLock: true,
+      revisionCompilerVersion: "pragma.dsl/v2",
+    });
+    expect(await project.validate()).toEqual([
+      expect.objectContaining({ code: "compiler.version_metadata_mismatch" }),
+    ]);
+  });
+
+  it("rejects unsupported revision compiler metadata even when the lock is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-dsl-compiler-metadata-without-lock-"));
+    const entry = join(root, "pragma.yaml");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [runtimeProfile(), expertResource("1xddvess309a6gme", "Writes")],
+      }),
+    );
+
+    const project = await loadPragmaProject(entry, {
+      requireLock: true,
+      revisionCompilerVersion: "pragma.dsl/v99",
+    });
+    expect(await project.validate()).toEqual([
+      expect.objectContaining({
+        code: "compiler.version_unsupported",
+        message: expect.stringContaining("revision metadata"),
+        path: ["compilerVersion"],
+      }),
+    ]);
+    await expect(
+      project.compile("expert:1xddvess309a6gme", { workspace: root }),
+    ).rejects.toMatchObject({
+      diagnostics: [
+        expect.objectContaining({
+          code: "compiler.version_unsupported",
+        }),
+      ],
+    });
+  });
+
+  it("continues to read compatible pragma.dsl/v2 locks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-dsl-compiler-v2-"));
+    const entry = join(root, "pragma.yaml");
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: [],
+        resources: [runtimeProfile(), expertResource("1xddvess309a6gme", "Writes")],
+      }),
+    );
+    const unlocked = await loadPragmaProject(entry);
+    await writeFile(
+      join(root, "pragma.lock.yaml"),
+      formatPragmaYaml({
+        ...unlocked.createLock(),
+        compilerVersion: "pragma.dsl/v2",
+      }),
+    );
+
+    const project = await loadPragmaProject(entry, {
+      requireLock: true,
+      revisionCompilerVersion: "pragma.dsl/v2",
+    });
+    expect(await project.validate()).toEqual([]);
+    await expect(
+      project.compile("expert:1xddvess309a6gme", { workspace: root }),
+    ).resolves.toMatchObject({ ref: "expert:1xddvess309a6gme" });
+  });
+
+  it("compiles only the target dependency closure while preserving full project diagnostics", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-dsl-scoped-validation-"));
+    const entry = join(root, "pragma.yaml");
+    const brokenFlow = {
+      apiVersion: "pragma/v3" as const,
+      kind: "Flow" as const,
+      metadata: {
+        id: "t4kw6k4qpw8a7tjw",
+        name: "Broken Flow",
+        description: "Contains an unrelated ordinary cycle",
+        tags: [],
+      },
+      spec: {
+        graph: {
+          start: "one",
+          steps: {
+            one: { action: { ref: "action:one@1.0.0" } },
+            two: { action: { ref: "action:two@1.0.0" } },
+          },
+          transitions: {
+            one: "two",
+            two: "one",
+          },
+        },
+      },
+    };
+    const unrelatedEvaluation = {
+      apiVersion: "pragma/v3" as const,
+      kind: "Evaluation" as const,
+      metadata: {
+        id: "7k2m9q4v8np6r3dt",
+        name: "Missing Flow Evaluation",
+        description: "Targets an unrelated missing Flow",
+        tags: [],
+      },
+      spec: {
+        target: { ref: "flow:9h0j1k2m3n4p5q6r" },
+        method: {
+          type: "flow-run-dry" as const,
+          cases: [
+            {
+              id: "missing_flow",
+              name: "Missing Flow",
+              input: {},
+              mocks: {},
+              expect: { status: "succeeded" as const, path: [] },
+            },
+          ],
+        },
+      },
+    };
+    const sources = [
+      ["runtime.pragma.yaml", runtimeProfile()],
+      ["expert.pragma.yaml", expertResource("1xddvess309a6gme", "Independent")],
+      ["flow.pragma.yaml", brokenFlow],
+      ["evaluation.pragma.yaml", unrelatedEvaluation],
+    ] as const;
+    for (const [fileName, resource] of sources) {
+      await writeFile(join(root, fileName), formatPragmaYaml(resource));
+    }
+    await writeFile(
+      entry,
+      formatPragmaYaml({
+        apiVersion: "pragma/v3",
+        kind: "Bundle",
+        imports: sources.map(([fileName]) => `./${fileName}`),
+        resources: [],
+      }),
+    );
+
+    const project = await loadPragmaProject(entry);
+    expect(await project.validate()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "flow.graph.cycle.ordinary",
+          resourceRef: "flow:t4kw6k4qpw8a7tjw",
+        }),
+        expect.objectContaining({
+          code: "reference.invalid",
+          resourceRef: "evaluation:7k2m9q4v8np6r3dt",
+        }),
+      ]),
+    );
+    expect(await project.validateFor("expert:1xddvess309a6gme")).toEqual([]);
+    await expect(
+      project.compile("expert:1xddvess309a6gme", { workspace: root }),
+    ).resolves.toMatchObject({ ref: "expert:1xddvess309a6gme" });
   });
 
   it("turns an Expert, Team, or Flow reference into a tool through a versioned adapter", async () => {


### PR DESCRIPTION
## Summary

- introduce an explicit Interpreter compiler compatibility capability: new revisions write `pragma.dsl/v3` while the current runtime reads v2 and v3
- fail closed before resource parsing when revision metadata or `pragma.lock.yaml` requires an unsupported compiler, and report metadata disagreement separately from lock drift
- keep full-project health validation for authoring while compiling only the requested executor and its transitive dependency closure
- detect Desktop main/preload/renderer compiler skew at startup and rebuild Electron main/preload dependencies in development watch mode
- add ADR 029, engineering guardrails, and regression coverage for compiler upgrades, missing locks, stale components, unrelated invalid resources, and IPC failures

## Root cause

Commit `4f3f96c` added the independent Evaluation resource and removed `Flow.spec.runDry` without advancing the persisted compiler version. A long-running older Desktop process could therefore interpret a newer project with an older closed resource schema. Full-project validation, introduced earlier and later expanded with stricter Flow diagnostics, amplified one incompatible or unrelated resource into failure of every executor.

The previous compiler version was only part of generic lock comparison and was not an execution compatibility gate. Desktop also had no component capability handshake and its development command did not watch main/preload dependency changes.

## Impact

Published revisions now have an explicit compatibility boundary. Unsupported or inconsistent revisions cannot execute, compatible v2 revisions remain readable, unrelated invalid resources no longer disable independent executors, and stale Desktop components are blocked with an actionable startup error.

Closes #68

## Validation

- `pnpm check` — 20/20 workspaces passed
- `pnpm build` — 20/20 workspaces passed
- Interpreter — 76 tests passed
- Desktop — 503 tests passed
- Desktop preload bundle verification passed
- two-pass Claude Code review followed by independent verification; no blocking or correctness findings remain