### PR TITLE
Fix Desktop storage retention and Qoder command cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,8 @@ Server 与 Agent 的关系：
 - Runtime Session、Runtime 配置和插件安装副本不得写入 workspace。
 - 权威数据存放在 `~/.pragma/data/`，可恢复运行状态存放在 `state/`，有界诊断归档存放在
   `archives/`，可重建内容存放在 `cache/`；`tmp/` 与 `trash/` 使用短期保留策略。
+- Trash 只清理已完成且 journal 合法的删除项，固定按七天、总计 300 MiB、最多十项三个上限中
+  最先达到者淘汰；Desktop 在首个窗口创建后及成功删除 owner 后触发定向维护，不在启动时扫描全部 owner。
 - ExpertSession、Execution 与 Runtime Session 分别存放在 `~/.pragma/state/expert-sessions/`、`~/.pragma/state/executions/` 和 `~/.pragma/state/runtime-sessions/`。
 - Execution 大输出交接文件和 manifest 存放在
   `~/.pragma/state/executions/<executionId>/handoffs/`，作为可恢复 Execution 状态随 owner 生命周期清理；
@@ -320,6 +322,10 @@ Server 与 Agent 的关系：
   不得跨 Context 共享，`CODEX_SQLITE_HOME` 必须指向私有目录。宿主
   `~/.codex/plugins/cache` 作为可重建缓存可以直接链接共享；不得复制或扫描完整
   `plugins`、`packages`、通用 `cache` 或宿主 sessions 树。
+- Qoder CLI 新建 Runtime Session 将整个 `external-commands` 目录链接到
+  `~/.pragma/cache/runtimes/qodercli/external-commands/`；认证、Project、日志和 Session 状态继续私有。
+  已有 Session 的本地 `external-commands` 目录不得在启动时扫描、迁移或替换；Pragma 只清理共享缓存中
+  已完成的 `download-*` 与无活动锁保护的过期 `.tmp-*`。
 - Runtime 进程停止不等于持久数据删除。Mission 删除必须按 owner 图级联移动 ExpertSession、
   Execution、Runtime Session 和 ownership claim 到带 journal 的回收站。
 - 外部 ID 目录段统一通过 `@pragma/core` 的 `PragmaPaths` 编码和解析，具体 Runtime 或插件 loader 不自行拼接管理路径。

