### PR TITLE
Simplify completed Mission list

### DIFF
--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -632,6 +632,7 @@ function MissionRail(props: {
       <MissionRailGroup
         label={t("completed")}
         emptyLabel={t("noCompleted")}
+        variant="completed"
         missions={missionGroups.completed.visibleMissions}
         hiddenCount={missionGroups.completed.hiddenCount}
         now={props.now}
@@ -737,6 +738,7 @@ export function resolveMissionSearchCollapsed(input: {
 function MissionRailGroup(props: {
   readonly label: string;
   readonly emptyLabel: string;
+  readonly variant?: "default" | "completed";
   readonly missions: readonly MissionSummary[];
   readonly hiddenCount: number;
   readonly now: number;
@@ -748,8 +750,10 @@ function MissionRailGroup(props: {
   readonly onDelete: (mission: MissionSummary) => void;
   readonly onLoadMore: () => void;
 }) {
+  const completed = props.variant === "completed";
+
   return (
-    <section className="mission-rail-group">
+    <section className={completed ? "mission-rail-group is-completed" : "mission-rail-group"}>
       <h2>{props.label}</h2>
       {props.missions.length === 0 ? (
         <p className="mission-rail-empty">{props.emptyLabel}</p>
@@ -781,17 +785,26 @@ function MissionRailGroup(props: {
                   {showStatusDot ? (
                     <span className="mission-status-dot is-active" aria-hidden="true" />
                   ) : null}
-                  <span>
+                  <span className={completed ? "mission-row-completed-content" : undefined}>
                     <strong>{mission.title}</strong>
-                    <small>
-                      <span>{missionStatusLabel(mission)}</span>
+                    {completed ? (
                       <time
                         dateTime={mission.updatedAt}
                         title={formatMissionDateTime(mission.updatedAt)}
                       >
                         {formatMissionTime(mission.updatedAt, props.now)}
                       </time>
-                    </small>
+                    ) : (
+                      <small>
+                        <span>{missionStatusLabel(mission)}</span>
+                        <time
+                          dateTime={mission.updatedAt}
+                          title={formatMissionDateTime(mission.updatedAt)}
+                        >
+                          {formatMissionTime(mission.updatedAt, props.now)}
+                        </time>
+                      </small>
+                    )}
                   </span>
                 </button>
                 <div className="mission-row-actions">

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -12416,6 +12416,17 @@ textarea:focus-visible,
   text-transform: uppercase;
 }
 
+.mission-rail-group.is-completed {
+  margin-top: 22px;
+  padding-top: 14px;
+  border-top: 1px solid rgb(88 121 104 / 12%);
+}
+
+.mission-rail-group.is-completed h2 {
+  color: var(--faint);
+  font-weight: 560;
+}
+
 .mission-rail-empty {
   padding: 8px 6px;
 }
@@ -12564,6 +12575,41 @@ textarea:focus-visible,
 .mission-row time {
   color: var(--faint);
   font-variant-numeric: tabular-nums;
+}
+
+.mission-rail-group.is-completed .mission-row {
+  margin-top: 0;
+  border-radius: 6px;
+}
+
+.mission-rail-group.is-completed .mission-row-open {
+  align-items: center;
+  padding: 5px 8px;
+}
+
+.mission-row-open > span.mission-row-completed-content {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mission-row-completed-content strong {
+  min-width: 0;
+  color: var(--muted);
+  font-weight: 430;
+}
+
+.mission-row-completed-content time {
+  flex: none;
+  font-size: 11px;
+}
+
+.mission-rail-group.is-completed .mission-row:hover .mission-row-open,
+.mission-rail-group.is-completed .mission-row:focus-within .mission-row-open,
+.mission-rail-group.is-completed .mission-row.is-active .mission-row-open {
+  padding-right: 34px;
 }
 
 .mission-status-dot.is-active,


### PR DESCRIPTION
## Summary

- render completed Missions as a compact single-line row with title and update time
- remove redundant completed status text
- use lighter typography, shorter row height, and a subtle divider to distinguish completed Missions from active work
- preserve the existing hover delete action

## Why

Completed Missions previously reused the active Mission two-line layout, even though every item had the same lifecycle status. This made the archive visually heavier and repeated information that the section heading already communicates.

## Impact

The Mission rail is easier to scan: active work remains prominent while completed work takes less vertical space.

## Validation

- `pnpm --filter @pragma/desktop typecheck`
- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop exec vitest run src/renderer/src/pages/missions/MissionsPage.test.tsx` (36 tests passed)
- `pnpm --filter @pragma/desktop build`
- Prettier and `git diff --check`

The full Desktop suite also ran: 507 tests passed and one unrelated existing contract fixture failed in `src/shared/contracts/contracts.test.ts` (`app.name` schema validation).