### PR TITLE
Implement semantic memory phase three

### DIFF
--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -402,6 +402,13 @@ export async function createDesktopApplicationContainer(
     automaticHumanInteractionHandlerForToolPermissionMode: (mode) =>
       createAutomaticToolPermissionHandler(() => mode),
     assertStorageWriteAllowed: async () => await storageCapacityGuard.assertWriteAllowed(),
+    onExecutionLinked: async ({ mission, executionId }) => {
+      if (mission.origin.type === "system-memory") return;
+      await memoryPlane.registerSemanticExecutionContext({
+        executionId,
+        projectId: mission.project.id,
+      });
+    },
     getSystemExecutorFingerprint: async (mission) =>
       mission.executor.ref === MEMORY_CURATOR_REF
         ? await memoryCuratorRef.current?.fingerprint()
@@ -500,7 +507,10 @@ export async function createDesktopApplicationContainer(
     loggerProvider,
   });
   memoryCuratorRef.current = memoryCurator;
-  await memoryPlane.setEpisodicExtractor(memoryCurator.extractor);
+  await Promise.all([
+    memoryPlane.setEpisodicExtractor(memoryCurator.episodicExtractor),
+    memoryPlane.setSemanticExtractor(memoryCurator.semanticExtractor),
+  ]);
   const unsubscribeTokenCounter = tokenCounter.subscribe(() => {
     void missionRunner.invalidateEstimatedContextWindows().catch((error: unknown) => {
       mainLogger.warn(

--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.test.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.test.ts
@@ -63,6 +63,33 @@ describe("DesktopMemoryPlane", () => {
     });
     await plane.stop();
   });
+
+  it("registers stable local User and Project subjects without inventing a Repository", async () => {
+    const pragmaHome = await temporaryRoot("pragma-desktop-memory-subjects-");
+    const plane = await createDesktopMemoryPlane({
+      pragmaHome,
+      logger: createPragmaLogger(undefined, { component: "desktop.memory-test" }),
+    });
+
+    await plane.registerSemanticExecutionContext({
+      executionId: "execution-a",
+      projectId: "project-a",
+    });
+    const first = await plane.semanticStore.getSubjectContext("execution-a");
+    await plane.registerSemanticExecutionContext({
+      executionId: "execution-b",
+      projectId: "project-a",
+    });
+    const second = await plane.semanticStore.getSubjectContext("execution-b");
+
+    const firstUser = first?.subjectRefs.find((ref) => ref.type === "pragma.user");
+    const secondUser = second?.subjectRefs.find((ref) => ref.type === "pragma.user");
+    expect(firstUser?.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(secondUser).toEqual(firstUser);
+    expect(first?.subjectRefs).toContainEqual({ type: "pragma.project", id: "project-a" });
+    expect(first?.subjectRefs.some((ref) => ref.type === "pragma.repository")).toBe(false);
+    await plane.stop();
+  });
 });
 
 describe("Desktop Memory recall scope", () => {

--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
@@ -9,6 +9,7 @@ import {
 import {
   MemoryModuleRegistry,
   createEpisodicMemoryModule,
+  createSemanticMemoryModule,
   createFileMemoryExtractorProfileStore,
   createExecutionEvidenceAdapter,
   createFederatedMemoryContextStore,
@@ -22,15 +23,34 @@ import {
   type MemoryRecallScope,
   type EpisodicMemoryExtractor,
   type MemoryExtractorProfileStore,
+  type SemanticMemoryExtractor,
+  type SemanticMemoryStore,
 } from "@pragma/memory";
+
+import { createDesktopMemorySubjectIdentityStore } from "./memory-subject-identity.ts";
 
 export interface DesktopMemoryPlane {
   readonly executionStore: FileExecutionStore;
   readonly policies: MemoryPolicyStore;
   readonly extractorProfiles: MemoryExtractorProfileStore;
+  readonly semanticStore: SemanticMemoryStore;
   readonly contextStore: import("@pragma/core").ExpertAgentContextStore;
   setEpisodicExtractor(extractor: EpisodicMemoryExtractor | undefined): Promise<void>;
-  wakeEpisodicJobs(): Promise<void>;
+  setSemanticExtractor(extractor: SemanticMemoryExtractor | undefined): Promise<void>;
+  registerSemanticExecutionContext(input: {
+    readonly executionId: string;
+    readonly projectId: string;
+  }): Promise<void>;
+  reviseSemanticFact(
+    input: Omit<Parameters<SemanticMemoryStore["revise"]>[0], "actorRef" | "now">,
+  ): Promise<import("@pragma/shared").SemanticFact>;
+  verifySemanticFact(
+    input: Omit<Parameters<SemanticMemoryStore["verify"]>[0], "actorRef" | "now">,
+  ): Promise<import("@pragma/shared").SemanticFact>;
+  invalidateSemanticFact(
+    input: Omit<Parameters<SemanticMemoryStore["invalidate"]>[0], "actorRef" | "now">,
+  ): Promise<import("@pragma/shared").SemanticFact>;
+  wakeMemoryJobs(): Promise<void>;
   getStatus(): Promise<{
     readonly state: "running" | "stopped" | "degraded";
     readonly feed: { readonly lastSequence: number; readonly eventCount: number };
@@ -67,7 +87,12 @@ export async function createDesktopMemoryPlane(options: {
   const publisher = createMemoryEvidencePublisher(canonical);
   const registry = new MemoryModuleRegistry();
   const episodic = await createEpisodicMemoryModule({ pragmaHome: options.pragmaHome });
+  const semantic = await createSemanticMemoryModule({ pragmaHome: options.pragmaHome });
+  const subjectIdentities = createDesktopMemorySubjectIdentityStore({
+    pragmaHome: options.pragmaHome,
+  });
   registry.register(episodic);
+  registry.register(semantic);
   const contextStore = createFederatedMemoryContextStore(registry, {
     resolveRecallScope: async (context) => await resolveDesktopMemoryRecallScope(policies, context),
   });
@@ -143,13 +168,50 @@ export async function createDesktopMemoryPlane(options: {
     executionStore,
     policies,
     extractorProfiles,
+    semanticStore: semantic.store,
     contextStore,
     async setEpisodicExtractor(extractor) {
       await episodic.setExtractor(extractor);
       scheduler.wake();
     },
-    async wakeEpisodicJobs() {
-      await episodic.store.wakeNeedsAttention(new Date());
+    async setSemanticExtractor(extractor) {
+      await semantic.setExtractor(extractor);
+      scheduler.wake();
+    },
+    async registerSemanticExecutionContext(input) {
+      const localUser = await subjectIdentities.getLocalUserRef();
+      await semantic.registerExecutionSubjects({
+        executionId: input.executionId,
+        subjectRefs: [localUser, { type: "pragma.project", id: input.projectId }],
+      });
+      scheduler.wake();
+    },
+    async reviseSemanticFact(input) {
+      return await semantic.store.revise({
+        ...input,
+        actorRef: await subjectIdentities.getLocalUserRef(),
+        now: new Date(),
+      });
+    },
+    async verifySemanticFact(input) {
+      return await semantic.store.verify({
+        ...input,
+        actorRef: await subjectIdentities.getLocalUserRef(),
+        now: new Date(),
+      });
+    },
+    async invalidateSemanticFact(input) {
+      return await semantic.store.invalidate({
+        ...input,
+        actorRef: await subjectIdentities.getLocalUserRef(),
+        now: new Date(),
+      });
+    },
+    async wakeMemoryJobs() {
+      await Promise.all([
+        episodic.store.wakeNeedsAttention(new Date()),
+        semantic.store.wakeNeedsAttention(new Date()),
+      ]);
       scheduler.wake();
     },
     async getStatus() {
@@ -158,15 +220,21 @@ export async function createDesktopMemoryPlane(options: {
       for (const module of registry.list()) {
         const diagnostic = registry.diagnostic(module.descriptor.id);
         if (diagnostic === undefined) continue;
-        if (module.descriptor.id !== episodic.descriptor.id) {
+        if (
+          module.descriptor.id !== episodic.descriptor.id &&
+          module.descriptor.id !== semantic.descriptor.id
+        ) {
           modules.push(diagnostic);
           continue;
         }
-        const work = await episodic.store.inspect();
+        const work =
+          module.descriptor.id === episodic.descriptor.id
+            ? await episodic.store.inspect()
+            : await semantic.store.inspect();
         modules.push({
           ...diagnostic,
           work: {
-            records: work.episodes,
+            records: "episodes" in work ? work.episodes : work.facts,
             pending: work.pending,
             running: work.running,
             needsAttention: work.needsAttention,
@@ -201,6 +269,7 @@ export async function createDesktopMemoryPlane(options: {
       await running;
       await scheduler.stop();
       episodic.close();
+      semantic.close();
       canonical.close();
     },
   };

--- a/apps/desktop/src/main/features/memory/memory-curator.ts
+++ b/apps/desktop/src/main/features/memory/memory-curator.ts
@@ -11,10 +11,13 @@ import {
 import type { CompiledResource, InvocableResource } from "@pragma/interpreter";
 import {
   EpisodicExtractionOutputSchema,
+  SemanticExtractionOutputSchema,
   MEMORY_CURATOR_ID,
   MEMORY_CURATOR_PROMPT_VERSION,
+  SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION,
   MEMORY_CURATOR_REF,
   type EpisodicMemoryExtractor,
+  type SemanticMemoryExtractor,
   type MemoryExtractorProfile,
   type MemoryExtractorProfileStore,
 } from "@pragma/memory";
@@ -24,7 +27,8 @@ import type { MissionStore } from "../missions/mission-store.ts";
 import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
 
 export interface DesktopMemoryCurator {
-  readonly extractor: EpisodicMemoryExtractor;
+  readonly episodicExtractor: EpisodicMemoryExtractor;
+  readonly semanticExtractor: SemanticMemoryExtractor;
   compile(input: {
     readonly runtimes: RuntimeResolver;
     readonly workspace: string;
@@ -133,49 +137,49 @@ export function createDesktopMemoryCurator(options: {
     async fingerprint() {
       return await createFingerprint(await options.profiles.get());
     },
-    extractor: {
+    episodicExtractor: {
       async extract(input) {
         const profile = await options.profiles.get();
         const runtime = await resolveRuntime(profile);
-        const project = await options.project.ensurePublished();
-        const mission = await options.missions.create({
-          workspace: { path: options.workspace, basename: basename(options.workspace) },
-          goal: renderExtractionPrompt(input),
+        const content = await runCuratorMission({
+          options,
+          runtime,
+          jobId: input.jobId,
           title: `Memory extraction ${input.executionId.slice(0, 12)}`,
-          project: { id: project.projectId, revision: project.revision },
-          executor: { kind: "expert", ref: MEMORY_CURATOR_REF, name: "Memory Curator" },
-          origin: { type: "system-memory", jobId: input.jobId },
-          toolPermissionMode: "request-approval",
-          ...(runtime.modelSelection === undefined
-            ? {}
-            : {
-                modelOverride: {
-                  providerId: runtime.modelSelection.model.providerId,
-                  modelId: runtime.modelSelection.model.modelId,
-                  ...(runtime.modelSelection.thinkingLevel === undefined
-                    ? {}
-                    : { thinkingLevel: runtime.modelSelection.thinkingLevel }),
-                },
-              }),
+          goal: renderExtractionPrompt(input),
         });
-        await options.runner.run(mission.id);
-        await waitForMission(options.missions, mission.id);
-        const finished = await options.missions.get(mission.id);
-        if (finished.execution?.status !== "succeeded") {
-          throw new Error(`memory_curator_failed:${finished.execution?.error ?? "unknown"}`);
-        }
-        const chat = await options.runner.getChat({ id: mission.id, limit: 100 });
-        const content = chat.entries
-          .filter((entry) => entry.kind === "assistant")
-          .map((entry) => entry.content)
-          .at(-1);
-        if (content === undefined) throw new Error("memory_curator_output_missing");
         const output = EpisodicExtractionOutputSchema.parse(JSON.parse(extractJson(content)));
         return {
           output,
           provenance: {
             curatorRef: MEMORY_CURATOR_REF,
             promptVersion: MEMORY_CURATOR_PROMPT_VERSION,
+            profileRevision: profile.revision,
+            runtimeId: runtime.runtimeId,
+            providerId: runtime.modelSelection?.model.providerId ?? "runtime-managed",
+            modelId: runtime.modelSelection?.model.modelId ?? "runtime-default",
+            extractedAt: now().toISOString(),
+          },
+        };
+      },
+    },
+    semanticExtractor: {
+      async extract(input) {
+        const profile = await options.profiles.get();
+        const runtime = await resolveRuntime(profile);
+        const content = await runCuratorMission({
+          options,
+          runtime,
+          jobId: input.jobId,
+          title: `Semantic extraction ${input.executionId.slice(0, 12)}`,
+          goal: renderSemanticExtractionPrompt(input),
+        });
+        const output = SemanticExtractionOutputSchema.parse(JSON.parse(extractJson(content)));
+        return {
+          output,
+          provenance: {
+            curatorRef: MEMORY_CURATOR_REF,
+            promptVersion: SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION,
             profileRevision: profile.revision,
             runtimeId: runtime.runtimeId,
             providerId: runtime.modelSelection?.model.providerId ?? "runtime-managed",
@@ -217,6 +221,86 @@ function renderExtractionPrompt(input: Parameters<EpisodicMemoryExtractor["extra
   ].join("\n\n");
 }
 
+function renderSemanticExtractionPrompt(
+  input: Parameters<SemanticMemoryExtractor["extract"]>[0],
+): string {
+  const evidence: unknown[] = [];
+  let bytes = 0;
+  for (const item of [...input.evidence].reverse()) {
+    const serialized = JSON.stringify(item);
+    if (bytes + Buffer.byteLength(serialized) > 78_000) continue;
+    evidence.unshift(item);
+    bytes += Buffer.byteLength(serialized);
+  }
+  return [
+    "Extract current Semantic/Fact Memory from this safe Evidence projection.",
+    "Return retain=false when there is no stable, reusable fact. Do not turn historical outcomes into current truth.",
+    "Use only exact entries from allowedSubjectRefs and supplied messageId values. Never invent a subject id or Evidence id.",
+    "Use a namespaced predicate. normalizedValue must be a concise canonical value for deduplication.",
+    "Use conflictMode=exclusive only when the subject can have one current value for that predicate; otherwise use compatible.",
+    "Confidence must be between 0 and 0.95. Only include reviewAt or expiresAt when Evidence explicitly supports that time.",
+    "Output schema:",
+    '{"retain":true,"facts":[{"statement":"...","subjectRefs":[{"type":"pragma.user","id":"..."}],"predicate":"user.preference.language","normalizedValue":"zh-Hans","conflictMode":"exclusive|compatible","confidence":0.0,"evidenceRefs":["..."],"reviewAt":"optional ISO time","expiresAt":"optional ISO time"}]}',
+    'or {"retain":false,"reason":"no-stable-fact|insufficient-evidence|sensitive"}.',
+    "Allowed subjects:",
+    JSON.stringify(input.allowedSubjectRefs),
+    "Evidence:",
+    JSON.stringify(evidence),
+  ].join("\n\n");
+}
+
+async function runCuratorMission(input: {
+  readonly options: Pick<
+    Parameters<typeof createDesktopMemoryCurator>[0],
+    "project" | "missions" | "runner" | "workspace"
+  >;
+  readonly runtime: {
+    readonly runtimeId: string;
+    readonly modelSelection?: RuntimeModelSelection | undefined;
+  };
+  readonly jobId: string;
+  readonly title: string;
+  readonly goal: string;
+}): Promise<string> {
+  const project = await input.options.project.ensurePublished();
+  const mission = await input.options.missions.create({
+    workspace: {
+      path: input.options.workspace,
+      basename: basename(input.options.workspace),
+    },
+    goal: input.goal,
+    title: input.title,
+    project: { id: project.projectId, revision: project.revision },
+    executor: { kind: "expert", ref: MEMORY_CURATOR_REF, name: "Memory Curator" },
+    origin: { type: "system-memory", jobId: input.jobId },
+    toolPermissionMode: "request-approval",
+    ...(input.runtime.modelSelection === undefined
+      ? {}
+      : {
+          modelOverride: {
+            providerId: input.runtime.modelSelection.model.providerId,
+            modelId: input.runtime.modelSelection.model.modelId,
+            ...(input.runtime.modelSelection.thinkingLevel === undefined
+              ? {}
+              : { thinkingLevel: input.runtime.modelSelection.thinkingLevel }),
+          },
+        }),
+  });
+  await input.options.runner.run(mission.id);
+  await waitForMission(input.options.missions, mission.id);
+  const finished = await input.options.missions.get(mission.id);
+  if (finished.execution?.status !== "succeeded") {
+    throw new Error(`memory_curator_failed:${finished.execution?.error ?? "unknown"}`);
+  }
+  const chat = await input.options.runner.getChat({ id: mission.id, limit: 100 });
+  const content = chat.entries
+    .filter((entry) => entry.kind === "assistant")
+    .map((entry) => entry.content)
+    .at(-1);
+  if (content === undefined) throw new Error("memory_curator_output_missing");
+  return content;
+}
+
 async function waitForMission(missions: MissionStore, id: string): Promise<void> {
   const deadline = Date.now() + 10 * 60_000;
   while (Date.now() < deadline) {
@@ -240,6 +324,12 @@ function extractJson(content: string): string {
 
 async function createFingerprint(profile: MemoryExtractorProfile): Promise<string> {
   return createHash("sha256")
-    .update(JSON.stringify({ curator: MEMORY_CURATOR_PROMPT_VERSION, profile }))
+    .update(
+      JSON.stringify({
+        episodicCurator: MEMORY_CURATOR_PROMPT_VERSION,
+        semanticCurator: SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION,
+        profile,
+      }),
+    )
     .digest("hex");
 }

--- a/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
+++ b/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
@@ -9,6 +9,13 @@ import {
   UpdateDesktopAssetMemoryPolicySchema,
   UpdateDesktopGlobalMemoryPolicySchema,
   UpdateDesktopMemoryExtractorProfileSchema,
+  DesktopSemanticFactListSchema,
+  DesktopSemanticFactSchema,
+  GetDesktopSemanticFactSchema,
+  ListDesktopSemanticFactsSchema,
+  SearchDesktopSemanticFactsSchema,
+  ReviseDesktopSemanticFactSchema,
+  ReviewDesktopSemanticFactSchema,
 } from "../../../shared/contracts/index.ts";
 import type { DesktopMemoryPlane } from "./desktop-memory-plane.ts";
 
@@ -60,7 +67,50 @@ export function installMemoryPolicyHandlers(plane: DesktopMemoryPlane): void {
   ipcMain.handle("memory-extractor-profile:update", async (_event, input: unknown) => {
     const parsed = UpdateDesktopMemoryExtractorProfileSchema.parse(input);
     const profile = await plane.extractorProfiles.update(parsed);
-    await plane.wakeEpisodicJobs();
+    await plane.wakeMemoryJobs();
     return DesktopMemoryExtractorProfileSchema.parse(profile);
+  });
+  ipcMain.handle("memory-semantic:list", async (_event, input: unknown) => {
+    const parsed = ListDesktopSemanticFactsSchema.parse(input);
+    const facts = (await plane.semanticStore.list())
+      .filter((fact) => parsed.status === "all" || fact.status === parsed.status)
+      .filter(
+        (fact) =>
+          parsed.subjectRef === undefined ||
+          fact.subjectRefs.some(
+            (ref) => ref.type === parsed.subjectRef!.type && ref.id === parsed.subjectRef!.id,
+          ),
+      )
+      .slice(0, parsed.limit);
+    return DesktopSemanticFactListSchema.parse(facts);
+  });
+  ipcMain.handle("memory-semantic:search", async (_event, input: unknown) => {
+    const parsed = SearchDesktopSemanticFactsSchema.parse(input);
+    const facts = (await plane.semanticStore.search(parsed.query, parsed.limit * 2))
+      .filter((fact) => parsed.status === "all" || fact.status === parsed.status)
+      .slice(0, parsed.limit);
+    return DesktopSemanticFactListSchema.parse(facts);
+  });
+  ipcMain.handle("memory-semantic:get", async (_event, input: unknown) => {
+    const parsed = GetDesktopSemanticFactSchema.parse(input);
+    const fact = await plane.semanticStore.get(parsed.id);
+    if (fact === undefined) throw new Error("semantic_fact_not_found");
+    return DesktopSemanticFactSchema.parse(fact);
+  });
+  ipcMain.handle("memory-semantic:history", async (_event, input: unknown) => {
+    const parsed = GetDesktopSemanticFactSchema.parse(input);
+    return DesktopSemanticFactListSchema.parse(await plane.semanticStore.history(parsed.id));
+  });
+  ipcMain.handle("memory-semantic:revise", async (_event, input: unknown) => {
+    const parsed = ReviseDesktopSemanticFactSchema.parse(input);
+    return DesktopSemanticFactSchema.parse(await plane.reviseSemanticFact(parsed));
+  });
+  ipcMain.handle("memory-semantic:verify", async (_event, input: unknown) => {
+    const parsed = ReviewDesktopSemanticFactSchema.parse(input);
+    return DesktopSemanticFactSchema.parse(await plane.verifySemanticFact(parsed));
+  });
+  ipcMain.handle("memory-semantic:invalidate", async (_event, input: unknown) => {
+    const parsed = ReviewDesktopSemanticFactSchema.parse(input);
+    return DesktopSemanticFactSchema.parse(await plane.invalidateSemanticFact(parsed));
   });
 }

--- a/apps/desktop/src/main/features/memory/memory-subject-identity.ts
+++ b/apps/desktop/src/main/features/memory/memory-subject-identity.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { PragmaPaths, withFileLock } from "@pragma/core";
+import { z } from "zod";
+
+const DesktopMemorySubjectIdentitySchema = z
+  .object({
+    schemaVersion: z.literal("pragma.desktop-memory-subject-identity/v1"),
+    localUserId: z.string().uuid(),
+    createdAt: z.string().datetime(),
+  })
+  .strict();
+
+export interface DesktopMemorySubjectIdentityStore {
+  getLocalUserRef(): Promise<{ readonly type: "pragma.user"; readonly id: string }>;
+}
+
+export function createDesktopMemorySubjectIdentityStore(options: {
+  readonly pragmaHome: string;
+  readonly now?: (() => Date) | undefined;
+}): DesktopMemorySubjectIdentityStore {
+  const path = join(new PragmaPaths(options).memoryDataRoot(), "subject-identity.json");
+  const now = options.now ?? (() => new Date());
+
+  const read = async () => {
+    try {
+      return DesktopMemorySubjectIdentitySchema.parse(JSON.parse(await readFile(path, "utf8")));
+    } catch (error) {
+      if (isNotFound(error)) return undefined;
+      throw error;
+    }
+  };
+
+  return {
+    async getLocalUserRef() {
+      const existing = await read();
+      if (existing !== undefined) return { type: "pragma.user", id: existing.localUserId };
+      return await withFileLock(`${path}.lock`, async () => {
+        const current = await read();
+        if (current !== undefined) return { type: "pragma.user" as const, id: current.localUserId };
+        const created = DesktopMemorySubjectIdentitySchema.parse({
+          schemaVersion: "pragma.desktop-memory-subject-identity/v1",
+          localUserId: randomUUID(),
+          createdAt: now().toISOString(),
+        });
+        await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        const temporary = `${path}.${randomUUID()}.tmp`;
+        await writeFile(temporary, `${JSON.stringify(created, null, 2)}\n`, { mode: 0o600 });
+        await rename(temporary, path);
+        return { type: "pragma.user" as const, id: created.localUserId };
+      });
+    },
+  };
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { readonly code?: unknown }).code === "ENOENT"
+  );
+}

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -128,6 +128,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       startTurn: () => ({ outputText: "done", runtimeSessionId: "runtime" }),
       mapEvent: () => ({ events: [] }),
     });
+    const onExecutionLinked = vi.fn(async () => undefined);
     const runner = createMissionRunner({
       missions,
       project,
@@ -140,6 +141,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         defaultRuntimeId: "fake",
       }),
       assertStorageWriteAllowed: async () => undefined,
+      onExecutionLinked,
     });
 
     await runner.run(mission.id);
@@ -161,6 +163,11 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     );
 
     expect(compile).toHaveBeenCalledTimes(1);
+    expect(onExecutionLinked).toHaveBeenCalledTimes(2);
+    expect(onExecutionLinked).toHaveBeenCalledWith({
+      mission: expect.objectContaining({ id: mission.id }),
+      executionId: expect.any(String),
+    });
   });
 
   it("creates a successor Session when the live execution definition changes", async () => {

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -226,12 +226,26 @@ export function createMissionRunner(options: {
     | undefined;
   readonly assertStorageWriteAllowed?: (() => Promise<void>) | undefined;
   readonly assertExecutorReady?: ((ref: string) => void | Promise<void>) | undefined;
+  readonly onExecutionLinked?:
+    | ((input: { readonly mission: Mission; readonly executionId: string }) => Promise<void>)
+    | undefined;
 }): MissionRunner {
   const logger = createPragmaLogger(options.loggerProvider, {
     component: "desktop.mission-runner",
   });
   const executionStore =
     options.executionStore ?? createFileExecutionStore({ pragmaHome: options.pragmaHome });
+  const notifyExecutionLinked = async (mission: Mission, executionId: string): Promise<void> => {
+    try {
+      await options.onExecutionLinked?.({ mission, executionId });
+    } catch (error) {
+      logger.warn(
+        "mission.memory_subject_registration_failed",
+        "Memory subject context could not be registered; the Mission will continue.",
+        { error, missionId: mission.id, executionId },
+      );
+    }
+  };
   const expertSessionStore = createFileExpertSessionStore({
     executions: executionStore,
     pragmaHome: options.pragmaHome,
@@ -798,6 +812,7 @@ export function createMissionRunner(options: {
           executionId: mission.execution!.id,
           createdAt: executionStartedAt,
         });
+        await notifyExecutionLinked(mission, mission.execution!.id);
       }
       const handle = recoverable
         ? await app.flows.recover(compiled.value, {
@@ -815,6 +830,7 @@ export function createMissionRunner(options: {
           executionId: handle.executionId,
           createdAt: executionStartedAt,
         });
+        await notifyExecutionLinked(mission, handle.executionId);
       }
       const recoveredWaiting = recoverable && (await hasPendingHumanInteraction(handle));
       const running = await options.missions.updateExecution(mission.id, {
@@ -898,6 +914,7 @@ export function createMissionRunner(options: {
       executionId: turn.executionId,
       createdAt: executionStartedAt,
     });
+    await notifyExecutionLinked(mission, turn.executionId);
     const running = await options.missions.updateExecution(mission.id, {
       id: turn.executionId,
       inputMessageId,
@@ -1063,6 +1080,7 @@ export function createMissionRunner(options: {
       executionId: turn.executionId,
       createdAt: startedAt,
     });
+    await notifyExecutionLinked(mission, turn.executionId);
     const running = await options.missions.updateExecution(mission.id, {
       id: turn.executionId,
       inputMessageId: input.requestId,

--- a/apps/desktop/src/preload/api/memory.ts
+++ b/apps/desktop/src/preload/api/memory.ts
@@ -10,6 +10,13 @@ import {
   UpdateDesktopAssetMemoryPolicySchema,
   UpdateDesktopGlobalMemoryPolicySchema,
   UpdateDesktopMemoryExtractorProfileSchema,
+  DesktopSemanticFactListSchema,
+  DesktopSemanticFactSchema,
+  GetDesktopSemanticFactSchema,
+  ListDesktopSemanticFactsSchema,
+  SearchDesktopSemanticFactsSchema,
+  ReviseDesktopSemanticFactSchema,
+  ReviewDesktopSemanticFactSchema,
 } from "../../shared/contracts/memory.ts";
 
 export const memoryApi = {
@@ -51,6 +58,49 @@ export const memoryApi = {
         UpdateDesktopMemoryExtractorProfileSchema.parse(input),
       ),
     ),
+  listSemanticFacts: async (input = {}) =>
+    DesktopSemanticFactListSchema.parse(
+      await ipcRenderer.invoke("memory-semantic:list", ListDesktopSemanticFactsSchema.parse(input)),
+    ),
+  searchSemanticFacts: async (input) =>
+    DesktopSemanticFactListSchema.parse(
+      await ipcRenderer.invoke(
+        "memory-semantic:search",
+        SearchDesktopSemanticFactsSchema.parse(input),
+      ),
+    ),
+  getSemanticFact: async (input) =>
+    DesktopSemanticFactSchema.parse(
+      await ipcRenderer.invoke("memory-semantic:get", GetDesktopSemanticFactSchema.parse(input)),
+    ),
+  getSemanticFactHistory: async (input) =>
+    DesktopSemanticFactListSchema.parse(
+      await ipcRenderer.invoke(
+        "memory-semantic:history",
+        GetDesktopSemanticFactSchema.parse(input),
+      ),
+    ),
+  reviseSemanticFact: async (input) =>
+    DesktopSemanticFactSchema.parse(
+      await ipcRenderer.invoke(
+        "memory-semantic:revise",
+        ReviseDesktopSemanticFactSchema.parse(input),
+      ),
+    ),
+  verifySemanticFact: async (input) =>
+    DesktopSemanticFactSchema.parse(
+      await ipcRenderer.invoke(
+        "memory-semantic:verify",
+        ReviewDesktopSemanticFactSchema.parse(input),
+      ),
+    ),
+  invalidateSemanticFact: async (input) =>
+    DesktopSemanticFactSchema.parse(
+      await ipcRenderer.invoke(
+        "memory-semantic:invalidate",
+        ReviewDesktopSemanticFactSchema.parse(input),
+      ),
+    ),
 } satisfies Pick<
   PragmaDesktopAPI,
   | "getGlobalMemoryPolicy"
@@ -60,4 +110,11 @@ export const memoryApi = {
   | "getMemoryPlaneStatus"
   | "getMemoryExtractorProfile"
   | "updateMemoryExtractorProfile"
+  | "listSemanticFacts"
+  | "searchSemanticFacts"
+  | "getSemanticFact"
+  | "getSemanticFactHistory"
+  | "reviseSemanticFact"
+  | "verifySemanticFact"
+  | "invalidateSemanticFact"
 >;

--- a/apps/desktop/src/shared/contracts/api.ts
+++ b/apps/desktop/src/shared/contracts/api.ts
@@ -123,6 +123,12 @@ import type {
   DesktopMemoryPlaneStatus,
   DesktopMemoryExtractorProfile,
   UpdateDesktopMemoryExtractorProfile,
+  DesktopSemanticFact,
+  ListDesktopSemanticFacts,
+  SearchDesktopSemanticFacts,
+  GetDesktopSemanticFact,
+  ReviseDesktopSemanticFact,
+  ReviewDesktopSemanticFact,
 } from "./types.ts";
 
 export interface PragmaDesktopAPI {
@@ -145,6 +151,13 @@ export interface PragmaDesktopAPI {
   updateMemoryExtractorProfile: (
     input: UpdateDesktopMemoryExtractorProfile,
   ) => Promise<DesktopMemoryExtractorProfile>;
+  listSemanticFacts: (input?: ListDesktopSemanticFacts) => Promise<DesktopSemanticFact[]>;
+  searchSemanticFacts: (input: SearchDesktopSemanticFacts) => Promise<DesktopSemanticFact[]>;
+  getSemanticFact: (input: GetDesktopSemanticFact) => Promise<DesktopSemanticFact>;
+  getSemanticFactHistory: (input: GetDesktopSemanticFact) => Promise<DesktopSemanticFact[]>;
+  reviseSemanticFact: (input: ReviseDesktopSemanticFact) => Promise<DesktopSemanticFact>;
+  verifySemanticFact: (input: ReviewDesktopSemanticFact) => Promise<DesktopSemanticFact>;
+  invalidateSemanticFact: (input: ReviewDesktopSemanticFact) => Promise<DesktopSemanticFact>;
   pickWorkspace: () => Promise<PickWorkspaceResult>;
   validateWorkspace: (path: string) => Promise<ValidateWorkspaceResult>;
   getModelProviderSettings: () => Promise<ModelProviderSettingsSnapshot>;

--- a/apps/desktop/src/shared/contracts/memory.ts
+++ b/apps/desktop/src/shared/contracts/memory.ts
@@ -4,6 +4,7 @@ import {
   MemoryGlobalPolicySchema,
   MemoryModuleDiagnosticSchema,
   MemorySubjectRefSchema,
+  SemanticFactSchema,
 } from "@pragma/shared";
 import { z } from "zod";
 
@@ -91,3 +92,58 @@ export const UpdateDesktopMemoryExtractorProfileSchema = z.object({
       .strict(),
   ]),
 });
+
+export const ListDesktopSemanticFactsSchema = z
+  .object({
+    status: z.enum(["active", "invalidated", "all"]).default("active"),
+    subjectRef: MemorySubjectRefSchema.optional(),
+    limit: z.number().int().min(1).max(100).default(50),
+  })
+  .strict();
+
+export const SearchDesktopSemanticFactsSchema = z
+  .object({
+    query: z.string().trim().min(1).max(2_000),
+    status: z.enum(["active", "invalidated", "all"]).default("active"),
+    limit: z.number().int().min(1).max(100).default(50),
+  })
+  .strict();
+
+export const GetDesktopSemanticFactSchema = z.object({ id: z.string().min(1) }).strict();
+
+export const ReviseDesktopSemanticFactSchema = z
+  .object({
+    id: z.string().min(1),
+    expectedRevision: z.number().int().positive(),
+    reason: z.string().trim().min(1).max(2_000),
+    patch: z
+      .object({
+        statement: z.string().trim().min(1).max(4_000).optional(),
+        predicate: z
+          .string()
+          .regex(/^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)+$/)
+          .max(200)
+          .optional(),
+        normalizedValue: z.string().trim().min(1).max(2_000).optional(),
+        conflictMode: z.enum(["exclusive", "compatible"]).optional(),
+        confidence: z.number().min(0).max(0.95).optional(),
+        reviewAt: z.string().datetime().nullable().optional(),
+        expiresAt: z.string().datetime().nullable().optional(),
+      })
+      .strict()
+      .refine((patch) => Object.values(patch).some((value) => value !== undefined), {
+        message: "Semantic fact revision requires at least one change.",
+      }),
+  })
+  .strict();
+
+export const ReviewDesktopSemanticFactSchema = z
+  .object({
+    id: z.string().min(1),
+    expectedRevision: z.number().int().positive(),
+    reason: z.string().trim().min(1).max(2_000),
+  })
+  .strict();
+
+export const DesktopSemanticFactSchema = SemanticFactSchema;
+export const DesktopSemanticFactListSchema = z.array(DesktopSemanticFactSchema);

--- a/apps/desktop/src/shared/contracts/types.ts
+++ b/apps/desktop/src/shared/contracts/types.ts
@@ -192,6 +192,12 @@ import {
   UpdateDesktopAssetMemoryPolicySchema,
   UpdateDesktopGlobalMemoryPolicySchema,
   UpdateDesktopMemoryExtractorProfileSchema,
+  DesktopSemanticFactSchema,
+  ListDesktopSemanticFactsSchema,
+  SearchDesktopSemanticFactsSchema,
+  GetDesktopSemanticFactSchema,
+  ReviseDesktopSemanticFactSchema,
+  ReviewDesktopSemanticFactSchema,
 } from "./memory.ts";
 export type DesktopAppInfo = z.infer<typeof DesktopAppInfoSchema>;
 export type PragmaBundleModuleOptions = z.infer<typeof PragmaBundleModuleOptionsSchema>;
@@ -244,6 +250,12 @@ export type DesktopMemoryExtractorProfile = z.infer<typeof DesktopMemoryExtracto
 export type UpdateDesktopMemoryExtractorProfile = z.infer<
   typeof UpdateDesktopMemoryExtractorProfileSchema
 >;
+export type DesktopSemanticFact = z.infer<typeof DesktopSemanticFactSchema>;
+export type ListDesktopSemanticFacts = z.input<typeof ListDesktopSemanticFactsSchema>;
+export type SearchDesktopSemanticFacts = z.input<typeof SearchDesktopSemanticFactsSchema>;
+export type GetDesktopSemanticFact = z.infer<typeof GetDesktopSemanticFactSchema>;
+export type ReviseDesktopSemanticFact = z.infer<typeof ReviseDesktopSemanticFactSchema>;
+export type ReviewDesktopSemanticFact = z.infer<typeof ReviewDesktopSemanticFactSchema>;
 export type ModelProviderModel = z.infer<typeof ModelProviderModelSchema>;
 export type ModelCompatibilityProfileDescriptor = z.infer<
   typeof ModelCompatibilityProfileDescriptorSchema

--- a/docs/adr/031-extensible-memory-plane.md
+++ b/docs/adr/031-extensible-memory-plane.md
@@ -6,6 +6,7 @@
 - Implementation plan: [Memory Plane 落地计划](../architecture/memory-plane-implementation-plan.md)
 - Durable delivery decision: [ADR 032](./032-durable-canonical-event-feed.md)
 - Layered projection and Episodic decision: [ADR 033](./033-layered-episodic-memory.md)
+- Semantic conflict and governance decision: [ADR 034](./034-conservative-semantic-memory.md)
 
 ## Context
 

--- a/docs/adr/034-conservative-semantic-memory.md
+++ b/docs/adr/034-conservative-semantic-memory.md
@@ -1,0 +1,44 @@
+# ADR 034: Conservative Semantic Memory
+
+- Status: Accepted
+- Date: 2026-08-03
+- Extends: [ADR 031](./031-extensible-memory-plane.md)
+
+## Context
+
+Episodic Memory 回答“过去发生过什么”，不能作为当前真值。Semantic Memory 需要从同一安全 Evidence
+独立提炼当前事实，同时处理 subject 身份、重复观察、矛盾、时效、权限和人工更正。模型不能从正文杜撰
+User、Project 或 Repository 的稳定 ID，新证据也不能只因置信度较高就静默覆盖冲突事实。
+
+Desktop 当前没有 Repository registry，也没有跨设备账户身份。为 Repository 路径构造临时身份会把代码
+仓库错误地变成所有 Agent 任务的前置条件，因此不属于本阶段。
+
+## Decision
+
+`pragma.memory.semantic` 是独立的 dynamic-projection Module，直接消费安全 execution Evidence，不依赖
+Episodic Memory 或 WorkingState。每个事实记录 statement、subjectRefs、predicate、normalizedValue、
+confidence、时效、Evidence、visibility、binding、冲突和 provenance。
+
+Subject 使用 allowlist：Desktop 为每个普通 Mission Execution 幂等登记安装级 local User 和 Pragma
+Project；根 Expert/ExpertTeam/Flow 与 producer Expert 来自 Evidence attribution。Curator 只能选择这组
+引用。Repository subject 暂不发现或登记。
+
+同 subject、predicate、normalizedValue 的观察合并 Evidence；同 subject/predicate 且声明 exclusive 的
+不同值双向标记 `conflictsWith`。冲突事实并存，更高置信度不会自动 supersede 另一条事实。失效、过期和
+superseded 投影不进入默认 recall，冲突事实则全部暴露并要求核验 Evidence。
+
+治理 mutation 使用 revision CAS。同一 fact id 的更正、验证和失效都生成新的不可变 revision、保留旧
+快照并写原子审计；更正不会改写 subject、visibility、sensitivity 或 binding。新事实默认只允许根资产
+recall，export 为 deny。
+
+Semantic job 在权威事实事务中写 applied-job 标记。若事实已提交但 job 状态尚未完成，恢复只补齐 job，
+不再次调用 Curator。MissionRunner 在 execution 创建或恢复后登记 subject context，不反查或扫描全部
+Mission，也不升级 Core Execution 协议。
+
+## Consequences
+
+- Semantic 与 Episodic 可独立失败、重试、诊断和演进；
+- 当前事实具有可解释冲突和完整 revision history，不以自动覆盖换取表面简洁；
+- local User 是安装级身份，跨设备账户合并必须由后续显式迁移解决；
+- Repository subject、主动排序和管理中心 UI 继续属于后续阶段；
+- Renderer 可通过类型化 IPC 查询和治理事实，但阶段 3 不提供管理页面。

--- a/docs/architecture/current-architecture-overview.md
+++ b/docs/architecture/current-architecture-overview.md
@@ -204,7 +204,7 @@ Expert 未指定 Runtime 时由 Resolver 读取，而不是在 Expert 或 DSL �
 
 ### P2：Memory Plane 第一阶段已落地，业务 Memory Module 仍待迁移
 
-**状态：ADR 031 已接受；Canonical Feed、Module SPI、策略与 Desktop 入口已实现。**
+**状态：ADR 031–034 已接受；Canonical Feed、Module SPI、策略、Episodic 与 Semantic Module 已实现。**
 
 ADR 002 曾把 Memory System 定义为 Core 抽象，但当前 `MemorySystem`、Memory record、Evidence Store 和 Distillation SPI 都在 `@pragma/plugin-memory`。ADR 003 又只完成了部分实现，代码已经同时包含 direct-write memory 与 evidence distillation。两份旧 ADR 现已被 ADR 031 替代。
 
@@ -220,8 +220,9 @@ ADR 031 已替代 ADR 002/003，并由 `docs/architecture/memory-plane-implement
   Memory type，不新增独立 KnowledgeBase/MemoryAsset 对象；Skill Candidate 评测后升级为现有 Capability；
 - `plugin-memory` 在完成历史数据导入和调用方迁移后删除。
 
-当前还没有生产级 Episodic/Semantic Module、主动召回、管理中心或分享导出，因此旧插件仍只作为后续
-owner-scoped 导入的数据来源保留，不能把第一阶段基础设施描述成完整长期记忆能力。
+当前已能形成按资产隔离的历史 Episode 和带冲突、置信度、时效、revision history 的 Semantic Fact。
+主动召回排序、管理中心、Knowledge/Skill Candidate、分享导出与 legacy owner-scoped 导入仍未完成，
+旧插件只作为后续迁移数据源保留。
 
 ### P2：Desktop Main Process 正在变成第二个业务内核
 

--- a/docs/architecture/memory-plane-implementation-plan.md
+++ b/docs/architecture/memory-plane-implementation-plan.md
@@ -1,8 +1,8 @@
 # Memory Plane 落地计划
 
 - Status: Active plan
-- Last updated: 2026-08-01
-- Decisions: [ADR 031](../adr/031-extensible-memory-plane.md)、[ADR 032](../adr/032-durable-canonical-event-feed.md)、[ADR 033](../adr/033-layered-episodic-memory.md)
+- Last updated: 2026-08-03
+- Decisions: [ADR 031](../adr/031-extensible-memory-plane.md)、[ADR 032](../adr/032-durable-canonical-event-feed.md)、[ADR 033](../adr/033-layered-episodic-memory.md)、[ADR 034](../adr/034-conservative-semantic-memory.md)
 
 ## 最终链路
 
@@ -39,7 +39,7 @@ Memory。Knowledge、CodeGraph 仍是 Memory type，不新增 KnowledgeBase/Know
 | ---- | --------- | ----------------------------------------------------------- |
 | 1    | Completed | 内置 Plane、Canonical Event Bus、Module SPI、策略与设置入口 |
 | 2    | Completed | 分层召回协议与 Episodic Memory：历史、结果、失败与恢复      |
-| 3    | Planned   | Semantic / Fact Memory：真值、冲突、时效和置信度            |
+| 3    | Completed | Semantic / Fact Memory：真值、冲突、时效和置信度            |
 | 4    | Planned   | 主动召回排序、完整 binding 治理、管理中心与 Mission 可见性  |
 | 5    | Planned   | Knowledge Memory：多层提炼、稳定 revision 与团队分享        |
 | 6    | Planned   | Skill Memory Candidate、Evaluation 与 Capability 升级       |
@@ -227,23 +227,31 @@ Desktop 提供设置入口。
 - Migration: 新 Episodic Store 从 v1 开始并拒绝未来版本；Mission v5→v6 相邻升级补充 user origin
 - Verification: `pnpm check`、`pnpm build`，并覆盖 Expert/Team/Flow Runtime root identity、Desktop
   recall scope 解析、Memory Module 作用域契约和 Episodic list/search/detail/Evidence 越权测试
-- Known limitations: 当前仅有 Episodic 生产模块；Semantic、Knowledge、Skill Candidate、管理中心、分享、
+- Known limitations: 阶段 2 完成时仅有 Episodic 生产模块；Knowledge、Skill Candidate、管理中心、分享、
   跨设备同步和 query-aware retrieval ranking 仍属于后续阶段
 
 ## 阶段 3：Semantic / Fact Memory
 
 ### 目标
 
-回答“当前相信什么是真的”，支持 User、Project、Repository、Expert 等 subject，同时允许经治理绑定为
-团队资产。
+回答“当前相信什么是真的”。Subject Schema 保持可扩展；本阶段由 Desktop 登记 User、Project，并从
+Evidence 使用 Expert、ExpertTeam、Flow 等运行归属，允许经治理绑定为团队资产。Repository 留待后续
+具备明确发现和身份规则的阶段。
 
-### 交付
+### 已完成范围
 
-- statement、subjectRefs、confidence、observed/verified/review/expires 时间；
-- evidenceRefs、conflictsWith、supersedes、invalidatedAt；
-- extract、normalize、entity resolution、conflict grouping、temporal invalidation；
-- 不按 Personal/Project/Expert 建物理孤岛；subject 与 binding 分离；
-- `memory/semantic/**` Context projection 与更正/失效 API。
+- `pragma.memory.semantic` 独立消费安全 execution Evidence，以 subject、predicate 和 normalized value
+  归一化事实；相同观察合并 Evidence，exclusive 不同值双向标记冲突，不自动覆盖；
+- Fact 保存 confidence、observed/verified/review/expires 时间、Evidence、冲突、失效、binding、权限和
+  Curator provenance；验证只允许由治理 API 完成；
+- Desktop 为普通 Mission Execution 幂等登记安装级 local User 和 Pragma Project subject，根资产与
+  producer Expert 使用 Evidence attribution；Curator 只能选择 allowlist subject；
+- Repository subject 不在本阶段发现或登记，非代码 Agent 任务不依赖仓库；
+- 独立 facts/jobs SQLite、applied-job、lease、退避和 needs-attention 覆盖模型失败与提交后崩溃恢复；
+- `memory/semantic/**` 提供 summary、index、item、Evidence 四层投影；expired、invalidated、superseded
+  默认不召回，冲突事实全部保留并标记；
+- Desktop preload/main 提供 list、search、detail、history、revise、verify、invalidate 类型化 IPC；
+  mutation 使用 revision CAS，同 fact id 保存不可变 revision history 与原子治理审计；管理 UI 留在阶段 4。
 
 ### 退出门槛
 
@@ -251,6 +259,22 @@ Desktop 提供设置入口。
 - 过期/失效事实不参与默认召回；
 - user-private 事实不会因绑定自动变为 team-shareable；
 - Expert/Team/Flow 的有效策略能阻止对应 capture 或 recall。
+
+### Implementation record
+
+- Status: Completed
+- Protocols: `pragma.memory-semantic/v1`、`pragma.memory-semantic-job/v1`、
+  `pragma.memory-semantic-extraction-input/v1`、
+  `pragma.memory-semantic-execution-subject-context/v1`、
+  `pragma.memory-semantic-governance-event/v1`
+- Storage: `data/memory/modules/<semantic>/facts.sqlite` 与
+  `state/memory/modules/<semantic>/jobs.sqlite`
+- Migration: 新 Semantic Store 与 Desktop local User identity 从 v1 开始；未修改 Core Execution、Mission、
+  Interpreter compiler 或 Episodic Store
+- Verification: Memory/Shared/Desktop typecheck、Memory tests、Desktop Memory/Mission integration tests；
+  完整 `pnpm check` 与 `pnpm build`
+- Known limitations: 尚无 Repository subject、跨设备账户合并、管理中心 UI、主动召回排序、分享导出或
+  legacy Fact importer
 
 ## 阶段 4：主动召回、完整治理 UI 与可见性
 

--- a/docs/usage/memory.md
+++ b/docs/usage/memory.md
@@ -6,7 +6,7 @@ Pragma 的新 Memory Plane 是 Desktop 内置能力，随应用启动，不需�
 
 ## 当前已经可用的能力
 
-当前已完成 Memory Plane 基础设施、策略和 Episodic Memory：
+当前已完成 Memory Plane 基础设施、策略、Episodic Memory 和 Semantic Memory：
 
 - Execution 语义事件通过持久 Canonical Event Feed 交给 Memory Plane；
 - Memory Evidence 自动记录 root Expert/ExpertTeam/Flow 与实际 producer Expert；
@@ -19,8 +19,13 @@ Pragma 的新 Memory Plane 是 Desktop 内置能力，随应用启动，不需�
 - 独立 Expert 只能看到自己的 Episode；Team/Flow 内 Expert 看到当前 Team/Flow Episode 与自己的个人
   Episode，不会混入其他专家或其他团队资产；
 - 模型通过 `memory/episodic/items/**` 按需读取详情，需要核验时再读取精确 Evidence 引用。
+- 独立 Semantic Module 会提炼当前事实、偏好和约束；相同事实合并 Evidence，矛盾事实并存并标记，
+  不会因为新事实置信度较高而自动覆盖；
+- Semantic 默认召回排除过期、失效和 superseded 投影，验证、更正和失效通过 revision CAS 保存历史；
+- Semantic subject 只来自可验证 allowlist：安装级 local User、Pragma Project、根资产和 producer Expert。
+  当前不发现 Repository subject，普通 Agent 任务不依赖代码仓库。
 
-当前尚未实现生产级 Semantic/Fact、Knowledge、Skill Candidate 或 CodeGraph Module。查询相关的主动
+当前尚未实现 Knowledge、Skill Candidate 或 CodeGraph Module。查询相关的主动
 召回排序、Memory 管理中心、候选评审和分享也在后续阶段。
 
 ## 分层加载
@@ -38,6 +43,9 @@ memory/<type>/evidence/<evidenceId>.md  # 按需核验证据
 
 guide 最多 2KB，overview 最多 6KB。普通搜索不会返回 Evidence；模型必须先找到详情中的稳定引用，再精确
 读取证据。Episodic 是历史先例，不代表当前事实。
+
+Semantic 是当前信念投影，也不是无条件真值。详情会展示 confidence、review/expiry、冲突和 Evidence；
+发生冲突时必须读取双方详情与证据，不得根据索引顺序猜测胜者。
 
 因此可以询问独立 Expert“你以前做过什么”：回答只依据该 Expert 作为根资产执行过的个人 Episode。
 在 Team/Flow 中询问时，模型还可以使用当前 Team/Flow 的共同履历，但提示词和详情会明确区分
@@ -72,8 +80,8 @@ global ∩ root asset ∩ producer experts ∩ mission restriction
 这些设置属于本机 Host binding metadata，不写入 Pragma DSL，不生成 Project Revision。
 
 这里的“每个资产一个 Memory Store”是逻辑授权视图，不是每个 Expert/Team/Flow 创建一套 SQLite 或目录。
-Episodic Module 仍使用共享物理 Store，并在查询阶段按稳定 root asset 与当前 Expert 过滤 list、search、
-detail 和 Evidence。
+Episodic 与 Semantic Module 都使用各自的共享物理 Store，并在查询阶段按稳定 binding 与当前 Expert
+过滤 list、search、detail 和 Evidence。
 
 ## 类型边界
 
@@ -89,8 +97,9 @@ Knowledge 与 CodeGraph 仍是 Memory type，不是独立 KnowledgeBase 或 Memo
 
 ## 团队资产与分享
 
-事实描述的 subject 和它绑定给谁是两个维度。一个事实可以描述 User、Project 或 Repository，同时在权限
-允许、经过提炼后绑定给 Expert、ExpertTeam 或 Flow，成为团队资产的一部分。
+事实描述的 subject 和它绑定给谁是两个维度。当前自动 subject 支持 local User、Pragma Project、
+Expert、ExpertTeam 与 Flow；Repository 等其他 subject 等有稳定 registry 后再接入。事实可以在权限允许、
+经过提炼后绑定给 Expert、ExpertTeam 或 Flow，成为团队资产的一部分。
 
 未来分享 Expert/ExpertTeam/Flow 时，可选择一并导出绑定且允许 export 的 published/team-shareable
 Memory revision。分享不会新建一个知识库对象，也不会自动导出私有原始 Evidence。
@@ -112,6 +121,9 @@ Memory revision。分享不会新建一个知识库对象，也不会自动导�
 ~/.pragma/state/event-bus/handoff-quarantine/ # 原样保留的损坏/未来版本 handoff；所属 Execution fail closed
 ~/.pragma/state/memory/                     # checkpoint/dead-letter/outbox
 ~/.pragma/state/memory/modules/<episodic>/jobs.sqlite # Evidence aggregation and durable jobs
+~/.pragma/data/memory/modules/<semantic>/facts.sqlite # Semantic projection, revisions and audit
+~/.pragma/state/memory/modules/<semantic>/jobs.sqlite # Semantic Evidence, subjects and durable jobs
+~/.pragma/data/memory/subject-identity.json # Desktop installation-local User identity
 ```
 
 Memory 数据不写 Agent workspace。正常启动不会扫描全部 Mission、Execution 或 legacy memory 目录。
@@ -120,5 +132,6 @@ Memory 数据不写 Agent workspace。正常启动不会扫描全部 Mission、E
 
 - [ADR 031: Extensible Memory Plane](../adr/031-extensible-memory-plane.md)
 - [ADR 032: Durable Canonical Event Feed](../adr/032-durable-canonical-event-feed.md)
+- [ADR 034: Conservative Semantic Memory](../adr/034-conservative-semantic-memory.md)
 - [Memory Plane 落地计划](../architecture/memory-plane-implementation-plan.md)
 - [旧 Memory System ADR（已被替代）](../adr/002-memory-system.md)

--- a/packages/memory/src/curator.ts
+++ b/packages/memory/src/curator.ts
@@ -1,3 +1,4 @@
 export const MEMORY_CURATOR_ID = "0000000000memory";
 export const MEMORY_CURATOR_REF = `expert:${MEMORY_CURATOR_ID}`;
 export const MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator/v1";
+export const SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator.semantic/v1";

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -11,4 +11,8 @@ export * from "./episodic/store.ts";
 export * from "./episodic/context.ts";
 export * from "./episodic/module.ts";
 export * from "./episodic/extractor-profile.ts";
+export * from "./semantic/schema.ts";
+export * from "./semantic/store.ts";
+export * from "./semantic/context.ts";
+export * from "./semantic/module.ts";
 export * from "./curator.ts";

--- a/packages/memory/src/semantic/context.ts
+++ b/packages/memory/src/semantic/context.ts
@@ -1,0 +1,223 @@
+import {
+  StaticContextStore,
+  type ExpertAgentContextItemSeed,
+  type ExpertAgentContextStore,
+} from "@pragma/core";
+import type { MemoryEvidenceEnvelope, SemanticFact } from "@pragma/shared";
+
+import type { SemanticMemoryStore } from "./store.ts";
+import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
+
+export function createSemanticMemoryContextProvider(
+  store: SemanticMemoryStore,
+  scope: MemoryRecallScope,
+  now: () => Date,
+): ExpertAgentContextStore {
+  const rootStore = async (): Promise<StaticContextStore> => {
+    const timestamp = now();
+    const facts = await store.listForRecall(scope, timestamp);
+    return new StaticContextStore([
+      {
+        id: "summary.md",
+        content: renderSummary(facts, timestamp),
+        metadata: metadata(
+          "Current effective facts, confidence, conflicts, and review state.",
+          "model_decision",
+          "high",
+        ),
+      },
+      {
+        id: "index.md",
+        content: renderIndex(facts),
+        metadata: metadata(
+          "Searchable Semantic Memory index. Read details before relying on a fact.",
+          "model_decision",
+          "normal",
+        ),
+      },
+    ]);
+  };
+
+  return {
+    listContext: async (input) => await (await rootStore()).listContext(input),
+    async readContext(input) {
+      if (input.id === "summary.md" || input.id === "index.md") {
+        return await (await rootStore()).readContext(input);
+      }
+      const factId = readPathId(input.id, "items/");
+      if (factId !== undefined) {
+        const fact = await store.getForRecall(scope, factId, now());
+        return await new StaticContextStore(fact === undefined ? [] : [factSeed(fact)]).readContext(
+          input,
+        );
+      }
+      const evidenceId = readPathId(input.id, "evidence/");
+      if (evidenceId !== undefined) {
+        const evidence = await store.getEvidenceForRecall(scope, evidenceId, now());
+        return await new StaticContextStore(
+          evidence === undefined ? [] : [evidenceSeed(evidence)],
+        ).readContext(input);
+      }
+      return await new StaticContextStore().readContext(input);
+    },
+    async searchContext(input) {
+      const root = await rootStore();
+      const rootMatches = await root.searchContext(input);
+      if (!rootMatches.ok) return rootMatches;
+      const remaining = Math.max(0, (input.maxResults ?? 20) - rootMatches.value.length);
+      if (remaining === 0) return rootMatches;
+      const facts = await store.searchForRecall(scope, input.query, remaining, now());
+      const details = await new StaticContextStore(facts.map(factSeed)).searchContext({
+        ...input,
+        maxResults: remaining,
+      });
+      return details.ok ? { ...details, value: [...rootMatches.value, ...details.value] } : details;
+    },
+    addContext: async (input) => await new StaticContextStore().addContext(input),
+    editContext: async (input) => await new StaticContextStore().editContext(input),
+    deleteContext: async (input) => await new StaticContextStore().deleteContext(input),
+  };
+}
+
+function factSeed(fact: SemanticFact): ExpertAgentContextItemSeed {
+  return {
+    id: `items/${fact.id}.md`,
+    revision: String(fact.revision),
+    content: renderFact(fact),
+    metadata: metadata(
+      `Semantic fact: ${oneLine(fact.statement, 180)}`,
+      "manual",
+      fact.verifiedAt === undefined ? "normal" : "high",
+      fact.sensitivity,
+    ),
+  };
+}
+
+function evidenceSeed(evidence: MemoryEvidenceEnvelope): ExpertAgentContextItemSeed {
+  return {
+    id: `evidence/${evidence.messageId}.md`,
+    content: renderEvidence(evidence),
+    metadata: metadata(
+      "Supporting Evidence for a Semantic Memory fact.",
+      "manual",
+      "low",
+      evidence.sensitivity,
+    ),
+  };
+}
+
+function renderSummary(facts: readonly SemanticFact[], now: Date): string {
+  const verified = facts.filter((fact) => fact.verifiedAt !== undefined).length;
+  const conflicting = facts.filter((fact) => fact.conflictsWith.length > 0).length;
+  const dueForReview = facts.filter(
+    (fact) => fact.reviewAt !== undefined && fact.reviewAt <= now.toISOString(),
+  ).length;
+  return [
+    "# Semantic Memory Summary",
+    "",
+    "Semantic Memory describes current beliefs. Conflicts and review dates are evidence to inspect, not instructions to hide.",
+    "",
+    `- Effective facts: ${facts.length}`,
+    `- Verified facts: ${verified}`,
+    `- Facts with conflicts: ${conflicting}`,
+    `- Due for review: ${dueForReview}`,
+    "",
+    ...facts.slice(0, 6).map(renderIndexLine),
+    ...(facts.length === 0 ? ["- No effective facts are available in this scope."] : []),
+    "",
+  ].join("\n");
+}
+
+function renderIndex(facts: readonly SemanticFact[]): string {
+  return [
+    "# Semantic Memory Index",
+    "",
+    "Read the fact detail when confidence, freshness, conflict, or provenance matters.",
+    "",
+    ...(facts.length === 0
+      ? ["- No effective facts are available in this scope."]
+      : facts.map(renderIndexLine)),
+    "",
+  ].join("\n");
+}
+
+function renderIndexLine(fact: SemanticFact): string {
+  const flags = [
+    fact.verifiedAt === undefined ? undefined : "verified",
+    fact.conflictsWith.length === 0 ? undefined : `conflicts:${fact.conflictsWith.length}`,
+    fact.reviewAt === undefined ? undefined : `review:${fact.reviewAt}`,
+  ].filter((value): value is string => value !== undefined);
+  return `- ${fact.id} | confidence ${fact.confidence.toFixed(2)}${flags.length === 0 ? "" : ` | ${flags.join(", ")}`} | ${oneLine(fact.statement, 240)}`;
+}
+
+function renderFact(fact: SemanticFact): string {
+  return [
+    `# Fact ${fact.id}`,
+    "",
+    `- Revision: ${fact.revision}`,
+    `- Subjects: ${fact.subjectRefs.map(refLabel).join(", ")}`,
+    `- Predicate: ${fact.predicate}`,
+    `- Normalized value: ${fact.normalizedValue}`,
+    `- Confidence: ${fact.confidence.toFixed(2)}`,
+    `- Observed: ${fact.observedAt}`,
+    `- Verified: ${fact.verifiedAt ?? "no"}`,
+    `- Review: ${fact.reviewAt ?? "not scheduled"}`,
+    `- Expires: ${fact.expiresAt ?? "not scheduled"}`,
+    `- Conflicts: ${fact.conflictsWith.join(", ") || "none"}`,
+    "",
+    "## Statement",
+    fact.statement,
+    "",
+    "## Evidence",
+    ...fact.evidenceRefs.map((id) => `- evidence/${id}.md`),
+    "",
+    ...(fact.conflictsWith.length === 0
+      ? []
+      : [
+          "This fact conflicts with another active fact. Inspect both facts and their Evidence before choosing one.",
+          "",
+        ]),
+  ].join("\n");
+}
+
+function renderEvidence(evidence: MemoryEvidenceEnvelope): string {
+  return [
+    `# Evidence ${evidence.messageId}`,
+    "",
+    `- Topic: ${evidence.topic}`,
+    `- Schema: ${evidence.schemaRef}`,
+    `- Occurred: ${evidence.occurredAt}`,
+    `- Source: ${evidence.sourceRef.type}:${evidence.sourceRef.id}`,
+    `- Sensitivity: ${evidence.sensitivity}`,
+    "",
+    "## Safe payload",
+    "```json",
+    JSON.stringify(evidence.payload, null, 2),
+    "```",
+    "",
+  ].join("\n");
+}
+
+function readPathId(path: string, prefix: "items/" | "evidence/"): string | undefined {
+  if (!path.startsWith(prefix) || !path.endsWith(".md")) return undefined;
+  const id = path.slice(prefix.length, -3);
+  return id.length === 0 || id.includes("/") ? undefined : id;
+}
+
+function metadata(
+  description: string,
+  trigger: "always_on" | "model_decision" | "manual",
+  priority: "critical" | "high" | "normal" | "low",
+  sensitivity: "public" | "internal" | "confidential" | "restricted" = "internal",
+) {
+  return { description, trigger, priority, trustLevel: "system" as const, sensitivity };
+}
+
+function refLabel(ref: { readonly type: string; readonly id: string }): string {
+  return `${ref.type}:${ref.id}`;
+}
+
+function oneLine(value: string, max: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length <= max ? normalized : `${normalized.slice(0, max - 1)}…`;
+}

--- a/packages/memory/src/semantic/module.ts
+++ b/packages/memory/src/semantic/module.ts
@@ -1,0 +1,293 @@
+import type { MemoryEvidenceEnvelope, MemorySubjectRef } from "@pragma/shared";
+
+import { createSemanticMemoryContextProvider } from "./context.ts";
+import {
+  SemanticExecutionSubjectContextSchema,
+  SemanticExtractionInputSchema,
+  SemanticExtractionOutputSchema,
+  type SemanticMemoryExtractor,
+} from "./schema.ts";
+import { createSemanticMemoryStore, type SemanticMemoryStore } from "./store.ts";
+import type { MemoryModule } from "../pipeline/memory-module.ts";
+
+export interface SemanticMemoryModule extends MemoryModule {
+  readonly store: SemanticMemoryStore;
+  setExtractor(extractor: SemanticMemoryExtractor | undefined): Promise<void>;
+  registerExecutionSubjects(input: {
+    readonly executionId: string;
+    readonly subjectRefs: readonly MemorySubjectRef[];
+    readonly registeredAt?: string | undefined;
+  }): Promise<void>;
+  close(): void;
+}
+
+export async function createSemanticMemoryModule(
+  options: {
+    readonly pragmaHome?: string | undefined;
+    readonly extractor?: SemanticMemoryExtractor | undefined;
+    readonly now?: (() => Date) | undefined;
+  } = {},
+): Promise<SemanticMemoryModule> {
+  const store = await createSemanticMemoryStore(options);
+  const now = options.now ?? (() => new Date());
+  let extractor = options.extractor;
+
+  return {
+    descriptor: {
+      id: "pragma.memory.semantic",
+      version: "1.0.0",
+      pathPrefix: "semantic",
+      storageModel: "dynamic-projection",
+      purpose: "projection",
+      contextLayers: {
+        usagePrompt:
+          "Use Semantic Memory for current beliefs, preferences, constraints, and facts. Check confidence, freshness, conflicts, and Evidence before relying on important claims.",
+        summaryPath: "summary.md",
+        indexPath: "index.md",
+        itemsPrefix: "items/",
+        evidencePrefix: "evidence/",
+        summaryMaxBytes: 2_048,
+        indexMaxBytes: 4_096,
+      },
+    },
+    subscriptions: [
+      { topic: "execution.message.appended", schemaRefs: ["pragma.memory.execution-message/v2"] },
+      {
+        topic: "execution.execution.terminal",
+        schemaRefs: ["pragma.memory.execution-terminal/v2"],
+      },
+      ...(["started", "completed", "failed"] as const).map((phase) => ({
+        topic: `execution.tool.${phase}`,
+        schemaRefs: ["pragma.memory.tool-event/v2"],
+      })),
+      { topic: "artifact.created", schemaRefs: ["pragma.memory.artifact-event/v1"] },
+      {
+        topic: "artifact.handoff.registered",
+        schemaRefs: ["pragma.memory.handoff-artifact/v1"],
+      },
+    ],
+    createContextProvider(scope) {
+      return createSemanticMemoryContextProvider(store, scope, now);
+    },
+    async consume(envelopes) {
+      await store.ingest(envelopes);
+      return {};
+    },
+    async runBackgroundOnce() {
+      if (extractor === undefined) return;
+      const job = await store.claimDueJob(now());
+      if (job === undefined) return;
+      try {
+        if (await store.hasAppliedJob(job.id)) {
+          await store.completePreviouslyApplied(job);
+          return;
+        }
+        const subjectContext = await store.getSubjectContext(job.executionId);
+        if (subjectContext === undefined) throw new Error("semantic_subject_context_missing");
+        const evidence = sanitizeEvidence(await store.readEvidence(job.executionId));
+        if (evidence.some((item) => item.sensitivity === "restricted")) {
+          await store.completeRejected(job, "sensitive");
+          return;
+        }
+        if (!hasTextEvidence(evidence)) {
+          await store.completeRejected(job, "insufficient-evidence");
+          return;
+        }
+        const visibility = strictestVisibility(evidence);
+        if (visibility === undefined) {
+          await store.completeRejected(job, "policy");
+          return;
+        }
+        const attribution = resolveAttribution(evidence);
+        const allowedSubjectRefs = uniqueRefs([
+          ...subjectContext.subjectRefs,
+          attribution.rootRef,
+          ...attribution.producerRefs,
+        ]);
+        const input = SemanticExtractionInputSchema.parse({
+          schemaVersion: "pragma.memory-semantic-extraction-input/v1",
+          jobId: job.id,
+          executionId: job.executionId,
+          allowedSubjectRefs,
+          evidence,
+        });
+        const extracted = await extractor.extract(input);
+        const output = SemanticExtractionOutputSchema.parse(extracted.output);
+        if (!output.retain) {
+          await store.completeRejected(job, output.reason);
+          return;
+        }
+        assertCandidateRefs(output.facts, evidence, allowedSubjectRefs);
+        await store.completeRetained({
+          job,
+          candidates: output.facts,
+          evidence,
+          rootRef: attribution.rootRef,
+          producerRefs: attribution.producerRefs,
+          visibility,
+          sensitivity: strictestSensitivity(evidence),
+          extractor: extracted.provenance,
+          now: now(),
+        });
+      } catch (error) {
+        await store.fail({
+          job,
+          errorCode: errorCode(error),
+          now: now(),
+          retry: isConfigurationError(error) ? "configuration" : "transient",
+        });
+      }
+    },
+    async setExtractor(next) {
+      extractor = next;
+      if (next !== undefined) await store.wakeNeedsAttention(now());
+    },
+    async registerExecutionSubjects(input) {
+      await store.registerSubjectContext(
+        SemanticExecutionSubjectContextSchema.parse({
+          schemaVersion: "pragma.memory-semantic-execution-subject-context/v1",
+          executionId: input.executionId,
+          subjectRefs: uniqueRefs(input.subjectRefs),
+          registeredAt: input.registeredAt ?? now().toISOString(),
+        }),
+      );
+    },
+    store,
+    close() {
+      store.close();
+    },
+  };
+}
+
+function hasTextEvidence(evidence: readonly MemoryEvidenceEnvelope[]): boolean {
+  return evidence.some((item) => {
+    if (item.schemaRef !== "pragma.memory.execution-message/v2") return false;
+    const payload = item.payload as { readonly message?: { readonly text?: unknown } };
+    return typeof payload.message?.text === "string" && payload.message.text.trim() !== "";
+  });
+}
+
+function assertCandidateRefs(
+  facts: readonly {
+    readonly subjectRefs: readonly MemorySubjectRef[];
+    readonly evidenceRefs: readonly string[];
+    readonly reviewAt?: string | undefined;
+    readonly expiresAt?: string | undefined;
+  }[],
+  evidence: readonly MemoryEvidenceEnvelope[],
+  subjects: readonly MemorySubjectRef[],
+): void {
+  const evidenceIds = new Set(evidence.map((item) => item.messageId));
+  const subjectIds = new Set(subjects.map(refKey));
+  const occurredAt = new Map(evidence.map((item) => [item.messageId, item.occurredAt]));
+  for (const fact of facts) {
+    for (const ref of fact.subjectRefs) {
+      if (!subjectIds.has(refKey(ref))) throw new Error("semantic_subject_ref_invalid");
+    }
+    for (const ref of fact.evidenceRefs) {
+      if (!evidenceIds.has(ref)) throw new Error("semantic_evidence_ref_invalid");
+    }
+    const observedAt = fact.evidenceRefs
+      .map((ref) => occurredAt.get(ref)!)
+      .toSorted()
+      .at(-1)!;
+    if (fact.reviewAt !== undefined && fact.reviewAt <= observedAt) {
+      throw new Error("semantic_review_time_invalid");
+    }
+    if (fact.expiresAt !== undefined && fact.expiresAt <= observedAt) {
+      throw new Error("semantic_expiry_time_invalid");
+    }
+  }
+}
+
+function resolveAttribution(evidence: readonly MemoryEvidenceEnvelope[]): {
+  readonly rootRef: MemorySubjectRef;
+  readonly producerRefs: readonly MemorySubjectRef[];
+} {
+  const roots = uniqueRefs(
+    evidence.flatMap((item) => (item.attribution ? [item.attribution.rootRef] : [])),
+  );
+  if (
+    roots.length !== 1 ||
+    !["pragma.expert", "pragma.expert-team", "pragma.flow"].includes(roots[0]!.type)
+  ) {
+    throw new Error("semantic_root_attribution_invalid");
+  }
+  return {
+    rootRef: roots[0]!,
+    producerRefs: uniqueRefs(evidence.flatMap((item) => item.attribution?.producerRefs ?? [])),
+  };
+}
+
+function strictestSensitivity(evidence: readonly MemoryEvidenceEnvelope[]) {
+  const order = ["public", "internal", "confidential", "restricted"] as const;
+  return order[Math.max(...evidence.map((item) => order.indexOf(item.sensitivity)), 0)]!;
+}
+
+function strictestVisibility(evidence: readonly MemoryEvidenceEnvelope[]) {
+  const restricted = evidence.filter((item) => item.visibility.mode === "restricted");
+  if (restricted.length > 0) {
+    const principals = restricted
+      .map(
+        (item) =>
+          new Map(
+            item.visibility.mode === "restricted"
+              ? item.visibility.principals.map((ref) => [refKey(ref), ref])
+              : [],
+          ),
+      )
+      .reduce((left, right) => new Map([...left].filter(([key]) => right.has(key))));
+    return principals.size === 0
+      ? undefined
+      : { mode: "restricted" as const, principals: [...principals.values()] };
+  }
+  return evidence.every((item) => item.visibility.mode === "public")
+    ? { mode: "public" as const }
+    : { mode: "host-private" as const };
+}
+
+function sanitizeEvidence(
+  evidence: readonly MemoryEvidenceEnvelope[],
+): readonly MemoryEvidenceEnvelope[] {
+  return evidence.map((item) => ({ ...item, payload: redactValue(item.payload) }));
+}
+
+function redactValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value
+      .replace(/\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,}\b/g, "[REDACTED_CREDENTIAL]")
+      .replace(/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, "[REDACTED_CREDENTIAL]")
+      .replace(/(authorization\s*[:=]\s*(?:bearer\s+)?)[^\s,;]+/gi, "$1[REDACTED_CREDENTIAL]")
+      .replace(
+        /((?:password|passwd|secret|token|api[_-]?key)\s*[:=]\s*)[^\s,;]+/gi,
+        "$1[REDACTED_CREDENTIAL]",
+      );
+  }
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactValue(item)]));
+}
+
+function uniqueRefs(refs: readonly MemorySubjectRef[]): MemorySubjectRef[] {
+  return [...new Map(refs.map((ref) => [refKey(ref), ref])).values()];
+}
+
+function refKey(ref: MemorySubjectRef): string {
+  return `${ref.type}\0${ref.id}`;
+}
+
+function errorCode(error: unknown): string {
+  return error instanceof Error
+    ? error.message.split(":", 1)[0] || "semantic_extraction_failed"
+    : "semantic_extraction_failed";
+}
+
+function isConfigurationError(error: unknown): boolean {
+  const code = errorCode(error);
+  return (
+    code.includes("unavailable") ||
+    code.includes("configuration") ||
+    code.includes("profile") ||
+    code === "semantic_subject_context_missing"
+  );
+}

--- a/packages/memory/src/semantic/schema.ts
+++ b/packages/memory/src/semantic/schema.ts
@@ -1,0 +1,111 @@
+import {
+  MemoryEvidenceEnvelopeSchema,
+  MemorySubjectRefSchema,
+  SemanticFactExtractorProvenanceSchema,
+  SemanticFactSchema,
+} from "@pragma/shared";
+import { z } from "zod";
+
+export const SEMANTIC_JOB_SCHEMA_VERSION = "pragma.memory-semantic-job/v1" as const;
+export const SEMANTIC_SUBJECT_CONTEXT_SCHEMA_VERSION =
+  "pragma.memory-semantic-execution-subject-context/v1" as const;
+export const SEMANTIC_GOVERNANCE_EVENT_SCHEMA_VERSION =
+  "pragma.memory-semantic-governance-event/v1" as const;
+
+export const SemanticFactCandidateSchema = z
+  .object({
+    statement: z.string().trim().min(1).max(4_000),
+    subjectRefs: z.array(MemorySubjectRefSchema).min(1).max(20),
+    predicate: z
+      .string()
+      .regex(/^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)+$/)
+      .max(200),
+    normalizedValue: z.string().trim().min(1).max(2_000),
+    conflictMode: z.enum(["exclusive", "compatible"]),
+    confidence: z.number().min(0).max(0.95),
+    evidenceRefs: z.array(z.string().min(1)).min(1).max(100),
+    reviewAt: z.string().datetime().optional(),
+    expiresAt: z.string().datetime().optional(),
+  })
+  .strict();
+
+export const SemanticExtractionInputSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.memory-semantic-extraction-input/v1"),
+    jobId: z.string().min(1),
+    executionId: z.string().min(1),
+    allowedSubjectRefs: z.array(MemorySubjectRefSchema).min(1).max(200),
+    evidence: z.array(MemoryEvidenceEnvelopeSchema).min(1).max(2_000),
+  })
+  .strict();
+
+export const SemanticExtractionOutputSchema = z.discriminatedUnion("retain", [
+  z
+    .object({
+      retain: z.literal(true),
+      facts: z.array(SemanticFactCandidateSchema).min(1).max(50),
+    })
+    .strict(),
+  z
+    .object({
+      retain: z.literal(false),
+      reason: z.enum(["no-stable-fact", "insufficient-evidence", "sensitive"]),
+    })
+    .strict(),
+]);
+
+export const SemanticExtractionJobSchema = z
+  .object({
+    schemaVersion: z.literal(SEMANTIC_JOB_SCHEMA_VERSION),
+    id: z.string().min(1),
+    executionId: z.string().min(1),
+    terminalMessageId: z.string().min(1),
+    status: z.enum(["pending", "running", "needs_attention", "completed"]),
+    attempts: z.number().int().nonnegative(),
+    retryAt: z.string().datetime().optional(),
+    leaseUntil: z.string().datetime().optional(),
+    lastErrorCode: z.string().min(1).optional(),
+    completion: z.enum(["retained", "rejected"]).optional(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const SemanticExecutionSubjectContextSchema = z
+  .object({
+    schemaVersion: z.literal(SEMANTIC_SUBJECT_CONTEXT_SCHEMA_VERSION),
+    executionId: z.string().min(1),
+    subjectRefs: z.array(MemorySubjectRefSchema).min(1).max(20),
+    registeredAt: z.string().datetime(),
+  })
+  .strict();
+
+export const SemanticGovernanceEventSchema = z
+  .object({
+    schemaVersion: z.literal(SEMANTIC_GOVERNANCE_EVENT_SCHEMA_VERSION),
+    id: z.string().min(1),
+    factId: z.string().min(1),
+    previousRevision: z.number().int().positive(),
+    revision: z.number().int().positive(),
+    action: z.enum(["revise", "verify", "invalidate"]),
+    reason: z.string().trim().min(1).max(2_000),
+    actorRef: MemorySubjectRefSchema,
+    occurredAt: z.string().datetime(),
+  })
+  .strict();
+
+export type SemanticFactCandidate = z.infer<typeof SemanticFactCandidateSchema>;
+export type SemanticExtractionInput = z.infer<typeof SemanticExtractionInputSchema>;
+export type SemanticExtractionOutput = z.infer<typeof SemanticExtractionOutputSchema>;
+export type SemanticExtractionJob = z.infer<typeof SemanticExtractionJobSchema>;
+export type SemanticExecutionSubjectContext = z.infer<typeof SemanticExecutionSubjectContextSchema>;
+export type SemanticGovernanceEvent = z.infer<typeof SemanticGovernanceEventSchema>;
+
+export interface SemanticMemoryExtractor {
+  extract(input: SemanticExtractionInput): Promise<{
+    readonly output: SemanticExtractionOutput;
+    readonly provenance: z.infer<typeof SemanticFactExtractorProvenanceSchema>;
+  }>;
+}
+
+export const SemanticFactRevisionSnapshotSchema = SemanticFactSchema;
+export type SemanticFactRevisionSnapshot = z.infer<typeof SemanticFactRevisionSnapshotSchema>;

--- a/packages/memory/src/semantic/store.ts
+++ b/packages/memory/src/semantic/store.ts
@@ -1,0 +1,1089 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { PragmaPaths } from "@pragma/core";
+import {
+  MemoryEvidenceEnvelopeSchema,
+  SemanticFactSchema,
+  type MemoryEvidenceEnvelope,
+  type MemoryRevisionBinding,
+  type MemorySubjectRef,
+  type MemoryVisibilityPolicy,
+  type SemanticFact,
+  type SemanticFactExtractorProvenance,
+} from "@pragma/shared";
+
+import {
+  SemanticExecutionSubjectContextSchema,
+  SemanticExtractionJobSchema,
+  SemanticGovernanceEventSchema,
+  type SemanticExecutionSubjectContext,
+  type SemanticExtractionJob,
+  type SemanticFactCandidate,
+  type SemanticGovernanceEvent,
+} from "./schema.ts";
+import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
+
+export type SemanticRejectionReason =
+  "no-stable-fact" | "insufficient-evidence" | "sensitive" | "policy";
+
+export interface SemanticMemoryStoreDiagnostic {
+  readonly facts: number;
+  readonly pending: number;
+  readonly running: number;
+  readonly needsAttention: number;
+  readonly rejected: number;
+  readonly rejectedByReason: Readonly<Record<SemanticRejectionReason, number>>;
+}
+
+export interface SemanticFactMaterialization {
+  readonly job: SemanticExtractionJob;
+  readonly candidates: readonly SemanticFactCandidate[];
+  readonly evidence: readonly MemoryEvidenceEnvelope[];
+  readonly rootRef: MemorySubjectRef;
+  readonly producerRefs: readonly MemorySubjectRef[];
+  readonly visibility: MemoryVisibilityPolicy;
+  readonly sensitivity: "public" | "internal" | "confidential" | "restricted";
+  readonly extractor: SemanticFactExtractorProvenance;
+  readonly now: Date;
+}
+
+export interface SemanticFactRevisionInput {
+  readonly id: string;
+  readonly expectedRevision: number;
+  readonly actorRef: MemorySubjectRef;
+  readonly reason: string;
+  readonly patch: {
+    readonly statement?: string | undefined;
+    readonly predicate?: string | undefined;
+    readonly normalizedValue?: string | undefined;
+    readonly conflictMode?: "exclusive" | "compatible" | undefined;
+    readonly confidence?: number | undefined;
+    readonly reviewAt?: string | null | undefined;
+    readonly expiresAt?: string | null | undefined;
+  };
+  readonly now: Date;
+}
+
+export interface SemanticMemoryStore {
+  ingest(envelopes: readonly MemoryEvidenceEnvelope[]): Promise<void>;
+  registerSubjectContext(context: SemanticExecutionSubjectContext): Promise<void>;
+  getSubjectContext(executionId: string): Promise<SemanticExecutionSubjectContext | undefined>;
+  claimDueJob(now: Date): Promise<SemanticExtractionJob | undefined>;
+  readEvidence(executionId: string): Promise<readonly MemoryEvidenceEnvelope[]>;
+  hasAppliedJob(jobId: string): Promise<boolean>;
+  completePreviouslyApplied(job: SemanticExtractionJob): Promise<void>;
+  completeRetained(input: SemanticFactMaterialization): Promise<readonly SemanticFact[]>;
+  completeRejected(job: SemanticExtractionJob, reason: SemanticRejectionReason): Promise<void>;
+  fail(input: {
+    readonly job: SemanticExtractionJob;
+    readonly errorCode: string;
+    readonly now: Date;
+    readonly retry: "transient" | "configuration";
+  }): Promise<void>;
+  wakeNeedsAttention(now: Date): Promise<void>;
+  list(): Promise<readonly SemanticFact[]>;
+  search(query: string, limit: number): Promise<readonly SemanticFact[]>;
+  get(id: string): Promise<SemanticFact | undefined>;
+  history(id: string): Promise<readonly SemanticFact[]>;
+  listForRecall(scope: MemoryRecallScope, now: Date): Promise<readonly SemanticFact[]>;
+  searchForRecall(
+    scope: MemoryRecallScope,
+    query: string,
+    limit: number,
+    now: Date,
+  ): Promise<readonly SemanticFact[]>;
+  getForRecall(scope: MemoryRecallScope, id: string, now: Date): Promise<SemanticFact | undefined>;
+  getEvidenceForRecall(
+    scope: MemoryRecallScope,
+    messageId: string,
+    now: Date,
+  ): Promise<MemoryEvidenceEnvelope | undefined>;
+  revise(input: SemanticFactRevisionInput): Promise<SemanticFact>;
+  verify(input: {
+    readonly id: string;
+    readonly expectedRevision: number;
+    readonly actorRef: MemorySubjectRef;
+    readonly reason: string;
+    readonly now: Date;
+  }): Promise<SemanticFact>;
+  invalidate(input: {
+    readonly id: string;
+    readonly expectedRevision: number;
+    readonly actorRef: MemorySubjectRef;
+    readonly reason: string;
+    readonly now: Date;
+  }): Promise<SemanticFact>;
+  inspect(): Promise<SemanticMemoryStoreDiagnostic>;
+  close(): void;
+}
+
+export async function createSemanticMemoryStore(
+  options: { readonly pragmaHome?: string | undefined } = {},
+): Promise<SemanticMemoryStore> {
+  const paths = new PragmaPaths(options);
+  const moduleId = "pragma.memory.semantic";
+  const dataRoot = paths.memoryModuleDataRoot(moduleId);
+  const stateRoot = paths.memoryModuleStateRoot(moduleId);
+  await Promise.all([
+    mkdir(dataRoot, { recursive: true, mode: 0o700 }),
+    mkdir(stateRoot, { recursive: true, mode: 0o700 }),
+  ]);
+  const data = new DatabaseSync(join(dataRoot, "facts.sqlite"));
+  const state = new DatabaseSync(join(stateRoot, "jobs.sqlite"));
+  try {
+    initializeData(data);
+    initializeState(state);
+  } catch (error) {
+    tryClose(data);
+    tryClose(state);
+    throw error;
+  }
+
+  const writeJob = (job: SemanticExtractionJob): void => {
+    state
+      .prepare(
+        `INSERT INTO jobs(id, execution_id, terminal_message_id, status, retry_at, lease_until, job_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET status=excluded.status, retry_at=excluded.retry_at,
+           lease_until=excluded.lease_until, job_json=excluded.job_json`,
+      )
+      .run(
+        job.id,
+        job.executionId,
+        job.terminalMessageId,
+        job.status,
+        job.retryAt ?? null,
+        job.leaseUntil ?? null,
+        JSON.stringify(job),
+      );
+  };
+
+  const finishJob = (job: SemanticExtractionJob, completion: "retained" | "rejected"): void => {
+    const finished = SemanticExtractionJobSchema.parse({
+      ...job,
+      status: "completed",
+      completion,
+      retryAt: undefined,
+      leaseUntil: undefined,
+      lastErrorCode: undefined,
+      updatedAt: new Date().toISOString(),
+    });
+    writeJob(finished);
+    state.prepare("DELETE FROM evidence WHERE execution_id = ?").run(job.executionId);
+  };
+
+  const governanceMutation = (
+    action: "revise" | "verify" | "invalidate",
+    input: {
+      readonly id: string;
+      readonly expectedRevision: number;
+      readonly actorRef: MemorySubjectRef;
+      readonly reason: string;
+      readonly now: Date;
+    },
+    mutate: (current: SemanticFact) => SemanticFact,
+  ): SemanticFact => {
+    data.exec("BEGIN IMMEDIATE;");
+    try {
+      const current = readFact(data, input.id);
+      if (current === undefined) throw new Error("semantic_fact_not_found");
+      if (current.revision !== input.expectedRevision) {
+        throw revisionConflict(input.expectedRevision, current.revision);
+      }
+      let next = SemanticFactSchema.parse(mutate(current));
+      assertNoDuplicate(data, next);
+      persistFactRevision(data, next);
+      const mutable = new Set([next.id]);
+      recomputeConflicts(data, mutable);
+      next = readRequiredFact(data, next.id);
+      const event = SemanticGovernanceEventSchema.parse({
+        schemaVersion: "pragma.memory-semantic-governance-event/v1",
+        id: randomUUID(),
+        factId: next.id,
+        previousRevision: current.revision,
+        revision: next.revision,
+        action,
+        reason: input.reason,
+        actorRef: input.actorRef,
+        occurredAt: input.now.toISOString(),
+      });
+      insertGovernanceEvent(data, event);
+      data.exec("COMMIT;");
+      return next;
+    } catch (error) {
+      rollback(data);
+      throw error;
+    }
+  };
+
+  return {
+    async ingest(envelopes) {
+      if (envelopes.length === 0) return;
+      const insertEvidence = state.prepare(
+        `INSERT OR IGNORE INTO evidence(message_id, execution_id, occurred_at, envelope_json)
+         VALUES (?, ?, ?, ?)`,
+      );
+      state.exec("BEGIN IMMEDIATE;");
+      try {
+        for (const raw of envelopes) {
+          const envelope = MemoryEvidenceEnvelopeSchema.parse(raw);
+          if (envelope.correlationId === undefined) continue;
+          insertEvidence.run(
+            envelope.messageId,
+            envelope.correlationId,
+            envelope.occurredAt,
+            JSON.stringify(envelope),
+          );
+          if (envelope.topic !== "execution.execution.terminal") continue;
+          const id = semanticJobId(envelope.messageId);
+          if (readJob(state, id) !== undefined) continue;
+          writeJob(
+            SemanticExtractionJobSchema.parse({
+              schemaVersion: "pragma.memory-semantic-job/v1",
+              id,
+              executionId: envelope.correlationId,
+              terminalMessageId: envelope.messageId,
+              status: "pending",
+              attempts: 0,
+              updatedAt: envelope.occurredAt,
+            }),
+          );
+        }
+        state.exec("COMMIT;");
+      } catch (error) {
+        rollback(state);
+        throw error;
+      }
+    },
+
+    async registerSubjectContext(raw) {
+      const context = SemanticExecutionSubjectContextSchema.parse(raw);
+      state
+        .prepare(
+          `INSERT INTO subject_contexts(execution_id, context_json) VALUES (?, ?)
+           ON CONFLICT(execution_id) DO UPDATE SET context_json=excluded.context_json`,
+        )
+        .run(context.executionId, JSON.stringify(context));
+      const rows = state
+        .prepare(
+          "SELECT job_json AS jobJson FROM jobs WHERE execution_id = ? AND status = 'needs_attention'",
+        )
+        .all(context.executionId) as unknown as readonly { readonly jobJson: string }[];
+      for (const row of rows) {
+        const job = SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
+        if (job.lastErrorCode !== "semantic_subject_context_missing") continue;
+        writeJob(
+          SemanticExtractionJobSchema.parse({
+            ...job,
+            status: "pending",
+            retryAt: context.registeredAt,
+            lastErrorCode: undefined,
+            updatedAt: context.registeredAt,
+          }),
+        );
+      }
+    },
+
+    async getSubjectContext(executionId) {
+      const row = state
+        .prepare("SELECT context_json AS contextJson FROM subject_contexts WHERE execution_id = ?")
+        .get(executionId) as { readonly contextJson: string } | undefined;
+      return row === undefined
+        ? undefined
+        : SemanticExecutionSubjectContextSchema.parse(JSON.parse(row.contextJson));
+    },
+
+    async claimDueJob(now) {
+      state.exec("BEGIN IMMEDIATE;");
+      try {
+        const row = state
+          .prepare(
+            `SELECT job_json AS jobJson FROM jobs
+             WHERE (status = 'pending' AND (retry_at IS NULL OR retry_at <= ?))
+                OR (status = 'running' AND lease_until <= ?)
+             ORDER BY retry_at IS NOT NULL, retry_at, id LIMIT 1`,
+          )
+          .get(now.toISOString(), now.toISOString()) as unknown as
+          { readonly jobJson: string } | undefined;
+        if (row === undefined) {
+          state.exec("COMMIT;");
+          return undefined;
+        }
+        const current = SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
+        const claimed = SemanticExtractionJobSchema.parse({
+          ...current,
+          status: "running",
+          attempts: current.attempts + 1,
+          retryAt: undefined,
+          leaseUntil: new Date(now.getTime() + 5 * 60_000).toISOString(),
+          updatedAt: now.toISOString(),
+        });
+        writeJob(claimed);
+        state.exec("COMMIT;");
+        return claimed;
+      } catch (error) {
+        rollback(state);
+        throw error;
+      }
+    },
+
+    async readEvidence(executionId) {
+      const rows = state
+        .prepare(
+          "SELECT envelope_json AS envelopeJson FROM evidence WHERE execution_id = ? ORDER BY occurred_at, message_id",
+        )
+        .all(executionId) as unknown as readonly { readonly envelopeJson: string }[];
+      const retained = data
+        .prepare(
+          `SELECT DISTINCT e.envelope_json AS envelopeJson FROM evidence e
+           JOIN fact_evidence fe ON fe.evidence_id = e.message_id
+           JOIN current_facts f ON f.id = fe.fact_id
+           WHERE json_extract(e.envelope_json, '$.correlationId') = ?`,
+        )
+        .all(executionId) as unknown as readonly { readonly envelopeJson: string }[];
+      const unique = new Map<string, MemoryEvidenceEnvelope>();
+      for (const row of [...retained, ...rows]) {
+        const envelope = MemoryEvidenceEnvelopeSchema.parse(JSON.parse(row.envelopeJson));
+        unique.set(envelope.messageId, envelope);
+      }
+      return [...unique.values()]
+        .toSorted(
+          (left, right) =>
+            left.occurredAt.localeCompare(right.occurredAt) ||
+            left.messageId.localeCompare(right.messageId),
+        )
+        .slice(-2_000);
+    },
+
+    async hasAppliedJob(jobId) {
+      return (
+        data.prepare("SELECT 1 AS found FROM applied_jobs WHERE job_id = ?").get(jobId) !==
+        undefined
+      );
+    },
+
+    async completePreviouslyApplied(job) {
+      state.exec("BEGIN IMMEDIATE;");
+      try {
+        finishJob(job, "retained");
+        state.exec("COMMIT;");
+      } catch (error) {
+        rollback(state);
+        throw error;
+      }
+    },
+
+    async completeRetained(input) {
+      const evidenceById = new Map(input.evidence.map((item) => [item.messageId, item]));
+      const touched = new Set<string>();
+      data.exec("BEGIN IMMEDIATE;");
+      try {
+        if (data.prepare("SELECT 1 FROM applied_jobs WHERE job_id = ?").get(input.job.id)) {
+          data.exec("COMMIT;");
+        } else {
+          for (const candidate of input.candidates) {
+            const subjects = uniqueRefs(candidate.subjectRefs);
+            let existing = findEquivalentFact(data, subjects, candidate);
+            const cited = candidate.evidenceRefs.map((id) => {
+              const envelope = evidenceById.get(id);
+              if (envelope === undefined) throw new Error(`semantic_evidence_ref_invalid:${id}`);
+              return envelope;
+            });
+            const observedAt = cited
+              .map((item) => item.occurredAt)
+              .toSorted()
+              .at(-1)!;
+            const mergedVisibility =
+              existing === undefined
+                ? input.visibility
+                : intersectVisibility(existing.visibility, input.visibility);
+            if (mergedVisibility === undefined) existing = undefined;
+            const timestamp = input.now.toISOString();
+            const priorRevision = existing?.revision;
+            const id = existing?.id ?? semanticFactId(input.job.id, candidate);
+            const record = SemanticFactSchema.parse({
+              schemaVersion: "pragma.memory-semantic/v1",
+              id,
+              revision: (existing?.revision ?? 0) + 1,
+              statement: candidate.statement,
+              subjectRefs: subjects,
+              predicate: candidate.predicate,
+              normalizedValue: candidate.normalizedValue,
+              conflictMode: candidate.conflictMode,
+              confidence: Math.max(existing?.confidence ?? 0, candidate.confidence),
+              observedAt:
+                existing === undefined
+                  ? observedAt
+                  : [existing.observedAt, observedAt].toSorted()[0],
+              ...(existing?.verifiedAt === undefined ? {} : { verifiedAt: existing.verifiedAt }),
+              ...optionalTime("reviewAt", earliestTime(existing?.reviewAt, candidate.reviewAt)),
+              ...optionalTime("expiresAt", earliestTime(existing?.expiresAt, candidate.expiresAt)),
+              evidenceRefs: uniqueStrings([
+                ...(existing?.evidenceRefs ?? []),
+                ...candidate.evidenceRefs,
+              ]),
+              conflictsWith: existing?.conflictsWith ?? [],
+              supersedes:
+                priorRevision === undefined
+                  ? []
+                  : appendRevisionRef(existing!.supersedes, id, priorRevision),
+              status: "active",
+              visibility: mergedVisibility ?? input.visibility,
+              sensitivity: strictestSensitivity(existing?.sensitivity, input.sensitivity),
+              bindings: mergeBindings(existing?.bindings ?? [], input.rootRef),
+              rootRefs: uniqueRefs([...(existing?.rootRefs ?? []), input.rootRef]),
+              producerRefs: uniqueRefs([...(existing?.producerRefs ?? []), ...input.producerRefs]),
+              extractor: input.extractor,
+              createdAt: existing?.createdAt ?? timestamp,
+              updatedAt: timestamp,
+            });
+            persistFactRevision(data, record);
+            touched.add(record.id);
+            for (const envelope of cited) {
+              data
+                .prepare(
+                  "INSERT OR IGNORE INTO evidence(message_id, occurred_at, envelope_json) VALUES (?, ?, ?)",
+                )
+                .run(envelope.messageId, envelope.occurredAt, JSON.stringify(envelope));
+              data
+                .prepare("INSERT OR IGNORE INTO fact_evidence(fact_id, evidence_id) VALUES (?, ?)")
+                .run(record.id, envelope.messageId);
+            }
+          }
+          recomputeConflicts(data, touched);
+          data
+            .prepare(
+              "INSERT INTO applied_jobs(job_id, terminal_message_id, applied_at) VALUES (?, ?, ?)",
+            )
+            .run(input.job.id, input.job.terminalMessageId, input.now.toISOString());
+          data.exec("COMMIT;");
+        }
+      } catch (error) {
+        rollback(data);
+        throw error;
+      }
+      state.exec("BEGIN IMMEDIATE;");
+      try {
+        finishJob(input.job, "retained");
+        state.exec("COMMIT;");
+      } catch (error) {
+        rollback(state);
+        throw error;
+      }
+      return [...touched].map((id) => readRequiredFact(data, id));
+    },
+
+    async completeRejected(job, reason) {
+      state.exec("BEGIN IMMEDIATE;");
+      try {
+        finishJob(job, "rejected");
+        incrementCounter(state, "rejected_total");
+        incrementCounter(state, `rejected_${reason.replaceAll("-", "_")}`);
+        state.exec("COMMIT;");
+      } catch (error) {
+        rollback(state);
+        throw error;
+      }
+    },
+
+    async fail(input) {
+      const needsAttention = input.retry === "configuration" || input.job.attempts >= 3;
+      const delay = input.job.attempts <= 1 ? 60_000 : 5 * 60_000;
+      writeJob(
+        SemanticExtractionJobSchema.parse({
+          ...input.job,
+          status: needsAttention ? "needs_attention" : "pending",
+          leaseUntil: undefined,
+          ...(needsAttention
+            ? { retryAt: undefined }
+            : { retryAt: new Date(input.now.getTime() + delay).toISOString() }),
+          lastErrorCode: input.errorCode,
+          updatedAt: input.now.toISOString(),
+        }),
+      );
+    },
+
+    async wakeNeedsAttention(now) {
+      const rows = state
+        .prepare("SELECT job_json AS jobJson FROM jobs WHERE status = 'needs_attention'")
+        .all() as unknown as readonly { readonly jobJson: string }[];
+      for (const row of rows) {
+        const job = SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
+        writeJob(
+          SemanticExtractionJobSchema.parse({
+            ...job,
+            status: "pending",
+            retryAt: now.toISOString(),
+            lastErrorCode: undefined,
+            updatedAt: now.toISOString(),
+          }),
+        );
+      }
+    },
+
+    async list() {
+      return readFactRows(
+        data
+          .prepare(
+            "SELECT record_json AS recordJson FROM current_facts ORDER BY updated_at DESC, id",
+          )
+          .all(),
+      );
+    },
+
+    async search(query, limit) {
+      return searchFacts(data, undefined, query, limit, new Date(8640000000000000));
+    },
+
+    async get(id) {
+      return readFact(data, id);
+    },
+
+    async history(id) {
+      return readFactRows(
+        data
+          .prepare(
+            "SELECT record_json AS recordJson FROM fact_revisions WHERE fact_id = ? ORDER BY revision DESC",
+          )
+          .all(id),
+      );
+    },
+
+    async listForRecall(scope, now) {
+      const access = recallPredicate("current_facts", scope, now);
+      return readFactRows(
+        data
+          .prepare(
+            `SELECT record_json AS recordJson FROM current_facts WHERE ${access.sql}
+             ORDER BY json_extract(record_json, '$.verifiedAt') IS NOT NULL DESC,
+               json_extract(record_json, '$.confidence') DESC, updated_at DESC, id`,
+          )
+          .all(...access.parameters),
+      );
+    },
+
+    async searchForRecall(scope, query, limit, now) {
+      return searchFacts(data, scope, query, limit, now);
+    },
+
+    async getForRecall(scope, id, now) {
+      const access = recallPredicate("current_facts", scope, now);
+      const row = data
+        .prepare(
+          `SELECT record_json AS recordJson FROM current_facts WHERE id = ? AND ${access.sql}`,
+        )
+        .get(id, ...access.parameters) as { readonly recordJson: string } | undefined;
+      return row === undefined ? undefined : SemanticFactSchema.parse(JSON.parse(row.recordJson));
+    },
+
+    async getEvidenceForRecall(scope, messageId, now) {
+      const access = recallPredicate("f", scope, now);
+      const row = data
+        .prepare(
+          `SELECT e.envelope_json AS envelopeJson FROM evidence e
+           JOIN fact_evidence fe ON fe.evidence_id = e.message_id
+           JOIN current_facts f ON f.id = fe.fact_id
+           WHERE e.message_id = ? AND ${access.sql} LIMIT 1`,
+        )
+        .get(messageId, ...access.parameters) as { readonly envelopeJson: string } | undefined;
+      return row === undefined
+        ? undefined
+        : MemoryEvidenceEnvelopeSchema.parse(JSON.parse(row.envelopeJson));
+    },
+
+    async revise(input) {
+      return governanceMutation("revise", input, (current) => {
+        const timestamp = input.now.toISOString();
+        return SemanticFactSchema.parse({
+          ...current,
+          ...definedPatch(input.patch),
+          revision: current.revision + 1,
+          supersedes: appendRevisionRef(current.supersedes, current.id, current.revision),
+          updatedAt: timestamp,
+        });
+      });
+    },
+
+    async verify(input) {
+      return governanceMutation("verify", input, (current) => ({
+        ...current,
+        revision: current.revision + 1,
+        confidence: 1,
+        verifiedAt: input.now.toISOString(),
+        supersedes: appendRevisionRef(current.supersedes, current.id, current.revision),
+        updatedAt: input.now.toISOString(),
+      }));
+    },
+
+    async invalidate(input) {
+      return governanceMutation("invalidate", input, (current) => ({
+        ...current,
+        revision: current.revision + 1,
+        status: "invalidated",
+        invalidatedAt: input.now.toISOString(),
+        supersedes: appendRevisionRef(current.supersedes, current.id, current.revision),
+        updatedAt: input.now.toISOString(),
+      }));
+    },
+
+    async inspect() {
+      const byStatus = new Map(
+        (
+          state
+            .prepare("SELECT status, COUNT(*) AS count FROM jobs GROUP BY status")
+            .all() as unknown as readonly {
+            readonly status: string;
+            readonly count: number;
+          }[]
+        ).map((row) => [row.status, row.count]),
+      );
+      const counters = new Map(
+        (
+          state
+            .prepare("SELECT name, value FROM counters WHERE name LIKE 'rejected_%'")
+            .all() as unknown as readonly { readonly name: string; readonly value: number }[]
+        ).map((row) => [row.name, row.value]),
+      );
+      const facts = data
+        .prepare("SELECT COUNT(*) AS count FROM current_facts")
+        .get() as unknown as {
+        readonly count: number;
+      };
+      return {
+        facts: facts.count,
+        pending: byStatus.get("pending") ?? 0,
+        running: byStatus.get("running") ?? 0,
+        needsAttention: byStatus.get("needs_attention") ?? 0,
+        rejected: counters.get("rejected_total") ?? 0,
+        rejectedByReason: {
+          "no-stable-fact": counters.get("rejected_no_stable_fact") ?? 0,
+          "insufficient-evidence": counters.get("rejected_insufficient_evidence") ?? 0,
+          sensitive: counters.get("rejected_sensitive") ?? 0,
+          policy: counters.get("rejected_policy") ?? 0,
+        },
+      };
+    },
+
+    close() {
+      state.close();
+      data.close();
+    },
+  };
+}
+
+export function semanticFactId(jobId: string, candidate: SemanticFactCandidate): string {
+  return `fact-${createHash("sha256")
+    .update(
+      JSON.stringify([
+        jobId,
+        subjectKey(candidate.subjectRefs),
+        candidate.predicate,
+        candidate.normalizedValue,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 24)}`;
+}
+
+function semanticJobId(terminalMessageId: string): string {
+  return `semantic-${createHash("sha256").update(terminalMessageId).digest("hex").slice(0, 24)}`;
+}
+
+function initializeData(database: DatabaseSync): void {
+  assertVersion(database, "pragma.memory-semantic-store");
+  database.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = FULL;
+    CREATE TABLE IF NOT EXISTS current_facts (
+      id TEXT PRIMARY KEY,
+      revision INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      record_json TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS semantic_facts_status_updated
+      ON current_facts(status, updated_at DESC);
+    CREATE TABLE IF NOT EXISTS fact_revisions (
+      fact_id TEXT NOT NULL,
+      revision INTEGER NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (fact_id, revision)
+    );
+    CREATE TABLE IF NOT EXISTS evidence (
+      message_id TEXT PRIMARY KEY,
+      occurred_at TEXT NOT NULL,
+      envelope_json TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS fact_evidence (
+      fact_id TEXT NOT NULL,
+      evidence_id TEXT NOT NULL,
+      PRIMARY KEY (fact_id, evidence_id),
+      FOREIGN KEY (fact_id) REFERENCES current_facts(id) ON DELETE CASCADE,
+      FOREIGN KEY (evidence_id) REFERENCES evidence(message_id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS applied_jobs (
+      job_id TEXT PRIMARY KEY,
+      terminal_message_id TEXT NOT NULL,
+      applied_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS governance_events (
+      id TEXT PRIMARY KEY,
+      fact_id TEXT NOT NULL,
+      revision INTEGER NOT NULL,
+      event_json TEXT NOT NULL
+    );
+    PRAGMA user_version = 1;
+  `);
+}
+
+function initializeState(database: DatabaseSync): void {
+  assertVersion(database, "pragma.memory-semantic-jobs");
+  database.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = FULL;
+    CREATE TABLE IF NOT EXISTS evidence (
+      message_id TEXT PRIMARY KEY,
+      execution_id TEXT NOT NULL,
+      occurred_at TEXT NOT NULL,
+      envelope_json TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS semantic_evidence_execution
+      ON evidence(execution_id, occurred_at);
+    CREATE TABLE IF NOT EXISTS jobs (
+      id TEXT PRIMARY KEY,
+      execution_id TEXT NOT NULL,
+      terminal_message_id TEXT NOT NULL UNIQUE,
+      status TEXT NOT NULL,
+      retry_at TEXT,
+      lease_until TEXT,
+      job_json TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS semantic_jobs_due ON jobs(status, retry_at, lease_until);
+    CREATE TABLE IF NOT EXISTS subject_contexts (
+      execution_id TEXT PRIMARY KEY,
+      context_json TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS counters (name TEXT PRIMARY KEY, value INTEGER NOT NULL);
+    PRAGMA user_version = 1;
+  `);
+}
+
+function assertVersion(database: DatabaseSync, family: string): void {
+  const row = database.prepare("PRAGMA user_version").get() as unknown as {
+    readonly user_version: number;
+  };
+  if (row.user_version > 1) {
+    database.close();
+    throw new Error(`unsupported-state-version:${family}/v${row.user_version}`);
+  }
+}
+
+function readJob(database: DatabaseSync, id: string): SemanticExtractionJob | undefined {
+  const row = database.prepare("SELECT job_json AS jobJson FROM jobs WHERE id = ?").get(id) as
+    { readonly jobJson: string } | undefined;
+  return row === undefined ? undefined : SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
+}
+
+function readFact(database: DatabaseSync, id: string): SemanticFact | undefined {
+  const row = database
+    .prepare("SELECT record_json AS recordJson FROM current_facts WHERE id = ?")
+    .get(id) as { readonly recordJson: string } | undefined;
+  return row === undefined ? undefined : SemanticFactSchema.parse(JSON.parse(row.recordJson));
+}
+
+function readRequiredFact(database: DatabaseSync, id: string): SemanticFact {
+  const fact = readFact(database, id);
+  if (fact === undefined) throw new Error("semantic_fact_not_found");
+  return fact;
+}
+
+function readFactRows(rows: readonly unknown[]): SemanticFact[] {
+  return (rows as readonly { readonly recordJson: string }[]).map((row) =>
+    SemanticFactSchema.parse(JSON.parse(row.recordJson)),
+  );
+}
+
+function persistFactRevision(database: DatabaseSync, fact: SemanticFact): void {
+  const record = SemanticFactSchema.parse(fact);
+  database
+    .prepare(
+      `INSERT INTO current_facts(id, revision, status, updated_at, record_json)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET revision=excluded.revision, status=excluded.status,
+         updated_at=excluded.updated_at, record_json=excluded.record_json`,
+    )
+    .run(record.id, record.revision, record.status, record.updatedAt, JSON.stringify(record));
+  database
+    .prepare("INSERT INTO fact_revisions(fact_id, revision, record_json) VALUES (?, ?, ?)")
+    .run(record.id, record.revision, JSON.stringify(record));
+}
+
+function replaceCurrentRevision(database: DatabaseSync, fact: SemanticFact): void {
+  const record = SemanticFactSchema.parse(fact);
+  database
+    .prepare("UPDATE current_facts SET status = ?, updated_at = ?, record_json = ? WHERE id = ?")
+    .run(record.status, record.updatedAt, JSON.stringify(record), record.id);
+  database
+    .prepare("UPDATE fact_revisions SET record_json = ? WHERE fact_id = ? AND revision = ?")
+    .run(JSON.stringify(record), record.id, record.revision);
+}
+
+function findEquivalentFact(
+  database: DatabaseSync,
+  subjects: readonly MemorySubjectRef[],
+  candidate: Pick<SemanticFactCandidate, "predicate" | "normalizedValue">,
+): SemanticFact | undefined {
+  return readFactRows(
+    database
+      .prepare(
+        `SELECT record_json AS recordJson FROM current_facts
+         WHERE status = 'active'
+           AND json_extract(record_json, '$.predicate') = ?
+           AND json_extract(record_json, '$.normalizedValue') = ?`,
+      )
+      .all(candidate.predicate, candidate.normalizedValue),
+  ).find((fact) => subjectKey(fact.subjectRefs) === subjectKey(subjects));
+}
+
+function assertNoDuplicate(database: DatabaseSync, fact: SemanticFact): void {
+  const duplicate = findEquivalentFact(database, fact.subjectRefs, fact);
+  if (
+    duplicate !== undefined &&
+    duplicate.id !== fact.id &&
+    intersectVisibility(duplicate.visibility, fact.visibility) !== undefined
+  ) {
+    throw new Error("semantic_fact_duplicate");
+  }
+}
+
+function recomputeConflicts(database: DatabaseSync, mutable: ReadonlySet<string>): void {
+  const facts = readFactRows(
+    database
+      .prepare("SELECT record_json AS recordJson FROM current_facts WHERE status = 'active'")
+      .all(),
+  );
+  const desired = new Map<string, Set<string>>(facts.map((fact) => [fact.id, new Set()]));
+  for (let leftIndex = 0; leftIndex < facts.length; leftIndex += 1) {
+    const left = facts[leftIndex]!;
+    for (let rightIndex = leftIndex + 1; rightIndex < facts.length; rightIndex += 1) {
+      const right = facts[rightIndex]!;
+      if (
+        left.conflictMode !== "exclusive" ||
+        right.conflictMode !== "exclusive" ||
+        left.predicate !== right.predicate ||
+        left.normalizedValue === right.normalizedValue ||
+        subjectKey(left.subjectRefs) !== subjectKey(right.subjectRefs)
+      ) {
+        continue;
+      }
+      desired.get(left.id)!.add(right.id);
+      desired.get(right.id)!.add(left.id);
+    }
+  }
+  for (const fact of facts) {
+    const conflictsWith = [...desired.get(fact.id)!].toSorted();
+    if (sameStrings(fact.conflictsWith, conflictsWith)) continue;
+    if (mutable.has(fact.id)) {
+      replaceCurrentRevision(database, SemanticFactSchema.parse({ ...fact, conflictsWith }));
+      continue;
+    }
+    persistFactRevision(
+      database,
+      SemanticFactSchema.parse({
+        ...fact,
+        revision: fact.revision + 1,
+        conflictsWith,
+        supersedes: appendRevisionRef(fact.supersedes, fact.id, fact.revision),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+  }
+}
+
+function searchFacts(
+  database: DatabaseSync,
+  scope: MemoryRecallScope | undefined,
+  query: string,
+  limit: number,
+  now: Date,
+): SemanticFact[] {
+  const escaped = query
+    .trim()
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+  const normalizedLimit = Math.max(1, Math.min(100, Math.trunc(limit)));
+  const access = scope === undefined ? undefined : recallPredicate("current_facts", scope, now);
+  return readFactRows(
+    database
+      .prepare(
+        `SELECT record_json AS recordJson FROM current_facts
+         WHERE lower(record_json) LIKE lower(?) ESCAPE '\\'
+           ${access === undefined ? "" : `AND ${access.sql}`}
+         ORDER BY json_extract(record_json, '$.verifiedAt') IS NOT NULL DESC,
+           json_extract(record_json, '$.confidence') DESC, updated_at DESC, id LIMIT ?`,
+      )
+      .all(`%${escaped}%`, ...(access?.parameters ?? []), normalizedLimit),
+  );
+}
+
+function recallPredicate(
+  alias: "current_facts" | "f",
+  scope: MemoryRecallScope,
+  now: Date,
+): { readonly sql: string; readonly parameters: readonly string[] } {
+  const refs = uniqueRefs([scope.rootRef, scope.expertRef]);
+  const clauses = refs.map(
+    () =>
+      `EXISTS (
+        SELECT 1 FROM json_each(${alias}.record_json, '$.bindings') AS binding
+        WHERE json_extract(binding.value, '$.consumerRef.type') = ?
+          AND json_extract(binding.value, '$.consumerRef.id') = ?
+          AND json_extract(binding.value, '$.recall') = 'allow'
+      )`,
+  );
+  return {
+    sql: `json_extract(${alias}.record_json, '$.status') = 'active'
+      AND json_extract(${alias}.record_json, '$.visibility.mode') != 'restricted'
+      AND (json_extract(${alias}.record_json, '$.expiresAt') IS NULL
+        OR json_extract(${alias}.record_json, '$.expiresAt') > ?)
+      AND (${clauses.join(" OR ")})`,
+    parameters: [now.toISOString(), ...refs.flatMap((ref) => [ref.type, ref.id])],
+  };
+}
+
+function insertGovernanceEvent(database: DatabaseSync, event: SemanticGovernanceEvent): void {
+  database
+    .prepare("INSERT INTO governance_events(id, fact_id, revision, event_json) VALUES (?, ?, ?, ?)")
+    .run(event.id, event.factId, event.revision, JSON.stringify(event));
+}
+
+function definedPatch(patch: SemanticFactRevisionInput["patch"]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) result[key] = value === null ? undefined : value;
+  }
+  return result;
+}
+
+function intersectVisibility(
+  left: MemoryVisibilityPolicy,
+  right: MemoryVisibilityPolicy,
+): MemoryVisibilityPolicy | undefined {
+  if (left.mode === "restricted" && right.mode === "restricted") {
+    const rightPrincipals = new Set(right.principals.map(refKey));
+    const principals = left.principals.filter((ref) => rightPrincipals.has(refKey(ref)));
+    return principals.length === 0 ? undefined : { mode: "restricted", principals };
+  }
+  if (left.mode === "restricted") return left;
+  if (right.mode === "restricted") return right;
+  if (left.mode === "host-private" || right.mode === "host-private") {
+    return { mode: "host-private" };
+  }
+  return { mode: "public" };
+}
+
+function strictestSensitivity(
+  left: SemanticFact["sensitivity"] | undefined,
+  right: SemanticFact["sensitivity"],
+): SemanticFact["sensitivity"] {
+  if (left === undefined) return right;
+  const order = ["public", "internal", "confidential", "restricted"] as const;
+  return order[Math.max(order.indexOf(left), order.indexOf(right))]!;
+}
+
+function earliestTime(left: string | undefined, right: string | undefined): string | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return [left, right].toSorted()[0];
+}
+
+function optionalTime(
+  key: "reviewAt" | "expiresAt",
+  value: string | undefined,
+): Record<string, string> {
+  return value === undefined ? {} : { [key]: value };
+}
+
+function mergeBindings(
+  existing: readonly MemoryRevisionBinding[],
+  rootRef: MemorySubjectRef,
+): MemoryRevisionBinding[] {
+  const byRef = new Map(existing.map((binding) => [refKey(binding.consumerRef), binding]));
+  if (!byRef.has(refKey(rootRef))) {
+    byRef.set(refKey(rootRef), {
+      consumerRef: rootRef,
+      recall: "allow",
+      export: "deny",
+      permissionRevision: 1,
+    });
+  }
+  return [...byRef.values()].map((binding) => ({ ...binding, export: "deny" as const }));
+}
+
+function appendRevisionRef(
+  refs: readonly { readonly factId: string; readonly revision: number }[],
+  factId: string,
+  revision: number,
+) {
+  return [...refs, { factId, revision }].slice(-100);
+}
+
+function subjectKey(refs: readonly MemorySubjectRef[]): string {
+  return uniqueRefs(refs)
+    .map((ref) => `${ref.type}\0${ref.id}`)
+    .toSorted()
+    .join("\x01");
+}
+
+function refKey(ref: MemorySubjectRef): string {
+  return `${ref.type}\0${ref.id}`;
+}
+
+function uniqueRefs(refs: readonly MemorySubjectRef[]): MemorySubjectRef[] {
+  return [...new Map(refs.map((ref) => [`${ref.type}\0${ref.id}`, ref])).values()].toSorted(
+    (left, right) => left.type.localeCompare(right.type) || left.id.localeCompare(right.id),
+  );
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)].toSorted();
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function revisionConflict(expected: number, actual: number): Error {
+  const error = new Error("semantic_fact_revision_conflict");
+  Object.assign(error, { expected, actual });
+  return error;
+}
+
+function incrementCounter(database: DatabaseSync, name: string): void {
+  database
+    .prepare(
+      `INSERT INTO counters(name, value) VALUES (?, 1)
+       ON CONFLICT(name) DO UPDATE SET value = value + 1`,
+    )
+    .run(name);
+}
+
+function rollback(database: DatabaseSync): void {
+  try {
+    database.exec("ROLLBACK;");
+  } catch {
+    // No transaction remained active.
+  }
+}
+
+function tryClose(database: DatabaseSync): void {
+  try {
+    database.close();
+  } catch {
+    // Best effort during initialization failure.
+  }
+}

--- a/packages/memory/test/semantic-memory.test.ts
+++ b/packages/memory/test/semantic-memory.test.ts
@@ -1,0 +1,512 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { PragmaPaths } from "@pragma/core";
+import {
+  MemoryEvidenceEnvelopeSchema,
+  type MemoryEvidenceEnvelope,
+  type MemorySubjectRef,
+} from "@pragma/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MemoryModuleRegistry,
+  SemanticExtractionOutputSchema,
+  createFederatedMemoryContextStore,
+  createSemanticMemoryModule,
+  type MemoryRecallScope,
+  type SemanticExtractionInput,
+  type SemanticMemoryExtractor,
+} from "../src/index.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Semantic Memory", () => {
+  it("extracts evidence-traceable facts into the layered Context without Episodic Memory", async () => {
+    const extractor = fakeExtractor();
+    const module = await createSemanticMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor,
+    });
+    await module.registerExecutionSubjects({
+      executionId: "execution-a",
+      subjectRefs: [ref("pragma.user", "local-user"), ref("pragma.project", "project-a")],
+    });
+    const evidence = executionEvidence("execution-a", "Use concise Chinese answers.");
+
+    await module.consume(evidence);
+    await module.runBackgroundOnce?.();
+
+    const facts = await module.store.list();
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({
+      statement: "The user prefers concise Chinese answers.",
+      subjectRefs: [{ type: "pragma.user", id: "local-user" }],
+      predicate: "user.preference.response-language",
+      normalizedValue: "zh-Hans:concise",
+      bindings: [{ consumerRef: { type: "pragma.expert", id: "expert-a" }, export: "deny" }],
+    });
+
+    const registry = new MemoryModuleRegistry();
+    registry.register(module);
+    const context = scopedContext(registry, expertScope("expert-a"));
+    const listed = await context.listContext({});
+    expect(listed.ok && listed.value.map((item) => item.id)).toEqual([
+      "catalog.md",
+      "guide.md",
+      "overview.md",
+      "semantic/index.md",
+      "semantic/summary.md",
+    ]);
+    const detail = await context.readContext({ id: `semantic/items/${facts[0]!.id}.md` });
+    expect(detail.ok && detail.value.content).toContain(
+      "The user prefers concise Chinese answers.",
+    );
+    const evidenceDetail = await context.readContext({
+      id: `semantic/evidence/${evidence[0]!.messageId}.md`,
+    });
+    expect(evidenceDetail.ok && evidenceDetail.value.content).toContain("Safe payload");
+    const search = await context.searchContext({ query: evidence[0]!.messageId });
+    expect(search.ok && search.value.some((item) => item.id.includes("/evidence/"))).toBe(false);
+    module.close();
+  });
+
+  it("merges equivalent observations and preserves exclusive conflicts symmetrically", async () => {
+    const extractor = fakeExtractor((input) => {
+      const text = evidenceText(input);
+      return text.includes("light")
+        ? { statement: "The theme is light.", normalizedValue: "light" }
+        : { statement: "The theme is dark.", normalizedValue: "dark" };
+    });
+    const module = await createSemanticMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor,
+    });
+    for (const [executionId, text] of [
+      ["execution-dark-1", "The theme is dark."],
+      ["execution-dark-2", "The theme is dark."],
+      ["execution-light", "The theme is light."],
+    ] as const) {
+      await module.registerExecutionSubjects({
+        executionId,
+        subjectRefs: [ref("pragma.user", "local-user")],
+      });
+      await module.consume(executionEvidence(executionId, text));
+      await module.runBackgroundOnce?.();
+    }
+
+    const facts = await module.store.list();
+    expect(facts).toHaveLength(2);
+    const dark = facts.find((fact) => fact.normalizedValue === "dark")!;
+    const light = facts.find((fact) => fact.normalizedValue === "light")!;
+    expect(dark.evidenceRefs.length).toBeGreaterThan(1);
+    expect(dark.conflictsWith).toEqual([light.id]);
+    expect(light.conflictsWith).toEqual([dark.id]);
+    expect(dark.status).toBe("active");
+    expect(light.status).toBe("active");
+    module.close();
+  });
+
+  it("finishes an applied job after a crash without invoking the Curator twice", async () => {
+    const root = await temporaryRoot();
+    const extractor = fakeExtractor();
+    const module = await createSemanticMemoryModule({ pragmaHome: root, extractor });
+    await module.registerExecutionSubjects({
+      executionId: "execution-crash",
+      subjectRefs: [ref("pragma.user", "local-user")],
+    });
+    await module.consume(executionEvidence("execution-crash", "Use concise Chinese answers."));
+    await module.runBackgroundOnce?.();
+    simulateJobCompletionCrash(root);
+
+    await module.runBackgroundOnce?.();
+
+    expect(extractor.extract).toHaveBeenCalledOnce();
+    expect((await module.store.inspect()).running).toBe(0);
+    expect(await module.store.list()).toHaveLength(1);
+    module.close();
+  });
+
+  it("isolates bindings across Experts and excludes expired facts from recall", async () => {
+    const now = new Date("2026-08-03T12:00:00.000Z");
+    const extractor = fakeExtractor((input) => ({
+      statement: `Fact for ${input.executionId}`,
+      normalizedValue: input.executionId,
+      ...(input.executionId === "execution-a" ? { expiresAt: "2026-08-03T11:00:00.000Z" } : {}),
+    }));
+    const module = await createSemanticMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor,
+      now: () => now,
+    });
+    for (const [executionId, expertId] of [
+      ["execution-a", "expert-a"],
+      ["execution-b", "expert-b"],
+    ] as const) {
+      await module.registerExecutionSubjects({
+        executionId,
+        subjectRefs: [ref("pragma.user", "local-user")],
+      });
+      await module.consume(executionEvidence(executionId, `Fact for ${expertId}`, expertId));
+      await module.runBackgroundOnce?.();
+    }
+    const registry = new MemoryModuleRegistry();
+    registry.register(module);
+    const contextA = scopedContext(registry, expertScope("expert-a"));
+    const indexA = await contextA.readContext({ id: "semantic/index.md" });
+    expect(indexA.ok && indexA.value.content).not.toContain("execution-a");
+    expect(indexA.ok && indexA.value.content).not.toContain("execution-b");
+    const contextB = scopedContext(registry, expertScope("expert-b"));
+    const indexB = await contextB.readContext({ id: "semantic/index.md" });
+    expect(indexB.ok && indexB.value.content).toContain("execution-b");
+    module.close();
+  });
+
+  it("combines a Team binding with the current Expert personal facts without exposing peers", async () => {
+    const extractor = fakeExtractor((input) => ({
+      statement: `Fact for ${input.executionId}`,
+      normalizedValue: input.executionId,
+    }));
+    const module = await createSemanticMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor,
+    });
+    const cases = [
+      {
+        executionId: "personal-a",
+        rootRef: ref("pragma.expert", "expert-a"),
+        producerRef: ref("pragma.expert", "expert-a"),
+      },
+      {
+        executionId: "personal-b",
+        rootRef: ref("pragma.expert", "expert-b"),
+        producerRef: ref("pragma.expert", "expert-b"),
+      },
+      {
+        executionId: "team-a",
+        rootRef: ref("pragma.expert-team", "team-a"),
+        producerRef: ref("pragma.expert", "expert-a"),
+      },
+    ];
+    for (const item of cases) {
+      await module.registerExecutionSubjects({
+        executionId: item.executionId,
+        subjectRefs: [ref("pragma.user", "local-user")],
+      });
+      await module.consume(
+        executionEvidenceForRoot(
+          item.executionId,
+          `Fact for ${item.executionId}`,
+          item.rootRef,
+          item.producerRef,
+        ),
+      );
+      await module.runBackgroundOnce?.();
+    }
+
+    const registry = new MemoryModuleRegistry();
+    registry.register(module);
+    const team = scopedContext(registry, {
+      rootRef: { type: "pragma.expert-team", id: "team-a" },
+      expertRef: { type: "pragma.expert", id: "expert-a" },
+    });
+    const index = await team.readContext({ id: "semantic/index.md" });
+    expect(index.ok && index.value.content).toMatch(
+      /team-a[\s\S]*personal-a|personal-a[\s\S]*team-a/,
+    );
+    expect(index.ok && index.value.content).not.toContain("personal-b");
+    const foreign = (await module.store.list()).find(
+      (fact) => fact.normalizedValue === "personal-b",
+    )!;
+    await expect(
+      team.readContext({ id: `semantic/items/${foreign.id}.md` }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "context_not_found" } });
+    module.close();
+  });
+
+  it("keeps immutable revision history for correction, verification, and invalidation", async () => {
+    const module = await createSemanticMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor: fakeExtractor(),
+    });
+    await module.registerExecutionSubjects({
+      executionId: "execution-governance",
+      subjectRefs: [ref("pragma.user", "local-user")],
+    });
+    await module.consume(executionEvidence("execution-governance", "Use concise Chinese answers."));
+    await module.runBackgroundOnce?.();
+    const initial = (await module.store.list())[0]!;
+    const actorRef = ref("pragma.user", "local-user");
+    const revised = await module.store.revise({
+      id: initial.id,
+      expectedRevision: initial.revision,
+      actorRef,
+      reason: "User corrected the preference.",
+      patch: {
+        statement: "The user prefers detailed Chinese answers.",
+        normalizedValue: "zh-Hans:detailed",
+      },
+      now: new Date("2026-08-03T13:00:00.000Z"),
+    });
+    await expect(
+      module.store.verify({
+        id: initial.id,
+        expectedRevision: initial.revision,
+        actorRef,
+        reason: "Stale revision",
+        now: new Date("2026-08-03T13:01:00.000Z"),
+      }),
+    ).rejects.toThrow("semantic_fact_revision_conflict");
+    const verified = await module.store.verify({
+      id: revised.id,
+      expectedRevision: revised.revision,
+      actorRef,
+      reason: "The user explicitly confirmed this preference.",
+      now: new Date("2026-08-03T13:01:00.000Z"),
+    });
+    expect(verified.confidence).toBe(1);
+    const invalidated = await module.store.invalidate({
+      id: verified.id,
+      expectedRevision: verified.revision,
+      actorRef,
+      reason: "The preference is no longer valid.",
+      now: new Date("2026-08-03T13:02:00.000Z"),
+    });
+    expect(invalidated.status).toBe("invalidated");
+    const history = await module.store.history(initial.id);
+    expect(history.map((revision) => revision.revision)).toEqual([4, 3, 2, 1]);
+    expect(history.at(-1)?.statement).toBe("The user prefers concise Chinese answers.");
+    module.close();
+  });
+
+  it("reopens the current store version and rejects a future data version", async () => {
+    const root = await temporaryRoot();
+    const module = await createSemanticMemoryModule({
+      pragmaHome: root,
+      extractor: fakeExtractor(),
+    });
+    module.close();
+
+    const reopened = await createSemanticMemoryModule({
+      pragmaHome: root,
+      extractor: fakeExtractor(),
+    });
+    reopened.close();
+
+    const database = new DatabaseSync(
+      join(
+        new PragmaPaths({ pragmaHome: root }).memoryModuleDataRoot("pragma.memory.semantic"),
+        "facts.sqlite",
+      ),
+    );
+    database.exec("PRAGMA user_version = 2");
+    database.close();
+
+    await expect(
+      createSemanticMemoryModule({ pragmaHome: root, extractor: fakeExtractor() }),
+    ).rejects.toThrow("unsupported-state-version:pragma.memory-semantic-store/v2");
+  });
+
+  it("rejects extractor subject and Evidence references outside the supplied allowlists", async () => {
+    const extractor = fakeExtractor(() => ({
+      statement: "Untrusted fact.",
+      normalizedValue: "untrusted",
+      subjectRefs: [ref("pragma.repository", "invented")],
+      evidenceRefs: ["invented-evidence"],
+    }));
+    const module = await createSemanticMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor,
+    });
+    await module.registerExecutionSubjects({
+      executionId: "execution-invalid",
+      subjectRefs: [ref("pragma.user", "local-user")],
+    });
+    await module.consume(executionEvidence("execution-invalid", "Remember this stable fact."));
+    await module.runBackgroundOnce?.();
+    expect(await module.store.list()).toEqual([]);
+    expect((await module.store.inspect()).running).toBe(0);
+    expect(extractor.extract).toHaveBeenCalledOnce();
+    module.close();
+  });
+});
+
+function fakeExtractor(
+  customize: (input: SemanticExtractionInput) => Partial<{
+    statement: string;
+    normalizedValue: string;
+    subjectRefs: readonly MemorySubjectRef[];
+    evidenceRefs: readonly string[];
+    expiresAt: string;
+  }> = () => ({}),
+): SemanticMemoryExtractor & { extract: ReturnType<typeof vi.fn> } {
+  const extract = vi.fn(async (input: SemanticExtractionInput) => {
+    const custom = customize(input);
+    const user = input.allowedSubjectRefs.find((item) => item.type === "pragma.user")!;
+    const evidenceRef = input.evidence.find(
+      (item) => item.schemaRef === "pragma.memory.execution-message/v2",
+    )!.messageId;
+    return {
+      output: SemanticExtractionOutputSchema.parse({
+        retain: true as const,
+        facts: [
+          {
+            statement: "The user prefers concise Chinese answers.",
+            subjectRefs: [user],
+            predicate: "user.preference.response-language",
+            normalizedValue: "zh-Hans:concise",
+            conflictMode: "exclusive" as const,
+            confidence: 0.8,
+            evidenceRefs: [evidenceRef],
+            ...custom,
+          },
+        ],
+      }),
+      provenance: {
+        curatorRef: "expert:0000000000memory",
+        promptVersion: "pragma.memory-curator.semantic/v1",
+        profileRevision: 0,
+        runtimeId: "runtime",
+        providerId: "provider",
+        modelId: "model",
+        extractedAt: "2026-08-03T12:00:00.000Z",
+      },
+    };
+  });
+  return { extract };
+}
+
+function evidenceText(input: SemanticExtractionInput): string {
+  return input.evidence
+    .flatMap((item) => {
+      const payload = item.payload as { readonly message?: { readonly text?: unknown } };
+      return typeof payload.message?.text === "string" ? [payload.message.text] : [];
+    })
+    .join("\n");
+}
+
+function executionEvidence(
+  executionId: string,
+  text: string,
+  expertId = "expert-a",
+): readonly MemoryEvidenceEnvelope[] {
+  const rootRef = ref("pragma.expert", expertId);
+  return executionEvidenceForRoot(executionId, text, rootRef, rootRef);
+}
+
+function executionEvidenceForRoot(
+  executionId: string,
+  text: string,
+  rootRef: MemorySubjectRef,
+  producerRef: MemorySubjectRef,
+): readonly MemoryEvidenceEnvelope[] {
+  return [
+    evidence(
+      executionId,
+      `${executionId}-message`,
+      "execution.message.appended",
+      text,
+      rootRef,
+      producerRef,
+    ),
+    evidence(
+      executionId,
+      `${executionId}-terminal`,
+      "execution.execution.terminal",
+      undefined,
+      rootRef,
+      producerRef,
+    ),
+  ];
+}
+
+function evidence(
+  executionId: string,
+  messageId: string,
+  topic: "execution.message.appended" | "execution.execution.terminal",
+  text: string | undefined,
+  rootRef: MemorySubjectRef,
+  producerRef: MemorySubjectRef,
+): MemoryEvidenceEnvelope {
+  return MemoryEvidenceEnvelopeSchema.parse({
+    schemaVersion: "pragma.memory-evidence/v1",
+    messageId,
+    topic,
+    schemaRef:
+      topic === "execution.message.appended"
+        ? "pragma.memory.execution-message/v2"
+        : "pragma.memory.execution-terminal/v2",
+    sourceRef: {
+      type: "pragma.execution-event",
+      id: messageId,
+      canonicalEventId: `canonical-${messageId}`,
+    },
+    subjectRefs: [ref("pragma.execution", executionId), rootRef],
+    correlationId: executionId,
+    occurredAt:
+      topic === "execution.message.appended"
+        ? "2026-08-03T10:00:00.000Z"
+        : "2026-08-03T10:00:01.000Z",
+    visibility: { mode: "host-private" },
+    sensitivity: "confidential",
+    bindings: [{ consumerRef: rootRef, access: "allow" }],
+    attribution: { rootRef, producerRefs: [producerRef] },
+    policySnapshot: {
+      capture: true,
+      recall: true,
+      learning: "local-candidates",
+      appliedRevisions: [],
+    },
+    payload: text === undefined ? { outcome: "succeeded" } : { message: { role: "user", text } },
+  });
+}
+
+function scopedContext(registry: MemoryModuleRegistry, scope: MemoryRecallScope) {
+  return createFederatedMemoryContextStore(registry, { resolveRecallScope: () => scope });
+}
+
+function expertScope(id: string): MemoryRecallScope {
+  return {
+    rootRef: { type: "pragma.expert", id },
+    expertRef: { type: "pragma.expert", id },
+  };
+}
+
+function ref(type: string, id: string): MemorySubjectRef {
+  return { type, id };
+}
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pragma-semantic-"));
+  roots.push(root);
+  return root;
+}
+
+function simulateJobCompletionCrash(pragmaHome: string): void {
+  const database = new DatabaseSync(
+    join(
+      new PragmaPaths({ pragmaHome }).memoryModuleStateRoot("pragma.memory.semantic"),
+      "jobs.sqlite",
+    ),
+  );
+  const row = database.prepare("SELECT id, job_json AS jobJson FROM jobs LIMIT 1").get() as {
+    readonly id: string;
+    readonly jobJson: string;
+  };
+  const job = JSON.parse(row.jobJson) as Record<string, unknown>;
+  delete job["completion"];
+  job["status"] = "running";
+  job["leaseUntil"] = "2026-08-03T00:00:00.000Z";
+  database
+    .prepare("UPDATE jobs SET status = 'running', lease_until = ?, job_json = ? WHERE id = ?")
+    .run(job["leaseUntil"] as string, JSON.stringify(job), row.id);
+  database.close();
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from "./model-provider.schema.ts";
 export * from "./pragma-text-limits.ts";
 export * from "./mission/mission-executor.schema.ts";
 export * from "./memory/memory-plane.schema.ts";
+export * from "./memory/semantic-memory.schema.ts";
 export * from "./result.ts";
 export * from "./runtime-context-window.schema.ts";
 export {

--- a/packages/shared/src/memory/semantic-memory.schema.ts
+++ b/packages/shared/src/memory/semantic-memory.schema.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+import {
+  MemoryRevisionBindingSchema,
+  MemorySensitivitySchema,
+  MemorySubjectRefSchema,
+  MemoryVisibilityPolicySchema,
+} from "./memory-plane.schema.ts";
+
+export const SEMANTIC_FACT_SCHEMA_VERSION = "pragma.memory-semantic/v1" as const;
+
+export const SemanticFactRevisionRefSchema = z
+  .object({
+    factId: z.string().min(1),
+    revision: z.number().int().positive(),
+  })
+  .strict();
+
+export const SemanticFactExtractorProvenanceSchema = z
+  .object({
+    curatorRef: z.string().min(1),
+    promptVersion: z.string().min(1),
+    profileRevision: z.number().int().nonnegative(),
+    runtimeId: z.string().min(1),
+    providerId: z.string().min(1),
+    modelId: z.string().min(1),
+    responseModel: z.string().min(1).optional(),
+    extractedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const SemanticFactSchema = z
+  .object({
+    schemaVersion: z.literal(SEMANTIC_FACT_SCHEMA_VERSION),
+    id: z.string().min(1),
+    revision: z.number().int().positive(),
+    statement: z.string().trim().min(1).max(4_000),
+    subjectRefs: z.array(MemorySubjectRefSchema).min(1).max(20),
+    predicate: z
+      .string()
+      .regex(/^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)+$/)
+      .max(200),
+    normalizedValue: z.string().trim().min(1).max(2_000),
+    conflictMode: z.enum(["exclusive", "compatible"]),
+    confidence: z.number().min(0).max(1),
+    observedAt: z.string().datetime(),
+    verifiedAt: z.string().datetime().optional(),
+    reviewAt: z.string().datetime().optional(),
+    expiresAt: z.string().datetime().optional(),
+    evidenceRefs: z.array(z.string().min(1)).min(1).max(500),
+    conflictsWith: z.array(z.string().min(1)).max(100),
+    supersedes: z.array(SemanticFactRevisionRefSchema).max(100),
+    status: z.enum(["active", "invalidated"]),
+    invalidatedAt: z.string().datetime().optional(),
+    visibility: MemoryVisibilityPolicySchema,
+    sensitivity: MemorySensitivitySchema,
+    bindings: z.array(MemoryRevisionBindingSchema).min(1).max(100),
+    rootRefs: z.array(MemorySubjectRefSchema).min(1).max(20),
+    producerRefs: z.array(MemorySubjectRefSchema).max(100),
+    extractor: SemanticFactExtractorProvenanceSchema,
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict()
+  .superRefine((fact, context) => {
+    if (fact.status === "invalidated" && fact.invalidatedAt === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["invalidatedAt"],
+        message: "Invalidated Semantic facts require invalidatedAt.",
+      });
+    }
+    if (fact.status === "active" && fact.invalidatedAt !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["invalidatedAt"],
+        message: "Active Semantic facts cannot carry invalidatedAt.",
+      });
+    }
+    for (const [field, value] of [
+      ["reviewAt", fact.reviewAt],
+      ["expiresAt", fact.expiresAt],
+    ] as const) {
+      if (value !== undefined && value <= fact.observedAt) {
+        context.addIssue({
+          code: "custom",
+          path: [field],
+          message: `${field} must be later than observedAt.`,
+        });
+      }
+    }
+  });
+
+export type SemanticFactRevisionRef = z.infer<typeof SemanticFactRevisionRefSchema>;
+export type SemanticFactExtractorProvenance = z.infer<typeof SemanticFactExtractorProvenanceSchema>;
+export type SemanticFact = z.infer<typeof SemanticFactSchema>;


### PR DESCRIPTION
## What changed

- add the `pragma.memory.semantic` module with versioned fact schemas, SQLite storage, independent extraction jobs, Evidence traceability, conflict handling, expiry, confidence, and immutable revision history
- expose scoped Semantic Memory Context projections and Desktop list/search/detail/history/revise/verify/invalidate IPC
- register stable Desktop User and Project subjects for Mission executions and run Semantic extraction through the hidden Memory Curator
- document the conservative fact model in ADR 034 and mark Memory Plane phase three complete

## Why

Phase three of the Memory Plane needs a governed answer to “what do we currently believe is true” without coupling Core to Memory or silently overwriting conflicting evidence. This implementation keeps facts conservative, attributable, scoped, and recoverable.

## Impact

- Desktop can capture and recall Semantic facts alongside Episodic Memory
- conflicting facts remain visible instead of being automatically superseded
- corrections keep the same fact identity with immutable revision and governance history
- Repository subject discovery and management UI remain intentionally deferred

## Validation

- `pnpm check`
- `pnpm build`
- focused Desktop Memory and Mission tests: 23 passed
- Memory package: 26 tests passed
- Desktop suite: 103 test files / 611 tests passed
- Claude Code review completed; the accepted Curator lifecycle duplication finding was fixed and all findings were independently verified
- `git diff --check`