### PR TITLE
fix(desktop): localize referenced resource deletion errors

### DIFF
--- a/apps/desktop/src/main/features/projects/pragma-project-store.test.ts
+++ b/apps/desktop/src/main/features/projects/pragma-project-store.test.ts
@@ -904,10 +904,16 @@ describe("PragmaProjectStore", () => {
 
     await expect(
       project.remove({ baseRevision: 1, ref: "team:p8cbn3cg2avyksn4" }),
-    ).rejects.toMatchObject({ code: "resource_referenced" });
+    ).rejects.toMatchObject({
+      code: "resource_referenced",
+      referencedBy: [{ ref: "flow:n37vf3n8d5g3j195", name: "Team consumer" }],
+    });
     await expect(
       project.remove({ baseRevision: 1, ref: "flow:ceq0qxcgdv75wg6b" }),
-    ).rejects.toMatchObject({ code: "resource_referenced" });
+    ).rejects.toMatchObject({
+      code: "resource_referenced",
+      referencedBy: [{ ref: "flow:3th2yww0c5q3m65t", name: "Parent flow" }],
+    });
     expect((await project.get()).revision).toBe(1);
   });
 
@@ -965,6 +971,7 @@ describe("PragmaProjectStore", () => {
       code: "resource_referenced",
       message:
         "This resource is used by another Expert, Expert Team, Flow, or Evaluation. Remove those dependencies before deleting it.",
+      referencedBy: [{ ref: "evaluation:7h8j9k0m1n2p3q4r", name: "Release Run Dry" }],
     });
   });
 

