### PR TITLE
Improve Flow Run Dry evaluation actions

### DIFF
--- a/apps/desktop/src/renderer/src/i18n/resources/en/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/studio.ts
@@ -41,6 +41,10 @@ export const studio = {
   llmJudgeDescription: "Evaluate Experts and Expert Teams against reusable datasets.",
   evaluationNeedsFlow: "Create a Flow before adding a Run Dry evaluation.",
   noEvaluationsYet: "No evaluations yet.",
+  deleteEvaluation: "Delete this Run Dry suite?",
+  deleteEvaluationAction: "Delete suite",
+  deleteEvaluationDescription:
+    "“{{name}}” and all of its cases will be permanently removed. The target Flow will not be changed.",
   integrations: "Integrations",
   integrationsDescription:
     "Connect Experts, Teams, and Flows to schedules today, with reusable connections for webhooks and chat channels next.",
@@ -156,8 +160,7 @@ export const studio = {
   evaluationIdentity: "Evaluation identity",
   evaluationName: "Evaluation name",
   evaluationTarget: "Target Flow",
-  changeEvaluationTargetConfirm:
-    "Changing the target Flow clears every existing case and result. Continue?",
+  evaluationActions: "Evaluation actions",
   runDryTitle: "Flow run dry cases",
   runDryDescription:
     "Maintain fast unit cases for “{{name}}” with mocked model, action, nested Flow, and Human Task results.",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/studio.ts
@@ -40,6 +40,9 @@ export const studio = {
   llmJudgeDescription: "使用可复用测评集评估专家与专家团队。",
   evaluationNeedsFlow: "请先创建 Flow，再添加 Run Dry 测评。",
   noEvaluationsYet: "还没有测评。",
+  deleteEvaluation: "删除此 Run Dry 用例集？",
+  deleteEvaluationAction: "删除用例集",
+  deleteEvaluationDescription: "“{{name}}”及其中的全部用例将被永久删除，目标 Flow 不会受到影响。",
   integrations: "集成",
   integrationsDescription:
     "将专家、团队和流程接入定时策略，并为后续 Webhook 与各类聊天渠道预留可复用连接。",
@@ -150,7 +153,7 @@ export const studio = {
   evaluationIdentity: "测评信息",
   evaluationName: "测评名称",
   evaluationTarget: "目标 Flow",
-  changeEvaluationTargetConfirm: "更换目标 Flow 会清空现有全部用例和运行结果。是否继续？",
+  evaluationActions: "测评操作",
   runDryTitle: "Flow Run Dry 用例",
   runDryDescription:
     "为“{{name}}”维护快速单元用例，以 Mock 替代模型、Action、嵌套 Flow 与 Human Task 的真实结果。",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/studio.ts
@@ -40,6 +40,9 @@ export const studio = {
   llmJudgeDescription: "使用可重用評測集評估專家與專家團隊。",
   evaluationNeedsFlow: "請先建立 Flow，再新增 Run Dry 評測。",
   noEvaluationsYet: "尚無評測。",
+  deleteEvaluation: "刪除此 Run Dry 案例集？",
+  deleteEvaluationAction: "刪除案例集",
+  deleteEvaluationDescription: "「{{name}}」及其中的全部案例將被永久刪除，目標 Flow 不會受到影響。",
   integrations: "整合",
   integrationsDescription:
     "將專家、團隊和流程接入排程策略，並為後續 Webhook 與各類聊天管道預留可重複使用的連線。",
@@ -150,7 +153,7 @@ export const studio = {
   evaluationIdentity: "評測資訊",
   evaluationName: "評測名稱",
   evaluationTarget: "目標 Flow",
-  changeEvaluationTargetConfirm: "更換目標 Flow 會清空現有全部案例與執行結果。是否繼續？",
+  evaluationActions: "評測操作",
   runDryTitle: "Flow Run Dry 案例",
   runDryDescription:
     "為「{{name}}」維護快速單元案例，以 Mock 取代模型、Action、巢狀 Flow 與 Human Task 的真實結果。",

--- a/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.test.tsx
@@ -87,6 +87,7 @@ describe("EvaluationDirectoryFragment", () => {
       <EvaluationDirectoryFragment
         project={project}
         onCreate={() => undefined}
+        onDelete={async () => undefined}
         onOpen={() => undefined}
         onRun={async () => ({
           passed: true,
@@ -104,6 +105,8 @@ describe("EvaluationDirectoryFragment", () => {
     expect(html).toContain("Release flow");
     expect(html).toContain("Rollback flow");
     expect(html).toContain("1 case");
+    expect(html).toContain('aria-haspopup="menu"');
+    expect(html).toContain('aria-expanded="false"');
     expect(html).not.toContain("Dataset + LLM-as-Judge");
   });
 });

--- a/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.tsx
@@ -8,6 +8,7 @@ import {
   MagnifyingGlass,
   Play,
   Plus,
+  Trash,
   User,
   UsersThree,
   WarningCircle,
@@ -22,6 +23,7 @@ import {
 import type { PragmaProjectSnapshot } from "../../../../shared/contracts/index.ts";
 import { errorMessage } from "../../lib/errors.ts";
 import { StudioScreenFrame } from "../studio/StudioScreenFrame.tsx";
+import { StudioConfirmationDialog } from "../studio/StudioDialog.tsx";
 import { desktopApi } from "../studio/studio-model.ts";
 
 type EvaluationTarget = PragmaExpertResource | PragmaExpertTeamResource | PragmaFlowResource;
@@ -55,11 +57,15 @@ export function EvaluationDirectoryFragment(props: {
   readonly onOpen: (evaluation: PragmaEvaluationResource) => void;
   readonly onCreate: (resourceId: string, flow: PragmaFlowResource) => void;
   readonly onRun: (evaluation: PragmaEvaluationResource) => Promise<PragmaFlowRunDrySuiteResult>;
+  readonly onDelete: (evaluation: PragmaEvaluationResource) => Promise<void>;
 }) {
   const { t, i18n } = useTranslation("studio");
   const [error, setError] = useState<string | null>(null);
   const [allocating, setAllocating] = useState(false);
   const [running, setRunning] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<PragmaEvaluationResource | null>(null);
   const [search, setSearch] = useState("");
   const [expandedKinds, setExpandedKinds] = useState<ReadonlySet<EvaluationTargetKind>>(new Set());
   const [runStates, setRunStates] = useState<
@@ -164,6 +170,29 @@ export function EvaluationDirectoryFragment(props: {
       if (mountedRef.current) setError(errorMessage(cause));
     } finally {
       if (mountedRef.current) setRunning(false);
+    }
+  };
+
+  const deleteEvaluation = async () => {
+    if (pendingDelete === null || deleting) return;
+    const evaluation = pendingDelete;
+    setDeleting(true);
+    setError(null);
+    try {
+      await props.onDelete(evaluation);
+      if (!mountedRef.current) return;
+      setRunStates((current) => {
+        const next = { ...current };
+        delete next[evaluation.metadata.id];
+        return next;
+      });
+      setPendingDelete(null);
+    } catch (cause) {
+      if (!mountedRef.current) return;
+      setPendingDelete(null);
+      setError(errorMessage(cause));
+    } finally {
+      if (mountedRef.current) setDeleting(false);
     }
   };
 
@@ -330,54 +359,100 @@ export function EvaluationDirectoryFragment(props: {
                         const runState = runStates[evaluation.metadata.id];
                         const failedCases = runState?.result.summary.failed ?? 0;
                         return (
-                          <button
-                            className="evaluation-suite-row"
-                            type="button"
-                            key={evaluation.metadata.id}
-                            onClick={() => props.onOpen(evaluation)}
-                          >
-                            <span className="evaluation-suite-name">
-                              <span className="evaluation-suite-file" aria-hidden="true">
-                                <GitBranch size={16} />
-                              </span>
-                              <strong>{evaluation.metadata.name}</strong>
-                            </span>
-                            <span>
-                              {t("evaluationCaseCount", {
-                                count: evaluation.spec.method.cases.length,
-                              })}
-                            </span>
-                            <span>{coverageLabel(runState?.result, t)}</span>
-                            <span
-                              className={
-                                runState === undefined
-                                  ? "evaluation-run-status"
-                                  : runState.result.passed
-                                    ? "evaluation-run-status is-success"
-                                    : "evaluation-run-status is-error"
-                              }
+                          <div className="evaluation-suite-row" key={evaluation.metadata.id}>
+                            <button
+                              className="evaluation-suite-open"
+                              type="button"
+                              onClick={() => props.onOpen(evaluation)}
                             >
-                              {runState === undefined ? null : runState.result.passed ? (
-                                <CheckCircle size={17} weight="fill" aria-hidden="true" />
-                              ) : (
-                                <WarningCircle size={17} weight="fill" aria-hidden="true" />
-                              )}
-                              {runState === undefined
-                                ? t("notRun")
-                                : runState.result.passed
-                                  ? t("passed")
-                                  : t("failedCases", { count: failedCases })}
+                              <span className="evaluation-suite-name">
+                                <span className="evaluation-suite-file" aria-hidden="true">
+                                  <GitBranch size={16} />
+                                </span>
+                                <strong>{evaluation.metadata.name}</strong>
+                              </span>
+                              <span>
+                                {t("evaluationCaseCount", {
+                                  count: evaluation.spec.method.cases.length,
+                                })}
+                              </span>
+                              <span>{coverageLabel(runState?.result, t)}</span>
+                              <span
+                                className={
+                                  runState === undefined
+                                    ? "evaluation-run-status"
+                                    : runState.result.passed
+                                      ? "evaluation-run-status is-success"
+                                      : "evaluation-run-status is-error"
+                                }
+                              >
+                                {runState === undefined ? null : runState.result.passed ? (
+                                  <CheckCircle size={17} weight="fill" aria-hidden="true" />
+                                ) : (
+                                  <WarningCircle size={17} weight="fill" aria-hidden="true" />
+                                )}
+                                {runState === undefined
+                                  ? t("notRun")
+                                  : runState.result.passed
+                                    ? t("passed")
+                                    : t("failedCases", { count: failedCases })}
+                              </span>
+                              <span>
+                                {runState === undefined
+                                  ? "—"
+                                  : new Intl.DateTimeFormat(i18n.language, {
+                                      hour: "2-digit",
+                                      minute: "2-digit",
+                                    }).format(runState.finishedAt)}
+                              </span>
+                            </button>
+                            <span
+                              className="evaluation-suite-actions"
+                              onBlur={(event) => {
+                                if (!event.currentTarget.contains(event.relatedTarget)) {
+                                  setOpenMenuId(null);
+                                }
+                              }}
+                            >
+                              <button
+                                type="button"
+                                aria-label={t("moreActions", { name: evaluation.metadata.name })}
+                                aria-haspopup="menu"
+                                aria-expanded={openMenuId === evaluation.metadata.id}
+                                onClick={() =>
+                                  setOpenMenuId((current) =>
+                                    current === evaluation.metadata.id
+                                      ? null
+                                      : evaluation.metadata.id,
+                                  )
+                                }
+                              >
+                                <DotsThree size={20} weight="bold" aria-hidden="true" />
+                              </button>
+                              {openMenuId === evaluation.metadata.id ? (
+                                <div
+                                  className="evaluation-suite-menu"
+                                  role="menu"
+                                  aria-label={t("moreActions", {
+                                    name: evaluation.metadata.name,
+                                  })}
+                                >
+                                  <button
+                                    type="button"
+                                    role="menuitem"
+                                    onClick={() => {
+                                      setOpenMenuId(null);
+                                      setPendingDelete(evaluation);
+                                      setError(null);
+                                    }}
+                                  >
+                                    <Trash size={16} aria-hidden="true" />
+                                    {t("deleteEvaluationAction")}
+                                  </button>
+                                </div>
+                              ) : null}
                             </span>
-                            <span>
-                              {runState === undefined
-                                ? "—"
-                                : new Intl.DateTimeFormat(i18n.language, {
-                                    hour: "2-digit",
-                                    minute: "2-digit",
-                                  }).format(runState.finishedAt)}
-                            </span>
-                            <DotsThree size={20} weight="bold" aria-hidden="true" />
-                          </button>
+                          </div>
                         );
                       })}
                     </div>
@@ -406,6 +481,20 @@ export function EvaluationDirectoryFragment(props: {
         <p className="form-error evaluation-directory-error" role="alert">
           {error}
         </p>
+      ) : null}
+      {pendingDelete ? (
+        <StudioConfirmationDialog
+          title={t("deleteEvaluation")}
+          description={t("deleteEvaluationDescription", {
+            name: pendingDelete.metadata.name,
+          })}
+          cancelLabel={t("cancel")}
+          confirmLabel={t("deleteEvaluationAction")}
+          busyLabel={t("deleting")}
+          busy={deleting}
+          onCancel={() => setPendingDelete(null)}
+          onConfirm={() => void deleteEvaluation()}
+        />
       ) : null}
     </StudioScreenFrame>
   );

--- a/apps/desktop/src/renderer/src/pages/evaluations/EvaluationsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/EvaluationsPage.tsx
@@ -94,6 +94,15 @@ export function EvaluationsPage() {
           project={project}
           onCreate={(resourceId, flow) => setDraft(createFlowRunDryEvaluation(resourceId, flow))}
           onOpen={setDraft}
+          onDelete={async (evaluation) => {
+            const api = typeof window === "undefined" ? undefined : window.pragmaDesktop;
+            if (api === undefined) throw new Error("Desktop bridge is unavailable.");
+            const snapshot = await api.deletePragmaResource({
+              baseRevision: project.revision,
+              ref: canonicalPragmaResourceRef(evaluation),
+            });
+            setProject(snapshot);
+          }}
           onRun={async (evaluation) => {
             const api = typeof window === "undefined" ? undefined : window.pragmaDesktop;
             if (api === undefined) throw new Error("Desktop bridge is unavailable.");

--- a/apps/desktop/src/renderer/src/pages/evaluations/FlowRunDryFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/FlowRunDryFragment.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { PragmaEvaluationResourceSchema } from "@pragma/evaluation/ast";
 import { PragmaFlowResourceSchema } from "@pragma/interpreter/ast";
 
-import { createRunDryTargetChangeState, FlowRunDryFragment } from "./FlowRunDryFragment.tsx";
+import { FlowRunDryFragment } from "./FlowRunDryFragment.tsx";
 
 describe("FlowRunDryFragment", () => {
   it("renders persisted cases and transition coverage in a dedicated developer screen", () => {
@@ -95,25 +95,9 @@ describe("FlowRunDryFragment", () => {
     expect(html).toContain("flow-run-dry-identity");
     expect(html).toContain("flow-run-dry-form-grid");
     expect(html).toContain("flow-run-dry-case-editor");
-  });
-
-  it("clears cases, selection, results, and errors when the target Flow changes", () => {
-    const next = createRunDryTargetChangeState("flow:6h7j8k9m0n1p2q3r");
-
-    expect(next).toMatchObject({
-      targetRef: "flow:6h7j8k9m0n1p2q3r",
-      drafts: [
-        {
-          id: "case_1",
-          name: "Case 1",
-          input: "{}",
-          mocks: "{}",
-          path: "",
-        },
-      ],
-      result: null,
-      formError: null,
-    });
-    expect(next.selectedKey).toBe(next.drafts[0]?.key);
+    expect(html).toContain("flow-run-dry-toolbar");
+    expect(html).toContain("flow-run-dry-static-value");
+    expect(html).toContain('Target Flow</span><div class="flow-run-dry-static-value"');
+    expect(html).not.toContain("Target Flow</span><select");
   });
 });

--- a/apps/desktop/src/renderer/src/pages/evaluations/FlowRunDryFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/FlowRunDryFragment.tsx
@@ -1,6 +1,14 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, CheckCircle, Play, Plus, Trash, XCircle } from "@phosphor-icons/react";
+import {
+  ArrowLeft,
+  CheckCircle,
+  GitBranch,
+  Play,
+  Plus,
+  Trash,
+  XCircle,
+} from "@phosphor-icons/react";
 import {
   PragmaEvaluationResourceSchema,
   PragmaFlowRunDrySuiteSchema,
@@ -26,17 +34,6 @@ interface RunDryCaseDraft {
   readonly errorContains: string;
 }
 
-export function createRunDryTargetChangeState(targetRef: string) {
-  const draft = emptyCaseDraft(1);
-  return {
-    targetRef,
-    drafts: [draft] as readonly RunDryCaseDraft[],
-    selectedKey: draft.key,
-    result: null,
-    formError: null,
-  };
-}
-
 export function FlowRunDryFragment(props: {
   readonly evaluation: PragmaEvaluationResource;
   readonly flows: readonly PragmaFlowResource[];
@@ -50,12 +47,14 @@ export function FlowRunDryFragment(props: {
   );
   const [name, setName] = useState(props.evaluation.metadata.name);
   const [description, setDescription] = useState(props.evaluation.metadata.description);
-  const [targetRef, setTargetRef] = useState(props.evaluation.spec.target.ref);
   const [selectedKey, setSelectedKey] = useState<string | null>(drafts[0]?.key ?? null);
   const [result, setResult] = useState<PragmaFlowRunDrySuiteResult | null>(null);
   const [busy, setBusy] = useState<"save" | "run" | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const selected = drafts.find((draft) => draft.key === selectedKey) ?? null;
+  const targetFlow = props.flows.find(
+    (flow) => `flow:${flow.metadata.id}` === props.evaluation.spec.target.ref,
+  );
 
   const updateSelected = (patch: Partial<RunDryCaseDraft>) => {
     if (selected === null) return;
@@ -79,16 +78,6 @@ export function FlowRunDryFragment(props: {
     setSelectedKey(next[Math.min(index, next.length - 1)]?.key ?? null);
     setResult(null);
   };
-  const changeTarget = (nextTargetRef: string) => {
-    if (nextTargetRef === targetRef) return;
-    if (!window.confirm(t("changeEvaluationTargetConfirm"))) return;
-    const next = createRunDryTargetChangeState(nextTargetRef);
-    setTargetRef(next.targetRef);
-    setDrafts(next.drafts);
-    setSelectedKey(next.selectedKey);
-    setResult(next.result);
-    setFormError(next.formError);
-  };
   const materialize = (): PragmaFlowRunDrySuite => {
     const cases = drafts.map(draftToCase);
     return PragmaFlowRunDrySuiteSchema.parse({ cases });
@@ -102,7 +91,7 @@ export function FlowRunDryFragment(props: {
         description: description.trim(),
       },
       spec: {
-        target: { ref: targetRef },
+        target: props.evaluation.spec.target,
         method: { type: "flow-run-dry", cases: materialize().cases },
       },
     });
@@ -146,11 +135,19 @@ export function FlowRunDryFragment(props: {
           <h1 id="flow-run-dry-heading">{t("runDryTitle")}</h1>
           <p>{t("runDryDescription", { name })}</p>
         </div>
-        <div className="detail-actions">
-          <button className="secondary-button" type="button" onClick={addCase}>
-            <Plus size={17} aria-hidden="true" />
-            {t("addRunDryCase")}
-          </button>
+      </header>
+
+      <div className="flow-run-dry-toolbar" role="toolbar" aria-label={t("evaluationActions")}>
+        <button
+          className="secondary-button"
+          type="button"
+          disabled={busy !== null}
+          onClick={addCase}
+        >
+          <Plus size={17} aria-hidden="true" />
+          {t("addRunDryCase")}
+        </button>
+        <div>
           <button
             className="secondary-button"
             type="button"
@@ -169,7 +166,7 @@ export function FlowRunDryFragment(props: {
             {busy === "save" ? t("saving") : t("saveCases")}
           </button>
         </div>
-      </header>
+      </div>
 
       <section
         className="flow-run-dry-editor flow-run-dry-identity"
@@ -180,16 +177,13 @@ export function FlowRunDryFragment(props: {
             <span>{t("evaluationName")}</span>
             <input value={name} onChange={(event) => setName(event.target.value)} />
           </label>
-          <label>
+          <div className="flow-run-dry-static-field">
             <span>{t("evaluationTarget")}</span>
-            <select value={targetRef} onChange={(event) => changeTarget(event.target.value)}>
-              {props.flows.map((flow) => (
-                <option key={flow.metadata.id} value={`flow:${flow.metadata.id}`}>
-                  {flow.metadata.name}
-                </option>
-              ))}
-            </select>
-          </label>
+            <div className="flow-run-dry-static-value">
+              <GitBranch size={17} aria-hidden="true" />
+              <strong>{targetFlow?.metadata.name ?? props.evaluation.spec.target.ref}</strong>
+            </div>
+          </div>
         </div>
         <label>
           <span>{t("description")}</span>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -6713,27 +6713,33 @@ p {
 }
 
 .flow-run-dry-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 24px;
+  display: block;
 }
 
 .flow-run-dry-heading > div:first-child {
   min-width: 0;
 }
 
-.flow-run-dry-heading .detail-actions {
+.flow-run-dry-toolbar {
   display: flex;
-  min-width: 0;
   align-items: center;
-  justify-content: flex-end;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: var(--surface-soft);
+}
+
+.flow-run-dry-toolbar > div {
+  display: flex;
+  align-items: center;
   gap: 10px;
 }
 
-.flow-run-dry-heading .detail-actions > button {
+.flow-run-dry-toolbar button {
   min-height: 42px;
+  white-space: nowrap;
 }
 
 .evaluations-page {
@@ -6938,7 +6944,8 @@ p {
 
 .evaluation-target-group > div > button:focus-visible,
 .evaluation-target-more:focus-visible,
-.evaluation-suite-row:focus-visible {
+.evaluation-suite-open:focus-visible,
+.evaluation-suite-actions > button:focus-visible {
   outline: 0;
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
@@ -7042,10 +7049,9 @@ p {
   min-width: 720px;
 }
 
-.evaluation-suite-table-heading,
-.evaluation-suite-row {
+.evaluation-suite-table-heading {
   display: grid;
-  grid-template-columns: minmax(190px, 1.4fr) 92px 118px 100px 92px 24px;
+  grid-template-columns: minmax(190px, 1.4fr) 92px 118px 100px 92px 32px;
   align-items: center;
   gap: 12px;
 }
@@ -7060,11 +7066,26 @@ p {
 }
 
 .evaluation-suite-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 32px;
+  align-items: center;
+  gap: 12px;
   width: 100%;
   min-height: 54px;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+}
+
+.evaluation-suite-open {
+  display: grid;
+  grid-template-columns: minmax(190px, 1.4fr) 92px 118px 100px 92px;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 53px;
   padding: 0 8px;
   border: 0;
-  border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--muted);
   cursor: pointer;
@@ -7073,8 +7094,71 @@ p {
   text-align: left;
 }
 
-.evaluation-suite-row:hover {
+.evaluation-suite-row:hover,
+.evaluation-suite-row:focus-within {
   background: var(--surface-soft);
+}
+
+.evaluation-suite-actions {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.evaluation-suite-actions > button {
+  display: grid;
+  width: 30px;
+  height: 32px;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.evaluation-suite-actions > button:hover,
+.evaluation-suite-actions > button[aria-expanded="true"] {
+  background: var(--surface-muted);
+  color: var(--text);
+}
+
+.evaluation-suite-menu {
+  position: absolute;
+  z-index: 8;
+  top: calc(100% + 4px);
+  right: 0;
+  width: 154px;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: #fff;
+  box-shadow: var(--shadow-panel);
+}
+
+.evaluation-suite-menu button {
+  display: flex;
+  width: 100%;
+  min-height: 36px;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 9px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #a14c3b;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  text-align: left;
+}
+
+.evaluation-suite-menu button:hover,
+.evaluation-suite-menu button:focus-visible {
+  outline: 0;
+  background: #fff2ee;
 }
 
 .evaluation-suite-name {
@@ -7372,6 +7456,33 @@ p {
   min-width: 0;
   gap: 7px;
   font-weight: 600;
+}
+
+.flow-run-dry-static-field {
+  display: grid;
+  min-width: 0;
+  gap: 7px;
+  font-weight: 600;
+}
+
+.flow-run-dry-static-value {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  gap: 9px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--surface-soft);
+  color: var(--text-secondary);
+}
+
+.flow-run-dry-static-value strong {
+  overflow: hidden;
+  color: var(--text);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .flow-run-dry-editor input,
@@ -7723,10 +7834,6 @@ p {
     display: grid;
   }
 
-  .flow-run-dry-heading .detail-actions {
-    justify-content: flex-start;
-  }
-
   .flow-run-dry-workspace {
     grid-template-columns: 1fr;
   }
@@ -7749,12 +7856,16 @@ p {
     grid-template-columns: 1fr;
   }
 
-  .flow-run-dry-heading .detail-actions {
+  .flow-run-dry-toolbar {
     display: grid;
-    grid-template-columns: 1fr;
   }
 
-  .flow-run-dry-heading .detail-actions > button {
+  .flow-run-dry-toolbar > div {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .flow-run-dry-toolbar button {
     width: 100%;
   }
 


### PR DESCRIPTION
## What changed

- add a three-dot menu to each Flow Run Dry suite row with a destructive delete action
- require confirmation before deleting an Evaluation resource and all of its cases
- keep the target Flow fixed on both new and existing evaluation screens
- reorganize Add case, Run all, and Save cases into a responsive toolbar
- add English, Simplified Chinese, and Traditional Chinese copy and update renderer tests

## Why

Flow Run Dry suites could only remove individual cases, leaving no way to delete the full suite from the Evaluations directory. The target Flow was also mutable after creation, which could silently invalidate the suite's cases, and the header actions wrapped awkwardly at narrower widths.

## Impact

Users can now delete an entire Run Dry suite from the list after confirmation. The associated Flow remains unchanged. Evaluation targets are read-only after suite creation, and the primary actions remain aligned across desktop and narrow layouts.

## Validation

- `pnpm --filter @pragma/desktop typecheck`
- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop test` (89 files, 540 tests)
- `pnpm --filter @pragma/desktop build`
- `git diff --check`
