### PR TITLE
Document direct execution of Desktop bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ pnpm --filter @pragma/desktop dev
 
 Desktop is the simplest way to start a mission, choose a workspace, and use local or connected runtimes.
 
-Studio can export any Expert, ExpertTeam, or Flow as a portable `.pragma` bundle. The export includes its reusable dependency graph as canonical DSL and can optionally include capabilities, plugins, knowledge, and visual Flow layouts. Secrets, local sessions, Missions, and machine-specific paths stay local. Another Desktop can import the bundle, or your own agent system can load the DSL through the Pragma interpreter.
+Studio can export any Expert, ExpertTeam, or Flow as a portable `.pragma` bundle. The export includes its reusable dependency graph as canonical DSL and can optionally include capabilities, plugins, knowledge, and visual Flow layouts. Secrets, local sessions, Missions, and machine-specific paths stay local. Another Desktop can import the bundle, or your own agent system can pass the exported file directly to `@pragma/interpreter`—without unpacking it or depending on Desktop code—and compile its root into a runnable `@pragma/core` object.
 
 ### Describe a reusable AI-native system with Pragma DSL
 
@@ -221,52 +221,65 @@ spec:
 
 The same language describes Experts, ExpertTeams, Flows, capabilities, context, runtime profiles, and evaluations. Definitions can be stored with a project, generated from compiled objects, reviewed in Git, exported from Desktop, and moved between hosts.
 
-### Load, compile, stream, and get the final result
+### Load and run a Desktop bundle in your own agent system
 
-After importing or unpacking an exported project, a custom host can load the project entry, compile the complete dependency graph, and execute it with the host's own runtime bindings:
+The `.pragma` file exported by Desktop implements the Interpreter-owned `pragma.bundle/v1` protocol. A custom Host can load the archive directly, select one of its exported roots, resolve that root's dependency closure against its own Runtime and Host bindings, and run the compiled object through `@pragma/core`:
 
 ```ts
 import { createPragma, type Flow } from "@pragma/core";
 import { loadPragmaProject } from "@pragma/interpreter";
 
-const project = await loadPragmaProject("./pragma.yaml");
-const diagnostics = await project.validate();
-if (diagnostics.some((item) => item.severity === "error")) {
-  throw new Error(JSON.stringify(diagnostics, null, 2));
-}
-
-const compiled = await project.compile<Flow>("flow:t9ne4d8njvvxv2ea", {
-  workspace: process.cwd(),
-  runtimes: myRuntimeResolver,
+const project = await loadPragmaProject({
+  kind: "bundle",
+  source: { kind: "file", path: "./ai-native-delivery.pragma" },
 });
 
-const app = createPragma({ runtimes: myRuntimeResolver });
-const execution = await app.flows.start(compiled.value, {
-  input: { brief: "Build and verify the next product release." },
-});
+try {
+  // A bundle can export more than one root. This example runs its Flow root.
+  const root = project.bundle?.manifest.roots.find((ref) => ref.startsWith("flow:"));
+  if (root === undefined) throw new Error("The bundle does not export a Flow root.");
 
-const output = await execution.subscribeOutput({ scope: { kind: "all" } });
-const streaming = (async () => {
-  try {
-    for await (const item of output) {
-      process.stdout.write(item.delta ?? String(item.value ?? ""));
-    }
-  } finally {
-    await output.close();
+  const prepared = await project.prepareCompile<Flow>(root, {
+    workspace: process.cwd(),
+    runtimes: myRuntimeResolver,
+  });
+  if (prepared.status !== "ready") {
+    // `needs_binding` identifies Runtime, capability, secret, or other Host
+    // requirements that your integration must provide before compiling.
+    throw new Error(`Bundle root is not runnable: ${JSON.stringify(prepared, null, 2)}`);
   }
-})();
 
-const result = await execution.result;
-await streaming;
+  const app = createPragma({ runtimes: myRuntimeResolver });
+  const execution = await app.flows.start(prepared.compiled.value, {
+    input: { brief: "Build and verify the next product release." },
+  });
 
-console.log("Final result:", result);
+  const output = await execution.subscribeOutput({ scope: { kind: "all" } });
+  const streaming = (async () => {
+    try {
+      for await (const item of output) {
+        process.stdout.write(item.delta ?? String(item.value ?? ""));
+      }
+    } finally {
+      await output.close();
+    }
+  })();
 
-// The same Execution exposes the complete audit trail.
-const audit = await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 });
-console.log("Audit events:", audit.items.length);
+  const result = await execution.result;
+  await streaming;
+
+  console.log("Final result:", result);
+
+  // The same Execution exposes the complete audit trail.
+  const audit = await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 });
+  console.log("Audit events:", audit.items.length);
+} finally {
+  // Bundle projects use a temporary extraction root owned by the Interpreter.
+  await project.dispose();
+}
 ```
 