--- a/apps/desktop/src/main/features/projects/pragma-project-store.ts
+++ b/apps/desktop/src/main/features/projects/pragma-project-store.ts
@@ -54,6 +54,7 @@ import {
 
 import {
   PragmaProjectSnapshotSchema,
+  type DesktopMutationReferencedResource,
   type PragmaProjectSnapshot,
   type PragmaYamlValidationResult,
 } from "../../../shared/contracts/index.ts";
@@ -163,6 +164,7 @@ export class PragmaProjectStoreError extends Error {
           readonly retryable: boolean;
         }
       | undefined = undefined,
+    readonly referencedBy: readonly DesktopMutationReferencedResource[] = [],
   ) {
     super(message);
     this.name = "PragmaProjectStoreError";
@@ -170,10 +172,7 @@ export class PragmaProjectStoreError extends Error {
 }
 
 export type PragmaProjectRevisionUnavailableStage =
-  | "manifest"
-  | "compiler-migration"
-  | "validation"
-  | "io";
+  "manifest" | "compiler-migration" | "validation" | "io";
 
 export class PragmaProjectRevisionUnavailableError extends Error {
   readonly code = "project_revision_unavailable";
@@ -445,10 +444,19 @@ export function createPragmaProjectStore(options: {
       if (resource === undefined) {
         throw new PragmaProjectStoreError("resource_not_found", `Resource not found: ${input.ref}`);
       }
-      if (referencingPragmaResources(snapshot.resources, input.ref).length > 0) {
+      const referencedBy = referencingPragmaResources(snapshot.resources, input.ref).map(
+        (referencingResource) => ({
+          ref: canonicalPragmaResourceRef(referencingResource),
+          name: referencingResource.metadata.name,
+        }),
+      );
+      if (referencedBy.length > 0) {
         throw new PragmaProjectStoreError(
           "resource_referenced",
           "This resource is used by another Expert, Expert Team, Flow, or Evaluation. Remove those dependencies before deleting it.",
+          [],
+          undefined,
+          referencedBy,
         );
       }
       return await apply({

--- a/apps/desktop/src/main/platform/ipc/desktop-mutation-result.test.ts
+++ b/apps/desktop/src/main/platform/ipc/desktop-mutation-result.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { DesktopMutationError } from "../../../shared/contracts/index.ts";
 import { runDesktopMutation } from "./desktop-mutation-result.ts";
 import { MissionOperationError } from "../../features/missions/mission-operation-error.ts";
 import {
@@ -45,12 +44,32 @@ describe("runDesktopMutation", () => {
         },
       },
     });
-    if (result.ok) throw new Error("Expected a mutation failure.");
-    expect(new DesktopMutationError(result.error)).toMatchObject({
-      code: "revision_conflict",
-      conflict: {
-        conflictingRefs: ["expert:1xddvess309a6gme"],
-        retryable: false,
+  });
+
+  it("preserves referenced resource details across the IPC boundary", async () => {
+    const result = await runDesktopMutation(async () => {
+      throw new PragmaProjectStoreError(
+        "resource_referenced",
+        "The resource is referenced.",
+        [],
+        undefined,
+        [
+          { ref: "expert:1xddvess309a6gme", name: "Code reviewer" },
+          { ref: "flow:ceq0qxcgdv75wg6b", name: "Issue reporter" },
+        ],
+      );
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "resource_referenced",
+        message: "The resource is referenced.",
+        diagnostics: [],
+        referencedBy: [
+          { ref: "expert:1xddvess309a6gme", name: "Code reviewer" },
+          { ref: "flow:ceq0qxcgdv75wg6b", name: "Issue reporter" },
+        ],
       },
     });
   });
@@ -105,14 +124,6 @@ describe("runDesktopMutation", () => {
           targetCompilerVersion: "pragma.dsl/v3",
           retryable: false,
         },
-      },
-    });
-    if (result.ok) throw new Error("Expected a revision failure.");
-    expect(new DesktopMutationError(result.error)).toMatchObject({
-      code: "project_revision_unavailable",
-      revisionFailure: {
-        projectId: "studio",
-        revision: 41,
       },
     });
   });

--- a/apps/desktop/src/main/platform/ipc/desktop-mutation-result.ts
+++ b/apps/desktop/src/main/platform/ipc/desktop-mutation-result.ts
@@ -51,6 +51,7 @@ function serializeDesktopMutationError(error: unknown): DesktopMutationErrorData
       message: error.message,
       diagnostics: error.diagnostics,
       ...(error.conflict === undefined ? {} : { conflict: error.conflict }),
+      ...(error.referencedBy.length === 0 ? {} : { referencedBy: error.referencedBy }),
     });
   }
   if (error instanceof ExpertDefinitionStoreError) {

--- a/apps/desktop/src/preload/invoke-mutation.test.ts
+++ b/apps/desktop/src/preload/invoke-mutation.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock("electron", () => ({ ipcRenderer: { invoke: mocks.invoke } }));
+
+import { invokeMutation } from "./invoke-mutation.ts";
+
+describe("invokeMutation", () => {
+  beforeEach(() => {
+    mocks.invoke.mockReset();
+  });
+
+  it("returns successful mutation values", async () => {
+    mocks.invoke.mockResolvedValue({ ok: true, value: { revision: 3 } });
+
+    await expect(invokeMutation("pragma-project:get")).resolves.toEqual({ revision: 3 });
+  });
+
+  it("rejects with bridge-safe structured error data", async () => {
+    const error = {
+      code: "resource_referenced",
+      message: "The resource is referenced.",
+      diagnostics: [],
+      referencedBy: [
+        { ref: "expert:1xddvess309a6gme", name: "Code reviewer" },
+        { ref: "flow:ceq0qxcgdv75wg6b", name: "Issue reporter" },
+      ],
+    };
+    mocks.invoke.mockResolvedValue({ ok: false, error });
+
+    await expect(invokeMutation("pragma-project:delete", {})).rejects.toEqual(error);
+  });
+
+  it("rejects extension refs that cannot identify a referencing project resource", async () => {
+    mocks.invoke.mockResolvedValue({
+      ok: false,
+      error: {
+        code: "resource_referenced",
+        message: "The resource is referenced.",
+        diagnostics: [],
+        referencedBy: [{ ref: "action:review@v1", name: "Review action" }],
+      },
+    });
+
+    await expect(invokeMutation("pragma-project:delete", {})).rejects.toMatchObject({
+      name: "ZodError",
+    });
+  });
+});

--- a/apps/desktop/src/preload/invoke-mutation.ts
+++ b/apps/desktop/src/preload/invoke-mutation.ts
@@ -1,12 +1,12 @@
 import { ipcRenderer } from "electron";
 
-import { DesktopMutationError, DesktopMutationResultSchema } from "../shared/contracts/mutation.ts";
+import { DesktopMutationResultSchema } from "../shared/contracts/mutation.ts";
 
 export async function invokeMutation(
   channel: string,
   ...args: readonly unknown[]
 ): Promise<unknown> {
   const result = DesktopMutationResultSchema.parse(await ipcRenderer.invoke(channel, ...args));
-  if (!result.ok) throw new DesktopMutationError(result.error);
+  if (!result.ok) throw result.error;
   return result.value;
 }

--- a/apps/desktop/src/renderer/src/i18n/resources/en/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/studio.ts
@@ -151,6 +151,26 @@ export const studio = {
   deleteResourceAction: "Delete",
   deleteResourceDescription:
     "“{{name}}” will be permanently removed. Resources that depend on it must be updated before it can be deleted.",
+  deleteResourceReferenced:
+    "This resource cannot be deleted because it is referenced by {{references}}. Remove those dependencies first.",
+  deleteResourceReferencedMore_one:
+    "This resource cannot be deleted because it is referenced by {{references}} and {{count}} more resource. Remove those dependencies first.",
+  deleteResourceReferencedMore_other:
+    "This resource cannot be deleted because it is referenced by {{references}} and {{count}} more resources. Remove those dependencies first.",
+  deleteResourceReferencedUnknown:
+    "This resource is still referenced and cannot be deleted. Remove its dependencies first.",
+  deleteResourceReference: "{{kind}} “{{name}}”",
+  deleteResourceReferenceSeparator: ", ",
+  deleteResourceKind: {
+    expert: "Expert",
+    team: "Expert Team",
+    flow: "Flow",
+    automation: "Automation",
+    capability: "Capability",
+    contextStore: "Context Store",
+    runtimeProfile: "Runtime Profile",
+    evaluation: "Evaluation",
+  },
   backTeams: "Back to teams",
   backTeamDetail: "Back to team details",
   backExpertDetail: "Back to expert details",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/studio.ts
@@ -143,6 +143,25 @@ export const studio = {
   deleteResource: "删除此{{kind}}？",
   deleteResourceAction: "删除",
   deleteResourceDescription: "“{{name}}”将被永久删除。删除前，必须先更新所有依赖它的资源。",
+  deleteResourceReferenced:
+    "该资源被以下资源引用，无法删除：{{references}}。请先移除这些依赖关系。",
+  deleteResourceReferencedMore_one:
+    "该资源被以下资源引用，无法删除：{{references}}，以及另外{{count}}个资源。请先移除这些依赖关系。",
+  deleteResourceReferencedMore_other:
+    "该资源被以下资源引用，无法删除：{{references}}，以及另外{{count}}个资源。请先移除这些依赖关系。",
+  deleteResourceReferencedUnknown: "该资源仍被其他资源引用，无法删除。请先移除相关依赖关系。",
+  deleteResourceReference: "{{kind}}“{{name}}”",
+  deleteResourceReferenceSeparator: "、",
+  deleteResourceKind: {
+    expert: "专家",
+    team: "专家团队",
+    flow: "流程",
+    automation: "自动化",
+    capability: "能力",
+    contextStore: "上下文存储",
+    runtimeProfile: "运行时配置",
+    evaluation: "测评",
+  },
   backTeams: "返回专家团队列表",
   backTeamDetail: "返回团队详情",
   backExpertDetail: "返回专家详情",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/studio.ts
@@ -143,6 +143,25 @@ export const studio = {
   deleteResource: "刪除此{{kind}}？",
   deleteResourceAction: "刪除",
   deleteResourceDescription: "“{{name}}”將被永久刪除。刪除前，必須先更新所有依賴它的資源。",
+  deleteResourceReferenced:
+    "該資源被以下資源引用，無法刪除：{{references}}。請先移除這些依賴關係。",
+  deleteResourceReferencedMore_one:
+    "該資源被以下資源引用，無法刪除：{{references}}，以及另外{{count}}個資源。請先移除這些依賴關係。",
+  deleteResourceReferencedMore_other:
+    "該資源被以下資源引用，無法刪除：{{references}}，以及另外{{count}}個資源。請先移除這些依賴關係。",
+  deleteResourceReferencedUnknown: "該資源仍被其他資源引用，無法刪除。請先移除相關依賴關係。",
+  deleteResourceReference: "{{kind}}「{{name}}」",
+  deleteResourceReferenceSeparator: "、",
+  deleteResourceKind: {
+    expert: "專家",
+    team: "專家團隊",
+    flow: "流程",
+    automation: "自動化",
+    capability: "能力",
+    contextStore: "上下文儲存",
+    runtimeProfile: "執行環境設定",
+    evaluation: "評測",
+  },
   backTeams: "返回專家團隊列表",
   backTeamDetail: "返回團隊詳情",
   backExpertDetail: "返回專家詳情",

--- a/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   PragmaExpertResourceSchema,
@@ -8,8 +8,10 @@ import {
   type PragmaExpertResource,
 } from "@pragma/interpreter/ast";
 import type { PragmaProjectSnapshot } from "../../../../shared/contracts/index.ts";
+import { i18n } from "../../i18n/index.ts";
 
 import {
+  deletePragmaResourceErrorMessage,
   matchesResourceDirectoryQuery,
   matchingTeamExperts,
   PragmaResourceDetailFragment,
@@ -17,6 +19,10 @@ import {
   TeamEditor,
 } from "./PragmaResourceDirectoryFragment.tsx";
 import { createEmptyFlow } from "./flow-editor/flow-model.ts";
+
+afterEach(async () => {
+  await i18n.changeLanguage("en");
+});
 
 function expert(index: number): PragmaExpertResource {
   const id = String(index).padStart(16, "0");
@@ -210,6 +216,50 @@ describe("PragmaResourceDirectoryFragment", () => {
 });
 
 describe("PragmaResourceDetailFragment", () => {
+  it.each([
+    ["en", "Expert “Code reviewer”", "Flow “Issue reporter”", "1 more resource"],
+    ["zh-Hans", "专家“Code reviewer”", "流程“Issue reporter”", "另外1个资源"],
+    ["zh-Hant", "專家「Code reviewer」", "流程「Issue reporter」", "另外1個資源"],
+  ] as const)(
+    "localizes and truncates referenced-resource deletion errors in %s",
+    async (locale, first, second, remainder) => {
+      await i18n.changeLanguage(locale);
+      const message = deletePragmaResourceErrorMessage(
+        {
+          code: "resource_referenced",
+          message: "Raw backend message",
+          diagnostics: [],
+          referencedBy: [
+            { ref: "expert:0000000000000001", name: "Code reviewer" },
+            { ref: "flow:ffdfk2cczgqjda7q", name: "Issue reporter" },
+            { ref: "automation:hrxn3mv2e991j2rj", name: "Nightly cleanup" },
+          ],
+        },
+        i18n.getFixedT(locale, "studio"),
+      );
+
+      expect(message).toContain(first);
+      expect(message).toContain(second);
+      expect(message).toContain(remainder);
+      expect(message).not.toContain("Nightly cleanup");
+      expect(message).not.toContain("Raw backend message");
+    },
+  );
+
+  it("uses a localized fallback when reference details are unavailable", async () => {
+    await i18n.changeLanguage("zh-Hans");
+    expect(
+      deletePragmaResourceErrorMessage(
+        {
+          code: "resource_referenced",
+          message: "Raw backend message",
+          diagnostics: [],
+        },
+        i18n.getFixedT("zh-Hans", "studio"),
+      ),
+    ).toBe("该资源仍被其他资源引用，无法删除。请先移除相关依赖关系。");
+  });
+
   it("shows Team details with edit and delete actions", () => {
     const experts = [expert(1), expert(2)];
     const team = PragmaExpertTeamResourceSchema.parse({

--- a/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -15,7 +16,9 @@ import {
 } from "@phosphor-icons/react";
 import {
   PragmaExpertTeamResourceSchema,
+  PragmaResourceKindSchema,
   canonicalPragmaResourceRef,
+  parsePragmaReference,
   type PragmaExpertResource,
   type PragmaExpertTeamResource,
   type PragmaFlowResource,
@@ -25,7 +28,10 @@ import {
   pragmaUnicodeLength,
   truncatePragmaTrimmedUnicode,
 } from "@pragma/shared";
-import type { PragmaProjectSnapshot } from "../../../../shared/contracts/index.ts";
+import {
+  DesktopMutationErrorSchema,
+  type PragmaProjectSnapshot,
+} from "../../../../shared/contracts/index.ts";
 
 import { CharacterCount } from "../../components/CharacterCount.tsx";
 import { errorMessage } from "../../lib/errors.ts";
@@ -39,6 +45,17 @@ type TeamExpertPickerKind = "coordinator" | "members";
 export type ResourceEditorMode = "create" | "edit";
 
 const TEAM_EXPERT_RESULT_LIMIT = 8;
+const DELETE_REFERENCE_LIMIT = 2;
+const DELETE_REFERENCE_KIND_KEYS = {
+  expert: "deleteResourceKind.expert",
+  team: "deleteResourceKind.team",
+  flow: "deleteResourceKind.flow",
+  automation: "deleteResourceKind.automation",
+  capability: "deleteResourceKind.capability",
+  "context-store": "deleteResourceKind.contextStore",
+  "runtime-profile": "deleteResourceKind.runtimeProfile",
+  evaluation: "deleteResourceKind.evaluation",
+} as const;
 type FlowHumanPrompt = NonNullable<
   PragmaFlowResource["spec"]["graph"]["steps"][string]["human"]
 >["prompt"];
@@ -49,6 +66,34 @@ function expertRef(expert: PragmaExpertResource): string {
 
 function normalized(value: string): string {
   return value.trim().toLocaleLowerCase();
+}
+
+export function deletePragmaResourceErrorMessage(error: unknown, t: TFunction<"studio">): string {
+  const parsed = DesktopMutationErrorSchema.safeParse(error);
+  if (!parsed.success || parsed.data.code !== "resource_referenced") {
+    return errorMessage(error);
+  }
+
+  const referencedBy = parsed.data.referencedBy ?? [];
+  if (referencedBy.length === 0) return t("deleteResourceReferencedUnknown");
+
+  const visibleReferences = referencedBy.slice(0, DELETE_REFERENCE_LIMIT);
+  const references = visibleReferences
+    .map(({ ref, name }) =>
+      t("deleteResourceReference", {
+        kind: t(
+          DELETE_REFERENCE_KIND_KEYS[
+            PragmaResourceKindSchema.parse(parsePragmaReference(ref).kind)
+          ],
+        ),
+        name,
+      }),
+    )
+    .join(t("deleteResourceReferenceSeparator"));
+  const remaining = referencedBy.length - visibleReferences.length;
+  return remaining > 0
+    ? t("deleteResourceReferencedMore", { references, count: remaining })
+    : t("deleteResourceReferenced", { references });
 }
 
 export function matchingTeamExperts(
@@ -225,7 +270,7 @@ export function PragmaResourceDetailFragment(props: {
     try {
       await props.onDelete();
     } catch (cause) {
-      setDeleteError(errorMessage(cause));
+      setDeleteError(deletePragmaResourceErrorMessage(cause, t));
       setConfirmOpen(false);
     } finally {
       setDeleting(false);
@@ -277,7 +322,7 @@ export function PragmaResourceDetailFragment(props: {
         </div>
       </header>
       {deleteError ? (
-        <p className="form-error" role="alert">
+        <p className="form-error pragma-resource-delete-error" role="alert">
           {deleteError}
         </p>
       ) : null}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1615,6 +1615,14 @@ html.is-resizing-sidebar * {
   font-size: 13px;
 }
 
+.pragma-resource-delete-error {
+  display: -webkit-box;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .provider-actions {
   justify-content: flex-end;
   margin-top: 3px;

--- a/apps/desktop/src/shared/contracts/mutation.ts
+++ b/apps/desktop/src/shared/contracts/mutation.ts
@@ -1,4 +1,8 @@
-import { PragmaDiagnosticSchema, PragmaResourceRefSchema } from "@pragma/interpreter/ast";
+import {
+  PragmaDiagnosticSchema,
+  PragmaResourceRefSchema,
+  PragmaSemanticResourceRefSchema,
+} from "@pragma/interpreter/ast";
 import { z } from "zod";
 
 export const DesktopMutationConflictSchema = z
@@ -21,6 +25,13 @@ export const DesktopProjectRevisionFailureSchema = z
   })
   .strict();
 
+export const DesktopMutationReferencedResourceSchema = z
+  .object({
+    ref: PragmaSemanticResourceRefSchema,
+    name: z.string().min(1).max(1_000),
+  })
+  .strict();
+
 export const DesktopMutationErrorSchema = z
   .object({
     code: z.string().trim().min(1).max(100),
@@ -28,6 +39,7 @@ export const DesktopMutationErrorSchema = z
     diagnostics: z.array(PragmaDiagnosticSchema).default([]),
     conflict: DesktopMutationConflictSchema.optional(),
     revisionFailure: DesktopProjectRevisionFailureSchema.optional(),
+    referencedBy: z.array(DesktopMutationReferencedResourceSchema).optional(),
   })
   .strict();
 
@@ -37,19 +49,6 @@ export const DesktopMutationResultSchema = z.discriminatedUnion("ok", [
 ]);
 
 export type DesktopMutationErrorData = z.infer<typeof DesktopMutationErrorSchema>;
-
-export class DesktopMutationError extends Error {
-  readonly code: string;
-  readonly diagnostics: DesktopMutationErrorData["diagnostics"];
-  readonly conflict: DesktopMutationErrorData["conflict"];
-  readonly revisionFailure: DesktopMutationErrorData["revisionFailure"];
-
-  constructor(input: DesktopMutationErrorData) {
-    super(input.message);
-    this.name = "DesktopMutationError";
-    this.code = input.code;
-    this.diagnostics = input.diagnostics;
-    this.conflict = input.conflict;
-    this.revisionFailure = input.revisionFailure;
-  }
-}
+export type DesktopMutationReferencedResource = z.infer<
+  typeof DesktopMutationReferencedResourceSchema
+>;


### PR DESCRIPTION
## Summary

- carry structured referencing-resource details from the project store through Desktop IPC and the preload bridge
- render localized deletion errors in English, Simplified Chinese, and Traditional Chinese
- show the first two referencing resource names, summarize additional references, and clamp the alert to two visual lines
- tighten the mutation contract to semantic project resource refs and add Store, IPC, preload, renderer, and i18n coverage

## Root cause

The project store already found all referencing resources but discarded them before throwing `resource_referenced`. The renderer then displayed the backend English `message` directly. In addition, custom properties on an `Error` object do not survive Electron's isolated `contextBridge`, so structured details require a bridge-safe plain DTO.

## User impact

Users now see a productized message in their selected locale that identifies which resources block deletion and clearly summarizes larger dependency sets.

## Validation

- `pnpm check` — lint, typecheck, and tests passed across all 21 packages
- Desktop tests — 104 files, 622 tests passed
- `pnpm build` — all 21 packages built successfully
- Desktop preload bundle verification passed
- Claude Code review completed with no blocking findings; the one accepted contract-hardening finding was fixed and tested

Closes #112