### PR TITLE
Fix Desktop capability identity reuse

### DIFF
--- a/apps/desktop/src/main/features/experts/expert-definition-store.ts
+++ b/apps/desktop/src/main/features/experts/expert-definition-store.ts
@@ -134,7 +134,7 @@ export function createExpertDefinitionStore(options: {
       const id = allocateExpertId(snapshot.resources, options.systemExperts);
       const requestedRef = `expert:${id}`;
       const { baseRevision, requiredUnchangedRefs, ...definition } = parsed;
-      const definitions = definitionToResources(definition, id);
+      const definitions = definitionToResources(definition, id, snapshot.resources);
       const updated = await options.project.apply({
         baseRevision,
         upserts: definitions,
@@ -169,7 +169,12 @@ export function createExpertDefinitionStore(options: {
       if (current === undefined) {
         throw new ExpertDefinitionStoreError("expert_not_found", "The expert no longer exists.");
       }
-      const definitions = definitionToResources(definition, current.metadata.id, current);
+      const definitions = definitionToResources(
+        definition,
+        current.metadata.id,
+        snapshot.resources,
+        current,
+      );
       const nextExpert = definitions.find(
         (resource): resource is PragmaExpertResource => resource.kind === "Expert",
       )!;
@@ -257,6 +262,7 @@ export function createExpertDefinitionStore(options: {
 function definitionToResources(
   definition: ExpertDefinitionWrite,
   expertId: string,
+  existingResources: readonly PragmaResource[],
   current?: PragmaExpertResource,
 ): PragmaResource[] {
   const runtimeId = derivePragmaResourceId(`desktop-managed:runtime:${expertId}`);
@@ -283,12 +289,19 @@ function definitionToResources(
       },
     },
   });
-  const capabilityResources = (definition.capabilities ?? []).map((capability) =>
-    PragmaCapabilityResourceSchema.parse({
+  const capabilityResourceIds = new Map(
+    (definition.capabilities ?? []).map((capability) => [
+      capability.capabilityId,
+      resolveDesktopCapabilityResourceId(capability.capabilityId, existingResources),
+    ]),
+  );
+  const capabilityResources = (definition.capabilities ?? []).map((capability) => {
+    const resourceId = capabilityResourceIds.get(capability.capabilityId)!;
+    return PragmaCapabilityResourceSchema.parse({
       apiVersion: "pragma/v3",
       kind: "Capability",
       metadata: {
-        id: desktopCapabilityResourceId(capability.capabilityId),
+        id: resourceId,
         name: `Capability ${capability.capabilityId}`,
         description: "Desktop-managed capability binding.",
         tags: ["desktop-managed"],
@@ -298,8 +311,8 @@ function definitionToResources(
         binding: desktopCapabilityBindingRef(capability.capabilityId, capability.revision),
         config: { key: capability.capabilityId },
       },
-    }),
-  );
+    });
+  });
   const contextResources = (definition.contextStoreMounts ?? []).map((mount) =>
     PragmaContextStoreResourceSchema.parse({
       apiVersion: "pragma/v3",
@@ -332,7 +345,7 @@ function definitionToResources(
       runtime: { ref: runtimeRef },
       capabilities: [
         ...(definition.capabilities ?? []).map((capability) => ({
-          ref: `capability:${desktopCapabilityResourceId(capability.capabilityId)}`,
+          ref: `capability:${capabilityResourceIds.get(capability.capabilityId)!}`,
           kind: capability.kind,
           ...(capability.kind === "tools" ? { tools: capability.toolNames } : {}),
         })),
@@ -504,6 +517,22 @@ export function pragmaExpertResourceToDesktopDefinition(
 
 function desktopCapabilityResourceId(id: string): string {
   return derivePragmaResourceId(`desktop-managed:capability:${id}`);
+}
+
+function resolveDesktopCapabilityResourceId(
+  id: string,
+  resources: readonly PragmaResource[],
+): string {
+  // DSL migrations preserve a resource's semantic identity, so its post-migration ID can differ
+  // from the ID generated for a newly created binding. The binding is the stable host identity.
+  const existing = resources.find(
+    (resource) =>
+      resource.kind === "Capability" &&
+      resource.spec.adapter === "pragma.capability.host@v1" &&
+      resource.metadata.tags.includes("desktop-managed") &&
+      parseDesktopCapabilityBindingRef(resource.spec.binding ?? "")?.id === id,
+  );
+  return existing?.metadata.id ?? desktopCapabilityResourceId(id);
 }
 
 function desktopContextResourceId(id: string): string {

--- a/apps/desktop/src/main/features/projects/pragma-project-store.test.ts
+++ b/apps/desktop/src/main/features/projects/pragma-project-store.test.ts
@@ -20,6 +20,7 @@ import type { ExpertDefinition, UpdateExpertDefinition } from "../../../shared/c
 import { createExpertDefinitionStore } from "../experts/expert-definition-store.ts";
 import { createPragmaProjectStore, PragmaProjectStoreError } from "./pragma-project-store.ts";
 import { createDesktopSystemExpertRegistry } from "../experts/system-expert-registry.ts";
+import { desktopCapabilityBindingRef } from "../../platform/bindings/desktop-binding-ref.ts";
 
 const directories: string[] = [];
 
@@ -1202,6 +1203,142 @@ describe("PragmaProjectStore", () => {
     } satisfies Partial<PragmaProjectStoreError>);
   });
 
+  it("reuses migrated desktop Capability identities when an Expert adds a skill", async () => {
+    const { project, experts } = await stores();
+    const existingCapabilityId = "009405fc-3ade-4df2-8e4b-eccab29e78c4";
+    const removedCapabilityId = "15ce47d6-217c-44b1-a830-61b086e8c61a";
+    const addedCapabilityId = "40bb8846-dba0-4662-9fd0-9e5d865741c8";
+    const migratedResourceId = derivePragmaResourceId(
+      `studio\0Capability\0capability_${existingCapabilityId.replaceAll("-", "")}`,
+    );
+    const removedResourceId = derivePragmaResourceId(
+      `studio\0Capability\0capability_${removedCapabilityId.replaceAll("-", "")}`,
+    );
+    const writer = exampleExpert();
+    const reviewer = exampleExpert("reviewer");
+    writer.spec.capabilities = [
+      { ref: `capability:${migratedResourceId}`, kind: "skill" },
+      { ref: `capability:${removedResourceId}`, kind: "tools", tools: ["run"] },
+    ];
+    reviewer.spec.capabilities = [{ ref: `capability:${migratedResourceId}`, kind: "skill" }];
+    await project.publish({
+      expectedRevision: 0,
+      resources: [
+        exampleRuntime(),
+        writer,
+        exampleRuntime("reviewer"),
+        reviewer,
+        desktopManagedCapability(existingCapabilityId, migratedResourceId),
+        desktopManagedCapability(removedCapabilityId, removedResourceId),
+      ],
+    });
+    const opened = await experts.get("expert:1xddvess309a6gme");
+
+    const saved = await experts.update(opened.ref, {
+      ...expertUpdate(opened, "Adds a newly installed skill"),
+      capabilities: [
+        ...opened.capabilities.filter(
+          (capability) => capability.capabilityId !== removedCapabilityId,
+        ),
+        { kind: "skill", capabilityId: addedCapabilityId, revision: 1 },
+      ],
+    });
+
+    expect(saved.capabilities).toEqual([
+      { kind: "skill", capabilityId: existingCapabilityId, revision: 1 },
+      { kind: "skill", capabilityId: addedCapabilityId, revision: 1 },
+    ]);
+    await expect(experts.get("expert:3sfd30h5017wd17d")).resolves.toMatchObject({
+      capabilities: [{ kind: "skill", capabilityId: existingCapabilityId, revision: 1 }],
+    });
+    const resources = (await project.get()).resources;
+    expect(
+      resources.filter(
+        (resource) =>
+          resource.kind === "Capability" &&
+          resource.metadata.name === `Capability ${existingCapabilityId}`,
+      ),
+    ).toEqual([
+      expect.objectContaining({ metadata: expect.objectContaining({ id: migratedResourceId }) }),
+    ]);
+    expect(resources).toContainEqual(
+      expect.objectContaining({
+        kind: "Capability",
+        metadata: expect.objectContaining({
+          id: derivePragmaResourceId(`desktop-managed:capability:${addedCapabilityId}`),
+          name: `Capability ${addedCapabilityId}`,
+        }),
+      }),
+    );
+    expect(resources.some((resource) => resource.metadata.id === removedResourceId)).toBe(false);
+  });
+
+  it("reuses migrated desktop Capability identities when creating an Expert", async () => {
+    const { project, experts } = await stores();
+    const existingCapabilityId = "009405fc-3ade-4df2-8e4b-eccab29e78c4";
+    const addedCapabilityId = "40bb8846-dba0-4662-9fd0-9e5d865741c8";
+    const migratedResourceId = derivePragmaResourceId(
+      `studio\0Capability\0capability_${existingCapabilityId.replaceAll("-", "")}`,
+    );
+    const writer = exampleExpert();
+    writer.spec.capabilities = [{ ref: `capability:${migratedResourceId}`, kind: "skill" }];
+    await project.publish({
+      expectedRevision: 0,
+      resources: [
+        exampleRuntime(),
+        writer,
+        desktopManagedCapability(existingCapabilityId, migratedResourceId),
+      ],
+    });
+
+    const created = await experts.create({
+      baseRevision: 1,
+      requiredUnchangedRefs: [],
+      name: "Reviewer",
+      description: "Reviews changes with shared guidance.",
+      tags: ["review"],
+      scope: "Review code changes.",
+      instructions: "Review the requested changes.",
+      model: { runtimeId: "codex", providerId: "openai", modelId: "gpt-test" },
+      capabilities: [
+        { kind: "skill", capabilityId: existingCapabilityId, revision: 1 },
+        { kind: "skill", capabilityId: addedCapabilityId, revision: 1 },
+      ],
+      contextStoreMounts: [],
+      plugins: [],
+      toolApprovals: {},
+    });
+
+    expect(created.capabilities).toHaveLength(2);
+    const resources = (await project.get()).resources;
+    expect(
+      resources.filter(
+        (resource) =>
+          resource.kind === "Capability" &&
+          resource.metadata.name === `Capability ${existingCapabilityId}`,
+      ),
+    ).toEqual([
+      expect.objectContaining({ metadata: expect.objectContaining({ id: migratedResourceId }) }),
+    ]);
+    expect(
+      resources.find(
+        (resource) => resource.kind === "Expert" && resource.metadata.id === created.id,
+      ),
+    ).toMatchObject({
+      spec: {
+        capabilities: [
+          { ref: `capability:${migratedResourceId}`, kind: "skill" },
+          {
+            ref: `capability:${derivePragmaResourceId(
+              `desktop-managed:capability:${addedCapabilityId}`,
+            )}`,
+            kind: "skill",
+          },
+        ],
+      },
+    });
+  });
+
   it("does not create a revision for an identical snapshot", async () => {
     const { directory, project } = await stores();
     const resources = [exampleRuntime(), exampleExpert()];
@@ -1375,6 +1512,27 @@ function portableCapability(): PragmaCapabilityResource {
       adapter: "pragma.capability.host@v1",
       binding: "binding:portable",
       config: { key: "portable" },
+    },
+  };
+}
+
+function desktopManagedCapability(
+  capabilityId: string,
+  resourceId: string,
+): PragmaCapabilityResource {
+  return {
+    apiVersion: "pragma/v3",
+    kind: "Capability",
+    metadata: {
+      id: resourceId,
+      name: `Capability ${capabilityId}`,
+      description: "Desktop-managed capability binding.",
+      tags: ["desktop-managed"],
+    },
+    spec: {
+      adapter: "pragma.capability.host@v1",
+      binding: desktopCapabilityBindingRef(capabilityId, 1),
+      config: { key: capabilityId },
     },
   };
 }


### PR DESCRIPTION
## Summary

- reuse existing Desktop-managed Capability resource identities through their stable host bindings
- create a new deterministic resource only when the Capability UUID has no existing project binding
- cover both Expert create and update paths, including shared capabilities and remove/add saves

## Root cause

After the `pragma/v2` to `pragma/v3` DSL migration, an existing Capability can have a migrated project-derived resource ID that differs from the ID newly derived by the Desktop editor. Saving an Expert regenerated the resource under the new ID while another Expert still referenced the migrated ID. The project then contained two Capability resources with the same name but different IDs and failed validation with `Duplicate Capability name`.

The Desktop now treats the parsed host binding as the stable Capability identity and reuses the matching resource ID.

## Impact

Experts can again be created or edited after the DSL identity migration. Removing an existing skill and adding a newly installed skill in the same save no longer reuses the wrong UUID or creates a duplicate Capability resource. Shared capabilities remain valid for other Experts.

## Validation

- Claude Code CR completed; all actionable coverage findings were addressed and independently verified
- `pnpm check` — lint, typecheck, and tests passed for all 20 workspace packages
- Desktop: 89 test files and 536 tests passed
- focused project-store regression suite: 45 tests passed
- Prettier and `git diff --check` passed

Closes #77