### PR TITLE
Distinguish expert output in Mission chat

### DIFF
--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@pragma/core";
 import type {
   PragmaExpertResource,
+  PragmaExpertTeamResource,
   PragmaFlowResource,
   PragmaRuntimeProfileResource,
 } from "@pragma/interpreter/ast";
@@ -591,8 +592,17 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         expect(chat.execution?.interruptible).toBe(true);
         expect(chat.entries).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ kind: "thinking", content: "Checking constraints." }),
-            expect.objectContaining({ kind: "tool", toolName: "read_file", status: "running" }),
+            expect.objectContaining({
+              kind: "thinking",
+              executorName: "Writer",
+              content: "Checking constraints.",
+            }),
+            expect.objectContaining({
+              kind: "tool",
+              executorName: "Writer",
+              toolName: "read_file",
+              status: "running",
+            }),
             expect.objectContaining({
               kind: "context_operation",
               operationId: "compact-live",
@@ -629,11 +639,11 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: "entry.upsert",
-          entry: expect.objectContaining({ kind: "thinking" }),
+          entry: expect.objectContaining({ kind: "thinking", executorName: "Writer" }),
         }),
         expect.objectContaining({
           type: "entry.upsert",
-          entry: expect.objectContaining({ kind: "tool" }),
+          entry: expect.objectContaining({ kind: "tool", executorName: "Writer" }),
         }),
         expect.objectContaining({
           type: "entry.upsert",
@@ -877,6 +887,186 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     );
   });
 