--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -85,6 +85,7 @@ import {
 import { validateWorkspace } from "../features/workspaces/workspace-scope.ts";
 import type { CredentialEncryption } from "../platform/security/credential-encryption.ts";
 import { initializeDesktopStorage } from "../platform/storage/storage-bootstrap.ts";
+import { createDesktopTrashMaintenance } from "../platform/storage/trash-maintenance.ts";
 
 export interface DesktopApplicationContainer {
   readonly startBackgroundTasks: () => void;
@@ -129,6 +130,10 @@ export async function createDesktopApplicationContainer(
     paths: pragmaPaths,
     refreshIntervalMs: 0,
     maxSnapshotAgeMs: 30_000,
+  });
+  const trashMaintenance = createDesktopTrashMaintenance({
+    paths: pragmaPaths,
+    logger: mainLogger,
   });
   const builtInDefaultWorkspace = pragmaPaths.workspaceRoot();
   const projectsPath = pragmaPaths.projectsRoot();
@@ -401,6 +406,7 @@ export async function createDesktopApplicationContainer(
     automaticHumanInteractionHandlerForToolPermissionMode: (mode) =>
       createAutomaticToolPermissionHandler(() => mode),
     assertStorageWriteAllowed: async () => await storageCapacityGuard.assertWriteAllowed(),
+    onStorageTrashed: () => trashMaintenance.schedule("mission-storage-trashed"),
     onExecutionLinked: async ({ mission, executionId }) => {
       if (mission.origin.type === "system-memory") return;
       await memoryPlane.registerSemanticExecutionContext({
@@ -527,6 +533,7 @@ export async function createDesktopApplicationContainer(
     creator: missionCreator,
     runner: missionRunner,
     loggerProvider,
+    onStorageTrashed: () => trashMaintenance.schedule("automation-storage-trashed"),
   });
   installAutomationHandlers(automationService);
   const defaultAgentTasks = createDesktopDefaultAgentTaskPort({
@@ -592,6 +599,7 @@ export async function createDesktopApplicationContainer(
     startBackgroundTasks() {
       if (backgroundTasksStarted) return;
       backgroundTasksStarted = true;
+      trashMaintenance.schedule("startup");
       runtimeProcessEnvironment.warmUp();
       void runtimeEnvironments.initialize().catch((error: unknown) => {
         mainLogger.warn(

--- a/apps/desktop/src/main/features/automations/automation-service.ts
+++ b/apps/desktop/src/main/features/automations/automation-service.ts
@@ -62,6 +62,7 @@ export function createAutomationService(options: {
   readonly creator: MissionCreator;
   readonly runner: MissionRunner;
   readonly loggerProvider?: PragmaLoggerProvider | undefined;
+  readonly onStorageTrashed?: (() => void) | undefined;
   readonly now?: (() => Date) | undefined;
 }): AutomationService {
   const logger = createPragmaLogger(options.loggerProvider, {
@@ -519,6 +520,7 @@ export function createAutomationService(options: {
           owner: { type: "automation-generation", id: ref },
           sources: [{ label: "state", path: options.paths.automationStateRoot(ref) }],
         });
+        options.onStorageTrashed?.();
       }
       if (snapshot.resources.every((candidate) => canonicalPragmaResourceRef(candidate) !== ref)) {
         throw new Error(`Automation was not published: ${ref}.`);
@@ -541,6 +543,7 @@ export function createAutomationService(options: {
           { label: "state", path: options.paths.automationStateRoot(input.ref) },
         ],
       });
+      options.onStorageTrashed?.();
     },
     async resetSession(ref) {
       const resource = await findAutomation(ref);
@@ -561,6 +564,7 @@ export function createAutomationService(options: {
         owner: { type: "automation-generation", id: ref },
         sources: [{ label: "state", path: options.paths.automationStateRoot(ref) }],
       });
+      options.onStorageTrashed?.();
       await scheduleResource(resource, binding);
       return await summaryFor(resource);
     },

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -295,6 +295,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     const openRevision = vi
       .spyOn(project, "openRevision")
       .mockRejectedValueOnce(new Error("usage attribution unavailable"));
+    const onStorageTrashed = vi.fn();
     const runtime = defineRuntimeDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
@@ -317,12 +318,14 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       }),
       usage,
       loggerProvider: createNoopLoggerProvider(),
+      onStorageTrashed,
     });
 
     await expect(runner.delete(target.id)).resolves.toBeUndefined();
     await expect(missions.get(target.id)).rejects.toThrow();
     expect(openRevision).toHaveBeenCalledTimes(1);
     expect(markSubjectDeleted).toHaveBeenCalledWith("mission", target.id);
+    expect(onStorageTrashed).toHaveBeenCalledOnce();
     expect(await missions.list()).toHaveLength(1);
   });
 

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -226,6 +226,7 @@ export function createMissionRunner(options: {
     | undefined;
   readonly assertStorageWriteAllowed?: (() => Promise<void>) | undefined;
   readonly assertExecutorReady?: ((ref: string) => void | Promise<void>) | undefined;
+  readonly onStorageTrashed?: (() => void) | undefined;
   readonly onExecutionLinked?:
     | ((input: { readonly mission: Mission; readonly executionId: string }) => Promise<void>)
     | undefined;
@@ -1196,6 +1197,7 @@ export function createMissionRunner(options: {
     else options.missions.forget?.(id);
     options.usage?.markSubjectDeleted("mission", id);
     executionContexts.delete(id);
+    options.onStorageTrashed?.();
   };
 
   const getContextWindowState = async (

--- a/apps/desktop/src/main/platform/storage/trash-maintenance.test.ts
+++ b/apps/desktop/src/main/platform/storage/trash-maintenance.test.ts
@@ -1,0 +1,64 @@
+import { PragmaPaths, type TrashMaintenanceResult } from "@pragma/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { createDesktopTrashMaintenance } from "./trash-maintenance.ts";
+
+describe("createDesktopTrashMaintenance", () => {
+  it("coalesces requests that arrive while maintenance is running", async () => {
+    let release: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const maintain = vi
+      .fn<() => Promise<TrashMaintenanceResult>>()
+      .mockImplementationOnce(async () => {
+        await blocked;
+        return result(1);
+      })
+      .mockResolvedValue(result(0));
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const maintenance = createDesktopTrashMaintenance({
+      paths: new PragmaPaths({ pragmaHome: "/tmp/pragma-trash-maintenance-test" }),
+      logger,
+      maintain,
+    });
+
+    maintenance.schedule("startup");
+    maintenance.schedule("mission-deleted");
+    maintenance.schedule("automation-deleted");
+    release?.();
+    await vi.waitFor(() => expect(maintain).toHaveBeenCalledTimes(2));
+
+    expect(logger.info).toHaveBeenCalledTimes(2);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs a failure without preventing a later retry", async () => {
+    const maintain = vi
+      .fn<() => Promise<TrashMaintenanceResult>>()
+      .mockRejectedValueOnce(new Error("busy"))
+      .mockResolvedValueOnce(result(1));
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const maintenance = createDesktopTrashMaintenance({
+      paths: new PragmaPaths({ pragmaHome: "/tmp/pragma-trash-maintenance-retry-test" }),
+      logger,
+      maintain,
+    });
+
+    maintenance.schedule("startup");
+    await vi.waitFor(() => expect(logger.warn).toHaveBeenCalledOnce());
+    maintenance.schedule("mission-deleted");
+    await vi.waitFor(() => expect(logger.info).toHaveBeenCalledOnce());
+
+    expect(maintain).toHaveBeenCalledTimes(2);
+  });
+});
+
+function result(deletedEntries: number): TrashMaintenanceResult {
+  return {
+    beforeBytes: deletedEntries,
+    afterBytes: 0,
+    deletedEntries,
+    reclaimedBytes: deletedEntries,
+  };
+}

--- a/apps/desktop/src/main/platform/storage/trash-maintenance.ts
+++ b/apps/desktop/src/main/platform/storage/trash-maintenance.ts
@@ -1,0 +1,61 @@
+import {
+  runTrashMaintenance,
+  type PragmaLogger,
+  type PragmaPaths,
+  type TrashMaintenanceResult,
+} from "@pragma/core";
+
+export interface DesktopTrashMaintenance {
+  schedule(reason: string): void;
+}
+
+export function createDesktopTrashMaintenance(options: {
+  readonly paths: PragmaPaths;
+  readonly logger: Pick<PragmaLogger, "info" | "warn">;
+  readonly maintain?: (() => Promise<TrashMaintenanceResult>) | undefined;
+}): DesktopTrashMaintenance {
+  const maintain =
+    options.maintain ?? (async () => await runTrashMaintenance({ paths: options.paths }));
+  let pendingReason: string | undefined;
+  let running = false;
+
+  const drain = async (): Promise<void> => {
+    if (running) return;
+    running = true;
+    try {
+      while (pendingReason !== undefined) {
+        const reason = pendingReason;
+        pendingReason = undefined;
+        try {
+          const result = await maintain();
+          options.logger.info(
+            "desktop.trash_maintenance_completed",
+            "Desktop Trash retention maintenance completed.",
+            {
+              reason,
+              deletedEntries: result.deletedEntries,
+              reclaimedBytes: result.reclaimedBytes,
+              trashBytes: result.afterBytes,
+            },
+          );
+        } catch (error) {
+          options.logger.warn(
+            "desktop.trash_maintenance_failed",
+            "Desktop Trash retention maintenance failed and will be retried later.",
+            { reason, error },
+          );
+        }
+      }
+    } finally {
+      running = false;
+      if (pendingReason !== undefined) void drain();
+    }
+  };
+
+  return {
+    schedule(reason) {
+      pendingReason = reason;
+      void drain();
+    },
+  };
+}

--- a/docs/adr/016-local-storage-lifecycle-and-content-addressing.md
+++ b/docs/adr/016-local-storage-lifecycle-and-content-addressing.md
@@ -40,9 +40,20 @@ but is diagnostic rather than the durable Mission chat source. Plugin packages a
 `cache/plugins/sha256/<fingerprint>`; Agent directories contain binding metadata only.
 
 Mission deletion is an owner-graph operation. It writes a deletion journal and moves uniquely owned
-ExpertSession, Execution, Runtime Session, ownership-claim, and archive data to a seven-day trash
-area. GC uses mark-sweep plus a grace period instead of mutable reference counts. Leased or referenced
-objects cannot be collected.
+ExpertSession, Execution, Runtime Session, ownership-claim, and archive data to the managed trash
+area. Completed trash entries are retained until the first of three fixed limits: seven days,
+300 MiB total, or ten entries. Incomplete and invalid deletion journals are never removed by this
+retention pass. Desktop schedules targeted trash maintenance after its first window is available and
+after successful owner deletions; startup does not scan or upgrade unrelated owners. GC uses
+mark-sweep plus a grace period instead of mutable reference counts. Leased or referenced objects
+cannot be collected.
+
+New Qoder CLI Runtime Sessions project one shared rebuildable external-command cache at
+`cache/runtimes/qodercli/external-commands` into their otherwise private Qoder configuration. Existing
+session-local `external-commands` directories are left untouched and are not discovered or migrated
+at startup. Qoder remains responsible for command installation and atomic `current` replacement;
+Pragma removes completed `download-*` archives and stale `.tmp-*` staging directories after Runtime
+use while respecting a live command lock.
 
 Default limits are 4 GiB soft and 6 GiB hard globally, 1 GiB for rebuildable cache, and 512 MiB or 90
 days for Execution archives. Persistent data is never silently evicted. At the hard limit Pragma
@@ -61,6 +72,10 @@ a process or machine failure without orphaning the legacy backup.
   complete project directory.
 - Mutable Codex session data remains isolated; ADR 026 defines how rebuildable native caches are
   projected without a Pragma-owned full cache snapshot.
+- Qoder authentication, project state, logs, and native session data remain private while new
+  sessions reuse downloaded external commands. Legacy active sessions keep their existing layout.
+- Trash retention is bounded without introducing a settings surface; an unfinished deletion journal
+  remains recoverable even when completed entries are pruned.
 - Keeping all Missions and all revisions can still consume the configured persistent capacity; the
   hard limit makes this bounded and requires an explicit owner deletion decision.
 - Mission chat remains readable after Execution diagnostic archives expire.

--- a/packages/core/src/storage/deletion-transaction.ts
+++ b/packages/core/src/storage/deletion-transaction.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { PragmaPaths } from "./pragma-paths.ts";
@@ -100,35 +100,6 @@ export async function runtimeSessionDeletionSources(
     }
   }
   return sources;
-}
-
-export async function purgeExpiredTrash(input: {
-  readonly paths: PragmaPaths;
-  readonly ttlMs: number;
-  readonly now?: number | undefined;
-}): Promise<{ readonly deleted: number }> {
-  let entries;
-  try {
-    entries = await readdir(input.paths.trashRoot(), { withFileTypes: true });
-  } catch (error) {
-    if (isNotFound(error)) return { deleted: 0 };
-    throw error;
-  }
-  const now = input.now ?? Date.now();
-  let deleted = 0;
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const journalPath = join(input.paths.deletionJournalRoot(), `${entry.name}.json`);
-    const journal = await readFile(journalPath, "utf8")
-      .then((value) => JSON.parse(value) as { readonly completedAt?: unknown })
-      .catch(() => undefined);
-    if (typeof journal?.completedAt !== "string") continue;
-    if (now - Date.parse(journal.completedAt) < input.ttlMs) continue;
-    await rm(join(input.paths.trashRoot(), entry.name), { recursive: true, force: true });
-    await rm(journalPath, { force: true });
-    deleted += 1;
-  }
-  return { deleted };
 }
 
 async function writeJournal(path: string, value: unknown): Promise<void> {

--- a/packages/core/src/storage/pragma-paths.ts
+++ b/packages/core/src/storage/pragma-paths.ts
@@ -431,6 +431,10 @@ export class PragmaPaths {
     return join(this.cacheRoot(), "runtimes", "codex");
   }
 
+  qoderCliExternalCommandsCacheRoot(): string {
+    return join(this.cacheRoot(), "runtimes", "qodercli", "external-commands");
+  }
+
   projectViewsCacheRoot(): string {
     return join(this.cacheRoot(), "project-views");
   }

--- a/packages/core/src/storage/storage-maintenance.ts
+++ b/packages/core/src/storage/storage-maintenance.ts
@@ -2,7 +2,6 @@ import { readFile, readdir, rm, rmdir, stat } from "node:fs/promises";
 import { basename, join } from "node:path";
 
 import { ContentAddressedStore, type ContentObjectRef } from "./content-addressed-store.ts";
-import { purgeExpiredTrash } from "./deletion-transaction.ts";
 import { withFileLock } from "./file-lock.ts";
 import { PragmaPaths } from "./pragma-paths.ts";
 import { DEFAULT_STORAGE_POLICY, type StoragePolicy } from "./storage-policy.ts";
@@ -29,6 +28,13 @@ export interface StorageMaintenanceResult {
   readonly deletedTrashEntries: number;
   readonly deletedContentObjects: number;
   readonly reclaimedContentBytes: number;
+}
+
+export interface TrashMaintenanceResult {
+  readonly beforeBytes: number;
+  readonly afterBytes: number;
+  readonly deletedEntries: number;
+  readonly reclaimedBytes: number;
 }
 
 export interface StorageCapacityGuard {
@@ -189,7 +195,7 @@ export async function runStorageMaintenance(input: {
       now,
       ttlOnly: true,
     });
-    const trash = await purgeExpiredTrash({ paths: input.paths, ttlMs: policy.trashTtlMs, now });
+    const trash = await pruneCompletedTrash({ paths: input.paths, policy, now });
     const roots = await readProjectSnapshotRoots(input.paths);
     const content = await new ContentAddressedStore(
       input.paths.contentObjectsRoot(),
@@ -221,12 +227,73 @@ export async function runStorageMaintenance(input: {
   });
 }
 
+export async function runTrashMaintenance(input: {
+  readonly paths: PragmaPaths;
+  readonly policy?: StoragePolicy | undefined;
+  readonly now?: number | undefined;
+}): Promise<TrashMaintenanceResult> {
+  const policy = input.policy ?? DEFAULT_STORAGE_POLICY;
+  const now = input.now ?? Date.now();
+  return await withFileLock(input.paths.storageGcLock(), async () => {
+    const beforeBytes = await directoryBytes(input.paths.trashRoot());
+    const result = await pruneCompletedTrash({ paths: input.paths, policy, now });
+    const afterBytes = await directoryBytes(input.paths.trashRoot());
+    return {
+      beforeBytes,
+      afterBytes,
+      deletedEntries: result.deleted,
+      reclaimedBytes: Math.max(0, beforeBytes - afterBytes),
+    };
+  });
+}
+
+async function pruneCompletedTrash(input: {
+  readonly paths: PragmaPaths;
+  readonly policy: StoragePolicy;
+  readonly now: number;
+}): Promise<{ readonly deleted: number }> {
+  const candidates = await completedTrashCandidates(input.paths);
+  let bytes = candidates.reduce((total, candidate) => total + candidate.bytes, 0);
+  let entries = candidates.length;
+  let deleted = 0;
+  for (const candidate of candidates) {
+    const expired = input.now - candidate.completedAt >= input.policy.trashTtlMs;
+    const overLimit =
+      bytes > input.policy.trashLimitBytes || entries > input.policy.trashMaxEntries;
+    if (!expired && !overLimit) continue;
+    await deleteTrashCandidate(candidate);
+    bytes -= candidate.bytes;
+    entries -= 1;
+    deleted += 1;
+  }
+  return { deleted };
+}
+
 async function purgeCompletedTrashForPressure(
   paths: PragmaPaths,
   reclaimBytes: number,
 ): Promise<{ readonly deleted: number }> {
+  const completed = await completedTrashCandidates(paths);
+  let reclaimed = 0;
+  let deleted = 0;
+  for (const candidate of completed) {
+    if (reclaimed >= reclaimBytes) break;
+    await deleteTrashCandidate(candidate);
+    reclaimed += candidate.bytes;
+    deleted += 1;
+  }
+  return { deleted };
+}
+
+interface CompletedTrashCandidate extends Candidate {
+  readonly deletionId: string;
+  readonly journalPath: string;
+  readonly completedAt: number;
+}
+
+async function completedTrashCandidates(paths: PragmaPaths): Promise<CompletedTrashCandidate[]> {
   const candidates = await directChildren(paths.trashRoot());
-  const completed = (
+  return (
     await Promise.all(
       candidates.map(async (candidate) => {
         const deletionId = basename(candidate.path);
@@ -235,33 +302,38 @@ async function purgeCompletedTrashForPressure(
           .then(
             (value) =>
               JSON.parse(value) as {
+                readonly schemaVersion?: unknown;
+                readonly deletionId?: unknown;
                 readonly status?: unknown;
                 readonly completedAt?: unknown;
               },
           )
           .catch(() => undefined);
-        if (journal?.status !== "trashed" || typeof journal.completedAt !== "string") {
+        if (
+          journal?.schemaVersion !== "pragma.storage-deletion/v1" ||
+          journal.deletionId !== deletionId ||
+          journal.status !== "trashed" ||
+          typeof journal.completedAt !== "string"
+        ) {
           return undefined;
         }
         const completedAt = Date.parse(journal.completedAt);
         return Number.isFinite(completedAt)
-          ? { ...candidate, journalPath, completedAt }
+          ? { ...candidate, deletionId, journalPath, completedAt }
           : undefined;
       }),
     )
   )
     .filter((candidate) => candidate !== undefined)
-    .toSorted((left, right) => left.completedAt - right.completedAt);
-  let reclaimed = 0;
-  let deleted = 0;
-  for (const candidate of completed) {
-    if (reclaimed >= reclaimBytes) break;
-    await rm(candidate.path, { recursive: true, force: true });
-    await rm(candidate.journalPath, { force: true });
-    reclaimed += candidate.bytes;
-    deleted += 1;
-  }
-  return { deleted };
+    .toSorted(
+      (left, right) =>
+        left.completedAt - right.completedAt || left.deletionId.localeCompare(right.deletionId),
+    );
+}
+
+async function deleteTrashCandidate(candidate: CompletedTrashCandidate): Promise<void> {
+  await rm(candidate.path, { recursive: true, force: true });
+  await rm(candidate.journalPath, { force: true });
 }
 
 interface Candidate {

--- a/packages/core/src/storage/storage-policy.ts
+++ b/packages/core/src/storage/storage-policy.ts
@@ -8,6 +8,8 @@ export interface StoragePolicy {
   readonly executionArchiveLimitBytes: number;
   readonly executionArchiveTtlMs: number;
   readonly temporaryTtlMs: number;
+  readonly trashLimitBytes: number;
+  readonly trashMaxEntries: number;
   readonly trashTtlMs: number;
   readonly contentGcGraceMs: number;
 }
@@ -26,6 +28,8 @@ export const DEFAULT_STORAGE_POLICY: StoragePolicy = Object.freeze({
   executionArchiveLimitBytes: 512 * MIB,
   executionArchiveTtlMs: 90 * DAY_MS,
   temporaryTtlMs: DAY_MS,
+  trashLimitBytes: 300 * MIB,
+  trashMaxEntries: 10,
   trashTtlMs: 7 * DAY_MS,
   contentGcGraceMs: DAY_MS,
 });

--- a/packages/core/test/pragma-paths.test.ts
+++ b/packages/core/test/pragma-paths.test.ts
@@ -37,4 +37,12 @@ describe("PragmaPaths", () => {
       "Invalid diagnostic archive date",
     );
   });
+
+  it("places Qoder external commands in the shared rebuildable Runtime cache", () => {
+    const paths = new PragmaPaths({ pragmaHome: join("", "pragma-home") });
+
+    expect(paths.qoderCliExternalCommandsCacheRoot()).toBe(
+      join(paths.cacheRoot(), "runtimes", "qodercli", "external-commands"),
+    );
+  });
 });

--- a/packages/core/test/storage-maintenance.test.ts
+++ b/packages/core/test/storage-maintenance.test.ts
@@ -10,6 +10,7 @@ import {
   assertStorageWriteAllowed,
   createStorageCapacityGuard,
   runStorageMaintenance,
+  runTrashMaintenance,
 } from "../src/storage/storage-maintenance.ts";
 import { DEFAULT_STORAGE_POLICY } from "../src/storage/storage-policy.ts";
 
@@ -202,4 +203,139 @@ describe("runStorageMaintenance", () => {
     ).resolves.toBeUndefined();
     await expect(readdir(paths.trashRoot())).resolves.toEqual([]);
   });
+
+  it("keeps only the newest completed trash entries within the count limit", async () => {
+    const root = await temporaryStorageRoot("pragma-trash-count-");
+    const paths = new PragmaPaths({ pragmaHome: root });
+    await createCompletedTrash(paths, "oldest", "2026-07-01T00:00:00.000Z", 1);
+    await createCompletedTrash(paths, "middle", "2026-07-02T00:00:00.000Z", 1);
+    await createCompletedTrash(paths, "newest", "2026-07-03T00:00:00.000Z", 1);
+
+    const result = await runTrashMaintenance({
+      paths,
+      now: Date.parse("2026-07-04T00:00:00.000Z"),
+      policy: {
+        ...DEFAULT_STORAGE_POLICY,
+        trashLimitBytes: Number.MAX_SAFE_INTEGER,
+        trashMaxEntries: 2,
+        trashTtlMs: Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    expect(result.deletedEntries).toBe(1);
+    await expect(readdir(paths.trashRoot())).resolves.toEqual(["middle", "newest"]);
+  });
+
+  it("removes oldest and oversized completed trash until the byte limit is satisfied", async () => {
+    const root = await temporaryStorageRoot("pragma-trash-bytes-");
+    const paths = new PragmaPaths({ pragmaHome: root });
+    await createCompletedTrash(paths, "old", "2026-07-01T00:00:00.000Z", 8);
+    await createCompletedTrash(paths, "new", "2026-07-02T00:00:00.000Z", 8);
+
+    const first = await runTrashMaintenance({
+      paths,
+      now: Date.parse("2026-07-03T00:00:00.000Z"),
+      policy: {
+        ...DEFAULT_STORAGE_POLICY,
+        trashLimitBytes: 10,
+        trashMaxEntries: Number.MAX_SAFE_INTEGER,
+        trashTtlMs: Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    expect(first.deletedEntries).toBe(1);
+    expect(first.reclaimedBytes).toBe(8);
+    await expect(readdir(paths.trashRoot())).resolves.toEqual(["new"]);
+
+    const second = await runTrashMaintenance({
+      paths,
+      now: Date.parse("2026-07-03T00:00:00.000Z"),
+      policy: {
+        ...DEFAULT_STORAGE_POLICY,
+        trashLimitBytes: 4,
+        trashMaxEntries: Number.MAX_SAFE_INTEGER,
+        trashTtlMs: Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    expect(second.deletedEntries).toBe(1);
+    await expect(readdir(paths.trashRoot())).resolves.toEqual([]);
+  });
+
+  it("expires completed trash but preserves incomplete deletion transactions", async () => {
+    const root = await temporaryStorageRoot("pragma-trash-ttl-");
+    const paths = new PragmaPaths({ pragmaHome: root });
+    await createCompletedTrash(paths, "expired", "2026-07-01T00:00:00.000Z", 1);
+    await createCompletedTrash(paths, "fresh", "2026-07-09T00:00:00.000Z", 1);
+    await createIncompleteTrash(paths, "moving", 1);
+    await createTrashFixture(paths, "invalid", 1, {
+      schemaVersion: "pragma.storage-deletion/v1",
+      deletionId: "different-id",
+      status: "trashed",
+      completedAt: "2026-07-01T00:00:00.000Z",
+    });
+
+    await runTrashMaintenance({
+      paths,
+      now: Date.parse("2026-07-10T00:00:00.000Z"),
+      policy: {
+        ...DEFAULT_STORAGE_POLICY,
+        trashLimitBytes: Number.MAX_SAFE_INTEGER,
+        trashMaxEntries: Number.MAX_SAFE_INTEGER,
+        trashTtlMs: 7 * 24 * 60 * 60 * 1_000,
+      },
+    });
+
+    await expect(readdir(paths.trashRoot())).resolves.toEqual(["fresh", "invalid", "moving"]);
+    await expect(stat(join(paths.deletionJournalRoot(), "invalid.json"))).resolves.toBeDefined();
+    await expect(stat(join(paths.deletionJournalRoot(), "moving.json"))).resolves.toBeDefined();
+  });
 });
+
+async function temporaryStorageRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function createCompletedTrash(
+  paths: PragmaPaths,
+  deletionId: string,
+  completedAt: string,
+  bytes: number,
+): Promise<void> {
+  await createTrashFixture(paths, deletionId, bytes, {
+    schemaVersion: "pragma.storage-deletion/v1",
+    deletionId,
+    status: "trashed",
+    completedAt,
+  });
+}
+
+async function createIncompleteTrash(
+  paths: PragmaPaths,
+  deletionId: string,
+  bytes: number,
+): Promise<void> {
+  await createTrashFixture(paths, deletionId, bytes, {
+    schemaVersion: "pragma.storage-deletion/v1",
+    deletionId,
+    status: "moving",
+  });
+}
+
+async function createTrashFixture(
+  paths: PragmaPaths,
+  deletionId: string,
+  bytes: number,
+  journal: unknown,
+): Promise<void> {
+  const trash = join(paths.trashRoot(), deletionId, "owner");
+  await mkdir(trash, { recursive: true });
+  await writeFile(join(trash, "payload.bin"), Buffer.alloc(bytes));
+  await mkdir(paths.deletionJournalRoot(), { recursive: true });
+  await writeFile(
+    join(paths.deletionJournalRoot(), `${deletionId}.json`),
+    `${JSON.stringify(journal)}\n`,
+  );
+}

--- a/packages/runtime/qodercli/src/adapter.ts
+++ b/packages/runtime/qodercli/src/adapter.ts
@@ -100,6 +100,7 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
           async () =>
             await prepareManagedQoderConfig({
               sessionDir,
+              externalCommandsCacheDir: ctx.paths.pragma.qoderCliExternalCommandsCacheRoot(),
               env: ctx.processEnvironment,
               logger: ctx.logger,
             }),
@@ -116,13 +117,13 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
           sessionStartedAt,
           async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
         );
-        let configDir: string;
+        let managedConfig: Awaited<ReturnType<typeof prepareManagedQoderConfig>>;
         let plugin: Awaited<ReturnType<typeof materializeQoderSkillPlugin>>;
         let mcpToolRegistry: McpToolRegistry | undefined;
         let mcpToolRegistryLease: McpToolRegistryLease | undefined;
         try {
           const prepared = await Promise.all([configPromise, pluginPromise, registryLeasePromise]);
-          [configDir, plugin, mcpToolRegistryLease] = prepared;
+          [managedConfig, plugin, mcpToolRegistryLease] = prepared;
           mcpToolRegistry = mcpToolRegistryLease.registry;
         } catch (error) {
           const registry = await Promise.allSettled([registryLeasePromise]);
@@ -143,7 +144,7 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
               sessionStartedAt,
               async () =>
                 await nativeSessionFileExists(
-                  join(configDir, "projects"),
+                  join(managedConfig.configDir, "projects"),
                   restoredRuntimeSessionId,
                 ),
             ))
@@ -180,7 +181,8 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
             auth: resolveQoderAuth(options),
             executablePath: resolveQoderCliExecutablePath(options),
             env: { ...ctx.processEnvironment },
-            configDir,
+            configDir: managedConfig.configDir,
+            externalCommandsCacheDir: managedConfig.externalCommandsCacheDir,
             mcpServerUrl: expertToolsMcpRegistration.url,
             plugin,
             logger: ctx.logger,

--- a/packages/runtime/qodercli/src/qoder-config.ts
+++ b/packages/runtime/qodercli/src/qoder-config.ts
@@ -1,13 +1,30 @@
-import { access, cp, mkdir } from "node:fs/promises";
+import {
+  access,
+  cp,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  stat,
+  symlink,
+} from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
-import type { PragmaLogger } from "@pragma/core";
+import { DEFAULT_STORAGE_POLICY, type PragmaLogger } from "@pragma/core";
 
 export interface PrepareManagedQoderConfigOptions {
   readonly sessionDir: string;
+  readonly externalCommandsCacheDir: string;
   readonly env?: NodeJS.ProcessEnv | undefined;
   readonly logger: Pick<PragmaLogger, "warn">;
+}
+
+export interface ManagedQoderConfig {
+  readonly configDir: string;
+  readonly externalCommandsCacheDir?: string | undefined;
 }
 
 const PRIVATE_STATE_DIRECTORIES = ["projects", "logs", "tmp"] as const;
@@ -26,9 +43,10 @@ const SHARED_CONFIG_SNAPSHOTS = [
 
 export async function prepareManagedQoderConfig({
   sessionDir,
+  externalCommandsCacheDir,
   env,
   logger,
-}: PrepareManagedQoderConfigOptions): Promise<string> {
+}: PrepareManagedQoderConfigOptions): Promise<ManagedQoderConfig> {
   const configDir = join(sessionDir, "config");
   await mkdir(configDir, { recursive: true, mode: 0o700 });
   await Promise.all(
@@ -67,7 +85,147 @@ export async function prepareManagedQoderConfig({
     }),
   );
 
-  return configDir;
+  const managedExternalCommandsCacheDir = await prepareSharedExternalCommands({
+    configDir,
+    cacheDir: externalCommandsCacheDir,
+    logger,
+  });
+  if (managedExternalCommandsCacheDir !== undefined) {
+    await cleanupManagedQoderExternalCommands(managedExternalCommandsCacheDir).catch((error) => {
+      logger.warn(
+        "runtime.qodercli_external_commands_cleanup_failed",
+        "Qoder CLI shared external-command artifacts could not be cleaned.",
+        { error },
+      );
+    });
+  }
+  return {
+    configDir,
+    ...(managedExternalCommandsCacheDir === undefined
+      ? {}
+      : { externalCommandsCacheDir: managedExternalCommandsCacheDir }),
+  };
+}
+
+export async function cleanupManagedQoderExternalCommands(
+  cacheDir: string,
+  options: {
+    readonly now?: number | undefined;
+    readonly temporaryTtlMs?: number | undefined;
+  } = {},
+): Promise<void> {
+  const now = options.now ?? Date.now();
+  const temporaryTtlMs = options.temporaryTtlMs ?? DEFAULT_STORAGE_POLICY.temporaryTtlMs;
+  const commands = await readdir(cacheDir, { withFileTypes: true }).catch((error: unknown) => {
+    if (isNotFoundError(error)) return [];
+    throw error;
+  });
+  await Promise.all(
+    commands.map(async (command) => {
+      if (!command.isDirectory() || !/^[a-z][a-z0-9-]*$/.test(command.name)) return;
+      const commandDir = join(cacheDir, command.name);
+      if (await hasLiveCommandLock(cacheDir, command.name)) return;
+      await removeCompletedDownloads(join(commandDir, "current"));
+      const entries = await readdir(commandDir, { withFileTypes: true }).catch((error: unknown) => {
+        if (isNotFoundError(error)) return [];
+        throw error;
+      });
+      await Promise.all(
+        entries
+          .filter((entry) => entry.name.startsWith(".tmp-"))
+          .map(async (entry) => {
+            const path = join(commandDir, entry.name);
+            const metadata = await stat(path).catch(() => undefined);
+            if (metadata === undefined || now - metadata.mtimeMs < temporaryTtlMs) return;
+            await rm(path, { recursive: true, force: true });
+          }),
+      );
+    }),
+  );
+}
+
+async function prepareSharedExternalCommands(input: {
+  readonly configDir: string;
+  readonly cacheDir: string;
+  readonly logger: Pick<PragmaLogger, "warn">;
+}): Promise<string | undefined> {
+  const target = join(input.configDir, "external-commands");
+  const existing = await lstat(target).catch((error: unknown) => {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  });
+  if (existing !== undefined) {
+    if (!existing.isSymbolicLink()) return undefined;
+    const linkedPath = resolve(dirname(target), await readlink(target));
+    if (linkedPath !== resolve(input.cacheDir)) return undefined;
+    await mkdir(input.cacheDir, { recursive: true, mode: 0o700 });
+    return input.cacheDir;
+  }
+
+  await mkdir(input.cacheDir, { recursive: true, mode: 0o700 });
+  try {
+    await symlink(
+      resolve(input.cacheDir),
+      target,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    return input.cacheDir;
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) throw error;
+    const raced = await lstat(target);
+    if (!raced.isSymbolicLink()) return undefined;
+    const linkedPath = resolve(dirname(target), await readlink(target));
+    if (linkedPath === resolve(input.cacheDir)) return input.cacheDir;
+    input.logger.warn(
+      "runtime.qodercli_external_commands_link_conflict",
+      "Qoder CLI session external commands already point to a different location; preserving it.",
+    );
+    return undefined;
+  }
+}
+
+async function removeCompletedDownloads(currentDir: string): Promise<void> {
+  const current = await lstat(currentDir).catch((error: unknown) => {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  });
+  if (current === undefined || !current.isDirectory()) return;
+  const entries = await readdir(currentDir, { withFileTypes: true });
+  await Promise.all(
+    entries
+      .filter((entry) => entry.name.startsWith("download-"))
+      .map(async (entry) => {
+        await rm(join(currentDir, entry.name), { recursive: true, force: true });
+      }),
+  );
+}
+
+async function hasLiveCommandLock(cacheDir: string, commandName: string): Promise<boolean> {
+  const lockPath = join(cacheDir, "locks", `${commandName}.lock`);
+  const content = await readFile(lockPath, "utf8").catch((error: unknown) => {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  });
+  if (content === undefined) return false;
+  let pid: unknown;
+  try {
+    const parsed = JSON.parse(content) as { readonly pid?: unknown };
+    pid = parsed.pid;
+  } catch {
+    const parsed = Number(content.trim());
+    pid = Number.isSafeInteger(parsed) ? parsed : undefined;
+  }
+  return typeof pid === "number" && isProcessAlive(pid);
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return isNodeError(error, "EPERM");
+  }
 }
 
 export function resolveSharedQoderConfigDir(env: NodeJS.ProcessEnv | undefined): string {
@@ -81,5 +239,13 @@ function readNonEmpty(value: string | undefined): string | undefined {
 }
 
 function isNotFoundError(error: unknown): boolean {
-  return error !== null && typeof error === "object" && "code" in error && error.code === "ENOENT";
+  return isNodeError(error, "ENOENT");
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return isNodeError(error, "EEXIST");
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return error !== null && typeof error === "object" && "code" in error && error.code === code;
 }

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -32,6 +32,7 @@ import {
 } from "@qoder-ai/qoder-agent-sdk";
 
 import { resolveQoderContextWindow } from "./models.ts";
+import { cleanupManagedQoderExternalCommands } from "./qoder-config.ts";
 import type { QoderCliRuntimePermissionMode } from "./types.ts";
 
 export type QoderNativeEvent =
@@ -61,6 +62,7 @@ export interface QoderNativeSession {
   readonly executablePath: string;
   readonly env: NodeJS.ProcessEnv;
   readonly configDir: string;
+  readonly externalCommandsCacheDir?: string | undefined;
   readonly mcpServerUrl: string;
   readonly plugin: { readonly path: string; readonly skills: readonly string[] };
   readonly logger: PragmaLogger;
@@ -451,6 +453,15 @@ async function runQoderQuery(
     session.toolRuntimeState.runId = undefined;
     session.toolRuntimeState.source = undefined;
     await q.close().catch(() => undefined);
+    if (session.externalCommandsCacheDir !== undefined) {
+      await cleanupManagedQoderExternalCommands(session.externalCommandsCacheDir).catch((error) => {
+        session.logger.warn(
+          "runtime.qodercli_external_commands_cleanup_failed",
+          "Qoder CLI shared external-command artifacts could not be cleaned after the turn.",
+          { error },
+        );
+      });
+    }
   }
 }
 

--- a/packages/runtime/qodercli/test/adapter.test.ts
+++ b/packages/runtime/qodercli/test/adapter.test.ts
@@ -41,7 +41,7 @@ vi.mock("@pragma/core", async (importOriginal) => {
 });
 
 vi.mock("../src/qoder-config.ts", () => ({
-  prepareManagedQoderConfig: vi.fn(async () => runtimeMocks.configDir),
+  prepareManagedQoderConfig: vi.fn(async () => ({ configDir: runtimeMocks.configDir })),
 }));
 
 vi.mock("../src/skills.ts", () => ({
@@ -158,7 +158,9 @@ function createSessionContext(
     workspace: "/workspace",
     logger: { info: vi.fn() },
     paths: {
-      pragma: {},
+      pragma: {
+        qoderCliExternalCommandsCacheRoot: () => join(sessionDir, "shared-external-commands"),
+      },
       systemSessionDir: sessionDir,
       runtimeSessionDir: () => sessionDir,
     },

--- a/packages/runtime/qodercli/test/qoder-config.test.ts
+++ b/packages/runtime/qodercli/test/qoder-config.test.ts
@@ -1,10 +1,21 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  cleanupManagedQoderExternalCommands,
   prepareManagedQoderConfig,
   resolveSharedQoderConfigDir,
 } from "../src/qoder-config.ts";
@@ -40,19 +51,20 @@ describe("prepareManagedQoderConfig", () => {
 
     const config = await prepareManagedQoderConfig({
       sessionDir: session,
+      externalCommandsCacheDir: join(root, "cache", "external-commands"),
       env: { QODER_CONFIG_DIR: shared },
       logger: { warn: vi.fn() },
     });
 
-    await expect(readFile(join(config, ".auth", "user"), "utf8")).resolves.toBe(
+    await expect(readFile(join(config.configDir, ".auth", "user"), "utf8")).resolves.toBe(
       "credential",
     );
     await expect(
-      readFile(join(config, ".models", "user", "catalog-v6"), "utf8"),
+      readFile(join(config.configDir, ".models", "user", "catalog-v6"), "utf8"),
     ).resolves.toBe("encrypted-catalog");
-    await expect(readFile(join(config, "projects", "missing"), "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    await expect(
+      readFile(join(config.configDir, "projects", "missing"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("does not overwrite login state already owned by a restored session", async () => {
@@ -66,23 +78,101 @@ describe("prepareManagedQoderConfig", () => {
     await writeFile(join(shared, ".auth", "user"), "new-global-login");
     await writeFile(join(shared, ".models", "user", "catalog-v6"), "new-global-catalog");
     await writeFile(join(session, "config", ".auth", "user"), "session-login");
-    await writeFile(
-      join(session, "config", ".models", "user", "catalog-v6"),
-      "session-catalog",
-    );
+    await writeFile(join(session, "config", ".models", "user", "catalog-v6"), "session-catalog");
 
     const config = await prepareManagedQoderConfig({
       sessionDir: session,
+      externalCommandsCacheDir: join(root, "cache", "external-commands"),
       env: { QODER_CONFIG_DIR: shared },
       logger: { warn: vi.fn() },
     });
 
-    await expect(readFile(join(config, ".auth", "user"), "utf8")).resolves.toBe(
+    await expect(readFile(join(config.configDir, ".auth", "user"), "utf8")).resolves.toBe(
       "session-login",
     );
     await expect(
-      readFile(join(config, ".models", "user", "catalog-v6"), "utf8"),
+      readFile(join(config.configDir, ".models", "user", "catalog-v6"), "utf8"),
     ).resolves.toBe("session-catalog");
+  });
+
+  it("links fresh sessions to one shared external-command cache", async () => {
+    const root = await temporaryRoot();
+    const cache = join(root, "cache", "external-commands");
+    const first = await prepareManagedQoderConfig({
+      sessionDir: join(root, "first"),
+      externalCommandsCacheDir: cache,
+      logger: { warn: vi.fn() },
+    });
+    const second = await prepareManagedQoderConfig({
+      sessionDir: join(root, "second"),
+      externalCommandsCacheDir: cache,
+      logger: { warn: vi.fn() },
+    });
+
+    expect(first.externalCommandsCacheDir).toBe(cache);
+    expect(second.externalCommandsCacheDir).toBe(cache);
+    await expect(realpath(join(first.configDir, "external-commands"))).resolves.toBe(
+      await realpath(cache),
+    );
+    await expect(realpath(join(second.configDir, "external-commands"))).resolves.toBe(
+      await realpath(cache),
+    );
+    expect((await lstat(join(first.configDir, "external-commands"))).isSymbolicLink()).toBe(true);
+  });
+
+  it("preserves an existing session-local external-command directory", async () => {
+    const root = await temporaryRoot();
+    const session = join(root, "legacy");
+    const legacy = join(session, "config", "external-commands");
+    await mkdir(join(legacy, "qoder-core", "current"), { recursive: true });
+    await writeFile(join(legacy, "qoder-core", "current", "command.json"), "legacy");
+
+    const config = await prepareManagedQoderConfig({
+      sessionDir: session,
+      externalCommandsCacheDir: join(root, "cache", "external-commands"),
+      logger: { warn: vi.fn() },
+    });
+
+    expect(config.externalCommandsCacheDir).toBeUndefined();
+    expect((await lstat(legacy)).isDirectory()).toBe(true);
+    await expect(
+      readFile(join(legacy, "qoder-core", "current", "command.json"), "utf8"),
+    ).resolves.toBe("legacy");
+  });
+
+  it("removes completed downloads and only stale unlocked temporary installs", async () => {
+    const root = await temporaryRoot();
+    const cache = join(root, "external-commands");
+    const command = join(cache, "qoder-core");
+    const current = join(command, "current");
+    const stale = join(command, ".tmp-stale");
+    const fresh = join(command, ".tmp-fresh");
+    await Promise.all([
+      mkdir(current, { recursive: true }),
+      mkdir(stale, { recursive: true }),
+      mkdir(fresh, { recursive: true }),
+    ]);
+    await writeFile(join(current, "download-qoder-core.zip"), "archive");
+    await writeFile(join(current, "bin"), "binary");
+    await utimes(stale, new Date(0), new Date(0));
+
+    await cleanupManagedQoderExternalCommands(cache, { now: 10_000, temporaryTtlMs: 1_000 });
+
+    await expect(stat(join(current, "download-qoder-core.zip"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(stat(join(current, "bin"))).resolves.toBeDefined();
+    await expect(stat(stale)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(fresh)).resolves.toBeDefined();
+
+    await mkdir(stale);
+    await utimes(stale, new Date(0), new Date(0));
+    await writeFile(join(current, "download-live.zip"), "archive");
+    await mkdir(join(cache, "locks"), { recursive: true });
+    await writeFile(join(cache, "locks", "qoder-core.lock"), JSON.stringify({ pid: process.pid }));
+    await cleanupManagedQoderExternalCommands(cache, { now: 10_000, temporaryTtlMs: 1_000 });
+    await expect(stat(stale)).resolves.toBeDefined();
+    await expect(stat(join(current, "download-live.zip"))).resolves.toBeDefined();
   });
 });
 


### PR DESCRIPTION
Fixes #111.

## What changed

- Bound completed Trash retention to the earliest of 7 days, 300 MiB, or 10 entries.
- Preserve incomplete, corrupt, and identity-mismatched deletion journals.
- Schedule targeted Desktop Trash maintenance after the first window is created and after Mission or Automation storage is trashed.
- Share Qoder CLI external commands for new Runtime Sessions through `~/.pragma/cache/runtimes/qodercli/external-commands/`.
- Keep existing Qoder session-local external command directories unchanged.
- Remove completed Qoder `download-*` archives and stale `.tmp-*` staging directories while respecting active command locks.
- Update ADR 016, repository guidance, and focused tests.

## Root cause

Core already had storage cleanup primitives, but Desktop never scheduled Trash retention maintenance outside hard-limit pressure. Qoder also placed downloaded external commands under each Runtime Session's private config directory, duplicating rebuildable command payloads.

## Impact

Trash can no longer grow indefinitely under normal Desktop use, while recoverable deletion transactions remain protected. New Qoder sessions reuse downloaded commands without changing authentication, project, log, or native session isolation. Existing active sessions are intentionally not migrated.

## Validation

- `pnpm check` — 21/21 packages passed
  - Core: 223/223 tests
  - Desktop: 616/616 tests
  - Qoder CLI: 29/29 tests
- `pnpm build` — 21/21 packages passed
- Desktop preload self-containment and `pragmaDesktop` bridge verification passed
- `git diff --check` passed
- Independent Claude Code review completed with no blocking findings