-The interpreter resolves the exported resource graph and the compiler turns it into runnable Core objects. `scope: { kind: "all" }` streams output from the root Flow and its nested Experts, Teams, and child Flows. Your application still owns the product experience, persistence, permissions, and infrastructure while receiving live output, a final result, and auditable execution events.
+No Desktop import step is involved: the Interpreter verifies the archive and lock, resolves the selected root's exported dependency graph, and compiles it into a runnable Core object. If `prepareCompile()` returns `needs_binding`, your Host can satisfy the reported Bundle requirements through the Interpreter's binding APIs before compiling. `scope: { kind: "all" }` streams output from the root Flow and its nested Experts, Teams, and child Flows. Your agent system continues to own Runtime selection, permissions, persistence, product experience, and infrastructure while reusing the system authored in Desktop.
 
 ## Learn more
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,7 @@ pnpm --filter @pragma/desktop dev
 
 Desktop 是启动 Mission、选择 Workspace，并使用本地或已连接 Runtime 的最简单入口。
 
-Studio 可以把任意 Expert、ExpertTeam 或 Flow 导出为可移植的 `.pragma` Bundle。导出文件会以规范化 DSL 包含它的可复用依赖图，并可选择携带 Capability、Plugin、知识库和 Flow 视觉布局；Secret、本地 Session、Mission 与机器相关路径始终留在本机。另一台 Desktop 可以直接导入，你自己的 Agent 系统也可以通过 Pragma Interpreter 加载其中的 DSL。
+Studio 可以把任意 Expert、ExpertTeam 或 Flow 导出为可移植的 `.pragma` Bundle。导出文件会以规范化 DSL 包含它的可复用依赖图，并可选择携带 Capability、Plugin、知识库和 Flow 视觉布局；Secret、本地 Session、Mission 与机器相关路径始终留在本机。另一台 Desktop 可以直接导入，你自己的 Agent 系统也可以把导出的文件直接交给 `@pragma/interpreter`，无需解包或依赖 Desktop 代码，再将其中的根资源编译成可运行的 `@pragma/core` 对象。
 
 ### 使用 Pragma DSL 描述可复用 AI-native 系统
 
@@ -221,52 +221,65 @@ spec:
 
 同一种语言可以描述 Expert、ExpertTeam、Flow、Capability、Context、Runtime Profile 与 Evaluation。定义可以跟随项目保存、从编译后的对象重新生成、在 Git 中评审、从 Desktop 导出，并在不同 Host 之间移动。
 
-### 加载、编译、获取流式输出与最终结果
+### 在自己的 Agent 系统中加载并运行 Desktop Bundle
 