+  it("identifies Team, delegated Expert, and Flow output in live and historical chat", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-executor-labels-"));
+    temporaryPaths.push(root);
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const writer = expertFixtureWithReviewerTool();
+    const reviewer = reviewerFixture();
+    const team = expertTeamFixture();
+    const flow = expertFlowFixture();
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), writer, reviewer, team, flow],
+    });
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const missionFor = async (
+      resource: PragmaExpertResource | PragmaExpertTeamResource | PragmaFlowResource,
+      goal: string,
+    ) =>
+      await missions.create({
+        workspace: { path: root, basename: "workspace" },
+        goal,
+        ...(resource.kind === "Flow" ? { flowInput: {} } : {}),
+        project: { id: snapshot.projectId, revision: snapshot.revision },
+        executor: missionExecutorSnapshot(resource),
+      });
+    const expertMission = await missionFor(writer, "Delegate review");
+    const teamMission = await missionFor(team, "Coordinate review");
+    const flowMission = await missionFor(flow, "Run review flow");
+    const runtime = defineRuntimeDriver<
+      never,
+      { context: RuntimeDriverSessionContext; id: string }
+    >({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: (context) => ({ context, id: `runtime:${context.systemSessionId}` }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn(session, turn) {
+        const tools = session.context.agent.tools ?? [];
+        const spawn = tools.find((tool) => tool.name === "spawn_expert");
+        const wait = tools.find((tool) => tool.name === "wait_experts");
+        const callReviewer = tools.find((tool) => tool.name === "call_reviewer");
+        let output = `${session.context.agent.id}:${turn.rawQuery}`;
+        if (
+          spawn !== undefined &&
+          wait !== undefined &&
+          session.context.agent.id === writer.metadata.id
+        ) {
+          const spawned = await spawn.call(
+            { expertId: reviewer.metadata.id, prompt: "Team review" },
+            turn.signal,
+            { execution: session.context.request.executionContext },
+          );
+          const invocationId = (spawned.details as { invocationId: string }).invocationId;
+          const waited = await wait.call({ invocationIds: [invocationId] }, turn.signal, {
+            execution: session.context.request.executionContext,
+          });
+          const completed = (waited.details as { completed: Array<{ output?: unknown }> })
+            .completed;
+          output = `writer:${String(completed[0]?.output)}`;
+        } else if (callReviewer !== undefined && turn.rawQuery === "Delegate review") {
+          const delegated = await callReviewer.call({ prompt: "Standalone review" }, turn.signal, {
+            execution: session.context.request.executionContext,
+          });
+          output = `writer:${String(delegated.details)}`;
+        }
+        turn.stream.write({
+          runId: turn.runId,
+          source: turn.source,
+          type: "message.delta",
+          payload: { role: "assistant", contentType: "text", delta: output },
+        });
+        return { outputText: output, runtimeSessionId: session.id };
+      },
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome: join(root, "state"),
+      runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
+    });
+    const updates: MissionChatUpdate[] = [];
+    const unsubscribe = runner.subscribeChat((update) => updates.push(update));
+
+    for (const mission of [expertMission, teamMission, flowMission]) {
+      await runner.run(mission.id);
+      await vi.waitFor(
+        async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+        { timeout: settlementTimeoutMs },
+      );
+    }
+
+    const expertChat = await runner.getChat({ id: expertMission.id, limit: 50 });
+    const teamChat = await runner.getChat({ id: teamMission.id, limit: 50 });
+    const flowChat = await runner.getChat({ id: flowMission.id, limit: 50 });
+    const expertOutputs = expertChat.entries.filter((entry) => entry.kind === "assistant");
+    const teamOutputs = teamChat.entries.filter((entry) => entry.kind === "assistant");
+    const flowOutputs = flowChat.entries.filter((entry) => entry.kind === "assistant");
+
+    expect(expertOutputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ executorId: writer.metadata.id, executorName: "Writer" }),
+        expect.objectContaining({ executorId: reviewer.metadata.id, executorName: "Reviewer" }),
+      ]),
+    );
+    expect(teamOutputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ executorId: writer.metadata.id, executorName: "Writer" }),
+        expect.objectContaining({ executorId: reviewer.metadata.id, executorName: "Reviewer" }),
+      ]),
+    );
+    expect(flowOutputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ executorId: reviewer.metadata.id, executorName: "Reviewer" }),
+      ]),
+    );
+    expect(
+      updates
+        .filter((update) => update.kind === "patch")
+        .flatMap((update) => update.patches)
+        .filter((patch) => patch.type === "entry.upsert")
+        .map((patch) => patch.entry)
+        .filter((entry) => entry.kind === "assistant"),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ executorId: writer.metadata.id, executorName: "Writer" }),
+        expect.objectContaining({ executorId: reviewer.metadata.id, executorName: "Reviewer" }),
+      ]),
+    );
+    unsubscribe();
+  });
+
+  it("keeps Work available with ID fallbacks when executor names cannot be read", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-work-name-fallback-"));
+    temporaryPaths.push(root);
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Read work without project metadata",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(
+        snapshot.resources.find((resource) => resource.kind === "Expert")!,
+      ),
+    });
+    vi.spyOn(project, "openRevision").mockRejectedValueOnce(
+      new Error("Project metadata unavailable"),
+    );
+    const unavailableRuntimes: RuntimeResolver = {
+      getDefaultRuntimeId: async () => "fake",
+      bind: async () => {
+        throw new Error("Runtime is unavailable.");
+      },
+      resolve: async () => {
+        throw new Error("Runtime is unavailable.");
+      },
+    };
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome: join(root, "state"),
+      runtimes: unavailableRuntimes,
+      loggerProvider: createNoopLoggerProvider(),
+    });
+
+    await expect(runner.getWork(mission.id)).resolves.toMatchObject({
+      missionId: mission.id,
+      records: [],
+    });
+  });
+
   it("keeps the captured live answer when the execution settles during a chat read", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-mission-chat-settlement-"));
     temporaryPaths.push(root);
@@ -937,23 +1127,26 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     await runner.run(mission.id);
     await deltaWritten;
 
-    const openRevision = project.openRevision.bind(project);
-    let enterProjectRead = (): void => undefined;
-    const projectReadEntered = new Promise<void>((resolve) => {
-      enterProjectRead = resolve;
+    const getMission = missions.get.bind(missions);
+    let missionReads = 0;
+    let enterFinalMissionRead = (): void => undefined;
+    const finalMissionReadEntered = new Promise<void>((resolve) => {
+      enterFinalMissionRead = resolve;
     });
-    let releaseProjectRead = (): void => undefined;
-    const projectReadCanFinish = new Promise<void>((resolve) => {
-      releaseProjectRead = resolve;
+    let releaseFinalMissionRead = (): void => undefined;
+    const finalMissionReadCanFinish = new Promise<void>((resolve) => {
+      releaseFinalMissionRead = resolve;
     });
-    vi.spyOn(project, "openRevision").mockImplementationOnce(async (revision) => {
-      enterProjectRead();
-      await projectReadCanFinish;
-      return await openRevision(revision);
+    vi.spyOn(missions, "get").mockImplementation(async (id) => {
+      if (id === mission.id && (missionReads += 1) === 2) {
+        enterFinalMissionRead();
+        await finalMissionReadCanFinish;
+      }
+      return await getMission(id);
     });
 
     const racedSnapshot = runner.getChat({ id: mission.id, limit: 50 });
-    await projectReadEntered;
+    await finalMissionReadEntered;
     finishTurn();
     try {
       await vi.waitFor(
@@ -973,7 +1166,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         { timeout: settlementTimeoutMs },
       );
     } finally {
-      releaseProjectRead();
+      releaseFinalMissionRead();
     }
 
     await expect(racedSnapshot).resolves.toMatchObject({
@@ -1069,8 +1262,8 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         createStaticRuntimeResolver({ runtimes: [runtimeForMode(mode)], defaultRuntimeId: "fake" }),
       ]),
     );
-    const runtimesForToolPermissionMode = vi.fn(
-      (mode: DesktopToolPermissionMode) => runtimeResolvers.get(mode)!,
+    const runtimesForToolPermissionMode = vi.fn((mode: DesktopToolPermissionMode) =>
+      runtimeResolvers.get(mode)!,
     );
     const runner = createMissionRunner({
       missions,
@@ -2393,6 +2586,95 @@ function expertFixture(): PragmaExpertResource {
       contextStores: [],
       plugins: [],
       tools: [],
+    },
+  };
+}
+
+function expertFixtureWithReviewerTool(): PragmaExpertResource {
+  const expert = expertFixture();
+  return {
+    ...expert,
+    spec: {
+      ...expert.spec,
+      tools: [
+        {
+          adapter: "pragma.tool.call@v1",
+          target: { ref: "expert:3sfd30h5017wd17d" },
+          tool: {
+            name: "call_reviewer",
+            description: "Call the reviewer",
+            approval: "none",
+          },
+        },
+      ],
+    },
+  };
+}
+
+function reviewerFixture(): PragmaExpertResource {
+  return {
+    ...expertFixture(),
+    metadata: {
+      id: "3sfd30h5017wd17d",
+      name: "Reviewer",
+      description: "Reviews proposed work",
+      tags: [],
+    },
+    spec: {
+      ...expertFixture().spec,
+      scope: "Review",
+      instructions: "Review the delegated work.",
+    },
+  };
+}
+
+function expertTeamFixture(): PragmaExpertTeamResource {
+  return {
+    apiVersion: "pragma/v3",
+    kind: "ExpertTeam",
+    metadata: {
+      id: "vyv9pwwzaksth2dd",
+      name: "Editorial Team",
+      description: "Coordinates writing and review",
+      tags: [],
+    },
+    spec: {
+      coordinator: { ref: "expert:1xddvess309a6gme" },
+      members: [{ ref: "expert:3sfd30h5017wd17d" }],
+      delegation: {
+        allow: { "1xddvess309a6gme": ["3sfd30h5017wd17d"], "3sfd30h5017wd17d": [] },
+        maxConcurrency: 2,
+        maxDepth: 2,
+        context: "context-policy:pragma.fresh@v1",
+        runtimes: {},
+      },
+    },
+  };
+}
+
+function expertFlowFixture(): PragmaFlowResource {
+  return {
+    apiVersion: "pragma/v3",
+    kind: "Flow",
+    metadata: {
+      id: "ffdfk2cczgqjda7q",
+      name: "Review Flow",
+      description: "Runs the reviewer",
+      tags: [],
+    },
+    spec: {
+      limits: { maxNodeVisits: 10 },
+      graph: {
+        start: "review",
+        steps: {
+          review: {
+            expert: { ref: "expert:3sfd30h5017wd17d" },
+            prompt: { segments: [{ text: "Flow review" }] },
+          },
+        },
+        loops: {},
+        transitions: { review: { end: true } },
+      },
     },
   };
 }

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -178,6 +178,8 @@ interface LiveMissionChat {
   sequence: number;
 }
 
+type ExecutorNameResolver = (executorId: string) => string | undefined;
+
 interface MissionExecutionContext {
   readonly app: ReturnType<typeof createPragma>;
   readonly runtimes: RuntimeResolver;
@@ -340,19 +342,38 @@ export function createMissionRunner(options: {
   const liveWorkOutputs = new Map<string, Map<string, LiveMissionChat>>();
   const executorNameCache = new Map<string, ReadonlyMap<string, string>>();
 
+  const readExecutorNames = async (
+    mission: Pick<Mission, "project">,
+  ): Promise<ReadonlyMap<string, string>> => {
+    const project = await options.project.openRevision(mission.project.revision);
+    return new Map(
+      project.listResources().map((resource) => [resource.metadata.id, resource.metadata.name]),
+    );
+  };
+
   const getExecutorNames = async (
     mission: Pick<Mission, "project">,
   ): Promise<ReadonlyMap<string, string>> => {
     const projectKey = `${mission.project.id}:${mission.project.revision}`;
     const existing = executorNameCache.get(projectKey);
     if (existing !== undefined) return existing;
-    const project = await options.project.openRevision(mission.project.revision);
-    const names = new Map(
-      project.listResources().map((resource) => [resource.metadata.id, resource.metadata.name]),
-    );
+    const names = await readExecutorNames(mission);
     executorNameCache.set(projectKey, names);
     return names;
   };
+
+  const getExecutorNamesOrFallback = async (
+    mission: Mission,
+    surface: "live" | "historical" | "work",
+  ): Promise<ReadonlyMap<string, string>> =>
+    await getExecutorNames(mission).catch((error: unknown) => {
+      logger.warn(
+        "mission.executor_names_unavailable",
+        `Mission ${mission.id} will use Expert IDs for ${surface} output labels.`,
+        { error, missionId: mission.id },
+      );
+      return new Map<string, string>();
+    });
 
   const trackOperation = (id: string, operation: PendingMissionOperation): void => {
     pendingOperations.set(id, operation);
@@ -640,19 +661,25 @@ export function createMissionRunner(options: {
   };
 
   const trackExecution = (input: {
-    readonly missionId: string;
+    readonly mission: Mission;
     readonly handle: MutableExecution & { readonly result: Promise<unknown> };
     readonly startedAt: string;
     readonly inputMessageId: string;
     readonly sessionId?: string | undefined;
+    readonly executorNames: ReadonlyMap<string, string>;
     readonly acceptedAt?: number | undefined;
     readonly onFinished?: (() => void | Promise<void>) | undefined;
   }): void => {
+    const missionId = input.mission.id;
+    const resolveExecutorName = createMissionExecutorNameResolver(
+      input.mission,
+      input.executorNames,
+    );
     let firstProjectionLogged = false;
     const live = observeMissionChat(
       input.handle,
       (patches) => {
-        emitChatPatches(input.missionId, patches);
+        emitChatPatches(missionId, patches);
         if (
           !firstProjectionLogged &&
           input.acceptedAt !== undefined &&
@@ -663,31 +690,29 @@ export function createMissionRunner(options: {
             "mission.first_ui_projection",
             "Mission emitted its first UI-visible text projection",
             {
-              missionId: input.missionId,
+              missionId,
               executionId: input.handle.executionId,
               elapsedMs: elapsedMissionMs(input.acceptedAt),
             },
           );
         }
       },
-      () => invalidateChat(input.missionId),
+      () => invalidateChat(missionId),
       (item) => {
         if (item.channel === "telemetry" && item.parentInvocationId === undefined) {
           const payload = asRecord(item.value);
           if (readString(payload, "type") === "context-window.updated") {
             const usage = RuntimeContextWindowUsageSchema.safeParse(payload["usage"]);
             if (usage.success) {
-              liveContextWindows.set(input.missionId, usage.data);
-              emitChatPatches(input.missionId, [
-                { type: "context-window.update", usage: usage.data },
-              ]);
+              liveContextWindows.set(missionId, usage.data);
+              emitChatPatches(missionId, [{ type: "context-window.update", usage: usage.data }]);
             }
           }
         }
         const sessionId = item.source.sessionId;
         if (item.source.parentSessionId !== undefined && sessionId !== undefined) {
           const recordId = `runtime-agent:${sessionId}`;
-          const byRecord = liveWorkOutputs.get(input.missionId) ?? new Map();
+          const byRecord = liveWorkOutputs.get(missionId) ?? new Map();
           const output =
             byRecord.get(recordId) ??
             ({
@@ -697,18 +722,22 @@ export function createMissionRunner(options: {
               close: async () => undefined,
             } satisfies LiveMissionChat);
           byRecord.set(recordId, output);
-          liveWorkOutputs.set(input.missionId, byRecord);
+          liveWorkOutputs.set(missionId, byRecord);
           if (item.channel !== "agent" && item.channel !== "progress") {
-            consumeLiveChatOutput(output, item, { includeNestedSource: true });
+            consumeLiveChatOutput(output, item, {
+              includeNestedSource: true,
+              resolveExecutorName,
+            });
           }
         }
-        invalidateWork(input.missionId);
+        invalidateWork(missionId);
       },
+      resolveExecutorName,
     );
-    liveChats.set(input.missionId, live);
+    liveChats.set(missionId, live);
     const settlement = observeExecution(
       options.missions,
-      input.missionId,
+      missionId,
       input.handle,
       input.startedAt,
       input.inputMessageId,
@@ -719,29 +748,29 @@ export function createMissionRunner(options: {
         await persistMissionExecutionProjection(
           options.missions,
           executionStore,
-          input.missionId,
+          missionId,
           input.handle.executionId,
         ),
     )
       .then(() => {
         if (input.acceptedAt !== undefined) {
           logger.info("mission.final_result", "Mission execution reached a final result", {
-            missionId: input.missionId,
+            missionId,
             executionId: input.handle.executionId,
             elapsedMs: elapsedMissionMs(input.acceptedAt),
           });
         }
       })
-      .finally(async () => await forgetActive(input.missionId, input.handle.executionId));
-    active.set(input.missionId, { handle: input.handle, settlement });
-    invalidateChat(input.missionId);
-    invalidateWork(input.missionId);
+      .finally(async () => await forgetActive(missionId, input.handle.executionId));
+    active.set(missionId, { handle: input.handle, settlement });
+    invalidateChat(missionId);
+    invalidateWork(missionId);
     void settlement.catch((error: unknown) => {
       logger.error(
         "mission.execution_observer_failed",
         `Failed to observe Mission execution ${input.handle.executionId}.`,
         error,
-        { missionId: input.missionId, executionId: input.handle.executionId },
+        { missionId, executionId: input.handle.executionId },
       );
     });
   };
@@ -765,6 +794,7 @@ export function createMissionRunner(options: {
     const compiled = await compileMissionExecutor(mission, runtimes);
     const compiledIdentity = await compilationIdentity(mission);
     logMissionPhase(logger, mission.id, "default_agent_compile", phaseStartedAt, acceptedAt);
+    const executorNames = await getExecutorNamesOrFallback(mission, "live");
     const modelSelection = toRuntimeModelSelection(mission.modelOverride);
     if (mission.modelOverride !== undefined && compiled !== undefined) {
       phaseStartedAt = performance.now();
@@ -837,8 +867,9 @@ export function createMissionRunner(options: {
         startedAt: executionStartedAt,
       });
       trackExecution({
-        missionId: mission.id,
+        mission,
         handle,
+        executorNames,
         startedAt: executionStartedAt,
         inputMessageId,
         acceptedAt,
@@ -920,8 +951,9 @@ export function createMissionRunner(options: {
       startedAt: executionStartedAt,
     });
     trackExecution({
-      missionId: mission.id,
+      mission,
       handle: turn,
+      executorNames,
       startedAt: executionStartedAt,
       inputMessageId,
       sessionId: session.sessionId,
@@ -995,6 +1027,7 @@ export function createMissionRunner(options: {
       }
       compiledExpert = compiled.value;
     }
+    const executorNames = await getExecutorNamesOrFallback(mission, "live");
     const rootExpert =
       compiledExpert === undefined
         ? undefined
@@ -1086,8 +1119,9 @@ export function createMissionRunner(options: {
       startedAt,
     });
     trackExecution({
-      missionId: mission.id,
+      mission,
       handle: turn,
+      executorNames,
       startedAt,
       inputMessageId: input.requestId,
       sessionId: session.sessionId,
@@ -1358,7 +1392,7 @@ export function createMissionRunner(options: {
       capturedLive?.executionId,
     );
 
-    const names = await getExecutorNames(mission);
+    const names = await getExecutorNamesOrFallback(mission, "historical");
     const current = active.get(mission.id);
     const pendingInteractions = await listMissionPendingHumanInteractions(mission);
 
@@ -1374,11 +1408,12 @@ export function createMissionRunner(options: {
     const latestMission = await options.missions.get(mission.id);
     const contextWindow = await getContextWindowState(latestMission);
     const revision = chatRevisions.get(mission.id) ?? 0;
+    const resolveExecutorName = createMissionExecutorNameResolver(mission, names);
     const namedEntries = entries.map((entry) => {
       if (entry.executorName !== undefined || entry.executorId === undefined) return entry;
       return {
         ...entry,
-        executorName: names.get(entry.executorId) ?? entry.executorId,
+        executorName: resolveExecutorName(entry.executorId) ?? entry.executorId,
       };
     });
     return {
@@ -1461,7 +1496,7 @@ export function createMissionRunner(options: {
         ? {}
         : { rootSessionId: mission.execution.sessionId }),
     });
-    const names = await getExecutorNames(mission);
+    const names = await getExecutorNamesOrFallback(mission, "work");
     const runtimeAgentOrdinals = createRuntimeAgentOrdinals(records);
     return {
       missionId: mission.id,
@@ -2437,11 +2472,26 @@ function messageRecordsToChatEntries(records: readonly AgentMessageRecord[]): Mi
   return entries;
 }
 
+function createMissionExecutorNameResolver(
+  mission: Pick<Mission, "executor">,
+  names: ReadonlyMap<string, string>,
+): ExecutorNameResolver {
+  // A Team or Flow name identifies the invocable resource, not the concrete Expert producing an
+  // entry. Their Experts must resolve through the pinned Project Revision or fall back to IDs.
+  const rootExpertId =
+    mission.executor.kind === "expert" && mission.executor.ref.startsWith("expert:")
+      ? mission.executor.ref.slice("expert:".length)
+      : undefined;
+  return (executorId) =>
+    names.get(executorId) ?? (executorId === rootExpertId ? mission.executor.name : undefined);
+}
+
 function observeMissionChat(
   execution: MutableExecution & { readonly result: Promise<unknown> },
   onOutput: (patches: readonly MissionChatPatch[]) => void,
   onInvalidate: () => void,
   onItem: (item: ExecutionOutputItem) => void,
+  resolveExecutorName: ExecutorNameResolver,
 ): LiveMissionChat {
   const chat: LiveMissionChat = {
     executionId: execution.executionId,
@@ -2458,7 +2508,9 @@ function observeMissionChat(
         for await (const item of subscription) {
           if (closed) break;
           onItem(item);
-          const patches = consumeLiveChatOutput(chat, item);
+          const patches = consumeLiveChatOutput(chat, item, {
+            resolveExecutorName,
+          });
           if (patches.length > 0) onOutput(patches);
           if (isTerminalContextCompactionOutput(item)) onInvalidate();
         }
@@ -2543,12 +2595,18 @@ function isTerminalContextCompactionOutput(item: ExecutionOutputItem): boolean {
 function consumeLiveChatOutput(
   chat: LiveMissionChat,
   item: ExecutionOutputItem,
-  options: { readonly includeNestedSource?: boolean } = {},
+  options: {
+    readonly includeNestedSource?: boolean;
+    readonly resolveExecutorName?: ExecutorNameResolver;
+  } = {},
 ): MissionChatPatch[] {
+  const executorName =
+    item.executorId === undefined ? undefined : options.resolveExecutorName?.(item.executorId);
   const base = {
     executionId: item.executionId,
     invocationId: item.invocationId,
     ...(item.executorId === undefined ? {} : { executorId: item.executorId }),
+    ...(executorName === undefined ? {} : { executorName }),
     createdAt: item.occurredAt,
   };
   if (item.channel === "agent") {

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -15,9 +15,11 @@ import {
   ContextWindowControl,
   groupMissionConversationEntries,
   MissionContextOperationEntry,
+  MissionChatEntryView,
   startMissionContextOperation,
   MissionDetailFragment,
   MissionThinkingEntry,
+  MissionToolCallBlock,
   MissionWorkDrawer,
   MissionsPage,
   missionWorkInputSenderName,
@@ -843,6 +845,189 @@ describe("Mission tool call grouping", () => {
       type: "entry",
       item: { entry: { kind: "agent_activity", action: "spawn" } },
     });
+  });
+
+  it("splits consecutive tool calls when the active Expert changes", () => {
+    const createdAt = "2026-07-21T00:00:00.000Z";
+    const blocks = groupMissionConversationEntries(
+      [
+        ["tool-1", "call-1", "writer"],
+        ["tool-2", "call-2", "researcher"],
+        ["tool-3", "call-3", "researcher"],
+      ].map(([id, toolCallId, executorId]) => ({
+        type: "durable" as const,
+        entry: {
+          id: id!,
+          kind: "tool" as const,
+          toolCallId: toolCallId!,
+          toolName: "read_file",
+          status: "succeeded" as const,
+          executorId: executorId!,
+          createdAt,
+        },
+      })),
+    );
+
+    expect(blocks).toMatchObject([
+      { type: "tools", entries: [{ id: "tool-1" }] },
+      { type: "tools", entries: [{ id: "tool-2" }, { id: "tool-3" }] },
+    ]);
+  });
+
+  it("does not collide an Expert ID with another entry's name", () => {
+    const createdAt = "2026-07-21T00:00:00.000Z";
+    const blocks = groupMissionConversationEntries([
+      {
+        type: "durable",
+        entry: {
+          id: "tool-by-id",
+          kind: "tool",
+          executorId: "shared-value",
+          toolCallId: "call-by-id",
+          toolName: "read_file",
+          status: "succeeded",
+          createdAt,
+        },
+      },
+      {
+        type: "durable",
+        entry: {
+          id: "tool-by-name",
+          kind: "tool",
+          executorName: "shared-value",
+          toolCallId: "call-by-name",
+          toolName: "search_files",
+          status: "succeeded",
+          createdAt,
+        },
+      },
+    ]);
+
+    expect(blocks).toMatchObject([
+      { type: "tools", entries: [{ id: "tool-by-id" }] },
+      { type: "tools", entries: [{ id: "tool-by-name" }] },
+    ]);
+  });
+});
+
+describe("Mission Expert output labels", () => {
+  const createdAt = "2026-07-21T00:00:00.000Z";
+
+  it("shows the friendly Expert name on answers, thinking, and tool groups", () => {
+    const answer = renderToStaticMarkup(
+      <MissionChatEntryView
+        entry={{
+          id: "answer",
+          kind: "assistant",
+          executorId: "writer",
+          executorName: "Writer",
+          content: "Draft complete.",
+          streaming: false,
+          createdAt,
+        }}
+        showExecutorLabel
+      />,
+    );
+    const thinking = renderToStaticMarkup(
+      <MissionThinkingEntry
+        entry={{
+          id: "thinking",
+          kind: "thinking",
+          executorId: "researcher",
+          executorName: "Researcher",
+          content: "Inspecting sources.",
+          streaming: true,
+          createdAt,
+        }}
+        showExecutorLabel
+      />,
+    );
+    const tools = renderToStaticMarkup(
+      <MissionToolCallBlock
+        collapsed
+        entries={[
+          {
+            id: "tool-1",
+            kind: "tool",
+            executorId: "reviewer",
+            executorName: "Reviewer",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            status: "succeeded",
+            createdAt,
+          },
+          {
+            id: "tool-2",
+            kind: "tool",
+            executorId: "reviewer",
+            executorName: "Reviewer",
+            toolCallId: "call-2",
+            toolName: "search_files",
+            status: "succeeded",
+            createdAt,
+          },
+        ]}
+        showExecutorLabel
+      />,
+    );
+
+    expect(answer).toContain('data-mission-executor-id="writer"');
+    expect(answer).toContain(">Writer<");
+    expect(thinking).toContain('data-mission-executor-id="researcher"');
+    expect(thinking).toContain(">Researcher<");
+    expect(tools).toContain('data-mission-executor-id="reviewer"');
+    expect(tools).toContain(">Reviewer<");
+  });
+
+  it("falls back to the Expert ID and keeps Work drawer output labels suppressed", () => {
+    const fallback = renderToStaticMarkup(
+      <MissionChatEntryView
+        entry={{
+          id: "answer",
+          kind: "assistant",
+          executorId: "expert-without-name",
+          content: "Done.",
+          streaming: false,
+          createdAt,
+        }}
+        showExecutorLabel
+      />,
+    );
+    const work = renderToStaticMarkup(
+      <MissionWorkDrawer
+        record={{
+          recordId: "runtime-agent:researcher",
+          kind: "runtime-agent",
+          sessionId: "researcher",
+          title: "Runtime Researcher",
+          origin: "runtime",
+          status: "running",
+          tasks: [],
+          summary: "Inspect",
+          createdAt,
+          updatedAt: createdAt,
+        }}
+        inputSenderName="Main agent"
+        entries={[
+          {
+            id: "answer",
+            kind: "assistant",
+            executorId: "parent-expert",
+            executorName: "Parent Expert",
+            content: "Runtime child output.",
+            streaming: false,
+            createdAt,
+          },
+        ]}
+        loading={false}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(fallback).toContain(">expert-without-name<");
+    expect(work).toContain("Runtime Researcher");
+    expect(work).not.toContain("mission-output-executor");
+    expect(work).not.toContain("Parent Expert");
   });
 });
 

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -1971,6 +1971,7 @@ export function MissionDetailFragment(props: {
                         collapsed={block.collapsed}
                         entries={block.entries}
                         key={`tools:${block.entries[0]!.id}`}
+                        showExecutorLabel
                       />
                     );
                   }
@@ -1993,6 +1994,7 @@ export function MissionDetailFragment(props: {
                       entry={block.item.entry}
                       key={block.item.entry.id}
                       paintExecutionId={block.item.entry.executionId ?? chat?.execution?.id}
+                      showExecutorLabel
                     />
                   );
                 })}
@@ -2724,10 +2726,11 @@ function MissionThinkingPlaceholder(props: { readonly executorName: string }) {
   );
 }
 
-const MissionChatEntryView = memo(function MissionChatEntryView(props: {
+export const MissionChatEntryView = memo(function MissionChatEntryView(props: {
   readonly entry: MissionChatEntry;
   readonly userLabel?: string | undefined;
   readonly paintExecutionId?: string | undefined;
+  readonly showExecutorLabel?: boolean | undefined;
 }) {
   if (props.entry.kind === "user") {
     return (
@@ -2742,10 +2745,16 @@ const MissionChatEntryView = memo(function MissionChatEntryView(props: {
     );
   }
   if (props.entry.kind === "thinking") {
-    return <MissionThinkingEntry entry={props.entry} paintExecutionId={props.paintExecutionId} />;
+    return (
+      <MissionThinkingEntry
+        entry={props.entry}
+        paintExecutionId={props.paintExecutionId}
+        showExecutorLabel={props.showExecutorLabel}
+      />
+    );
   }
   if (props.entry.kind === "tool") {
-    return <MissionToolCallEntry entry={props.entry} />;
+    return <MissionToolCallEntry entry={props.entry} showExecutorLabel={props.showExecutorLabel} />;
   }
   if (props.entry.kind === "agent_activity") {
     return <MissionAgentActivityEntry entry={props.entry} />;
@@ -2755,10 +2764,25 @@ const MissionChatEntryView = memo(function MissionChatEntryView(props: {
   }
   return (
     <div className="mission-assistant-message" data-mission-execution-id={props.paintExecutionId}>
+      {props.showExecutorLabel ? <MissionExecutorLabel entry={props.entry} /> : null}
       <MissionMessageContent source={props.entry.content} />
     </div>
   );
 });
+
+function MissionExecutorLabel(props: { readonly entry: MissionChatEntry }) {
+  const label = missionChatEntryExecutorLabel(props.entry);
+  if (label === undefined) return null;
+  return (
+    <small
+      className="mission-output-executor"
+      data-mission-executor-id={props.entry.executorId}
+      title={props.entry.executorId}
+    >
+      {label}
+    </small>
+  );
+}
 
 function MissionAgentActivityEntry(props: {
   readonly entry: Extract<MissionChatEntry, { kind: "agent_activity" }>;
@@ -2787,6 +2811,7 @@ function MissionAgentActivityEntry(props: {
 export function MissionThinkingEntry(props: {
   readonly entry: Extract<MissionChatEntry, { kind: "thinking" }>;
   readonly paintExecutionId?: string | undefined;
+  readonly showExecutorLabel?: boolean | undefined;
 }) {
   const { t } = useTranslation("missions");
   const [expanded, setExpanded] = useState(false);
@@ -2802,6 +2827,7 @@ export function MissionThinkingEntry(props: {
       data-mission-execution-id={props.paintExecutionId ?? props.entry.executionId}
       aria-live={streaming ? "polite" : undefined}
     >
+      {props.showExecutorLabel ? <MissionExecutorLabel entry={props.entry} /> : null}
       <p id={contentId}>{props.entry.content}</p>
       {streaming ? null : (
         <button
@@ -2819,26 +2845,43 @@ export function MissionThinkingEntry(props: {
   );
 }
 
-function MissionToolCallBlock(props: {
+export function MissionToolCallBlock(props: {
   readonly collapsed: boolean;
   readonly entries: readonly Extract<MissionChatEntry, { kind: "tool" }>[];
+  readonly showExecutorLabel?: boolean | undefined;
 }) {
   const { t } = useTranslation("missions");
-  if (props.entries.length === 1) return <MissionToolCallEntry entry={props.entries[0]!} />;
+  if (props.entries.length === 1) {
+    return (
+      <MissionToolCallEntry entry={props.entries[0]!} showExecutorLabel={props.showExecutorLabel} />
+    );
+  }
   if (!props.collapsed) {
     return (
       <div className="mission-tool-run">
         {props.entries.map((entry) => (
-          <MissionToolCallEntry entry={entry} key={entry.id} />
+          <MissionToolCallEntry
+            entry={entry}
+            key={entry.id}
+            showExecutorLabel={props.showExecutorLabel}
+          />
         ))}
       </div>
     );
   }
+  const showExecutorLabel =
+    props.showExecutorLabel === true &&
+    missionChatEntryExecutorLabel(props.entries[0]!) !== undefined;
   const status = toolGroupStatus(props.entries);
   return (
-    <details className={`mission-chat-activity mission-tool-entry mission-tool-group is-${status}`}>
+    <details
+      className={`mission-chat-activity mission-tool-entry mission-tool-group is-${status}${
+        showExecutorLabel ? " has-executor" : ""
+      }`}
+    >
       <summary>
         <Toolbox size={16} aria-hidden="true" />
+        {showExecutorLabel ? <MissionExecutorLabel entry={props.entries[0]!} /> : null}
         <span>{t("toolCalls", { count: props.entries.length })}</span>
         <small>{toolStatusLabel(status)}</small>
         <CaretDown size={14} aria-hidden="true" />
@@ -2854,9 +2897,14 @@ function MissionToolCallBlock(props: {
 
 function MissionToolCallEntry(props: {
   readonly entry: Extract<MissionChatEntry, { kind: "tool" }>;
+  readonly showExecutorLabel?: boolean | undefined;
 }) {
   const { t } = useTranslation("missions");
-  const className = `mission-chat-activity mission-tool-entry is-${props.entry.status}`;
+  const showExecutorLabel =
+    props.showExecutorLabel === true && missionChatEntryExecutorLabel(props.entry) !== undefined;
+  const className = `mission-chat-activity mission-tool-entry is-${props.entry.status}${
+    showExecutorLabel ? " has-executor" : ""
+  }`;
   const hasDetails =
     props.entry.inputPreview !== undefined ||
     props.entry.outputPreview !== undefined ||
@@ -2864,6 +2912,7 @@ function MissionToolCallEntry(props: {
   const row = (
     <>
       <Toolbox size={16} aria-hidden="true" />
+      {showExecutorLabel ? <MissionExecutorLabel entry={props.entry} /> : null}
       <span>{props.entry.toolName}</span>
       <small>{toolStatusLabel(props.entry.status)}</small>
     </>
@@ -3337,16 +3386,26 @@ export function groupMissionConversationEntries(
   entries: readonly MissionConversationEntry[],
 ): MissionConversationBlock[] {
   const blocks: MissionConversationBlock[] = [];
-  let pendingTools: Extract<MissionChatEntry, { kind: "tool" }>[] = [];
+  let pendingToolGroups: Array<Extract<MissionChatEntry, { kind: "tool" }>[]> = [];
   const flushTools = (collapsed: boolean): void => {
-    if (pendingTools.length === 0) return;
-    blocks.push({ type: "tools", entries: pendingTools, collapsed });
-    pendingTools = [];
+    for (const group of pendingToolGroups) {
+      blocks.push({ type: "tools", entries: group, collapsed });
+    }
+    pendingToolGroups = [];
   };
 
   for (const item of entries) {
     if (item.type === "durable" && item.entry.kind === "tool") {
-      pendingTools.push(item.entry);
+      const currentGroup = pendingToolGroups.at(-1);
+      const currentExecutor = currentGroup?.[0]
+        ? missionChatEntryExecutorKey(currentGroup[0])
+        : undefined;
+      const nextExecutor = missionChatEntryExecutorKey(item.entry);
+      if (currentGroup === undefined || currentExecutor !== nextExecutor) {
+        pendingToolGroups.push([item.entry]);
+      } else {
+        currentGroup.push(item.entry);
+      }
       continue;
     }
     flushTools(
@@ -3357,6 +3416,16 @@ export function groupMissionConversationEntries(
   }
   flushTools(false);
   return blocks;
+}
+
+function missionChatEntryExecutorKey(entry: MissionChatEntry): string {
+  if (entry.executorId !== undefined) return `id:${entry.executorId}`;
+  if (entry.executorName !== undefined) return `name:${entry.executorName}`;
+  return "unknown";
+}
+
+function missionChatEntryExecutorLabel(entry: MissionChatEntry): string | undefined {
+  return entry.executorName ?? entry.executorId;
 }
 
 export function applyMissionChatPatches(

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -15779,6 +15779,18 @@ textarea:focus-visible,
   width: 100%;
 }
 
+.mission-output-executor {
+  display: block;
+  overflow: hidden;
+  margin-bottom: 5px;
+  color: var(--green-dark);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .mission-user-message {
   display: flex;
   justify-content: end;
@@ -16454,6 +16466,18 @@ textarea:focus-visible,
   font-size: 12px;
 }
 
+.mission-tool-entry.has-executor summary,
+.mission-tool-entry.has-executor.mission-tool-static-row {
+  grid-template-columns: auto minmax(0, 140px) minmax(0, 1fr) auto auto;
+}
+
+.mission-tool-entry .mission-output-executor {
+  min-width: 0;
+  margin: 0;
+  color: var(--green-dark);
+  font-size: 10px;
+}
+
 .mission-chat-activity summary {
   cursor: pointer;
   list-style: none;
@@ -16505,6 +16529,11 @@ textarea:focus-visible,
   line-height: 1.6;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.mission-thinking-entry > .mission-output-executor {
+  grid-column: 1 / -1;
+  margin-bottom: 1px;
 }
 
 .mission-thinking-entry.is-expanded > p {


### PR DESCRIPTION
## Summary

- preserve concrete executor identity and resolve expert names for live and historical Mission chat entries
- display expert labels on assistant, thinking, and tool output in the Mission detail chat
- split adjacent tool groups when their executors differ, while keeping runtime-native subagent output scoped to the Work drawer
- fall back to stable expert IDs when immutable Project Revision metadata is unavailable
- cover Team delegation, standalone Expert subagents, Flow expert calls, history restoration, grouping, and fallback behavior

## Why

Mission team output and coordinator output were visually mixed together. The same ambiguity affected standalone Experts invoking subagents and Flows invoking Experts, because chat entries did not consistently carry and render the concrete executor name.

## Root cause

Runtime events exposed executor IDs, but the Mission chat projection and renderer did not consistently resolve those IDs against the pinned Project Revision or use them as a grouping and display boundary.

## User impact

Users can now see which expert produced each assistant, reasoning, or tool block across Team, standalone Expert, and Flow execution paths. Runtime-native subagents remain in the Work drawer to avoid duplicating internal work in the main conversation.

## Validation

- Claude Code review completed; every confirmed finding was fixed and independently verified
- `pnpm check`
- targeted Mission runner and renderer tests: 59 passed
- Desktop full suite: 106 test files, 635 tests passed
- Prettier and `git diff --check`
