### PR TITLE
Fix always-on context reinjection after compaction

### DIFF
--- a/packages/core/src/agent/context-manager.ts
+++ b/packages/core/src/agent/context-manager.ts
@@ -388,11 +388,19 @@ function throwPreloadError(
 function createAlwaysOnStartupMessages(
   contexts: readonly ExpertAgentContextItem[],
 ): readonly ExpertAgentStartupMessage[] {
-  const content = formatContextsSection("Always-on reference context", contexts);
+  const contextsSection = formatContextsSection("Always-on reference context", contexts);
 
-  if (content === undefined) {
+  if (contextsSection === undefined) {
     return [];
   }
+
+  const content = [
+    "System-maintained always-on context:",
+    "- During context compaction, do not include this block in the generated summary.",
+    "- This complete block supersedes any summary, paraphrase, or older copy of the same context in conversation history.",
+    "",
+    contextsSection,
+  ].join("\n");
 
   return [
     {
@@ -408,6 +416,7 @@ function formatContextAccessRulesSection(): string {
     "- Context ids are Context System identifiers, not local filesystem paths.",
     "- Use list_expert_context like a directory listing to discover context ids and descriptions.",
     "- Use search_expert_context to discover context by path or content, and read_expert_context when you know the context id.",
+    "- Always-on context must remain available. If its complete text is missing or uncertain, use read_expert_context to reload the relevant context id before relying on a summary or paraphrase.",
     '- Use add_expert_context, edit_expert_context, and delete_expert_context to write Context System content. Use edit_expert_context mode="replace" for full content or metadata replacement, and mode="search_replace" for exact text search/replace.',
     "- Do not use shell commands, local filesystem APIs, or runtime file tools to bypass the Context System for these context ids.",
   ].join("\n");

--- a/packages/core/src/runtime/context-compaction.ts
+++ b/packages/core/src/runtime/context-compaction.ts
@@ -4,6 +4,10 @@ export const RUNTIME_CONTEXT_COMPACTION_STAGES = {
   failed: "context.compaction.failed",
 } as const;
 
+export const RUNTIME_STARTUP_MESSAGE_STAGES = {
+  reinjectionSkipped: "context.startup_messages.reinjection_skipped",
+} as const;
+
 export type RuntimeContextCompactionStage =
   (typeof RUNTIME_CONTEXT_COMPACTION_STAGES)[keyof typeof RUNTIME_CONTEXT_COMPACTION_STAGES];
 

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -40,6 +40,12 @@ import {
   type RuntimeEventMappingResult,
   type RuntimeStreamWriter,
 } from "./stream-controller.ts";
+import {
+  RUNTIME_CONTEXT_COMPACTION_STAGES,
+  RUNTIME_STARTUP_MESSAGE_STAGES,
+  readRuntimeContextCompactionProgressData,
+} from "./context-compaction.ts";
+import { defaultRuntimeTokenCounter } from "./token-counter.ts";
 import { mergeUsage, hasNonZeroUsage } from "./usage.ts";
 import { createExpertAgentRunContext, type ExpertAgentRunContext } from "./run-context.ts";
 import { PragmaPaths } from "../storage/pragma-paths.ts";
@@ -174,11 +180,9 @@ export interface RuntimeDriver<TNativeEvent, TNativeSession, TPrepared = Runtime
   readonly defaultOutputParser?: RuntimeOutputParser | undefined;
   readonly outputRetryLimit?: number | undefined;
   readonly resolvePersistence?:
-    | ((context: RuntimePrepareContext) => RuntimeSessionPersistenceSpec | undefined)
-    | undefined;
+    ((context: RuntimePrepareContext) => RuntimeSessionPersistenceSpec | undefined) | undefined;
   readonly prepare?:
-    | ((context: RuntimePrepareContext) => Promise<TPrepared> | TPrepared)
-    | undefined;
+    ((context: RuntimePrepareContext) => Promise<TPrepared> | TPrepared) | undefined;
   readonly createSession: (
     context: RuntimeDriverSessionContext<TPrepared>,
   ) => Promise<TNativeSession> | TNativeSession;
@@ -219,16 +223,14 @@ export interface RuntimeDriver<TNativeEvent, TNativeSession, TPrepared = Runtime
       ) => Promise<RuntimeContextWindowUsage | undefined> | RuntimeContextWindowUsage | undefined)
     | undefined;
   readonly canCompactContext?:
-    | ((session: TNativeSession) => Promise<boolean> | boolean)
-    | undefined;
+    ((session: TNativeSession) => Promise<boolean> | boolean) | undefined;
   readonly compactContext?:
     | ((
         session: TNativeSession,
       ) => Promise<RuntimeContextWindowUsage | undefined> | RuntimeContextWindowUsage | undefined)
     | undefined;
   readonly cancelTurn?:
-    | ((session: TNativeSession, context: RuntimeCancelContext) => Promise<void> | void)
-    | undefined;
+    ((session: TNativeSession, context: RuntimeCancelContext) => Promise<void> | void) | undefined;
   readonly steerTurn?:
     | ((
         session: TNativeSession,
@@ -240,8 +242,7 @@ export interface RuntimeDriver<TNativeEvent, TNativeSession, TPrepared = Runtime
       ) => Promise<void> | void)
     | undefined;
   readonly closeSession?:
-    | ((session: TNativeSession, context: RuntimeCloseContext) => Promise<void> | void)
-    | undefined;
+    ((session: TNativeSession, context: RuntimeCloseContext) => Promise<void> | void) | undefined;
 }
 
 export function defineRuntimeDriver<
@@ -554,6 +555,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       lifecycle,
       logger,
       runContext,
+      startupMessages: agentContext.startupMessages,
       systemSessionId,
       outputRetryLimit: driver.outputRetryLimit,
       defaultOutputParser: driver.defaultOutputParser,
@@ -712,6 +714,8 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
   private watcher: RuntimeSessionWatcher | undefined;
   private activeRunId: string | undefined;
   private contextWindowCalibrated = false;
+  private initialStartupMessagesConsumed = false;
+  private startupMessagesReinjectionPending = false;
 
   constructor(
     private readonly options: {
@@ -722,6 +726,7 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
       readonly lifecycle: AgentLifecycle<ExpertAgentRunContext | undefined>;
       readonly logger: PragmaLogger;
       readonly runContext: ExpertAgentRunContext;
+      readonly startupMessages: readonly ExpertAgentStartupMessage[];
       readonly systemSessionId: string;
       readonly outputRetryLimit?: number | undefined;
       readonly defaultOutputParser?: RuntimeOutputParser | undefined;
@@ -775,6 +780,7 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
           : async () => {
               this.assertIdle("compact the context window");
               const usage = await this.options.driver.compactContext!(this.options.nativeSession);
+              this.rearmStartupMessages();
               await this.options.persistContextWindowUsage(usage ?? null);
               await this.options.checkpoint("context.compacted");
               return usage;
@@ -801,6 +807,7 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
       context: this.options.runContext,
       logger: this.options.logger,
       mapEvent: this.options.driver.mapEvent,
+      onEvent: (event) => this.observeRuntimeEvent(event),
     });
     let enteredLifecycle = false;
     let finalized = false;
@@ -1012,11 +1019,7 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
     controller: ReturnType<typeof createRuntimeStreamController<TNativeEvent>>,
     observeUsage: (usage: AgentMessageUsage | undefined) => void,
   ): Promise<RuntimeRunResult<TOutput>> {
-    const startupMessages =
-      this.options.driver.consumeStartupMessages?.(this.options.nativeSession, {
-        agent: this.options.agent,
-        runContext: this.options.runContext,
-      }) ?? [];
+    const startupMessages = this.takeStartupMessages();
     const maxAttempts =
       submission.output === undefined
         ? 1
@@ -1032,8 +1035,11 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
         attempt === 1
           ? createInitialRuntimePrompt(submission.query, submission.output)
           : createRuntimeOutputRetryPrompt(parseResult);
-      const attemptStartupMessages = attempt === 1 ? startupMessages : [];
       const contextWindow = await this.refreshContextWindow(false);
+      const attemptStartupMessages =
+        attempt === 1
+          ? this.applyStartupMessageBudget(startupMessages, contextWindow, submission, controller)
+          : [];
       controller.resetCapture();
       controller.beginUsagePreview({
         prompt,
@@ -1118,6 +1124,111 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
     controller.updateUsage(usage);
 
     return createRuntimeRunResult(runId, parseResult.value, usage);
+  }
+
+  private takeStartupMessages(): {
+    readonly kind: "initial" | "reinjection";
+    readonly messages: readonly ExpertAgentStartupMessage[];
+  } {
+    if (!this.initialStartupMessagesConsumed) {
+      this.initialStartupMessagesConsumed = true;
+      const messages =
+        this.options.driver.consumeStartupMessages?.(this.options.nativeSession, {
+          agent: this.options.agent,
+          runContext: this.options.runContext,
+        }) ?? [];
+      if (messages.length > 0) {
+        this.startupMessagesReinjectionPending = false;
+        return { kind: "initial", messages };
+      }
+    }
+
+    if (this.startupMessagesReinjectionPending) {
+      this.startupMessagesReinjectionPending = false;
+      return { kind: "reinjection", messages: this.options.startupMessages };
+    }
+
+    return { kind: "initial", messages: [] };
+  }
+
+  private applyStartupMessageBudget<TOutput>(
+    candidate: {
+      readonly kind: "initial" | "reinjection";
+      readonly messages: readonly ExpertAgentStartupMessage[];
+    },
+    contextWindow: RuntimeContextWindowUsage | undefined,
+    submission: RuntimeSubmitRequest<TOutput>,
+    controller: ReturnType<typeof createRuntimeStreamController<TNativeEvent>>,
+  ): readonly ExpertAgentStartupMessage[] {
+    if (
+      candidate.kind !== "reinjection" ||
+      candidate.messages.length === 0 ||
+      contextWindow?.usedTokens === null ||
+      contextWindow?.usedTokens === undefined
+    ) {
+      return candidate.messages;
+    }
+
+    const remainingTokens = Math.max(
+      0,
+      contextWindow.contextWindowTokens - contextWindow.usedTokens,
+    );
+    const thresholdTokens = Math.floor(remainingTokens * 0.5);
+    const count = defaultRuntimeTokenCounter.countText(
+      candidate.messages.map((message) => message.content).join("\n\n"),
+      {
+        runtimeKind: this.options.descriptor.kind,
+        providerId: submission.modelSelection?.model.providerId,
+        modelId: submission.modelSelection?.model.modelId,
+      },
+    );
+    if (count.tokens <= thresholdTokens) {
+      return candidate.messages;
+    }
+
+    const data = {
+      reason: "insufficient_remaining_context",
+      startupMessageTokens: count.tokens,
+      tokenCountSource: count.source,
+      remainingTokens,
+      thresholdTokens,
+      thresholdRatio: 0.5,
+      contextWindow,
+    };
+    this.options.logger.warn(
+      "runtime.startup_messages_reinjection_skipped",
+      "Always-on context reinjection was skipped because it exceeded the remaining context budget.",
+      data,
+    );
+    controller.writer.write({
+      runId: controller.source.runId,
+      source: controller.source,
+      type: "progress",
+      payload: {
+        stage: RUNTIME_STARTUP_MESSAGE_STAGES.reinjectionSkipped,
+        message:
+          "Always-on context reinjection was skipped; use read_expert_context when the full context is needed.",
+        data,
+      },
+    });
+    return [];
+  }
+
+  private observeRuntimeEvent(event: RuntimeStreamEvent): void {
+    if (
+      event.type !== "progress" ||
+      event.payload.stage !== RUNTIME_CONTEXT_COMPACTION_STAGES.completed ||
+      readRuntimeContextCompactionProgressData(event.payload.data) === undefined
+    ) {
+      return;
+    }
+    this.rearmStartupMessages();
+  }
+
+  private rearmStartupMessages(): void {
+    if (this.options.startupMessages.length > 0) {
+      this.startupMessagesReinjectionPending = true;
+    }
   }
 }
 

--- a/packages/core/src/runtime/stream-controller.ts
+++ b/packages/core/src/runtime/stream-controller.ts
@@ -101,6 +101,7 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
   readonly session: () => RuntimeSessionInfo;
   readonly context?: ExpertAgentRunContext | undefined;
   readonly logger: PragmaLogger;
+  readonly onEvent?: ((event: RuntimeStreamEvent) => void) | undefined;
   readonly mapEvent: (
     event: TNativeEvent,
     context: RuntimeEventMappingContext,
@@ -141,6 +142,7 @@ export function createRuntimeStreamController<TNativeEvent>(options: {
 
   const emit = (event: RuntimeStreamEventInput): void => {
     const emitted = emitter.emit(event);
+    options.onEvent?.(emitted);
     pendingHookCalls.push(
       dispatchExpertAgentHook(options.agent.hooks, "onStreamEvent", {
         agent: options.agent,

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -3539,6 +3539,15 @@ describe("Expert delegation declarations", () => {
       expect(context.agentContext.startupMessages[0]?.content).toContain(
         "Existing project context.",
       );
+      expect(context.agentContext.startupMessages[0]?.content).toContain(
+        "do not include this block in the generated summary",
+      );
+      expect(context.agentContext.startupMessages[0]?.content).toContain(
+        "supersedes any summary, paraphrase, or older copy",
+      );
+      expect(context.agentContext.systemPrompt).toContain(
+        "use read_expert_context to reload the relevant context id",
+      );
     }
 
     stats.sessionContexts.length = 0;

--- a/packages/core/test/runtime-startup-messages.test.ts
+++ b/packages/core/test/runtime-startup-messages.test.ts
@@ -1,0 +1,294 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  ContextSystem,
+  createRuntimeContextWindowUsage,
+  defaultRuntimeTokenCounter,
+  defineExpert,
+  defineRuntimeDriver,
+  RUNTIME_CONTEXT_COMPACTION_STAGES,
+  RUNTIME_STARTUP_MESSAGE_STAGES,
+  StaticContextStore,
+  type ExpertAgentStartupMessage,
+  type RuntimeContextWindowUsage,
+  type RuntimeDriverSessionContext,
+  type RuntimeTurnContext,
+} from "../src/index.ts";
+import { openRuntimeSession } from "../src/runtime/session-factory.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Runtime always-on startup messages", () => {
+  it("injects once and rearms only after completed automatic or manual compaction", async () => {
+    const fixture = await createFixture();
+    try {
+      await submit(fixture.session, "first");
+      await submit(fixture.session, "without-compaction");
+      await submit(fixture.session, "auto-compact");
+      await submit(fixture.session, "after-auto");
+      await submit(fixture.session, "steady-again");
+
+      expect(fixture.stats.turns.map((turn) => turn.startupMessages.length)).toEqual([
+        1, 0, 0, 1, 0,
+      ]);
+
+      await fixture.session.contextWindow?.compact?.();
+      await submit(fixture.session, "after-manual");
+      await submit(fixture.session, "after-manual-steady");
+
+      expect(fixture.stats.turns.slice(-2).map((turn) => turn.startupMessages.length)).toEqual([
+        1, 0,
+      ]);
+      expect(fixture.stats.compact).toHaveBeenCalledOnce();
+    } finally {
+      await fixture.session.close();
+    }
+  });
+
+  it("coalesces compactions, ignores failed events, and keeps retries free of reinjection", async () => {
+    const fixture = await createFixture();
+    try {
+      const retry = fixture.session.submit({
+        query: "retry-after-compaction",
+        output: z.object({ ok: z.boolean() }),
+        outputRetryLimit: 1,
+        execution: {},
+      });
+      await collectEvents(retry.events);
+      await expect(retry.result).resolves.toMatchObject({ result: { output: { ok: true } } });
+
+      expect(fixture.stats.turns.slice(0, 2).map((turn) => turn.startupMessages.length)).toEqual([
+        1, 0,
+      ]);
+
+      await submit(fixture.session, "after-retry");
+      await submit(fixture.session, "failed-compaction");
+      await submit(fixture.session, "after-failed");
+
+      expect(fixture.stats.turns.slice(2).map((turn) => turn.startupMessages.length)).toEqual([
+        1, 0, 0,
+      ]);
+    } finally {
+      await fixture.session.close();
+    }
+  });
+
+  it("skips oversized reinjection at the 50 percent gate and emits a diagnostic", async () => {
+    const fixture = await createFixture();
+    try {
+      await submit(fixture.session, "first");
+      await submit(fixture.session, "auto-compact");
+      fixture.stats.contextWindow = createRuntimeContextWindowUsage({
+        usedTokens: 99,
+        contextWindowTokens: 100,
+        measurement: "reported",
+      });
+
+      const skipped = await submit(fixture.session, "budget-gated");
+      expect(fixture.stats.turns.at(-1)?.startupMessages).toEqual([]);
+      expect(skipped.events).toContainEqual(
+        expect.objectContaining({
+          type: "progress",
+          payload: expect.objectContaining({
+            stage: RUNTIME_STARTUP_MESSAGE_STAGES.reinjectionSkipped,
+            data: expect.objectContaining({
+              reason: "insufficient_remaining_context",
+              remainingTokens: 1,
+              thresholdTokens: 0,
+              thresholdRatio: 0.5,
+            }),
+          }),
+        }),
+      );
+
+      await submit(fixture.session, "not-retried-without-compaction");
+      expect(fixture.stats.turns.at(-1)?.startupMessages).toEqual([]);
+
+      await submit(fixture.session, "auto-compact");
+      fixture.stats.contextWindow = {
+        ...fixture.stats.contextWindow,
+        usedTokens: null,
+        percent: null,
+      };
+      await submit(fixture.session, "unknown-usage-still-injects");
+      expect(fixture.stats.turns.at(-1)?.startupMessages).toHaveLength(1);
+    } finally {
+      await fixture.session.close();
+    }
+  });
+
+  it("allows reinjection exactly at the 50 percent budget boundary", async () => {
+    const fixture = await createFixture();
+    try {
+      await submit(fixture.session, "first");
+      await submit(fixture.session, "auto-compact");
+      await (
+        defaultRuntimeTokenCounter as typeof defaultRuntimeTokenCounter & {
+          readonly load: () => Promise<boolean>;
+        }
+      ).load();
+      const content = fixture.stats.turns[0]?.startupMessages
+        .map((message) => message.content)
+        .join("\n\n");
+      const startupMessageTokens = defaultRuntimeTokenCounter.countText(content ?? "").tokens;
+      fixture.stats.contextWindow = createRuntimeContextWindowUsage({
+        usedTokens: 1_000,
+        contextWindowTokens: 1_000 + startupMessageTokens * 2,
+        measurement: "reported",
+      });
+
+      const result = await submit(fixture.session, "at-boundary");
+
+      expect(fixture.stats.turns.at(-1)?.startupMessages).toHaveLength(1);
+      expect(result.events).not.toContainEqual(
+        expect.objectContaining({
+          type: "progress",
+          payload: expect.objectContaining({
+            stage: RUNTIME_STARTUP_MESSAGE_STAGES.reinjectionSkipped,
+          }),
+        }),
+      );
+    } finally {
+      await fixture.session.close();
+    }
+  });
+});
+
+interface TestNativeEvent {
+  readonly stage: string;
+  readonly data: unknown;
+}
+
+interface TestNativeSession {
+  readonly context: RuntimeDriverSessionContext;
+  pendingStartupMessages: readonly ExpertAgentStartupMessage[];
+}
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), "pragma-runtime-startup-"));
+  roots.push(root);
+  const stats = {
+    turns: [] as Array<{
+      readonly attempt: number;
+      readonly startupMessages: readonly ExpertAgentStartupMessage[];
+    }>,
+    compact: vi.fn(),
+    contextWindow: createRuntimeContextWindowUsage({
+      usedTokens: 10,
+      contextWindowTokens: 10_000,
+      measurement: "reported",
+    }) as RuntimeContextWindowUsage,
+  };
+  const contextSystem = new ContextSystem({
+    stores: {
+      project: new StaticContextStore([
+        {
+          id: "POLICY.md",
+          content: "Always verify the complete policy before acting.",
+          metadata: { trigger: "always_on" },
+        },
+      ]),
+    },
+    roots: [{ namespace: "project" }],
+  });
+  const agent = await defineExpert({
+    id: "startup-test",
+    name: "Startup Test",
+    description: "Tests always-on startup messages",
+    tags: ["test"],
+    scope: "test",
+    workspace: root,
+    pragmaHome: root,
+    contextSystem,
+  });
+  const runtime = defineRuntimeDriver<TestNativeEvent, TestNativeSession>({
+    descriptor: { id: "startup-runtime", kind: "startup-runtime", displayName: "Startup" },
+    createSession(context) {
+      return { context, pendingStartupMessages: context.agentContext.startupMessages };
+    },
+    consumeStartupMessages(session) {
+      const messages = session.pendingStartupMessages;
+      session.pendingStartupMessages = [];
+      return messages;
+    },
+    async startTurn(session, turn) {
+      stats.turns.push({ attempt: turn.attempt, startupMessages: turn.startupMessages });
+      if (
+        turn.rawQuery === "auto-compact" ||
+        (turn.rawQuery === "retry-after-compaction" && turn.attempt === 1)
+      ) {
+        writeCompactionEvent(turn, RUNTIME_CONTEXT_COMPACTION_STAGES.completed);
+        if (turn.rawQuery === "auto-compact") {
+          writeCompactionEvent(turn, RUNTIME_CONTEXT_COMPACTION_STAGES.completed);
+        }
+      }
+      if (turn.rawQuery === "failed-compaction") {
+        writeCompactionEvent(turn, RUNTIME_CONTEXT_COMPACTION_STAGES.failed);
+      }
+      return {
+        outputText:
+          turn.rawQuery === "retry-after-compaction"
+            ? turn.attempt === 1
+              ? "invalid"
+              : '{"ok":true}'
+            : "done",
+      };
+    },
+    mapEvent(event, context) {
+      return { events: [context.events.progress(event.stage, event.data)] };
+    },
+    readContextWindow() {
+      return stats.contextWindow;
+    },
+    compactContext() {
+      stats.compact();
+      return stats.contextWindow;
+    },
+  });
+  const session = await openRuntimeSession(runtime, {
+    agent,
+    owner: { type: "expert-session", ownerId: "owner", contextId: "context" },
+    pragmaHome: root,
+    systemSessionId: "system-session",
+  });
+  return { session, stats };
+}
+
+function writeCompactionEvent(turn: RuntimeTurnContext<TestNativeEvent>, stage: string): void {
+  turn.stream.writeNative({
+    stage,
+    data: {
+      operationId: `operation-${turn.runId}`,
+      trigger: "auto",
+      runtimeId: "startup-runtime",
+      ...(stage === RUNTIME_CONTEXT_COMPACTION_STAGES.failed
+        ? { errorMessage: "compaction failed" }
+        : {}),
+    },
+  });
+}
+
+async function submit(
+  session: Awaited<ReturnType<typeof createFixture>>["session"],
+  query: string,
+) {
+  const submission = session.submit({ query, execution: {} });
+  const eventsPromise = collectEvents(submission.events);
+  await submission.result;
+  return { events: await eventsPromise };
+}
+
+async function collectEvents(events: AsyncIterable<unknown>): Promise<unknown[]> {
+  const collected: unknown[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+}

--- a/packages/runtime/claude-code/src/session.ts
+++ b/packages/runtime/claude-code/src/session.ts
@@ -149,18 +149,6 @@ export function consumeClaudeCodeStartupMessages(
 ): readonly ExpertAgentStartupMessage[] {
   const startupMessages = session.pendingStartupMessages;
   session.pendingStartupMessages = [];
-
-  if (startupMessages.length > 0) {
-    const timestamp = Date.now();
-    session.messages.push(
-      ...startupMessages.map((message, index) => ({
-        role: "user" as const,
-        content: message.content,
-        timestamp: timestamp + index,
-      })),
-    );
-  }
-
   return startupMessages;
 }
 
@@ -171,11 +159,19 @@ export async function startClaudeCodeTurn(
   session.tokenModelIdentity = claudeTokenModelIdentity(
     turn.modelSelection?.model.modelId ?? session.defaultModelName,
   );
-  session.messages.push({
-    role: "user",
-    content: turn.rawQuery,
-    timestamp: Date.now(),
-  });
+  const timestamp = Date.now();
+  session.messages.push(
+    ...turn.startupMessages.map((message, index) => ({
+      role: message.role,
+      content: message.content,
+      timestamp: timestamp + index,
+    })),
+    {
+      role: "user",
+      content: turn.rawQuery,
+      timestamp: timestamp + turn.startupMessages.length,
+    },
+  );
 
   const unsubscribeCompaction = session.compactionHookRelay.subscribe((event) => {
     turn.stream.writeNative(event);

--- a/packages/runtime/claude-code/test/session.test.ts
+++ b/packages/runtime/claude-code/test/session.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { RuntimeEventMappingContext } from "@pragma/core";
 
 import {
+  consumeClaudeCodeStartupMessages,
   mapClaudeCodeNativeEvent,
   normalizeClaudeToolRuntimeEvents,
   readAssistantMessageEvent,
@@ -15,6 +16,21 @@ import {
   type ClaudeToolStreamState,
   type ClaudeCodeNativeSession,
 } from "../src/session.ts";
+
+describe("Claude Code startup messages", () => {
+  it("consumes mounted messages once without recording them before a turn", () => {
+    const session = {
+      pendingStartupMessages: [{ role: "user", content: "always-on context" }],
+      messages: [],
+    } as unknown as ClaudeCodeNativeSession;
+
+    expect(consumeClaudeCodeStartupMessages(session)).toEqual([
+      { role: "user", content: "always-on context" },
+    ]);
+    expect(consumeClaudeCodeStartupMessages(session)).toEqual([]);
+    expect(session.messages).toEqual([]);
+  });
+});
 
 describe("Claude Code context window", () => {
   it("pairs the latest assistant-step usage with the selected model context window", () => {

--- a/packages/runtime/codex/src/session.ts
+++ b/packages/runtime/codex/src/session.ts
@@ -144,18 +144,6 @@ export function consumeCodexStartupMessages(
 ): readonly ExpertAgentStartupMessage[] {
   const startupMessages = session.pendingStartupMessages;
   session.pendingStartupMessages = [];
-
-  if (startupMessages.length > 0) {
-    const timestamp = Date.now();
-    session.messages.push(
-      ...startupMessages.map((message, index) => ({
-        role: message.role,
-        content: message.content,
-        timestamp: timestamp + index,
-      })),
-    );
-  }
-
   return startupMessages;
 }
 
@@ -194,11 +182,19 @@ export async function startCodexTurn(
   });
   const unsubscribe = session.notificationBus.subscribe(observer.handleNotification);
 
-  session.messages.push({
-    role: "user",
-    content: turn.rawQuery,
-    timestamp: Date.now(),
-  });
+  const timestamp = Date.now();
+  session.messages.push(
+    ...turn.startupMessages.map((message, index) => ({
+      role: message.role,
+      content: message.content,
+      timestamp: timestamp + index,
+    })),
+    {
+      role: "user",
+      content: turn.rawQuery,
+      timestamp: timestamp + turn.startupMessages.length,
+    },
+  );
 
   try {
     await session.client.startTurn({

--- a/packages/runtime/codex/test/session.test.ts
+++ b/packages/runtime/codex/test/session.test.ts
@@ -200,7 +200,7 @@ describe("Codex turn completion", () => {
     const notificationBus = createCodexNotificationBus();
     const writeNative = vi.fn();
     const client = {
-      async startTurn() {
+      startTurn: vi.fn(async () => {
         notificationBus.publish({
           method: "item/started",
           params: {
@@ -226,7 +226,7 @@ describe("Codex turn completion", () => {
           method: "turn/completed",
           params: { threadId: "thread-1", turn: { status: "completed", error: null } },
         });
-      },
+      }),
     } as unknown as CodexAppServerClient;
     const session = createCodexNativeSession({
       client,
@@ -240,7 +240,7 @@ describe("Codex turn completion", () => {
       isRetry: false,
       rawQuery: "hello",
       prompt: "hello",
-      startupMessages: [],
+      startupMessages: [{ role: "user", content: "always-on context" }],
       signal: new AbortController().signal,
       source: {
         kind: "runtime",
@@ -259,6 +259,19 @@ describe("Codex turn completion", () => {
         },
       }),
     );
+    expect(client.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          { type: "text", text: "always-on context", text_elements: [] },
+          { type: "text", text: "hello", text_elements: [] },
+        ],
+      }),
+    );
+    expect(session.messages).toMatchObject([
+      { role: "user", content: "always-on context" },
+      { role: "user", content: "hello" },
+      { role: "assistant" },
+    ]);
     expect(writeNative).toHaveBeenCalledWith(
       expect.objectContaining({
         compaction: {

--- a/packages/runtime/pi/src/adapter.ts
+++ b/packages/runtime/pi/src/adapter.ts
@@ -38,6 +38,7 @@ import {
   canCompactPiContextWindow,
   compactPiContextWindow,
   collectPiUsage,
+  consumePiStartupMessages,
   createPiNativeSession,
   listPiMessages,
   mapPiAgentEvent,
@@ -295,9 +296,6 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             sessionStartedAt,
             async () => await createAgentSession(sessionOptions),
           ));
-          if (!piSessionManagerResult.resumedExistingSession) {
-            appendStartupMessages(session, ctx.agentContext.startupMessages);
-          }
           ctx.logger.info("runtime.pi_session_ready", "Runtime session preparation completed", {
             elapsedMs: piElapsedMs(sessionStartedAt),
             toolCount: sessionOptions.customTools?.length ?? 0,
@@ -318,6 +316,9 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
                 modelRuntime,
               },
               compactionKeepRecentTokens,
+              startupMessages: piSessionManagerResult.resumedExistingSession
+                ? []
+                : ctx.agentContext.startupMessages,
               tokenCounter: options.tokenCounter,
               tokenModelIdentity: piTokenModelIdentity(registeredProvider, selectedModel),
             }),
@@ -346,6 +347,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
         };
       },
       listMessages: listPiMessages,
+      consumeStartupMessages: consumePiStartupMessages,
       async startTurn(session, turn) {
         const selectedModel = turn.modelSelection?.model;
         if (selectedModel !== undefined) {
@@ -468,32 +470,4 @@ export function createPiSessionBashTool(options: {
       );
     },
   };
-}
-
-function appendStartupMessages(
-  session: AgentSession,
-  messages: readonly { readonly role: "user"; readonly content: string }[],
-): void {
-  if (messages.length === 0) {
-    return;
-  }
-
-  const timestamp = Date.now();
-  const piMessages = messages.map((message, index) => ({
-    role: message.role,
-    content: message.content,
-    timestamp: timestamp + index,
-  }));
-  const mutableSession = session as unknown as {
-    readonly state?: { messages: unknown[] } | undefined;
-    messages: unknown[];
-  };
-  const nextMessages = [...mutableSession.messages, ...piMessages];
-
-  if (mutableSession.state !== undefined) {
-    mutableSession.state.messages = nextMessages;
-    return;
-  }
-
-  mutableSession.messages = nextMessages;
 }

--- a/packages/runtime/pi/src/session.ts
+++ b/packages/runtime/pi/src/session.ts
@@ -14,6 +14,7 @@ import { randomUUID } from "node:crypto";
 import { AgentMessageUsageSchema, type AgentMessage, type AgentMessageUsage } from "@pragma/shared";
 import type {
   Expert,
+  ExpertAgentStartupMessage,
   RuntimeContextWindowUsage,
   RuntimeEventMappingContext,
   RuntimeEventMappingResult,
@@ -58,6 +59,7 @@ export interface PiNativeSession {
   readonly tokenCounter: RuntimeTokenCounter;
   tokenModelIdentity: RuntimeTokenModelIdentity;
   messageCountBeforeRun: number;
+  pendingStartupMessages: readonly ExpertAgentStartupMessage[];
   pendingCompactionOperationId?: string | undefined;
   compactionTriggerOverride?: RuntimeContextCompactionTrigger | undefined;
 }
@@ -78,6 +80,7 @@ export function createPiNativeSession(options: {
     readonly modelRuntime: ModelRuntime;
   };
   readonly compactionKeepRecentTokens: number;
+  readonly startupMessages?: readonly ExpertAgentStartupMessage[] | undefined;
   readonly tokenCounter?: RuntimeTokenCounter | undefined;
   readonly tokenModelIdentity?: RuntimeTokenModelIdentity | undefined;
 }): PiNativeSession {
@@ -86,6 +89,7 @@ export function createPiNativeSession(options: {
     tokenCounter: options.tokenCounter ?? defaultRuntimeTokenCounter,
     tokenModelIdentity: options.tokenModelIdentity ?? { runtimeKind: "cloud-pi-agent" },
     messageCountBeforeRun: options.session.messages.length,
+    pendingStartupMessages: options.startupMessages ?? [],
   };
 }
 
@@ -98,6 +102,14 @@ export function setPiTokenModelIdentity(
 
 export function listPiMessages(session: PiNativeSession): readonly AgentMessage[] {
   return convertPiAgentMessages(session.session.messages);
+}
+
+export function consumePiStartupMessages(
+  session: PiNativeSession,
+): readonly ExpertAgentStartupMessage[] {
+  const startupMessages = session.pendingStartupMessages;
+  session.pendingStartupMessages = [];
+  return startupMessages;
 }
 
 export async function startPiTurn(
@@ -153,7 +165,9 @@ export async function startPiTurn(
       nativeSession.session.setThinkingLevel(thinkingLevel);
     }
     await compactPiContextBeforePrompt(nativeSession);
-    await nativeSession.session.prompt(turn.prompt);
+    await nativeSession.session.prompt(
+      [...turn.startupMessages.map((message) => message.content), turn.prompt].join("\n\n"),
+    );
     assertAssistantTurnCompleted(
       nativeSession.session.messages.slice(nativeSession.messageCountBeforeRun),
     );

--- a/packages/runtime/pi/test/startup-messages.test.ts
+++ b/packages/runtime/pi/test/startup-messages.test.ts
@@ -1,0 +1,86 @@
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import type { RuntimeTurnContext } from "@pragma/core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  consumePiStartupMessages,
+  createPiNativeSession,
+  startPiTurn,
+  type PiNativeEvent,
+} from "../src/session.ts";
+
+describe("PI startup messages", () => {
+  it("consumes mounted startup messages once without mutating native history", () => {
+    const native = createNativeSession();
+
+    expect(consumePiStartupMessages(native)).toEqual([
+      { role: "user", content: "always-on context" },
+    ]);
+    expect(consumePiStartupMessages(native)).toEqual([]);
+    expect(native.session.messages).toEqual([]);
+  });
+
+  it("prepends turn startup messages after pre-prompt compaction", async () => {
+    const native = createNativeSession();
+    const startupMessages = consumePiStartupMessages(native);
+
+    await startPiTurn(native, createTurn(startupMessages));
+
+    expect(native.session.prompt).toHaveBeenCalledWith("always-on context\n\nuser prompt");
+  });
+});
+
+function createNativeSession() {
+  const messages: unknown[] = [];
+  const session = {
+    messages,
+    model: undefined,
+    prompt: vi.fn(async () => {
+      messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        stopReason: "stop",
+      });
+    }),
+    setModel: vi.fn(async () => undefined),
+    setThinkingLevel: vi.fn(),
+    subscribe: vi.fn(() => () => undefined),
+    getContextUsage: vi.fn(() => ({ tokens: 0, contextWindow: 128_000, percent: 0 })),
+    sessionManager: { getBranch: () => [] },
+    settingsManager: {
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    },
+  } as unknown as AgentSession;
+
+  return createPiNativeSession({
+    agent: { id: "pi-test" } as Parameters<typeof createPiNativeSession>[0]["agent"],
+    session,
+    streamState: {},
+    models: {
+      modelRegistry: {} as Parameters<typeof createPiNativeSession>[0]["models"]["modelRegistry"],
+      modelRuntime: {} as Parameters<typeof createPiNativeSession>[0]["models"]["modelRuntime"],
+    },
+    compactionKeepRecentTokens: 20_000,
+    startupMessages: [{ role: "user", content: "always-on context" }],
+  });
+}
+
+function createTurn(
+  startupMessages: RuntimeTurnContext<PiNativeEvent>["startupMessages"],
+): RuntimeTurnContext<PiNativeEvent> {
+  return {
+    runId: "run-1",
+    attempt: 1,
+    isRetry: false,
+    rawQuery: "user prompt",
+    prompt: "user prompt",
+    startupMessages,
+    signal: new AbortController().signal,
+    source: { kind: "runtime", runId: "run-1", path: [] },
+    stream: {
+      write: vi.fn(),
+      writeNative: vi.fn(),
+    },
+  };
+}

--- a/packages/runtime/qodercli/src/session.ts
+++ b/packages/runtime/qodercli/src/session.ts
@@ -98,11 +98,19 @@ export async function startQoderTurn(
 ): Promise<RuntimeTurnResult> {
   session.toolRuntimeState.runId = turn.runId;
   session.toolRuntimeState.source = turn.source;
-  session.messages.push({
-    role: "user",
-    content: turn.rawQuery,
-    timestamp: Date.now(),
-  });
+  const timestamp = Date.now();
+  session.messages.push(
+    ...turn.startupMessages.map((message, index) => ({
+      role: message.role,
+      content: message.content,
+      timestamp: timestamp + index,
+    })),
+    {
+      role: "user",
+      content: turn.rawQuery,
+      timestamp: timestamp + turn.startupMessages.length,
+    },
+  );
 
   const prompt = [...turn.startupMessages.map((message) => message.content), turn.prompt].join(
     "\n\n",
@@ -180,18 +188,6 @@ export function consumeQoderStartupMessages(
 ): readonly ExpertAgentStartupMessage[] {
   const startupMessages = session.pendingStartupMessages;
   session.pendingStartupMessages = [];
-
-  if (startupMessages.length > 0) {
-    const timestamp = Date.now();
-    session.messages.push(
-      ...startupMessages.map((message, index) => ({
-        role: message.role,
-        content: message.content,
-        timestamp: timestamp + index,
-      })),
-    );
-  }
-
   return startupMessages;
 }
 

--- a/packages/runtime/qodercli/test/session.test.ts
+++ b/packages/runtime/qodercli/test/session.test.ts
@@ -21,7 +21,7 @@ describe("Qoder startup messages", () => {
     queryMock.mockReset();
   });
 
-  it("consumes startup messages once and records them in session history", () => {
+  it("consumes startup messages once without recording them before a turn", () => {
     const session = createSession();
     session.pendingStartupMessages = [
       { role: "user", content: "always-on context one" },
@@ -33,13 +33,10 @@ describe("Qoder startup messages", () => {
       { role: "user", content: "always-on context two" },
     ]);
     expect(session.pendingStartupMessages).toEqual([]);
-    expect(session.messages).toMatchObject([
-      { role: "user", content: "always-on context one" },
-      { role: "user", content: "always-on context two" },
-    ]);
+    expect(session.messages).toEqual([]);
 
     expect(consumeQoderStartupMessages(session)).toEqual([]);
-    expect(session.messages).toHaveLength(2);
+    expect(session.messages).toEqual([]);
   });
 
   it("prepends startup messages to the first native prompt without double-counting fallback usage", async () => {
@@ -67,6 +64,11 @@ describe("Qoder startup messages", () => {
       messages: [],
       prompt: "always-on context one\n\nalways-on context two\n\nuser prompt",
     });
+    expect(session.messages.slice(0, 3)).toMatchObject([
+      { role: "user", content: "always-on context one" },
+      { role: "user", content: "always-on context two" },
+      { role: "user", content: "user prompt" },
+    ]);
     expect(sdkQuery.close).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## Summary

- manage always-on `startupMessages` lifecycle in the Core runtime driver
- rearm full-context injection after successful automatic or manual compaction
- apply a 50% remaining-context budget gate with a structured fallback diagnostic
- migrate PI away from direct native-history mutation and align runtime-local message mirrors
- strengthen prompt guidance so full always-on context supersedes summaries and can be reloaded on demand

## Root cause

Always-on context was injected only at session startup. Native runtime compaction could fold that content into a summary, leaving later turns without the authoritative full text and without any mechanism to restore it.

## Impact

After a successful compaction, the next new submission receives the full always-on context exactly once. Retries in the same submission do not replay it, repeated turns without compaction do not duplicate it, and oversized reinjection falls back to `read_expert_context` with a diagnostic event.

The rearm state remains process-local; no persistence schema or protocol version changes are introduced.

## Validation

- Claude Code CR completed; all findings were independently reviewed with no blocking defects accepted
- affected package tests: 348 passed across Core, PI, Codex, Claude Code, and Qoder CLI
- `pnpm check`: 21/21 workspace tasks passed
- `git diff --check`

Closes #109