-导入或解包已导出的项目后，自有 Host 可以加载项目入口、编译完整依赖图，并使用自己的 Runtime 绑定执行：
+Desktop 导出的 `.pragma` 文件实现了由 Interpreter 定义的 `pragma.bundle/v1` 协议。自有 Host 可以直接加载这个归档文件，选择其中一个导出根资源，使用自己的 Runtime 与 Host binding 解析该根资源的依赖闭包，再通过 `@pragma/core` 运行编译后的对象：
 
 ```ts
 import { createPragma, type Flow } from "@pragma/core";
 import { loadPragmaProject } from "@pragma/interpreter";
 
-const project = await loadPragmaProject("./pragma.yaml");
-const diagnostics = await project.validate();
-if (diagnostics.some((item) => item.severity === "error")) {
-  throw new Error(JSON.stringify(diagnostics, null, 2));
-}
-
-const compiled = await project.compile<Flow>("flow:t9ne4d8njvvxv2ea", {
-  workspace: process.cwd(),
-  runtimes: myRuntimeResolver,
+const project = await loadPragmaProject({
+  kind: "bundle",
+  source: { kind: "file", path: "./ai-native-delivery.pragma" },
 });
 
-const app = createPragma({ runtimes: myRuntimeResolver });
-const execution = await app.flows.start(compiled.value, {
-  input: { brief: "Build and verify the next product release." },
-});
+try {
+  // 一个 Bundle 可以导出多个根资源；本例运行其中的 Flow 根资源。
+  const root = project.bundle?.manifest.roots.find((ref) => ref.startsWith("flow:"));
+  if (root === undefined) throw new Error("Bundle 中没有导出的 Flow 根资源。");
 
-const output = await execution.subscribeOutput({ scope: { kind: "all" } });
-const streaming = (async () => {
-  try {
-    for await (const item of output) {
-      process.stdout.write(item.delta ?? String(item.value ?? ""));
-    }
-  } finally {
-    await output.close();
+  const prepared = await project.prepareCompile<Flow>(root, {
+    workspace: process.cwd(),
+    runtimes: myRuntimeResolver,
+  });
+  if (prepared.status !== "ready") {
+    // `needs_binding` 会列出集成方在编译前必须提供的 Runtime、Capability、
+    // Secret 或其他 Host requirement。
+    throw new Error(`Bundle 根资源暂不可运行：${JSON.stringify(prepared, null, 2)}`);
   }
-})();
 
-const result = await execution.result;
-await streaming;
+  const app = createPragma({ runtimes: myRuntimeResolver });
+  const execution = await app.flows.start(prepared.compiled.value, {
+    input: { brief: "Build and verify the next product release." },
+  });
 
-console.log("Final result:", result);
+  const output = await execution.subscribeOutput({ scope: { kind: "all" } });
+  const streaming = (async () => {
+    try {
+      for await (const item of output) {
+        process.stdout.write(item.delta ?? String(item.value ?? ""));
+      }
+    } finally {
+      await output.close();
+    }
+  })();
 
-// 同一个 Execution 提供完整审计事件。
-const audit = await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 });
-console.log("Audit events:", audit.items.length);
+  const result = await execution.result;
+  await streaming;
+
+  console.log("Final result:", result);
+
+  // 同一个 Execution 提供完整审计事件。
+  const audit = await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 });
+  console.log("Audit events:", audit.items.length);
+} finally {
+  // Bundle Project 使用由 Interpreter 管理的临时解包目录。
+  await project.dispose();
+}
 ```
 
-Interpreter 会解析导出的资源依赖图，Compiler 再把它编译成可运行的 Core 对象。`scope: { kind: "all" }` 会同时获得根 Flow 及其嵌套 Expert、ExpertTeam 与子 Flow 的流式输出。你的应用仍然完全掌控产品体验、持久化、权限和基础设施，同时获得实时输出、最终结果与可审计的执行事件。
+整个过程不需要经过 Desktop 的导入功能：Interpreter 会校验归档和 Lock，解析所选根资源的导出依赖图，再将其编译成可运行的 Core 对象。如果 `prepareCompile()` 返回 `needs_binding`，你的 Host 可以先通过 Interpreter 的 binding API 满足报告出的 Bundle requirements，再进行编译。`scope: { kind: "all" }` 会同时获得根 Flow 及其嵌套 Expert、ExpertTeam 与子 Flow 的流式输出。你的 Agent 系统仍然掌控 Runtime 选择、权限、持久化、产品体验和基础设施，同时复用在 Desktop 中构建的系统。
 
 ## 进一步了解
 


### PR DESCRIPTION
## Summary

- explain that Desktop exports the Interpreter-owned `pragma.bundle/v1` protocol
- show how an agent Host can load a Desktop-exported `.pragma` file directly through `@pragma/interpreter`
- replace the old unpacked-YAML example with the current `prepareCompile()` workflow
- demonstrate root selection, Runtime/Host binding diagnostics, Core execution, streaming output, audit events, and Interpreter cleanup
- keep the English and Simplified Chinese READMEs aligned

## Why

The previous README example loaded an unpacked `pragma.yaml` entry and called `compile()` directly. It did not demonstrate the public Bundle API introduced by the Desktop Host Adapter refactor, so readers could not see that a Desktop export can be consumed without Desktop code and embedded in their own agent system.

## Validation

- `pnpm exec prettier --check README.md README.zh-CN.md`
- `git diff --check origin/main..HEAD`
