### PR TITLE
Govern memory storage retention and recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -639,7 +639,17 @@ Expert API 设计要求：
 - `@pragma/core` 不得反向依赖 `@pragma/memory`；Core 的 Canonical Event Bus 必须保持 Memory 无关。
 - Module 静态注册，不扫描目录；Module id、版本和 Context prefix 必须唯一。
 - Module 不直接写另一个 Module Store，只通过版本化 Evidence/derived event 协作。
-- WorkingState、TODO、Task Board 与专家团白板不是 Memory Plane 的必需输入。
+- Memory 存储治理使用 `@pragma/memory` 的固定版本化 policy；Feed 只能在所有注册 consumer 的最小
+  checkpoint 之前清理，落后 consumer 固定的数据必须报告 degraded/blocked，不能为满足容量目标越过
+  checkpoint 删除。
+- 每个 Module 的待提炼 Evidence、curator prompt、失败 payload、job diagnostic 与 dead letter 必须有
+  硬上限或固定保留期；应用启动不得自动唤醒 `needs_attention`，只能由匹配的配置修复或用户显式 CAS
+  retry 触发。
+- Mission 删除只清理关联 Execution 的 Feed、job、Evidence、subject context 等 transient state，并使用
+  稳定 journal 保证可重放；已经提炼的 Episode/Fact 是独立治理的长期 Memory，不随 Mission 自动删除。
+- WorkingState、TODO、Task Board 与专家团白板不是 Memory Plane 的必需输入，但它们仍是独立的 Host
+  内置短期协作能力。共享条目按根 Team/Flow 与 Execution 授权，私有条目按稳定 Runtime Context
+  隔离；已提交变化可以发布 Evidence，但不得让私有内容在提炼、handoff 或导出时自动扩大可见性。
 
 禁止依赖 Interpreter、具体 Runtime、Expert plugin、Desktop UI、Server 应用层或 Client SDK。
 

--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -407,6 +407,9 @@ export async function createDesktopApplicationContainer(
       createAutomaticToolPermissionHandler(() => mode),
     assertStorageWriteAllowed: async () => await storageCapacityGuard.assertWriteAllowed(),
     onStorageTrashed: () => trashMaintenance.schedule("mission-storage-trashed"),
+    onOwnerDeleting: async ({ executionIds }) => {
+      await memoryPlane.deleteExecutionState(executionIds);
+    },
     onExecutionLinked: async ({ mission, executionId }) => {
       if (mission.origin.type === "system-memory") return;
       await memoryPlane.registerMemoryExecutionContext({
@@ -640,6 +643,13 @@ export async function createDesktopApplicationContainer(
         mainLogger.warn(
           "desktop.tokenizer_warmup_failed",
           "The Runtime token counter could not be warmed up.",
+          { error },
+        );
+      });
+      void memoryCurator.recoverOrphans().catch((error: unknown) => {
+        mainLogger.warn(
+          "desktop.memory_curator_orphan_cleanup_failed",
+          "Orphaned Memory Curator Missions could not be cleaned up.",
           { error },
         );
       });

--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
@@ -29,9 +29,12 @@ import {
   type SemanticMemoryStore,
   type EpisodicMemoryStore,
   type MemoryActivityStore,
+  DEFAULT_MEMORY_STORAGE_POLICY,
+  EXECUTION_EVIDENCE_ADAPTER_ID,
 } from "@pragma/memory";
 
 import { createDesktopMemorySubjectIdentityStore } from "./memory-subject-identity.ts";
+import { createMemoryCleanupJournal } from "./memory-cleanup-journal.ts";
 
 export type DesktopMemoryMutationResult =
   | {
@@ -84,12 +87,31 @@ export interface DesktopMemoryPlane {
     readonly reason: string;
   }): Promise<void>;
   wakeMemoryJobs(): Promise<void>;
+  retryMemoryJob(input: {
+    readonly module: "episodic" | "semantic";
+    readonly id: string;
+    readonly expectedRevision: number;
+  }): Promise<void>;
+  deleteExecutionState(executionIds: readonly string[]): Promise<void>;
+  maintainStorage(): Promise<void>;
   getStatus(): Promise<{
     readonly state: "running" | "stopped" | "degraded";
-    readonly feed: { readonly lastSequence: number; readonly eventCount: number };
+    readonly feed: import("@pragma/core").CanonicalEventFeedDiagnostic & {
+      readonly safeThroughSequence: number;
+      readonly blockedBytes: number;
+    };
     readonly delivery: { readonly pending: number; readonly quarantined: number };
     readonly lastError?: { readonly code: string; readonly occurredAt: string } | undefined;
     readonly modules: readonly import("@pragma/shared").MemoryModuleDiagnostic[];
+    readonly storagePolicy: Readonly<Record<string, string | number>>;
+    readonly maintenance: {
+      readonly lastRunAt?: string | undefined;
+      readonly deletedEvents: number;
+      readonly reclaimedBytes: number;
+      readonly deletedDeadLetters: number;
+      readonly deadLetterEntries: number;
+      readonly deadLetterBytes: number;
+    };
   }>;
   start(): void;
   stop(): Promise<void>;
@@ -125,6 +147,12 @@ export async function createDesktopMemoryPlane(options: {
     pragmaHome: options.pragmaHome,
   });
   const activity = createMemoryActivityStore({ pragmaHome: options.pragmaHome });
+  const cleanup = createMemoryCleanupJournal({
+    pragmaHome: options.pragmaHome,
+    feed: canonical,
+    episodic: episodic.store,
+    semantic: semantic.store,
+  });
   registry.register(episodic);
   registry.register(semantic);
   const contextStore = createFederatedMemoryContextStore(registry, {
@@ -161,6 +189,66 @@ export async function createDesktopMemoryPlane(options: {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let running: Promise<void> | undefined;
   let lastError: { readonly code: string; readonly occurredAt: string } | undefined;
+  let maintenanceRunning: Promise<void> | undefined;
+  let lastMaintenanceAtMs = 0;
+  let safeThroughSequence = 0;
+  let blockedBytes = 0;
+  let maintenanceDiagnostic: {
+    readonly lastRunAt?: string | undefined;
+    readonly deletedEvents: number;
+    readonly reclaimedBytes: number;
+    readonly deletedDeadLetters: number;
+    readonly deadLetterEntries: number;
+    readonly deadLetterBytes: number;
+  } = {
+    deletedEvents: 0,
+    reclaimedBytes: 0,
+    deletedDeadLetters: 0,
+    deadLetterEntries: 0,
+    deadLetterBytes: 0,
+  };
+
+  const maintainStorage = async (): Promise<void> => {
+    if (maintenanceRunning !== undefined) return await maintenanceRunning;
+    maintenanceRunning = (async () => {
+      const maintenanceNow = new Date();
+      await cleanup.recover();
+      const consumerIds = [
+        EXECUTION_EVIDENCE_ADAPTER_ID,
+        ...registry.list().map((module) => module.descriptor.id),
+      ];
+      const checkpoints = await Promise.all(consumerIds.map(async (id) => await state.read(id)));
+      safeThroughSequence = Math.min(...checkpoints.map((checkpoint) => checkpoint.sequence));
+      const feed = await canonical.maintain({
+        safeThrough: { sequence: safeThroughSequence },
+        retainAfter: new Date(
+          maintenanceNow.getTime() - DEFAULT_MEMORY_STORAGE_POLICY.canonicalFeedRetentionMs,
+        ).toISOString(),
+        targetBytes: DEFAULT_MEMORY_STORAGE_POLICY.canonicalFeedTargetBytes,
+      });
+      await Promise.all([
+        episodic.store.maintain(maintenanceNow),
+        semantic.store.maintain(maintenanceNow),
+      ]);
+      const pipeline = await state.maintain(maintenanceNow);
+      const deadLetters = await state.inspectDeadLetters();
+      blockedBytes = feed.blockedBytes;
+      lastMaintenanceAtMs = maintenanceNow.getTime();
+      maintenanceDiagnostic = {
+        lastRunAt: maintenanceNow.toISOString(),
+        deletedEvents: feed.deletedEvents,
+        reclaimedBytes: feed.reclaimedLogicalBytes,
+        deletedDeadLetters: pipeline.deletedDeadLetters,
+        deadLetterEntries: deadLetters.entries,
+        deadLetterBytes: deadLetters.bytes,
+      };
+    })();
+    try {
+      await maintenanceRunning;
+    } finally {
+      maintenanceRunning = undefined;
+    }
+  };
 
   const markDegraded = (code: string, error?: unknown): void => {
     if (lastError?.code === code) return;
@@ -189,6 +277,9 @@ export async function createDesktopMemoryPlane(options: {
       const recovery = await executionStore.recoverPendingCanonicalEvents();
       const adapted = await adapter.runOnce();
       await scheduler.runOnce();
+      if (Date.now() - lastMaintenanceAtMs >= DEFAULT_MEMORY_STORAGE_POLICY.maintenanceIntervalMs) {
+        await maintainStorage();
+      }
       if (recovery.quarantined > 0) {
         markDegraded("canonical_event_handoff_quarantined");
       } else if (recovery.failed > 0) {
@@ -290,10 +381,27 @@ export async function createDesktopMemoryPlane(options: {
     },
     async wakeMemoryJobs() {
       await Promise.all([
-        episodic.store.wakeNeedsAttention(new Date()),
-        semantic.store.wakeNeedsAttention(new Date()),
+        episodic.store.wakeNeedsAttention(new Date(), "configuration"),
+        semantic.store.wakeNeedsAttention(new Date(), "configuration"),
       ]);
       scheduler.wake();
+    },
+    async retryMemoryJob(input) {
+      const retry = {
+        id: input.id,
+        expectedRevision: input.expectedRevision,
+        now: new Date(),
+      };
+      if (input.module === "episodic") await episodic.store.retryJob(retry);
+      else await semantic.store.retryJob(retry);
+      scheduler.wake();
+    },
+    async deleteExecutionState(executionIds) {
+      await cleanup.cleanup(executionIds);
+      await maintainStorage();
+    },
+    async maintainStorage() {
+      await maintainStorage();
     },
     async getStatus() {
       const delivery = await executionStore.inspectCanonicalEventDelivery();
@@ -320,19 +428,29 @@ export async function createDesktopMemoryPlane(options: {
             running: work.running,
             needsAttention: work.needsAttention,
             rejected: work.rejected,
+            expired: work.expired,
+            evidenceRecords: work.evidenceRecords,
+            evidenceBytes: work.evidenceBytes,
+            truncatedExecutions: work.truncatedExecutions,
           },
         });
       }
       return {
         state: stopped
           ? "stopped"
-          : lastError !== undefined || delivery.quarantined > 0
+          : lastError !== undefined || delivery.quarantined > 0 || blockedBytes > 0
             ? "degraded"
             : "running",
-        feed: await canonical.inspect(),
+        feed: {
+          ...(await canonical.inspect()),
+          safeThroughSequence,
+          blockedBytes,
+        },
         delivery,
         ...(lastError === undefined ? {} : { lastError }),
         modules,
+        storagePolicy: desktopStoragePolicy(),
+        maintenance: maintenanceDiagnostic,
       };
     },
     start() {
@@ -348,6 +466,7 @@ export async function createDesktopMemoryPlane(options: {
       if (timer !== undefined) clearTimeout(timer);
       timer = undefined;
       await running;
+      await maintenanceRunning;
       await scheduler.stop();
       episodic.close();
       semantic.close();
@@ -376,4 +495,20 @@ export async function resolveDesktopMemoryRecallScope(
     occurredAt: now.toISOString(),
   });
   return policy.recall ? scope.data : undefined;
+}
+
+function desktopStoragePolicy(): Readonly<Record<string, string | number>> {
+  return {
+    schemaVersion: DEFAULT_MEMORY_STORAGE_POLICY.schemaVersion,
+    canonicalFeedRetentionDays: 30,
+    canonicalFeedTargetBytes: DEFAULT_MEMORY_STORAGE_POLICY.canonicalFeedTargetBytes,
+    evidenceMaxRecordsPerExecution: DEFAULT_MEMORY_STORAGE_POLICY.evidenceMaxRecordsPerExecution,
+    evidenceMaxBytesPerExecution: DEFAULT_MEMORY_STORAGE_POLICY.evidenceMaxBytesPerExecution,
+    extractionPromptMaxBytes: DEFAULT_MEMORY_STORAGE_POLICY.extractionPromptMaxBytes,
+    jobRecordRetentionDays: 30,
+    failedPayloadRetentionDays: 30,
+    deadLetterRetentionDays: 30,
+    deadLetterMaxEntries: DEFAULT_MEMORY_STORAGE_POLICY.deadLetterMaxEntries,
+    deadLetterMaxBytes: DEFAULT_MEMORY_STORAGE_POLICY.deadLetterMaxBytes,
+  };
 }

--- a/apps/desktop/src/main/features/memory/memory-cleanup-journal.test.ts
+++ b/apps/desktop/src/main/features/memory/memory-cleanup-journal.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createMemoryCleanupJournal } from "./memory-cleanup-journal.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Memory cleanup journal", () => {
+  it("replays only unfinished Mission deletion steps after a crash", async () => {
+    const pragmaHome = await mkdtemp(join(tmpdir(), "pragma-memory-cleanup-"));
+    roots.push(pragmaHome);
+    const forgetCorrelation = vi.fn(async () => ({ deletedEvents: 1 }));
+    let failEpisodic = true;
+    const deleteEpisodic = vi.fn(async () => {
+      if (failEpisodic) throw new Error("simulated-cleanup-crash");
+    });
+    const deleteSemantic = vi.fn(async () => undefined);
+    const journal = createMemoryCleanupJournal({
+      pragmaHome,
+      feed: { forgetCorrelation },
+      episodic: { deleteExecutionState: deleteEpisodic },
+      semantic: { deleteExecutionState: deleteSemantic },
+      now: () => new Date("2026-08-04T00:00:00.000Z"),
+    });
+
+    await expect(journal.cleanup(["execution-b", "execution-a"])).rejects.toThrow(
+      "simulated-cleanup-crash",
+    );
+    expect(forgetCorrelation).toHaveBeenCalledTimes(2);
+    expect(deleteSemantic).not.toHaveBeenCalled();
+
+    failEpisodic = false;
+    await expect(journal.recover()).resolves.toBe(1);
+    expect(forgetCorrelation).toHaveBeenCalledTimes(2);
+    expect(deleteEpisodic).toHaveBeenCalledTimes(2);
+    expect(deleteSemantic).toHaveBeenCalledOnce();
+    await expect(readdir(join(pragmaHome, "state", "memory", "cleanup-journal"))).resolves.toEqual(
+      [],
+    );
+  });
+});

--- a/apps/desktop/src/main/features/memory/memory-cleanup-journal.ts
+++ b/apps/desktop/src/main/features/memory/memory-cleanup-journal.ts
@@ -1,0 +1,162 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { PragmaPaths, withFileLock, type CanonicalEventFeed } from "@pragma/core";
+import {
+  DEFAULT_MEMORY_STORAGE_POLICY,
+  type EpisodicMemoryStore,
+  type SemanticMemoryStore,
+} from "@pragma/memory";
+import { z } from "zod";
+
+const CleanupJournalSchema = z.object({
+  schemaVersion: z.literal("pragma.memory-cleanup-journal/v1"),
+  id: z.string().min(1),
+  executionIds: z.array(z.string().min(1)).min(1),
+  completed: z.array(z.enum(["feed", "episodic", "semantic"])),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+type CleanupJournal = z.infer<typeof CleanupJournalSchema>;
+
+export interface MemoryCleanupJournal {
+  cleanup(executionIds: readonly string[]): Promise<void>;
+  recover(): Promise<number>;
+}
+
+export function createMemoryCleanupJournal(options: {
+  readonly pragmaHome: string;
+  readonly feed: Pick<CanonicalEventFeed, "forgetCorrelation">;
+  readonly episodic: Pick<EpisodicMemoryStore, "deleteExecutionState">;
+  readonly semantic: Pick<SemanticMemoryStore, "deleteExecutionState">;
+  readonly now?: (() => Date) | undefined;
+}): MemoryCleanupJournal {
+  const paths = new PragmaPaths({ pragmaHome: options.pragmaHome });
+  const root = paths.memoryCleanupJournalRoot();
+  const now = options.now ?? (() => new Date());
+
+  const replay = async (path: string, initial: CleanupJournal): Promise<void> => {
+    let journal = initial;
+    const complete = async (
+      step: CleanupJournal["completed"][number],
+      operation: () => Promise<void>,
+    ): Promise<void> => {
+      if (journal.completed.includes(step)) return;
+      await operation();
+      journal = CleanupJournalSchema.parse({
+        ...journal,
+        completed: [...journal.completed, step],
+        updatedAt: now().toISOString(),
+      });
+      await writeJsonAtomic(path, journal);
+    };
+    await complete("feed", async () => {
+      for (const executionId of journal.executionIds) {
+        await options.feed.forgetCorrelation(executionId);
+      }
+    });
+    await complete("episodic", async () => {
+      await options.episodic.deleteExecutionState(journal.executionIds, now());
+    });
+    await complete("semantic", async () => {
+      await options.semantic.deleteExecutionState(journal.executionIds, now());
+    });
+    await rm(path, { force: true });
+  };
+
+  return {
+    async cleanup(executionIds) {
+      const unique = [...new Set(executionIds)].toSorted();
+      if (unique.length === 0) return;
+      const id = createHash("sha256").update(JSON.stringify(unique)).digest("hex").slice(0, 24);
+      const path = join(root, `${id}.json`);
+      await withFileLock(`${path}.lock`, async () => {
+        let journal: CleanupJournal;
+        try {
+          journal = CleanupJournalSchema.parse(JSON.parse(await readFile(path, "utf8")));
+        } catch (error) {
+          if (!isNotFound(error)) throw error;
+          const timestamp = now().toISOString();
+          journal = CleanupJournalSchema.parse({
+            schemaVersion: "pragma.memory-cleanup-journal/v1",
+            id,
+            executionIds: unique,
+            completed: [],
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          });
+          await writeJsonAtomic(path, journal);
+        }
+        await replay(path, journal);
+      });
+    },
+
+    async recover() {
+      await removeStaleAtomicTemps(root, now());
+      let names: string[];
+      try {
+        names = await readdir(root);
+      } catch (error) {
+        if (isNotFound(error)) return 0;
+        throw error;
+      }
+      let recovered = 0;
+      for (const name of names.filter((value) => value.endsWith(".json")).slice(0, 100)) {
+        const path = join(root, name);
+        await withFileLock(`${path}.lock`, async () => {
+          let journal: CleanupJournal;
+          try {
+            journal = CleanupJournalSchema.parse(JSON.parse(await readFile(path, "utf8")));
+          } catch (error) {
+            if (isNotFound(error)) return;
+            throw error;
+          }
+          await replay(path, journal);
+          recovered += 1;
+        });
+      }
+      return recovered;
+    },
+  };
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+async function removeStaleAtomicTemps(root: string, now: Date): Promise<void> {
+  let names: string[];
+  try {
+    names = await readdir(root);
+  } catch (error) {
+    if (isNotFound(error)) return;
+    throw error;
+  }
+  const cutoff = now.getTime() - DEFAULT_MEMORY_STORAGE_POLICY.atomicTempRetentionMs;
+  for (const name of names.filter((value) => value.endsWith(".tmp"))) {
+    const path = join(root, name);
+    try {
+      if ((await stat(path)).mtimeMs <= cutoff) await rm(path, { force: true });
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { readonly code?: unknown }).code === "ENOENT"
+  );
+}

--- a/apps/desktop/src/main/features/memory/memory-curator.ts
+++ b/apps/desktop/src/main/features/memory/memory-curator.ts
@@ -1,8 +1,12 @@
-import { createHash } from "node:crypto";
-import { basename } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 
 import {
   ContextSystem,
+  PragmaPaths,
+  withFileLock,
+  createPragmaLogger,
   defineExpert,
   type PragmaLoggerProvider,
   type RuntimeModelSelection,
@@ -16,6 +20,9 @@ import {
   MEMORY_CURATOR_PROMPT_VERSION,
   SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION,
   MEMORY_CURATOR_REF,
+  DEFAULT_MEMORY_STORAGE_POLICY,
+  selectBoundedMemoryEvidence,
+  mergeMemoryEvidenceOmissionStats,
   type EpisodicMemoryExtractor,
   type SemanticMemoryExtractor,
   type MemoryExtractorProfile,
@@ -23,8 +30,22 @@ import {
 } from "@pragma/memory";
 
 import type { MissionRunner } from "../missions/mission-runner.ts";
-import type { MissionStore } from "../missions/mission-store.ts";
+import { MissionStoreError, type MissionStore } from "../missions/mission-store.ts";
 import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
+import { z } from "zod";
+
+const CuratorMissionRegistrySchema = z.object({
+  schemaVersion: z.literal("pragma.memory-curator-mission-registry/v1"),
+  entries: z
+    .array(
+      z.object({
+        missionId: z.string().uuid(),
+        jobId: z.string().min(1),
+        createdAt: z.string().datetime(),
+      }),
+    )
+    .max(DEFAULT_MEMORY_STORAGE_POLICY.curatorRegistryMaxEntries),
+});
 
 export interface DesktopMemoryCurator {
   readonly episodicExtractor: EpisodicMemoryExtractor;
@@ -36,6 +57,7 @@ export interface DesktopMemoryCurator {
     readonly loggerProvider?: PragmaLoggerProvider | undefined;
   }): Promise<CompiledResource<InvocableResource>>;
   fingerprint(): Promise<string>;
+  recoverOrphans(): Promise<number>;
 }
 
 export function createDesktopMemoryCurator(options: {
@@ -49,6 +71,9 @@ export function createDesktopMemoryCurator(options: {
   readonly loggerProvider?: PragmaLoggerProvider | undefined;
   readonly now?: (() => Date) | undefined;
 }): DesktopMemoryCurator {
+  const logger = createPragmaLogger(options.loggerProvider, {
+    component: "desktop.memory-curator",
+  });
   const now = options.now ?? (() => new Date());
 
   const resolveRuntime = async (
@@ -134,6 +159,40 @@ export function createDesktopMemoryCurator(options: {
 
   return {
     compile,
+    async recoverOrphans() {
+      await removeStaleCuratorTemps(options.pragmaHome);
+      const entries = await readCuratorMissionRegistry(options.pragmaHome);
+      let recovered = 0;
+      for (const entry of entries.slice(0, 100)) {
+        let mission;
+        try {
+          mission = await options.missions.get(entry.missionId);
+        } catch (error) {
+          if (error instanceof MissionStoreError && error.code === "mission_not_found") {
+            await unregisterCuratorMission(options.pragmaHome, entry.missionId);
+            continue;
+          }
+          logger.warn(
+            "desktop.memory_curator_orphan_read_failed",
+            "A registered Memory Curator Mission could not be inspected and was retained for retry.",
+            { error, missionId: entry.missionId },
+          );
+          continue;
+        }
+        const terminal =
+          mission.execution !== undefined &&
+          ["succeeded", "failed", "cancelled"].includes(mission.execution.status);
+        const stale =
+          Date.now() - Date.parse(entry.createdAt) >=
+          DEFAULT_MEMORY_STORAGE_POLICY.curatorOrphanGraceMs;
+        if (!terminal && !stale) continue;
+        if (await cleanupCuratorMission(options.runner, entry.missionId)) {
+          await unregisterCuratorMission(options.pragmaHome, entry.missionId);
+          recovered += 1;
+        }
+      }
+      return recovered;
+    },
     async fingerprint() {
       return await createFingerprint(await options.profiles.get());
     },
@@ -201,58 +260,76 @@ const CURATOR_INSTRUCTIONS = [
 ].join("\n");
 
 function renderExtractionPrompt(input: Parameters<EpisodicMemoryExtractor["extract"]>[0]): string {
-  const evidence: unknown[] = [];
-  let bytes = 0;
-  for (const item of [...input.evidence].reverse()) {
-    const serialized = JSON.stringify(item);
-    if (bytes + Buffer.byteLength(serialized) > 78_000) continue;
-    evidence.unshift(item);
-    bytes += Buffer.byteLength(serialized);
-  }
-  return [
-    "Extract an Episodic Memory from this safe Evidence projection.",
-    "Return retain=false for low-value or insufficient evidence.",
-    "Every goal, summary, attempt, failure/recovery, and outcome must cite one or more supplied messageId values in evidenceRefs.",
-    "Output schema:",
-    '{"retain":true,"language":"zh-Hans","goal":{"text":"...","evidenceRefs":["..."]},"summary":{"text":"...","evidenceRefs":["..."]},"attempts":[{"description":"...","result":"...","evidenceRefs":["..."]}],"failuresAndRecoveries":[{"failure":"...","recovery":"...","evidenceRefs":["..."]}],"outcome":{"status":"succeeded|failed|cancelled|interrupted","summary":"...","evidenceRefs":["..."]},"valueScore":0.0}',
-    'or {"retain":false,"reason":"low-value|insufficient-evidence|sensitive"}.',
-    "Evidence:",
-    JSON.stringify(evidence),
-  ].join("\n\n");
+  return renderBoundedPrompt(input.evidence, input.omittedEvidence, (retained, omissions) =>
+    [
+      "Extract an Episodic Memory from this safe Evidence projection.",
+      "Return retain=false for low-value or insufficient evidence.",
+      "Every goal, summary, attempt, failure/recovery, and outcome must cite one or more supplied messageId values in evidenceRefs.",
+      "Output schema:",
+      '{"retain":true,"language":"zh-Hans","goal":{"text":"...","evidenceRefs":["..."]},"summary":{"text":"...","evidenceRefs":["..."]},"attempts":[{"description":"...","result":"...","evidenceRefs":["..."]}],"failuresAndRecoveries":[{"failure":"...","recovery":"...","evidenceRefs":["..."]}],"outcome":{"status":"succeeded|failed|cancelled|interrupted","summary":"...","evidenceRefs":["..."]},"valueScore":0.0}',
+      'or {"retain":false,"reason":"low-value|insufficient-evidence|sensitive"}.',
+      "Evidence:",
+      JSON.stringify(retained),
+      "Omitted Evidence statistics (no omitted content):",
+      JSON.stringify(omissions),
+    ].join("\n\n"),
+  );
 }
 
 function renderSemanticExtractionPrompt(
   input: Parameters<SemanticMemoryExtractor["extract"]>[0],
 ): string {
-  const evidence: unknown[] = [];
-  let bytes = 0;
-  for (const item of [...input.evidence].reverse()) {
-    const serialized = JSON.stringify(item);
-    if (bytes + Buffer.byteLength(serialized) > 78_000) continue;
-    evidence.unshift(item);
-    bytes += Buffer.byteLength(serialized);
+  return renderBoundedPrompt(input.evidence, input.omittedEvidence, (retained, omissions) =>
+    [
+      "Extract current Semantic/Fact Memory from this safe Evidence projection.",
+      "Return retain=false when there is no stable, reusable fact. Do not turn historical outcomes into current truth.",
+      "Use only exact entries from allowedSubjectRefs and supplied messageId values. Never invent a subject id or Evidence id.",
+      "Use a namespaced predicate. normalizedValue must be a concise canonical value for deduplication.",
+      "Use conflictMode=exclusive only when the subject can have one current value for that predicate; otherwise use compatible.",
+      "Confidence must be between 0 and 0.95. Only include reviewAt or expiresAt when Evidence explicitly supports that time.",
+      "Output schema:",
+      '{"retain":true,"facts":[{"statement":"...","subjectRefs":[{"type":"pragma.user","id":"..."}],"predicate":"user.preference.language","normalizedValue":"zh-Hans","conflictMode":"exclusive|compatible","confidence":0.0,"evidenceRefs":["..."],"reviewAt":"optional ISO time","expiresAt":"optional ISO time"}]}',
+      'or {"retain":false,"reason":"no-stable-fact|insufficient-evidence|sensitive"}.',
+      "Allowed subjects:",
+      JSON.stringify(input.allowedSubjectRefs),
+      "Evidence:",
+      JSON.stringify(retained),
+      "Omitted Evidence statistics (no omitted content):",
+      JSON.stringify(omissions),
+    ].join("\n\n"),
+  );
+}
+
+function renderBoundedPrompt(
+  evidence: Parameters<EpisodicMemoryExtractor["extract"]>[0]["evidence"],
+  persistentOmissions: Parameters<EpisodicMemoryExtractor["extract"]>[0]["omittedEvidence"],
+  render: (
+    retained: readonly import("@pragma/shared").MemoryEvidenceEnvelope[],
+    omissions: Parameters<EpisodicMemoryExtractor["extract"]>[0]["omittedEvidence"],
+  ) => string,
+): string {
+  let evidenceBudget = DEFAULT_MEMORY_STORAGE_POLICY.extractionPromptMaxBytes;
+  for (;;) {
+    const selected = selectBoundedMemoryEvidence(evidence, {
+      maxRecords: DEFAULT_MEMORY_STORAGE_POLICY.evidenceMaxRecordsPerExecution,
+      maxBytes: evidenceBudget,
+    });
+    const prompt = render(
+      selected.retained,
+      mergeMemoryEvidenceOmissionStats(persistentOmissions, selected.omittedStats),
+    );
+    const overflow =
+      Buffer.byteLength(prompt) - DEFAULT_MEMORY_STORAGE_POLICY.extractionPromptMaxBytes;
+    if (overflow <= 0) return prompt;
+    if (evidenceBudget === 0) throw new Error("memory_curator_prompt_metadata_too_large");
+    evidenceBudget = Math.max(0, evidenceBudget - overflow - 512);
   }
-  return [
-    "Extract current Semantic/Fact Memory from this safe Evidence projection.",
-    "Return retain=false when there is no stable, reusable fact. Do not turn historical outcomes into current truth.",
-    "Use only exact entries from allowedSubjectRefs and supplied messageId values. Never invent a subject id or Evidence id.",
-    "Use a namespaced predicate. normalizedValue must be a concise canonical value for deduplication.",
-    "Use conflictMode=exclusive only when the subject can have one current value for that predicate; otherwise use compatible.",
-    "Confidence must be between 0 and 0.95. Only include reviewAt or expiresAt when Evidence explicitly supports that time.",
-    "Output schema:",
-    '{"retain":true,"facts":[{"statement":"...","subjectRefs":[{"type":"pragma.user","id":"..."}],"predicate":"user.preference.language","normalizedValue":"zh-Hans","conflictMode":"exclusive|compatible","confidence":0.0,"evidenceRefs":["..."],"reviewAt":"optional ISO time","expiresAt":"optional ISO time"}]}',
-    'or {"retain":false,"reason":"no-stable-fact|insufficient-evidence|sensitive"}.',
-    "Allowed subjects:",
-    JSON.stringify(input.allowedSubjectRefs),
-    "Evidence:",
-    JSON.stringify(evidence),
-  ].join("\n\n");
 }
 
 async function runCuratorMission(input: {
   readonly options: Pick<
     Parameters<typeof createDesktopMemoryCurator>[0],
-    "project" | "missions" | "runner" | "workspace"
+    "project" | "missions" | "runner" | "workspace" | "pragmaHome" | "loggerProvider"
   >;
   readonly runtime: {
     readonly runtimeId: string;
@@ -286,19 +363,36 @@ async function runCuratorMission(input: {
           },
         }),
   });
-  await input.options.runner.run(mission.id);
-  await waitForMission(input.options.missions, mission.id);
-  const finished = await input.options.missions.get(mission.id);
-  if (finished.execution?.status !== "succeeded") {
-    throw new Error(`memory_curator_failed:${finished.execution?.error ?? "unknown"}`);
+  const pragmaHome = input.options.pragmaHome;
+  const logger = createPragmaLogger(input.options.loggerProvider, {
+    component: "desktop.memory-curator",
+  });
+  await registerCuratorMission(pragmaHome, mission.id, input.jobId);
+  try {
+    await input.options.runner.run(mission.id);
+    await waitForMission(input.options.missions, mission.id);
+    const finished = await input.options.missions.get(mission.id);
+    if (finished.execution?.status !== "succeeded") {
+      throw new Error(`memory_curator_failed:${finished.execution?.error ?? "unknown"}`);
+    }
+    const chat = await input.options.runner.getChat({ id: mission.id, limit: 100 });
+    const content = chat.entries
+      .filter((entry) => entry.kind === "assistant")
+      .map((entry) => entry.content)
+      .at(-1);
+    if (content === undefined) throw new Error("memory_curator_output_missing");
+    return content;
+  } finally {
+    if (await cleanupCuratorMission(input.options.runner, mission.id)) {
+      await unregisterCuratorMission(pragmaHome, mission.id).catch((error: unknown) => {
+        logger.warn(
+          "desktop.memory_curator_registry_cleanup_failed",
+          "A completed Memory Curator Mission remains registered for later cleanup.",
+          { error, missionId: mission.id },
+        );
+      });
+    }
   }
-  const chat = await input.options.runner.getChat({ id: mission.id, limit: 100 });
-  const content = chat.entries
-    .filter((entry) => entry.kind === "assistant")
-    .map((entry) => entry.content)
-    .at(-1);
-  if (content === undefined) throw new Error("memory_curator_output_missing");
-  return content;
 }
 
 async function waitForMission(missions: MissionStore, id: string): Promise<void> {
@@ -332,4 +426,100 @@ async function createFingerprint(profile: MemoryExtractorProfile): Promise<strin
       }),
     )
     .digest("hex");
+}
+
+async function cleanupCuratorMission(runner: MissionRunner, missionId: string): Promise<boolean> {
+  try {
+    await runner.delete(missionId);
+    return true;
+  } catch {
+    await runner.interrupt(missionId).catch(() => undefined);
+    return await runner
+      .delete(missionId)
+      .then(() => true)
+      .catch(() => false);
+  }
+}
+
+async function registerCuratorMission(
+  pragmaHome: string,
+  missionId: string,
+  jobId: string,
+): Promise<void> {
+  await updateCuratorMissionRegistry(pragmaHome, (entries) => [
+    ...entries
+      .filter((entry) => entry.missionId !== missionId)
+      .slice(-(DEFAULT_MEMORY_STORAGE_POLICY.curatorRegistryMaxEntries - 1)),
+    { missionId, jobId, createdAt: new Date().toISOString() },
+  ]);
+}
+
+async function unregisterCuratorMission(pragmaHome: string, missionId: string): Promise<void> {
+  await updateCuratorMissionRegistry(pragmaHome, (entries) =>
+    entries.filter((entry) => entry.missionId !== missionId),
+  );
+}
+
+async function readCuratorMissionRegistry(pragmaHome: string) {
+  const path = new PragmaPaths({ pragmaHome }).memoryCuratorMissionRegistry();
+  try {
+    return CuratorMissionRegistrySchema.parse(JSON.parse(await readFile(path, "utf8"))).entries;
+  } catch (error) {
+    if (isNotFound(error)) return [];
+    throw error;
+  }
+}
+
+async function updateCuratorMissionRegistry(
+  pragmaHome: string,
+  update: (
+    entries: z.infer<typeof CuratorMissionRegistrySchema>["entries"],
+  ) => z.infer<typeof CuratorMissionRegistrySchema>["entries"],
+): Promise<void> {
+  const path = new PragmaPaths({ pragmaHome }).memoryCuratorMissionRegistry();
+  await withFileLock(`${path}.lock`, async () => {
+    const entries = await readCuratorMissionRegistry(pragmaHome);
+    const next = CuratorMissionRegistrySchema.parse({
+      schemaVersion: "pragma.memory-curator-mission-registry/v1",
+      entries: update(entries),
+    });
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    const temporary = `${path}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, `${JSON.stringify(next)}\n`, { mode: 0o600 });
+      await rename(temporary, path);
+    } finally {
+      await rm(temporary, { force: true });
+    }
+  });
+}
+
+async function removeStaleCuratorTemps(pragmaHome: string): Promise<void> {
+  const registry = new PragmaPaths({ pragmaHome }).memoryCuratorMissionRegistry();
+  const root = dirname(registry);
+  let names: string[];
+  try {
+    names = await readdir(root);
+  } catch (error) {
+    if (isNotFound(error)) return;
+    throw error;
+  }
+  const cutoff = Date.now() - DEFAULT_MEMORY_STORAGE_POLICY.atomicTempRetentionMs;
+  for (const name of names.filter((value) => value.endsWith(".tmp"))) {
+    const path = join(root, name);
+    try {
+      if ((await stat(path)).mtimeMs <= cutoff) await rm(path, { force: true });
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { readonly code?: unknown }).code === "ENOENT"
+  );
 }

--- a/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
+++ b/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
@@ -22,6 +22,9 @@ import {
   ReviewDesktopMemoryItemSchema,
   DesktopMissionMemoryActivitySchema,
   GetDesktopMissionMemoryActivitySchema,
+  DesktopMemoryExtractionJobSchema,
+  DesktopMemoryExtractionJobListSchema,
+  RetryDesktopMemoryExtractionJobSchema,
 } from "../../../shared/contracts/index.ts";
 import type { DesktopMemoryPlane } from "./desktop-memory-plane.ts";
 import type { MissionStore } from "../missions/mission-store.ts";
@@ -71,6 +74,31 @@ export function installMemoryPolicyHandlers(
   ipcMain.handle("memory-plane:status", async () =>
     DesktopMemoryPlaneStatusSchema.parse(await plane.getStatus()),
   );
+  ipcMain.handle("memory-extraction-jobs:list", async () => {
+    const jobs = [
+      ...(await Promise.all(
+        (await plane.episodicStore.listExtractionJobs()).map(
+          async (job) => await toDesktopExtractionJob("episodic", job, plane.episodicStore),
+        ),
+      )),
+      ...(await Promise.all(
+        (await plane.semanticStore.listExtractionJobs()).map(
+          async (job) => await toDesktopExtractionJob("semantic", job, plane.semanticStore),
+        ),
+      )),
+    ].toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    return DesktopMemoryExtractionJobListSchema.parse(jobs.slice(0, 100));
+  });
+  ipcMain.handle("memory-extraction-jobs:retry", async (_event, input: unknown) => {
+    const parsed = RetryDesktopMemoryExtractionJobSchema.parse(input);
+    await plane.retryMemoryJob(parsed);
+    const store = parsed.module === "episodic" ? plane.episodicStore : plane.semanticStore;
+    const job = (await store.listExtractionJobs()).find((candidate) => candidate.id === parsed.id);
+    if (job === undefined) throw new Error("memory_extraction_job_not_found");
+    return DesktopMemoryExtractionJobSchema.parse(
+      await toDesktopExtractionJob(parsed.module, job, store),
+    );
+  });
   ipcMain.handle("memory-extractor-profile:get", async () =>
     DesktopMemoryExtractorProfileSchema.parse(await plane.extractorProfiles.get()),
   );
@@ -228,6 +256,37 @@ function toDesktopFact(record: import("@pragma/shared").SemanticFact) {
     ...(record.reviewAt === undefined ? {} : { reviewAt: record.reviewAt }),
     ...(record.expiresAt === undefined ? {} : { expiresAt: record.expiresAt }),
     conflictsWith: record.conflictsWith,
+  };
+}
+
+async function toDesktopExtractionJob(
+  module: "episodic" | "semantic",
+  job:
+    import("@pragma/memory").EpisodicExtractionJob | import("@pragma/memory").SemanticExtractionJob,
+  store: Pick<import("@pragma/memory").EpisodicMemoryStore, "readEvidence" | "readOmissionStats">,
+) {
+  const hasPayload = ["pending", "running", "needs_attention"].includes(job.status);
+  const evidence = hasPayload ? await store.readEvidence(job.executionId) : [];
+  const omitted = await store.readOmissionStats(job.executionId);
+  return {
+    module,
+    id: job.id,
+    revision: job.revision,
+    status: job.status,
+    attempts: job.attempts,
+    totalAttempts: job.totalAttempts,
+    ...(job.lastErrorCode === undefined ? {} : { lastErrorCode: job.lastErrorCode }),
+    ...(job.failureClass === undefined ? {} : { failureClass: job.failureClass }),
+    evidenceRecords: evidence.length,
+    evidenceBytes: evidence.reduce(
+      (total, item) => total + Buffer.byteLength(JSON.stringify(item)),
+      0,
+    ),
+    omittedRecords: omitted.records,
+    updatedAt: job.updatedAt,
+    ...(job.attentionSince === undefined ? {} : { attentionSince: job.attentionSince }),
+    ...(job.completedAt === undefined ? {} : { completedAt: job.completedAt }),
+    ...(job.expiredAt === undefined ? {} : { expiredAt: job.expiredAt }),
   };
 }
 

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -223,6 +223,12 @@ export function createMissionRunner(options: {
   readonly assertStorageWriteAllowed?: (() => Promise<void>) | undefined;
   readonly assertExecutorReady?: ((ref: string) => void | Promise<void>) | undefined;
   readonly onStorageTrashed?: (() => void) | undefined;
+  readonly onOwnerDeleting?:
+    | ((input: {
+        readonly mission: Mission;
+        readonly executionIds: readonly string[];
+      }) => Promise<void>)
+    | undefined;
   readonly onExecutionLinked?:
     | ((input: { readonly mission: Mission; readonly executionId: string }) => Promise<void>)
     | undefined;
@@ -1154,6 +1160,7 @@ export function createMissionRunner(options: {
       sessionCompilationIdentities.delete(id);
       sessionDefinitionFingerprints.delete(id);
     }
+    await options.onOwnerDeleting?.({ mission, executionIds: [...executionIds] });
     const paths = new PragmaPaths({ pragmaHome: options.pragmaHome });
     const sources = [
       ...[...executionIds].map((executionId) => ({

--- a/apps/desktop/src/preload/api/memory.ts
+++ b/apps/desktop/src/preload/api/memory.ts
@@ -22,6 +22,9 @@ import {
   TightenDesktopMemoryAccessSchema,
   ReviewDesktopMemoryItemSchema,
   DesktopMissionMemoryActivitySchema,
+  DesktopMemoryExtractionJobListSchema,
+  DesktopMemoryExtractionJobSchema,
+  RetryDesktopMemoryExtractionJobSchema,
 } from "../../shared/contracts/memory.ts";
 
 export const memoryApi = {
@@ -52,6 +55,17 @@ export const memoryApi = {
     ),
   getMemoryPlaneStatus: async () =>
     DesktopMemoryPlaneStatusSchema.parse(await ipcRenderer.invoke("memory-plane:status")),
+  listMemoryExtractionJobs: async () =>
+    DesktopMemoryExtractionJobListSchema.parse(
+      await ipcRenderer.invoke("memory-extraction-jobs:list"),
+    ),
+  retryMemoryExtractionJob: async (input) =>
+    DesktopMemoryExtractionJobSchema.parse(
+      await ipcRenderer.invoke(
+        "memory-extraction-jobs:retry",
+        RetryDesktopMemoryExtractionJobSchema.parse(input),
+      ),
+    ),
   getMemoryExtractorProfile: async () =>
     DesktopMemoryExtractorProfileSchema.parse(
       await ipcRenderer.invoke("memory-extractor-profile:get"),
@@ -124,6 +138,8 @@ export const memoryApi = {
   | "getAssetMemoryPolicy"
   | "updateAssetMemoryPolicy"
   | "getMemoryPlaneStatus"
+  | "listMemoryExtractionJobs"
+  | "retryMemoryExtractionJob"
   | "getMemoryExtractorProfile"
   | "updateMemoryExtractorProfile"
   | "reviseSemanticFact"

--- a/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
@@ -39,5 +39,7 @@ export const memory = {
   loadError: "Memory could not be loaded.",
   actionError: "The memory change could not be saved.",
   healthSummary: "{{state}} · {{modules}} modules · {{events}} canonical events",
+  storageHealth:
+    "Feed {{logical}} / {{target}} · safe through {{safe}} · {{blocked}} blocked by durable consumers",
   permissionNote: "Permissions can only be kept or tightened in this phase.",
 };

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -145,7 +145,7 @@ export const missions = {
   memoryActivityUnavailable: "Memory activity is unavailable",
   noMemoryActivity: "No memory activity",
   noMemoryActivityDescription: "Run this mission to create capture and recall activity.",
-  memoryCaptured: "Captured",
+  memoryCaptured: "Evidence published (not memories)",
   memorySkipped: "Capture skipped",
   memoryCaptureFailed: "Capture failed",
   memoryListed: "Lists",

--- a/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
@@ -63,6 +63,18 @@ export const settings = {
       "{{state}} · {{events}} events · {{modules}} modules · {{pending}} pending · {{quarantined}} quarantined",
     moduleWorkSummary:
       "{{module}} · {{records}} records · {{pending}} extracting · {{attention}} need attention · {{rejected}} rejected",
+    storageGovernance: "Storage governance",
+    storageGovernanceDescription:
+      "Fixed, read-only retention limits bound raw events, extraction payloads, and diagnostics.",
+    storageSummary:
+      "{{events}} events · {{logical}} logical / {{file}} file · {{target}} target · safe through {{safe}} · {{blocked}} blocked",
+    retentionSummary:
+      "Feed {{feedDays}} days · jobs {{jobDays}} days · {{records}} or {{bytes}} per execution · {{deadLetters}} dead letters",
+    extractionJob: "{{module}} extraction job",
+    extractionJobSummary:
+      "{{status}} · {{attempts}} attempts · {{evidence}} Evidence retained · {{omitted}} omitted · {{error}}",
+    retryExtraction: "Retry extraction",
+    retryError: "The extraction job changed or can no longer be retried.",
     assetTitle: "Memory policy",
     assetDescription:
       "This team asset may only narrow the global policy. Runtime restrictions are intersected with this setting.",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
@@ -41,5 +41,6 @@ export const memory = {
   loadError: "无法加载记忆。",
   actionError: "无法保存记忆变更。",
   healthSummary: "{{state}} · {{modules}} 个模块 · {{events}} 个规范事件",
+  storageHealth: "Feed {{logical}} / {{target}} · 安全水位 {{safe}} · {{blocked}} 被持久消费者阻塞",
   permissionNote: "本阶段只能保持或收紧权限。",
 } satisfies DesktopTranslationResource["memory"];

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -138,7 +138,7 @@ export const missions = {
   memoryActivityUnavailable: "无法读取记忆活动",
   noMemoryActivity: "暂无记忆活动",
   noMemoryActivityDescription: "运行此任务后会产生捕获与召回活动。",
-  memoryCaptured: "已捕获",
+  memoryCaptured: "已发布 Evidence（不是记忆条数）",
   memorySkipped: "跳过捕获",
   memoryCaptureFailed: "捕获失败",
   memoryListed: "列举",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
@@ -60,6 +60,17 @@ export const settings = {
       "{{state}} · {{events}} 条事件 · {{modules}} 个模块 · {{pending}} 条待投递 · {{quarantined}} 条已隔离",
     moduleWorkSummary:
       "{{module}} · {{records}} 条记忆 · {{pending}} 条提炼中 · {{attention}} 条需处理 · {{rejected}} 条已拒绝",
+    storageGovernance: "存储治理",
+    storageGovernanceDescription: "以固定只读策略限制原始事件、提炼载荷和诊断数据的增长。",
+    storageSummary:
+      "{{events}} 条事件 · 逻辑 {{logical}} / 文件 {{file}} · 目标 {{target}} · 安全水位 {{safe}} · 阻塞 {{blocked}}",
+    retentionSummary:
+      "Feed {{feedDays}} 天 · 任务 {{jobDays}} 天 · 每次执行 {{records}} 条或 {{bytes}} · {{deadLetters}} 条死信",
+    extractionJob: "{{module}} 提炼任务",
+    extractionJobSummary:
+      "{{status}} · 累计 {{attempts}} 次 · 保留 {{evidence}} 条 Evidence · 省略 {{omitted}} 条 · {{error}}",
+    retryExtraction: "重试提炼",
+    retryError: "提炼任务已经变化或不再允许重试。",
     assetTitle: "记忆策略",
     assetDescription: "此团队资产只能收紧全局策略；运行时限制还会与本设置取交集。",
     effectiveSummary: "当前生效：采集{{capture}}，召回{{recall}}，学习{{learning}}",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
@@ -41,5 +41,6 @@ export const memory = {
   loadError: "無法載入記憶。",
   actionError: "無法儲存記憶變更。",
   healthSummary: "{{state}} · {{modules}} 個模組 · {{events}} 個規範事件",
+  storageHealth: "Feed {{logical}} / {{target}} · 安全水位 {{safe}} · {{blocked}} 被持久消費者阻塞",
   permissionNote: "本階段只能維持或縮小權限。",
 } satisfies DesktopTranslationResource["memory"];

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -138,7 +138,7 @@ export const missions = {
   memoryActivityUnavailable: "無法讀取記憶活動",
   noMemoryActivity: "暫無記憶活動",
   noMemoryActivityDescription: "執行此任務後會產生擷取與召回活動。",
-  memoryCaptured: "已擷取",
+  memoryCaptured: "已發佈 Evidence（不是記憶筆數）",
   memorySkipped: "略過擷取",
   memoryCaptureFailed: "擷取失敗",
   memoryListed: "列舉",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
@@ -60,6 +60,17 @@ export const settings = {
       "{{state}} · {{events}} 筆事件 · {{modules}} 個模組 · {{pending}} 筆待投遞 · {{quarantined}} 筆已隔離",
     moduleWorkSummary:
       "{{module}} · {{records}} 筆記憶 · {{pending}} 筆提煉中 · {{attention}} 筆需處理 · {{rejected}} 筆已拒絕",
+    storageGovernance: "儲存治理",
+    storageGovernanceDescription: "以固定唯讀策略限制原始事件、提煉載荷和診斷資料的增長。",
+    storageSummary:
+      "{{events}} 筆事件 · 邏輯 {{logical}} / 檔案 {{file}} · 目標 {{target}} · 安全水位 {{safe}} · 阻塞 {{blocked}}",
+    retentionSummary:
+      "Feed {{feedDays}} 天 · 任務 {{jobDays}} 天 · 每次執行 {{records}} 筆或 {{bytes}} · {{deadLetters}} 筆死信",
+    extractionJob: "{{module}} 提煉任務",
+    extractionJobSummary:
+      "{{status}} · 累計 {{attempts}} 次 · 保留 {{evidence}} 筆 Evidence · 省略 {{omitted}} 筆 · {{error}}",
+    retryExtraction: "重試提煉",
+    retryError: "提煉任務已經變更或不再允許重試。",
     assetTitle: "記憶策略",
     assetDescription: "此團隊資產只能收緊全域策略；執行階段限制還會與本設定取交集。",
     effectiveSummary: "目前生效：採集{{capture}}，召回{{recall}}，學習{{learning}}",

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
@@ -439,6 +439,16 @@ function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus | unde
           events: props.health.feed.eventCount,
         })}
       </p>
+      <p>
+        {t("storageHealth", {
+          logical: formatHealthBytes(props.health.feed.logicalBytes),
+          target: formatHealthBytes(
+            props.health.storagePolicy?.canonicalFeedTargetBytes ?? 512 * 1_024 * 1_024,
+          ),
+          blocked: formatHealthBytes(props.health.feed.blockedBytes),
+          safe: props.health.feed.safeThroughSequence,
+        })}
+      </p>
       {props.health.modules.map((module) => (
         <article key={module.moduleId}>
           <strong>
@@ -451,6 +461,10 @@ function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus | unde
       ))}
     </section>
   );
+}
+
+function formatHealthBytes(bytes: number): string {
+  return `${(bytes / (1_024 * 1_024)).toFixed(1)} MiB`;
 }
 
 function key(item: DesktopMemoryItem): string {

--- a/apps/desktop/src/renderer/src/pages/settings/MemorySettingsFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/MemorySettingsFragment.tsx
@@ -6,6 +6,7 @@ import type {
   DesktopMemoryExtractorProfile,
   DesktopMemoryPlaneStatus,
   DesktopRuntimeAvailability,
+  DesktopMemoryExtractionJob,
 } from "../../../../shared/contracts/index.ts";
 import { SelectMenu } from "../../components/SelectMenu.tsx";
 import { SettingsScreenFrame } from "./SettingsScreenFrame.tsx";
@@ -16,6 +17,7 @@ export function MemorySettingsFragment() {
   const [status, setStatus] = useState<DesktopMemoryPlaneStatus>();
   const [extractor, setExtractor] = useState<DesktopMemoryExtractorProfile>();
   const [runtimes, setRuntimes] = useState<readonly DesktopRuntimeAvailability[]>([]);
+  const [jobs, setJobs] = useState<readonly DesktopMemoryExtractionJob[]>([]);
   const [runtimeId, setRuntimeId] = useState("");
   const [modelKey, setModelKey] = useState("");
   const [saving, setSaving] = useState(false);
@@ -28,13 +30,15 @@ export function MemorySettingsFragment() {
       window.pragmaDesktop.getMemoryPlaneStatus(),
       window.pragmaDesktop.getMemoryExtractorProfile(),
       window.pragmaDesktop.getRuntimeAvailability(),
+      window.pragmaDesktop.listMemoryExtractionJobs(),
     ])
-      .then(([nextSnapshot, nextStatus, nextExtractor, nextRuntimes]) => {
+      .then(([nextSnapshot, nextStatus, nextExtractor, nextRuntimes, nextJobs]) => {
         if (cancelled) return;
         setSnapshot(nextSnapshot);
         setStatus(nextStatus);
         setExtractor(nextExtractor);
         setRuntimes(nextRuntimes);
+        setJobs(nextJobs);
         const selectedRuntime =
           nextExtractor.runtimeId ?? nextRuntimes.find((runtime) => runtime.isDefault)?.id ?? "";
         setRuntimeId(selectedRuntime);
@@ -99,6 +103,24 @@ export function MemorySettingsFragment() {
 
   const selectedRuntime = runtimes.find((runtime) => runtime.id === runtimeId);
   const models = selectedRuntime?.models ?? [];
+  const retryJob = async (job: DesktopMemoryExtractionJob) => {
+    setSaving(true);
+    setError(undefined);
+    try {
+      const updated = await window.pragmaDesktop.retryMemoryExtractionJob({
+        module: job.module,
+        id: job.id,
+        expectedRevision: job.revision,
+      });
+      setJobs((current) =>
+        current.map((candidate) => (candidate.id === job.id ? updated : candidate)),
+      );
+    } catch {
+      setError(t("memory.retryError"));
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <SettingsScreenFrame
@@ -237,10 +259,71 @@ export function MemorySettingsFragment() {
             {status === undefined ? t("memory.loading") : t(`memory.states.${status.state}`)}
           </span>
         </div>
+        {status?.storagePolicy === undefined ? null : (
+          <div className="setting-row">
+            <span className="setting-copy">
+              <strong>{t("memory.storageGovernance")}</strong>
+              <span>{t("memory.storageGovernanceDescription")}</span>
+              <small>
+                {t("memory.storageSummary", {
+                  events: status.feed.eventCount,
+                  logical: formatBytes(status.feed.logicalBytes),
+                  file: formatBytes(status.feed.fileBytes),
+                  target: formatBytes(status.storagePolicy.canonicalFeedTargetBytes),
+                  safe: status.feed.safeThroughSequence,
+                  blocked: formatBytes(status.feed.blockedBytes),
+                })}
+              </small>
+              <small>
+                {t("memory.retentionSummary", {
+                  feedDays: status.storagePolicy.canonicalFeedRetentionDays,
+                  jobDays: status.storagePolicy.jobRecordRetentionDays,
+                  records: status.storagePolicy.evidenceMaxRecordsPerExecution,
+                  bytes: formatBytes(status.storagePolicy.evidenceMaxBytesPerExecution),
+                  deadLetters: status.maintenance.deadLetterEntries,
+                })}
+              </small>
+            </span>
+          </div>
+        )}
+        {jobs
+          .filter((job) => ["needs_attention", "expired"].includes(job.status))
+          .map((job) => (
+            <div className="setting-row" key={`${job.module}:${job.id}`}>
+              <span className="setting-copy">
+                <strong>{t("memory.extractionJob", { module: job.module })}</strong>
+                <span>
+                  {t("memory.extractionJobSummary", {
+                    status: job.status,
+                    attempts: job.totalAttempts,
+                    evidence: job.evidenceRecords,
+                    omitted: job.omittedRecords,
+                    error: job.lastErrorCode ?? "—",
+                  })}
+                </span>
+              </span>
+              {job.status !== "needs_attention" ? null : (
+                <button
+                  type="button"
+                  className="secondary-button"
+                  disabled={saving}
+                  onClick={() => void retryJob(job)}
+                >
+                  {t("memory.retryExtraction")}
+                </button>
+              )}
+            </div>
+          ))}
       </div>
       {error === undefined ? null : <p className="form-error">{error}</p>}
     </SettingsScreenFrame>
   );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1_024) return `${bytes} B`;
+  if (bytes < 1_024 * 1_024) return `${(bytes / 1_024).toFixed(1)} KiB`;
+  return `${(bytes / (1_024 * 1_024)).toFixed(1)} MiB`;
 }
 
 function MemoryGlobalSwitch(props: {

--- a/apps/desktop/src/shared/contracts/api.ts
+++ b/apps/desktop/src/shared/contracts/api.ts
@@ -134,6 +134,8 @@ import type {
   TightenDesktopMemoryAccess,
   ReviewDesktopMemoryItem,
   DesktopMissionMemoryActivity,
+  DesktopMemoryExtractionJob,
+  RetryDesktopMemoryExtractionJob,
 } from "./types.ts";
 
 export interface PragmaDesktopAPI {
@@ -152,6 +154,10 @@ export interface PragmaDesktopAPI {
     input: UpdateDesktopAssetMemoryPolicy,
   ) => Promise<DesktopAssetMemoryPolicySnapshot>;
   getMemoryPlaneStatus: () => Promise<DesktopMemoryPlaneStatus>;
+  listMemoryExtractionJobs: () => Promise<DesktopMemoryExtractionJob[]>;
+  retryMemoryExtractionJob: (
+    input: RetryDesktopMemoryExtractionJob,
+  ) => Promise<DesktopMemoryExtractionJob>;
   getMemoryExtractorProfile: () => Promise<DesktopMemoryExtractorProfile>;
   updateMemoryExtractorProfile: (
     input: UpdateDesktopMemoryExtractorProfile,

--- a/apps/desktop/src/shared/contracts/contracts.test.ts
+++ b/apps/desktop/src/shared/contracts/contracts.test.ts
@@ -105,7 +105,7 @@ describe("desktop memory contracts", () => {
         delivery: { pending: 1, quarantined: 0 },
         modules: [],
       }),
-    ).toEqual({
+    ).toMatchObject({
       state: "running",
       feed: { lastSequence: 12, eventCount: 10 },
       delivery: { pending: 1, quarantined: 0 },

--- a/apps/desktop/src/shared/contracts/memory.ts
+++ b/apps/desktop/src/shared/contracts/memory.ts
@@ -54,6 +54,12 @@ export const DesktopMemoryPlaneStatusSchema = z.object({
   feed: z.object({
     lastSequence: z.number().int().nonnegative(),
     eventCount: z.number().int().nonnegative(),
+    logicalBytes: z.number().int().nonnegative().default(0),
+    fileBytes: z.number().int().nonnegative().default(0),
+    receiptCount: z.number().int().nonnegative().default(0),
+    oldestOccurredAt: z.string().datetime().optional(),
+    safeThroughSequence: z.number().int().nonnegative().default(0),
+    blockedBytes: z.number().int().nonnegative().default(0),
   }),
   delivery: z.object({
     pending: z.number().int().nonnegative(),
@@ -66,7 +72,66 @@ export const DesktopMemoryPlaneStatusSchema = z.object({
     })
     .optional(),
   modules: z.array(MemoryModuleDiagnosticSchema),
+  storagePolicy: z
+    .object({
+      schemaVersion: z.literal("pragma.memory-storage-policy/v1"),
+      canonicalFeedRetentionDays: z.literal(30),
+      canonicalFeedTargetBytes: z.literal(512 * 1_024 * 1_024),
+      evidenceMaxRecordsPerExecution: z.literal(2_000),
+      evidenceMaxBytesPerExecution: z.literal(16 * 1_024 * 1_024),
+      extractionPromptMaxBytes: z.literal(78_000),
+      jobRecordRetentionDays: z.literal(30),
+      failedPayloadRetentionDays: z.literal(30),
+      deadLetterRetentionDays: z.literal(30),
+      deadLetterMaxEntries: z.literal(10_000),
+      deadLetterMaxBytes: z.literal(64 * 1_024 * 1_024),
+    })
+    .optional(),
+  maintenance: z
+    .object({
+      lastRunAt: z.string().datetime().optional(),
+      deletedEvents: z.number().int().nonnegative(),
+      reclaimedBytes: z.number().int().nonnegative(),
+      deletedDeadLetters: z.number().int().nonnegative(),
+      deadLetterEntries: z.number().int().nonnegative(),
+      deadLetterBytes: z.number().int().nonnegative(),
+    })
+    .default({
+      deletedEvents: 0,
+      reclaimedBytes: 0,
+      deletedDeadLetters: 0,
+      deadLetterEntries: 0,
+      deadLetterBytes: 0,
+    }),
 });
+
+export const DesktopMemoryExtractionJobSchema = z.object({
+  module: z.enum(["episodic", "semantic"]),
+  id: z.string().min(1),
+  revision: z.number().int().positive(),
+  status: z.enum(["pending", "running", "needs_attention", "completed", "expired"]),
+  attempts: z.number().int().nonnegative(),
+  totalAttempts: z.number().int().nonnegative(),
+  lastErrorCode: z.string().min(1).optional(),
+  failureClass: z.enum(["configuration", "transient-exhausted"]).optional(),
+  evidenceRecords: z.number().int().nonnegative(),
+  evidenceBytes: z.number().int().nonnegative(),
+  omittedRecords: z.number().int().nonnegative(),
+  updatedAt: z.string().datetime(),
+  attentionSince: z.string().datetime().optional(),
+  completedAt: z.string().datetime().optional(),
+  expiredAt: z.string().datetime().optional(),
+});
+
+export const DesktopMemoryExtractionJobListSchema = z.array(DesktopMemoryExtractionJobSchema);
+
+export const RetryDesktopMemoryExtractionJobSchema = z
+  .object({
+    module: z.enum(["episodic", "semantic"]),
+    id: z.string().min(1),
+    expectedRevision: z.number().int().positive(),
+  })
+  .strict();
 
 export const DesktopMemoryExtractorProfileSchema = z
   .object({

--- a/apps/desktop/src/shared/contracts/types.ts
+++ b/apps/desktop/src/shared/contracts/types.ts
@@ -204,6 +204,8 @@ import {
   ReviewDesktopMemoryItemSchema,
   DesktopMissionMemoryActivitySchema,
   GetDesktopMissionMemoryActivitySchema,
+  DesktopMemoryExtractionJobSchema,
+  RetryDesktopMemoryExtractionJobSchema,
 } from "./memory.ts";
 export type DesktopAppInfo = z.infer<typeof DesktopAppInfoSchema>;
 export type PragmaBundleModuleOptions = z.infer<typeof PragmaBundleModuleOptionsSchema>;
@@ -268,6 +270,8 @@ export type TightenDesktopMemoryAccess = z.infer<typeof TightenDesktopMemoryAcce
 export type ReviewDesktopMemoryItem = z.infer<typeof ReviewDesktopMemoryItemSchema>;
 export type DesktopMissionMemoryActivity = z.infer<typeof DesktopMissionMemoryActivitySchema>;
 export type GetDesktopMissionMemoryActivity = z.infer<typeof GetDesktopMissionMemoryActivitySchema>;
+export type DesktopMemoryExtractionJob = z.infer<typeof DesktopMemoryExtractionJobSchema>;
+export type RetryDesktopMemoryExtractionJob = z.infer<typeof RetryDesktopMemoryExtractionJobSchema>;
 export type ModelProviderModel = z.infer<typeof ModelProviderModelSchema>;
 export type ModelCompatibilityProfileDescriptor = z.infer<
   typeof ModelCompatibilityProfileDescriptorSchema

--- a/docs/adr/031-extensible-memory-plane.md
+++ b/docs/adr/031-extensible-memory-plane.md
@@ -93,6 +93,10 @@ TaskMemory 原有语义本质是 TODO List Manager、handoff 区或多人白板�
 可以完全不使用它。WorkingState 的已提交变化可以成为 Evidence，但 Memory 提炼始终基于 canonical
 消息与执行事件，不依赖白板是否存在。
 
+“不是 Memory 的前置依赖”不表示不提供该产品能力。WorkingState 作为 Host 内置、Mission/Execution
+生命周期内的短期协作状态独立实现，支持团队共享条目和按 Runtime Context 隔离的私有条目；其协议、
+权限、持久化、工具和 Desktop UI 由落地计划的独立阶段交付，而不作为 `@pragma/memory` Module。
+
 ## Subject、生产者、绑定与团队资产
 
 以下维度必须分开：

--- a/docs/adr/032-durable-canonical-event-feed.md
+++ b/docs/adr/032-durable-canonical-event-feed.md
@@ -58,5 +58,6 @@ invoke the Module again, which is why Module mutation idempotency remains mandat
 - A malformed handoff only blocks its owning Execution, while degraded Plane health remains visible.
 - The Feed supplies global delivery order; business causality remains explicit through source,
   correlation, and causation ids.
-- Phase one retains Feed rows indefinitely. Retention, remote replication, and historical import
-  require later decisions.
+- Feed retention and safe-checkpoint compaction are governed by
+  [ADR 036](./036-memory-storage-retention-and-recovery.md). Remote replication and historical import
+  remain separate future decisions.

--- a/docs/adr/036-memory-storage-retention-and-recovery.md
+++ b/docs/adr/036-memory-storage-retention-and-recovery.md
@@ -1,0 +1,60 @@
+# ADR 036: Memory Storage Retention and Recovery
+
+- Status: Accepted
+- Date: 2026-08-04
+- Related: [ADR 031](./031-extensible-memory-plane.md), [ADR 032](./032-durable-canonical-event-feed.md), [ADR 033](./033-layered-episodic-memory.md), [ADR 034](./034-conservative-semantic-memory.md)
+
+## Context
+
+Memory extraction deliberately separates continuous Evidence capture from terminal-time model
+extraction. Without an explicit retention contract, a stalled consumer, a permanently failing model,
+or an unusually large Execution can make the Feed, per-Module Evidence, retry records, dead letters,
+and hidden curator Missions grow indefinitely. Deleting a Mission also needs a crash-safe distinction
+between transient extraction state and already-materialized long-term Memory.
+
+## Decision
+
+Memory uses one versioned, Host-owned storage policy. It is currently fixed and read-only:
+
+- Canonical Feed payloads have a 30-day retention window and a 512 MiB logical target. Maintenance
+  may delete only through the minimum durable checkpoint of every registered consumer. Event receipts
+  survive payload pruning, so replaying an old event id remains idempotent. Rows pinned by a lagging
+  consumer are never deleted to satisfy the target; health instead reports the blocked bytes.
+- Each Module retains at most 2,000 Evidence envelopes or 16 MiB per Execution. A deterministic
+  priority selector keeps terminal outcomes, user intent, final assistant output, failures, artifacts,
+  and summaries before routine lifecycle events. The prompt is independently bounded to 78 KiB.
+  Content-free omission counts remain visible to the curator and diagnostics.
+- Episodic Memory stores only Evidence cited by the retained Episode. Semantic Memory already stores
+  only Evidence cited by a retained Fact.
+- Automatic transient retries are bounded. Configuration failures and exhausted transient failures
+  enter `needs_attention`; application startup does not wake them. A matching configuration change or
+  an explicit CAS-protected user retry may wake them.
+- Failed payloads expire after 30 days. Their content, Evidence, and subject context are deleted and
+  replaced by a content-free `expired` diagnostic. Completed job records, expired diagnostics, and
+  dead letters use bounded 30-day retention; dead letters are additionally capped at 10,000 records
+  and 64 MiB per consumer.
+- Mission deletion writes a stable cleanup journal, deletes Feed payload/receipts and transient
+  Episodic/Semantic state for the Mission's Executions, then moves the Mission owner graph to trash.
+  Already-materialized Episode and Fact revisions remain governed long-term Memory. A short-lived
+  deleted-Execution marker prevents an in-flight extractor or replay from recreating transient state.
+- Memory SQLite upgrades run through statically registered adjacent migration chains under a file
+  lock. Each source version is backed up before mutation; stale migration backups and abandoned
+  atomic-write temporary files are removed after 30 days and one day respectively.
+- Hidden Memory Curator Missions are registered in a dedicated bounded registry. Normal completion
+  deletes them immediately; post-window recovery cleans only registered orphan entries after a
+  one-day grace period and never scans all Missions.
+
+Desktop runs targeted maintenance after its first window exists, hourly while active, after owner
+deletion, and on explicit maintenance requests. Startup does not scan all owners. Storage upgrades
+remain lazy, fail closed on future versions, and preserve the existing backup/journal rules.
+
+## Consequences
+
+- A lagging consumer can cause a visible degraded state, but cannot cause unacknowledged Feed data to
+  be silently discarded.
+- Large executions remain extractable from a representative, deterministic Evidence set rather than
+  growing model prompts without bound.
+- Failed extraction remains recoverable for a bounded period and requires an observable trigger;
+  repeated application starts no longer create an implicit retry loop.
+- Mission deletion is crash-recoverable and does not erase independently governed long-term Memory.
+- Receipt and diagnostic metadata can outlive source payloads, but contain no captured content.

--- a/docs/architecture/memory-plane-implementation-plan.md
+++ b/docs/architecture/memory-plane-implementation-plan.md
@@ -1,8 +1,8 @@
 # Memory Plane 落地计划
 
 - Status: Active plan
-- Last updated: 2026-08-03
-- Decisions: [ADR 031](../adr/031-extensible-memory-plane.md)、[ADR 032](../adr/032-durable-canonical-event-feed.md)、[ADR 033](../adr/033-layered-episodic-memory.md)、[ADR 034](../adr/034-conservative-semantic-memory.md)、[ADR 035](../adr/035-agent-driven-memory-recall-and-governance.md)
+- Last updated: 2026-08-04
+- Decisions: [ADR 031](../adr/031-extensible-memory-plane.md)、[ADR 032](../adr/032-durable-canonical-event-feed.md)、[ADR 033](../adr/033-layered-episodic-memory.md)、[ADR 034](../adr/034-conservative-semantic-memory.md)、[ADR 035](../adr/035-agent-driven-memory-recall-and-governance.md)、[ADR 036](../adr/036-memory-storage-retention-and-recovery.md)
 
 ## 最终链路
 
@@ -20,8 +20,9 @@ Federated ContextStore + Agent-driven Recall + Host Governance
 Skill Candidate 经 Evaluation 升级为现有 Skill Capability
 ```
 
-WorkingState、TODO List 和多人白板不在主链上；它们可以发布 Evidence，但 Agent 不使用白板也必须产生
-Memory。Knowledge、CodeGraph 仍是 Memory type，不新增 KnowledgeBase/KnowledgeAsset/MemoryAsset 对象。
+WorkingState、TODO List 和多人白板不在 Memory 提炼主链上，但仍是需要独立交付的 Host 内置短期协作
+能力；它们可以发布 Evidence，但 Agent 不使用白板也必须产生 Memory。Knowledge、CodeGraph 仍是
+Memory type，不新增 KnowledgeBase/KnowledgeAsset/MemoryAsset 对象。
 
 ## 执行原则
 
@@ -43,10 +44,11 @@ Memory。Knowledge、CodeGraph 仍是 Memory type，不新增 KnowledgeBase/Know
 | 2    | Completed | 分层召回协议与 Episodic Memory：历史、结果、失败与恢复       |
 | 3    | Completed | Semantic / Fact Memory：真值、冲突、时效和置信度             |
 | 4    | Completed | Agent 驱动召回、完整 binding 治理、管理中心与 Mission 可见性 |
-| 5    | Planned   | Knowledge Memory：多层提炼、稳定 revision 与团队分享         |
-| 6    | Planned   | Skill Memory Candidate、Evaluation 与 Capability 升级        |
-| 7    | Planned   | CodeGraph 独立 Module 扩展验收                               |
-| 8    | Planned   | 旧 plugin owner-scoped 导入、compiler cutover 与删除         |
+| 5    | Planned   | WorkingState / Task Board：短期 TODO、私有状态与团队白板     |
+| 6    | Planned   | Knowledge Memory：多层提炼、稳定 revision 与团队分享         |
+| 7    | Planned   | Skill Memory Candidate、Evaluation 与 Capability 升级        |
+| 8    | Planned   | CodeGraph 独立 Module 扩展验收                               |
+| 9    | Planned   | 旧 plugin owner-scoped 导入、compiler cutover 与删除         |
 
 状态只使用 `Planned`、`In progress`、`Blocked`、`Completed`。
 
@@ -115,7 +117,7 @@ Desktop 提供设置入口。
 - 设置页提供 Global capture/recall/learning 与 Plane health；
 - Expert、ExpertTeam、Flow 编辑页提供继承/收紧策略；
 - 不需要环境变量，不再对 legacy Memory plugin 做运行时二选一冲突判断；
-- 旧 plugin 仅作为阶段 8 的历史数据迁移源，不能继续定义新架构。
+- 旧 plugin 仅作为阶段 9 的历史数据迁移源，不能继续定义新架构。
 
 ### 持久路径
 
@@ -318,7 +320,66 @@ Expert/principal scope、binding/visibility、预算、审计和生命周期。�
 - Known limitations: 不提供跨设备账户合并、分享扩权审批、Knowledge/Skill/CodeGraph、legacy importer；
   不计划增加 Host prompt retrieval planner
 
-## 阶段 5：Knowledge Memory
+## 已完成的跨阶段存储治理
+
+存储治理不是新的 Memory 类型阶段，而是阶段 1–4 的横切完成项：
+
+- Feed v2 使用独立 receipt 保留历史 event id 幂等性，只在所有注册消费者的最小 checkpoint 之前按
+  30 天/512 MiB 目标清理 payload；落后消费者固定数据时报告 blocked bytes，不越过 checkpoint 删除；
+- 每个 Module、每个 Execution 的待提炼 Evidence 固定为最多 2,000 条或 16 MiB，按终态、用户意图、
+  最终回答、失败、artifact、summary 的确定性优先级保留；实际 curator prompt 再限制为 78 KiB；
+- Episode/Fact 只长期保存被产物引用的 Evidence；遗漏只保留按 topic 统计的 content-free 诊断；
+- configuration failure 与耗尽的 transient failure 进入 `needs_attention`，不因应用重启自动重试；配置
+  修复或用户在设置页执行带 revision 的显式重试后才重新入队；
+- 失败 payload 30 天后转为 `expired` 诊断并删除内容；completed/expired job、dead letter 和旧迁移备份均
+  有固定期限，dead letter 另有 10,000 条/64 MiB 上限；
+- Mission 删除通过稳定 cleanup journal 清除关联 Execution 的 Feed 与 transient extraction state，
+  已完成的 Episode/Fact 继续作为独立治理的长期 Memory；删除标记阻止在途提炼或事件重放复活状态；
+- 隐藏 Memory Curator Mission 正常结束立即删除；异常遗留只通过专用有界 registry 定向恢复，不扫描全部
+  Mission。
+
+具体不变量、时限和恢复语义见 [ADR 036](../adr/036-memory-storage-retention-and-recovery.md)。
+
+## 阶段 5：WorkingState / Task Board
+
+### 目标
+
+提供类似 TODO List 的短期工作记忆和多人协作白板。WorkingState 服务于正在进行的 Mission/Execution，
+不是长期 Memory type，也不是 Memory Plane 产生 Episodic、Semantic Memory 的前置条件；其已提交变化通过
+Canonical Event Feed 成为后续提炼可选使用的 Evidence。
+
+### 对象与权限边界
+
+- 支持 `todo`、`decision`、`question`、`progress`、`handoff`、`note` 等结构化条目；
+- 共享条目绑定当前根 ExpertTeam/Flow 与 Execution，参与该运行的 Agent 可在权限范围内协作读写；
+- 私有条目绑定稳定 `ownerContextId`，普通 Agent 只能由所属 Runtime Context 读取和修改，不能由团队成员、
+  coordinator 或通过猜测 ID 旁路读取；Host 用户治理和审计使用独立显式权限；
+- assignee 使用稳定 Expert/Context identity，不使用展示名称或数组顺序推导身份；
+- visibility、owner、scope 和 permission revision 分离，私有内容不能因 handoff、提炼或导出自动扩大可见性；
+- WorkingState 随 Mission/Execution owner 生命周期持久化和级联清理，不进入 Project Revision，也不写
+  Agent workspace。
+
+### 交付
+
+- 使用 Zod 定义当前协议、条目 revision、状态、assignee、visibility、provenance 和 mutation event；
+- 提供 `list/read/create/update/resolve/archive` managed tools，所有 mutation 使用 revision CAS；
+- 提供 durable Store、稳定 journal、原子 mutation、幂等重放和未来 schema fail-closed；
+- ExpertTeam/Flow 的共享视图与 Agent 私有视图在 Store 查询层鉴权，list、read 和精确 ID 读取使用同一规则；
+- Desktop 提供 Mission/Execution 白板、TODO 状态、负责人、共享/私有标识和治理审计；
+- 已提交 mutation 发布 content-safe Canonical Event；Evidence adapter 按原 visibility 保持或收紧权限，
+  不把私有正文暴露给其他 Agent；
+- 阶段 9 将旧 Task Memory 按 owner 显式导入 WorkingState 或归档 Evidence；阶段 5 不维持 dual-write。
+
+### 退出门槛
+
+- 不使用 WorkingState 的 Mission 仍能正常形成 Episodic/Semantic Memory；
+- 同一 Team/Flow Execution 的授权参与者能协作维护共享 TODO 和 handoff；
+- Agent A 无法从 list、read、精确 ID、Context 或 Evidence 读取 Agent B 的私有条目；
+- 并发更新产生明确 CAS 冲突，不静默覆盖；崩溃恢复不重复应用 mutation；
+- Mission/Execution 删除按 owner 图回收 WorkingState，且不影响长期 Memory 的独立生命周期；
+- 私有条目发布 Evidence、提炼、导出时不会自动提升为 shared/team-shareable。
+
+## 阶段 6：Knowledge Memory
 
 ### 目标
 
@@ -345,7 +406,7 @@ Context binding to Expert / ExpertTeam / Flow / Project
 - 分享包只含显式选择且 export binding 允许的 revision；
 - 导入分享包仍生成 Memory revision，不生成第二种知识库对象。
 
-## 阶段 6：Skill Memory Candidate → Skill Capability
+## 阶段 7：Skill Memory Candidate → Skill Capability
 
 ### 目标
 
@@ -359,7 +420,7 @@ Context binding to Expert / ExpertTeam / Flow / Project
 - draft、evaluating、approved、rejected、promoted 状态与审计；
 - promoted 后引用 Capability id/revision，不保留平行永久 Skill 内容 authority。
 
-## 阶段 7：CodeGraph Module
+## 阶段 8：CodeGraph Module
 
 ### 目标
 
@@ -373,7 +434,7 @@ Context binding to Expert / ExpertTeam / Flow / Project
 - 可绑定 Expert/ExpertTeam/Flow；
 - 实现不修改 Core Memory union、Episodic/Semantic Store 或联邦路由代码。
 
-## 阶段 8：旧插件导入与切换
+## 阶段 9：旧插件导入与切换
 
 ### 映射
 

--- a/docs/usage/memory.md
+++ b/docs/usage/memory.md
@@ -12,7 +12,8 @@ Pragma 的新 Memory Plane 是 Desktop 内置能力，随应用启动，不需�
 - Memory Evidence 自动记录 root Expert/ExpertTeam/Flow 与实际 producer Expert；
 - 每个 Memory Module 可以独立消费、重试、保存 checkpoint 和发布派生事件；
 - 联邦 `memory` ContextStore 可以按 Module prefix 路由只读内容；
-- Desktop 设置页可以控制全局 capture、recall、learning 并查看 Plane health；
+- Desktop 设置页可以控制全局 capture、recall、learning，并查看 Feed 容量、安全 checkpoint、固定保留
+  策略、Evidence 截断、dead letter 和提炼失败；
 - Expert、ExpertTeam、Flow 编辑页可以继承或收紧全局策略。
 - Execution 终态会创建持久提炼任务，由隐藏 Memory Curator 生成目标、尝试、失败、恢复和结果；
 - 普通 Expert、ExpertTeam 和 Flow 内 Expert 会加载有界 Memory guide、类型摘要与热点索引；
@@ -31,7 +32,9 @@ Pragma 的新 Memory Plane 是 Desktop 内置能力，随应用启动，不需�
 - Mission 的 Memory 页签显示每次 Execution 的 capture/recall 计数。搜索审计只保存 digest 和长度，
   不保存 query 原文。
 
-当前尚未实现 Knowledge、Skill Candidate、CodeGraph Module、候选评审、分享扩权审批或跨设备同步。
+当前尚未实现新版内置 WorkingState/Task Board、Knowledge、Skill Candidate、CodeGraph Module、候选评审、
+分享扩权审批或跨设备同步。旧 `@pragma/plugin-memory` 中的 Task Memory 只属于迁移源，不是新版
+WorkingState 的完成实现。
 
 ## 分层加载
 
@@ -69,13 +72,36 @@ Semantic 是当前信念投影，也不是无条件真值。详情会展示 conf
 - Capture：是否允许 canonical execution event 进入 Memory pipeline；
 - Recall：是否允许从 Memory Context 读取；
 - Learning：是否生成本地 Knowledge/Skill 候选；候选不会自动发布；
-- Health：Plane 状态、Feed event 数量和 Module 数量。
+- Health：Plane 状态、Feed logical/file bytes、安全 checkpoint、blocked bytes、Module Evidence 和
+  dead letter 数量；
 - Extraction model：继承系统默认模型，或固定 Memory Curator 使用的 Runtime 和模型。
 
 默认 capture、recall 开启，learning 为 local candidates。
 
 模型设置持久化为 `pragma.memory-extractor-profile/v1`，通过 revision CAS 更新，不使用环境变量。模型暂时
-不可用时任务保留在 durable queue；连续结构错误进入 needs-attention，设置变化后自动唤醒。
+不可用时任务保留在 durable queue；配置错误或耗尽自动重试后进入 `needs_attention`。应用重启不会自动
+唤醒这些任务：匹配的模型配置修复会唤醒 configuration failure，用户也可以在设置页按当前 revision
+显式重试。失败 Evidence 只保留 30 天，随后任务变成不含原始内容的 `expired` 诊断。
+
+## 存储治理与失败恢复
+
+Memory 持续捕获，但不会无限积累原始上下文：
+
+- Canonical Feed 的 payload 按 30 天、512 MiB 目标维护，删除边界是所有注册 consumer 的最小 durable
+  checkpoint。consumer 落后时数据会被固定并显示 blocked bytes，不会静默越界删除；
+- 每个 Module、每个 Execution 最多保留 2,000 条或 16 MiB 待提炼 Evidence；curator prompt 最多
+  78 KiB。超出部分按确定性优先级省略，并显示 content-free topic 计数；
+- Episode 和 Fact 只长期保存它们实际引用的 Evidence；完成的 job 与过期诊断保留 30 天；
+- dead letter 每个 consumer 保留 30 天，并同时限制为最多 10,000 条、64 MiB；
+- SQLite 升级在首次访问时按静态相邻迁移链执行，升级前备份保留 30 天；异常退出遗留的原子写临时文件
+  最多保留一天；
+- Mission 删除使用可重放 cleanup journal 清除该 Mission Execution 的 Feed、job、待提炼 Evidence 和
+  subject context。已经生成的 Episode/Fact 不随 Mission 删除；需要删除长期 Memory 时应在 Memory
+  管理中心执行独立的 invalidate/forget 治理；
+- 隐藏 Memory Curator Mission 正常结束立即删除；崩溃遗留通过专用 registry 定向恢复，不扫描所有
+  Mission。
+
+这些值来自 `pragma.memory-storage-policy/v1` 固定策略，设置页只读展示，当前不提供用户自定义。
 
 ### Expert、ExpertTeam、Flow
 
@@ -126,7 +152,7 @@ Memory revision。分享不会新建一个知识库对象，也不会自动导�
 ## Legacy plugin
 
 仓库中的 `@pragma/plugin-memory` 暂时只承担旧数据来源和兼容迁移窗口。新架构不再通过它启用 Plane，
-也不继续扩展旧 Task/Experience/Fact/Skill 文件 Store。阶段 8 会提供 owner-scoped、带备份和 journal 的
+也不继续扩展旧 Task/Experience/Fact/Skill 文件 Store。阶段 9 会提供 owner-scoped、带备份和 journal 的
 导入，然后升级受影响的 DSL compiler 并删除旧插件。
 
 ## 当前持久路径
@@ -139,10 +165,13 @@ Memory revision。分享不会新建一个知识库对象，也不会自动导�
 ~/.pragma/state/event-bus/handoffs/        # Execution durable handoff
 ~/.pragma/state/event-bus/handoff-quarantine/ # 原样保留的损坏/未来版本 handoff；所属 Execution fail closed
 ~/.pragma/state/memory/                     # checkpoint/dead-letter/outbox
+~/.pragma/state/memory/modules/<consumer>/dead-letters.sqlite # 有界 dead letter
 ~/.pragma/state/memory/modules/<episodic>/jobs.sqlite # Evidence aggregation and durable jobs
 ~/.pragma/data/memory/modules/<semantic>/facts.sqlite # Semantic projection, revisions and audit
 ~/.pragma/state/memory/modules/<semantic>/jobs.sqlite # Semantic Evidence, subjects and durable jobs
 ~/.pragma/state/memory/executions/<executionId>/activity.sqlite # capture/recall metadata audit
+~/.pragma/state/memory/cleanup-journal/     # Mission/Execution transient cleanup journal
+~/.pragma/state/memory/curator-missions.json # 有界隐藏 Curator Mission registry
 ~/.pragma/data/memory/subject-identity.json # Desktop installation-local User identity
 ```
 
@@ -154,5 +183,6 @@ Memory 数据不写 Agent workspace。正常启动不会扫描全部 Mission、E
 - [ADR 032: Durable Canonical Event Feed](../adr/032-durable-canonical-event-feed.md)
 - [ADR 034: Conservative Semantic Memory](../adr/034-conservative-semantic-memory.md)
 - [ADR 035: Agent-driven Memory Recall and Host Governance](../adr/035-agent-driven-memory-recall-and-governance.md)
+- [ADR 036: Memory Storage Retention and Recovery](../adr/036-memory-storage-retention-and-recovery.md)
 - [Memory Plane 落地计划](../architecture/memory-plane-implementation-plan.md)
 - [旧 Memory System ADR（已被替代）](../adr/002-memory-system.md)

--- a/packages/core/src/events/canonical-event-feed.ts
+++ b/packages/core/src/events/canonical-event-feed.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, rename, rm, stat } from "node:fs/promises";
 import { dirname } from "node:path";
-import { DatabaseSync } from "node:sqlite";
+import { backup, DatabaseSync } from "node:sqlite";
 
 import {
   CanonicalEventEnvelopeSchema,
@@ -9,6 +9,11 @@ import {
 } from "@pragma/shared";
 
 import { PragmaPaths } from "../storage/pragma-paths.ts";
+import {
+  CANONICAL_EVENT_FEED_V2_SCHEMA_SQL,
+  migrateCanonicalEventFeedV1ToV2,
+} from "../storage/migrations/canonical-event-feed/index.ts";
+import { withFileLock } from "../storage/file-lock.ts";
 
 export type CanonicalEventReadItem =
   | {
@@ -31,6 +36,26 @@ export interface CanonicalEventPage {
 export interface CanonicalEventFeedDiagnostic {
   readonly lastSequence: number;
   readonly eventCount: number;
+  readonly logicalBytes: number;
+  readonly fileBytes: number;
+  readonly receiptCount: number;
+  readonly oldestOccurredAt?: string | undefined;
+}
+
+export interface CanonicalEventMaintenanceInput {
+  readonly safeThrough: CanonicalEventCursor;
+  readonly retainAfter: string;
+  readonly targetBytes: number;
+  readonly vacuumMinimumBytes?: number | undefined;
+  readonly vacuumFreeRatio?: number | undefined;
+}
+
+export interface CanonicalEventMaintenanceResult {
+  readonly deletedEvents: number;
+  readonly reclaimedLogicalBytes: number;
+  readonly vacuumed: boolean;
+  readonly blockedBytes: number;
+  readonly diagnostic: CanonicalEventFeedDiagnostic;
 }
 
 export interface CanonicalEventFeed {
@@ -40,6 +65,8 @@ export interface CanonicalEventFeed {
     readonly limit: number;
   }): Promise<CanonicalEventPage>;
   inspect(): Promise<CanonicalEventFeedDiagnostic>;
+  maintain(input: CanonicalEventMaintenanceInput): Promise<CanonicalEventMaintenanceResult>;
+  forgetCorrelation(correlationId: string): Promise<{ readonly deletedEvents: number }>;
   close(): void;
 }
 
@@ -50,26 +77,61 @@ export async function createFileCanonicalEventFeed(
   const databasePath = paths.canonicalEventFeed();
   await mkdir(dirname(databasePath), { recursive: true, mode: 0o700 });
   const database = new DatabaseSync(databasePath);
-  initialize(database);
+  await withFileLock(`${databasePath}.migration.lock`, async () => {
+    if (readVersion(database) === 1) await ensureV1Backup(database, databasePath);
+    initialize(database);
+  });
+
+  const inspect = (): CanonicalEventFeedDiagnostic => inspectDatabase(database);
 
   return {
     async append(events) {
       const parsed = events.map((event) => CanonicalEventEnvelopeSchema.parse(event));
       if (parsed.length === 0) return;
+      const receipt = database.prepare("SELECT sequence FROM event_receipts WHERE event_id = ?");
+      const existing = database.prepare("SELECT sequence FROM canonical_events WHERE event_id = ?");
       const insert = database.prepare(
-        "INSERT OR IGNORE INTO canonical_events(event_id, topic, schema_ref, occurred_at, envelope_json) VALUES (?, ?, ?, ?, ?)",
+        `INSERT INTO canonical_events(
+           event_id, topic, schema_ref, correlation_id, occurred_at, envelope_bytes, envelope_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const insertReceipt = database.prepare(
+        `INSERT OR IGNORE INTO event_receipts(
+           event_id, sequence, correlation_id, source_type, source_id, source_cursor
+         ) VALUES (?, ?, ?, ?, ?, ?)`,
       );
       database.exec("BEGIN IMMEDIATE;");
       try {
+        let lastSequence = readLastSequence(database);
         for (const event of parsed) {
-          insert.run(
+          if (receipt.get(event.eventId) !== undefined) continue;
+          const alreadyStored = existing.get(event.eventId) as
+            { readonly sequence: number } | undefined;
+          let sequence = alreadyStored?.sequence;
+          if (sequence === undefined) {
+            const serialized = JSON.stringify(event);
+            const result = insert.run(
+              event.eventId,
+              event.topic,
+              event.schemaRef,
+              event.correlationId ?? null,
+              event.occurredAt,
+              Buffer.byteLength(serialized),
+              serialized,
+            );
+            sequence = Number(result.lastInsertRowid);
+          }
+          insertReceipt.run(
             event.eventId,
-            event.topic,
-            event.schemaRef,
-            event.occurredAt,
-            JSON.stringify(event),
+            sequence,
+            event.correlationId ?? null,
+            event.sourceRef.type,
+            event.sourceRef.id,
+            event.sourceRef.cursor ?? null,
           );
+          lastSequence = Math.max(lastSequence, sequence);
         }
+        writeLastSequence(database, lastSequence);
         database.exec("COMMIT;");
       } catch (error) {
         rollback(database);
@@ -115,12 +177,126 @@ export async function createFileCanonicalEventFeed(
     },
 
     async inspect() {
-      const row = database
-        .prepare(
-          "SELECT COALESCE(MAX(sequence), 0) AS lastSequence, COUNT(*) AS eventCount FROM canonical_events",
-        )
-        .get() as unknown as { readonly lastSequence: number; readonly eventCount: number };
-      return row;
+      return inspect();
+    },
+
+    async maintain(input) {
+      assertMaintenanceInput(input);
+      const before = inspect();
+      let deletedEvents = 0;
+      let reclaimedLogicalBytes = 0;
+      database.exec("BEGIN IMMEDIATE;");
+      try {
+        const expired = database
+          .prepare(
+            `SELECT sequence, COALESCE(envelope_bytes, length(CAST(envelope_json AS BLOB))) AS bytes
+             FROM canonical_events
+             WHERE sequence <= ? AND occurred_at < ?
+             ORDER BY sequence`,
+          )
+          .all(input.safeThrough.sequence, input.retainAfter) as unknown as readonly {
+          readonly sequence: number;
+          readonly bytes: number;
+        }[];
+        const expiredSequences = new Set(expired.map((row) => row.sequence));
+        let remainingBytes = before.logicalBytes - expired.reduce((sum, row) => sum + row.bytes, 0);
+        const pressure: number[] = [];
+        if (remainingBytes > input.targetBytes) {
+          const candidates = database
+            .prepare(
+              `SELECT sequence, COALESCE(envelope_bytes, length(CAST(envelope_json AS BLOB))) AS bytes
+               FROM canonical_events WHERE sequence <= ? ORDER BY sequence`,
+            )
+            .all(input.safeThrough.sequence) as unknown as readonly {
+            readonly sequence: number;
+            readonly bytes: number;
+          }[];
+          for (const candidate of candidates) {
+            if (remainingBytes <= input.targetBytes) break;
+            if (expiredSequences.has(candidate.sequence)) continue;
+            pressure.push(candidate.sequence);
+            remainingBytes -= candidate.bytes;
+          }
+        }
+        const sequences = [...expiredSequences, ...pressure];
+        const preserveReceipt = database.prepare(
+          `INSERT OR IGNORE INTO event_receipts(
+             event_id, sequence, correlation_id, source_type, source_id, source_cursor
+           )
+           SELECT event_id, sequence,
+             COALESCE(correlation_id, json_extract(envelope_json, '$.correlationId')),
+             json_extract(envelope_json, '$.sourceRef.type'),
+             json_extract(envelope_json, '$.sourceRef.id'),
+             json_extract(envelope_json, '$.sourceRef.cursor')
+           FROM canonical_events WHERE sequence = ?`,
+        );
+        const remove = database.prepare("DELETE FROM canonical_events WHERE sequence = ?");
+        for (const sequence of sequences) {
+          const row = database
+            .prepare(
+              "SELECT COALESCE(envelope_bytes, length(CAST(envelope_json AS BLOB))) AS bytes FROM canonical_events WHERE sequence = ?",
+            )
+            .get(sequence) as { readonly bytes: number } | undefined;
+          if (row === undefined) continue;
+          preserveReceipt.run(sequence);
+          remove.run(sequence);
+          deletedEvents += 1;
+          reclaimedLogicalBytes += row.bytes;
+        }
+        database.exec("COMMIT;");
+      } catch (error) {
+        rollback(database);
+        throw error;
+      }
+
+      let vacuumed = false;
+      const page = database.prepare("PRAGMA page_count").get() as unknown as {
+        readonly page_count: number;
+      };
+      const free = database.prepare("PRAGMA freelist_count").get() as unknown as {
+        readonly freelist_count: number;
+      };
+      const size = database.prepare("PRAGMA page_size").get() as unknown as {
+        readonly page_size: number;
+      };
+      const freeBytes = free.freelist_count * size.page_size;
+      if (
+        freeBytes >= (input.vacuumMinimumBytes ?? 64 * 1_024 * 1_024) &&
+        free.freelist_count / Math.max(1, page.page_count) >= (input.vacuumFreeRatio ?? 0.25)
+      ) {
+        database.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+        database.exec("VACUUM;");
+        vacuumed = true;
+      }
+      const diagnostic = inspect();
+      await removeExpiredV1Backup(databasePath, Date.parse(input.retainAfter));
+      return {
+        deletedEvents,
+        reclaimedLogicalBytes,
+        vacuumed,
+        blockedBytes: Math.max(0, diagnostic.logicalBytes - input.targetBytes),
+        diagnostic,
+      };
+    },
+
+    async forgetCorrelation(correlationId) {
+      if (correlationId.trim() === "") throw new TypeError("Correlation id is required.");
+      database.exec("BEGIN IMMEDIATE;");
+      try {
+        const result = database
+          .prepare(
+            `DELETE FROM canonical_events
+             WHERE correlation_id = ? OR
+               (correlation_id IS NULL AND json_extract(envelope_json, '$.correlationId') = ?)`,
+          )
+          .run(correlationId, correlationId);
+        database.prepare("DELETE FROM event_receipts WHERE correlation_id = ?").run(correlationId);
+        database.exec("COMMIT;");
+        return { deletedEvents: Number(result.changes) };
+      } catch (error) {
+        rollback(database);
+        throw error;
+      }
     },
 
     close() {
@@ -129,31 +305,121 @@ export async function createFileCanonicalEventFeed(
   };
 }
 
+async function ensureV1Backup(database: DatabaseSync, databasePath: string): Promise<void> {
+  const destination = `${databasePath}.v1.backup`;
+  try {
+    await stat(destination);
+    return;
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+  }
+  const temporary = `${destination}.tmp`;
+  await rm(temporary, { force: true });
+  await backup(database, temporary);
+  await rename(temporary, destination);
+}
+
+async function removeExpiredV1Backup(databasePath: string, cutoff: number): Promise<void> {
+  const path = `${databasePath}.v1.backup`;
+  try {
+    if ((await stat(path)).mtimeMs <= cutoff) await rm(path, { force: true });
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { readonly code?: unknown }).code === "ENOENT"
+  );
+}
+
 function initialize(database: DatabaseSync): void {
-  const version = database.prepare("PRAGMA user_version").get() as unknown as {
+  const version = readVersion(database);
+  if (version > 2) {
+    database.close();
+    throw new Error(`unsupported-state-version:pragma.canonical-event-feed/v${version}`);
+  }
+  database.exec("PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL;");
+  if (version === 0) {
+    database.exec(CANONICAL_EVENT_FEED_V2_SCHEMA_SQL);
+    return;
+  }
+  if (version === 1) {
+    migrateCanonicalEventFeedV1ToV2(database);
+  }
+}
+
+function inspectDatabase(database: DatabaseSync): CanonicalEventFeedDiagnostic {
+  const row = database
+    .prepare(
+      `SELECT COUNT(*) AS eventCount,
+         COALESCE(SUM(COALESCE(envelope_bytes, length(CAST(envelope_json AS BLOB)))), 0) AS logicalBytes,
+         MIN(occurred_at) AS oldestOccurredAt
+       FROM canonical_events`,
+    )
+    .get() as unknown as {
+    readonly eventCount: number;
+    readonly logicalBytes: number;
+    readonly oldestOccurredAt: string | null;
+  };
+  const receipts = database
+    .prepare("SELECT COUNT(*) AS count FROM event_receipts")
+    .get() as unknown as {
+    readonly count: number;
+  };
+  const pages = database.prepare("PRAGMA page_count").get() as unknown as {
+    readonly page_count: number;
+  };
+  const pageSize = database.prepare("PRAGMA page_size").get() as unknown as {
+    readonly page_size: number;
+  };
+  return {
+    lastSequence: readLastSequence(database),
+    eventCount: row.eventCount,
+    logicalBytes: row.logicalBytes,
+    fileBytes: pages.page_count * pageSize.page_size,
+    receiptCount: receipts.count,
+    ...(row.oldestOccurredAt === null ? {} : { oldestOccurredAt: row.oldestOccurredAt }),
+  };
+}
+
+function assertMaintenanceInput(input: CanonicalEventMaintenanceInput): void {
+  if (!Number.isSafeInteger(input.safeThrough.sequence) || input.safeThrough.sequence < 0) {
+    throw new RangeError("Canonical event safe sequence must be non-negative.");
+  }
+  if (Number.isNaN(Date.parse(input.retainAfter))) {
+    throw new TypeError("Canonical event retention cutoff must be an ISO date.");
+  }
+  if (!Number.isSafeInteger(input.targetBytes) || input.targetBytes < 0) {
+    throw new RangeError("Canonical event target bytes must be non-negative.");
+  }
+}
+
+function readVersion(database: DatabaseSync): number {
+  const row = database.prepare("PRAGMA user_version").get() as unknown as {
     readonly user_version: number;
   };
-  if (version.user_version > 1) {
-    database.close();
-    throw new Error(
-      `unsupported-state-version:pragma.canonical-event-feed/v${version.user_version}`,
-    );
-  }
-  database.exec(`
-    PRAGMA journal_mode = WAL;
-    PRAGMA synchronous = FULL;
-    CREATE TABLE IF NOT EXISTS canonical_events (
-      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
-      event_id TEXT NOT NULL UNIQUE,
-      topic TEXT NOT NULL,
-      schema_ref TEXT NOT NULL,
-      occurred_at TEXT NOT NULL,
-      envelope_json TEXT NOT NULL
-    );
-    CREATE INDEX IF NOT EXISTS canonical_events_topic_sequence
-      ON canonical_events(topic, sequence);
-    PRAGMA user_version = 1;
-  `);
+  return row.user_version;
+}
+
+function readLastSequence(database: DatabaseSync): number {
+  const row = database
+    .prepare("SELECT value FROM feed_metadata WHERE key = 'last_sequence'")
+    .get() as { readonly value: string } | undefined;
+  return row === undefined ? 0 : Number(row.value);
+}
+
+function writeLastSequence(database: DatabaseSync, sequence: number): void {
+  database
+    .prepare(
+      `INSERT INTO feed_metadata(key, value) VALUES ('last_sequence', ?)
+       ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
+    )
+    .run(String(sequence));
 }
 
 function rollback(database: DatabaseSync): void {

--- a/packages/core/src/storage/migrations/canonical-event-feed/index.ts
+++ b/packages/core/src/storage/migrations/canonical-event-feed/index.ts
@@ -1,0 +1,9 @@
+import { migrateCanonicalEventFeedV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export { CANONICAL_EVENT_FEED_V1_SCHEMA_SQL } from "./schemas/v1.ts";
+export { CANONICAL_EVENT_FEED_V2_SCHEMA_SQL } from "./schemas/v2.ts";
+export { migrateCanonicalEventFeedV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export const CANONICAL_EVENT_FEED_STORAGE_MIGRATIONS = [
+  { fromVersion: 1, toVersion: 2, migrate: migrateCanonicalEventFeedV1ToV2 },
+] as const;

--- a/packages/core/src/storage/migrations/canonical-event-feed/schemas/v1.ts
+++ b/packages/core/src/storage/migrations/canonical-event-feed/schemas/v1.ts
@@ -1,0 +1,12 @@
+export const CANONICAL_EVENT_FEED_V1_SCHEMA_SQL = `
+  CREATE TABLE canonical_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    topic TEXT NOT NULL,
+    schema_ref TEXT NOT NULL,
+    occurred_at TEXT NOT NULL,
+    envelope_json TEXT NOT NULL
+  );
+  CREATE INDEX canonical_events_topic_sequence ON canonical_events(topic, sequence);
+  PRAGMA user_version = 1;
+`;

--- a/packages/core/src/storage/migrations/canonical-event-feed/schemas/v2.ts
+++ b/packages/core/src/storage/migrations/canonical-event-feed/schemas/v2.ts
@@ -1,0 +1,26 @@
+export const CANONICAL_EVENT_FEED_V2_SCHEMA_SQL = `
+  CREATE TABLE canonical_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    topic TEXT NOT NULL,
+    schema_ref TEXT NOT NULL,
+    correlation_id TEXT,
+    occurred_at TEXT NOT NULL,
+    envelope_bytes INTEGER NOT NULL,
+    envelope_json TEXT NOT NULL
+  );
+  CREATE INDEX canonical_events_topic_sequence ON canonical_events(topic, sequence);
+  CREATE INDEX canonical_events_correlation ON canonical_events(correlation_id, sequence);
+  CREATE TABLE event_receipts (
+    event_id TEXT PRIMARY KEY,
+    sequence INTEGER NOT NULL,
+    correlation_id TEXT,
+    source_type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    source_cursor TEXT
+  );
+  CREATE INDEX event_receipts_correlation ON event_receipts(correlation_id);
+  CREATE TABLE feed_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  INSERT INTO feed_metadata(key, value) VALUES ('last_sequence', '0');
+  PRAGMA user_version = 2;
+`;

--- a/packages/core/src/storage/migrations/canonical-event-feed/steps/v1-to-v2.ts
+++ b/packages/core/src/storage/migrations/canonical-event-feed/steps/v1-to-v2.ts
@@ -1,0 +1,33 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export function migrateCanonicalEventFeedV1ToV2(database: DatabaseSync): void {
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    database.exec(`
+      ALTER TABLE canonical_events ADD COLUMN correlation_id TEXT;
+      ALTER TABLE canonical_events ADD COLUMN envelope_bytes INTEGER;
+      CREATE INDEX canonical_events_correlation ON canonical_events(correlation_id, sequence);
+      CREATE TABLE event_receipts (
+        event_id TEXT PRIMARY KEY,
+        sequence INTEGER NOT NULL,
+        correlation_id TEXT,
+        source_type TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        source_cursor TEXT
+      );
+      CREATE INDEX event_receipts_correlation ON event_receipts(correlation_id);
+      CREATE TABLE feed_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      INSERT INTO feed_metadata(key, value)
+        VALUES ('last_sequence', CAST((SELECT COALESCE(MAX(sequence), 0) FROM canonical_events) AS TEXT));
+      PRAGMA user_version = 2;
+    `);
+    database.exec("COMMIT;");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK;");
+    } catch {
+      // No migration transaction remained active.
+    }
+    throw error;
+  }
+}

--- a/packages/core/src/storage/pragma-paths.ts
+++ b/packages/core/src/storage/pragma-paths.ts
@@ -135,6 +135,14 @@ export class PragmaPaths {
     return join(this.stateRoot(), "memory");
   }
 
+  memoryCleanupJournalRoot(): string {
+    return join(this.memoryStateRoot(), "cleanup-journal");
+  }
+
+  memoryCuratorMissionRegistry(): string {
+    return join(this.memoryStateRoot(), "curator-missions.json");
+  }
+
   memoryCacheRoot(): string {
     return join(this.cacheRoot(), "memory");
   }
@@ -164,11 +172,7 @@ export class PragmaPaths {
   }
 
   memoryExecutionActivityRoot(executionId: string): string {
-    return join(
-      this.memoryStateRoot(),
-      "executions",
-      encodePragmaPathSegment(executionId),
-    );
+    return join(this.memoryStateRoot(), "executions", encodePragmaPathSegment(executionId));
   }
 
   memoryExecutionActivity(executionId: string): string {

--- a/packages/core/test/canonical-event-feed.test.ts
+++ b/packages/core/test/canonical-event-feed.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import type { ExecutionRecord, Invocation } from "@pragma/shared";
+import {
+  CanonicalEventEnvelopeSchema,
+  type ExecutionRecord,
+  type Invocation,
+} from "@pragma/shared";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -12,6 +16,7 @@ import {
   PragmaPaths,
   type CanonicalEventFeed,
 } from "../src/index.ts";
+import { CANONICAL_EVENT_FEED_V1_SCHEMA_SQL } from "../src/storage/migrations/canonical-event-feed/index.ts";
 
 describe("Canonical Event Feed", () => {
   it("relays committed Execution events with stable idempotency", async () => {
@@ -66,11 +71,11 @@ describe("Canonical Event Feed", () => {
     ).resolves.toMatchObject({ eventId: "event-one" });
     await store.appendEvent("execution", "root", "invocation.progress", { value: 2 }, "event-two");
     await expect(store.readEvents("execution")).resolves.toHaveLength(2);
-    await expect(durable.inspect()).resolves.toEqual({ lastSequence: 0, eventCount: 0 });
+    await expect(durable.inspect()).resolves.toMatchObject({ lastSequence: 0, eventCount: 0 });
 
     unavailable = false;
     await expect(store.recoverPendingCanonicalEvents()).resolves.toMatchObject({ failed: 0 });
-    await expect(durable.inspect()).resolves.toEqual({ lastSequence: 2, eventCount: 2 });
+    await expect(durable.inspect()).resolves.toMatchObject({ lastSequence: 2, eventCount: 2 });
     const page = await durable.read({ limit: 10 });
     expect(
       page.items.flatMap((item) =>
@@ -80,7 +85,7 @@ describe("Canonical Event Feed", () => {
       ),
     ).toEqual([1, 2]);
     await store.recoverPendingCanonicalEvents();
-    await expect(durable.inspect()).resolves.toEqual({ lastSequence: 2, eventCount: 2 });
+    await expect(durable.inspect()).resolves.toMatchObject({ lastSequence: 2, eventCount: 2 });
     durable.close();
   });
 
@@ -112,7 +117,7 @@ describe("Canonical Event Feed", () => {
       failed: 1,
       quarantined: 0,
     });
-    await expect(durable.inspect()).resolves.toEqual({ lastSequence: 0, eventCount: 0 });
+    await expect(durable.inspect()).resolves.toMatchObject({ lastSequence: 0, eventCount: 0 });
 
     await expect(store.recoverPendingCanonicalEvents()).resolves.toEqual({
       recovered: 2,
@@ -136,10 +141,10 @@ describe("Canonical Event Feed", () => {
     const paths = new PragmaPaths({ pragmaHome: home });
     await mkdir(dirname(paths.canonicalEventFeed()), { recursive: true });
     const future = new DatabaseSync(paths.canonicalEventFeed());
-    future.exec("PRAGMA user_version = 2;");
+    future.exec("PRAGMA user_version = 3;");
     future.close();
     await expect(createFileCanonicalEventFeed({ pragmaHome: home })).rejects.toThrow(
-      "unsupported-state-version:pragma.canonical-event-feed/v2",
+      "unsupported-state-version:pragma.canonical-event-feed/v3",
     );
 
     const otherHome = await mkdtemp(join(tmpdir(), "pragma-canonical-future-handoff-"));
@@ -184,12 +189,99 @@ describe("Canonical Event Feed", () => {
     const store = createFileExecutionStore({ pragmaHome: home, canonicalEventFeed: feed });
     await createExecution(store);
     await store.appendEvent("execution", "root", "invocation.progress", {}, "event-one");
-    await expect(durable.inspect()).resolves.toEqual({ lastSequence: 1, eventCount: 1 });
+    await expect(durable.inspect()).resolves.toMatchObject({ lastSequence: 1, eventCount: 1 });
 
     interruptAcknowledgement = false;
     await store.recoverPendingCanonicalEvents();
-    await expect(durable.inspect()).resolves.toEqual({ lastSequence: 1, eventCount: 1 });
+    await expect(durable.inspect()).resolves.toMatchObject({ lastSequence: 1, eventCount: 1 });
     durable.close();
+  });
+
+  it("prunes only acknowledged payloads and keeps replay receipts", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-canonical-retention-"));
+    const feed = await createFileCanonicalEventFeed({ pragmaHome: home });
+    const store = createFileExecutionStore({ pragmaHome: home, canonicalEventFeed: feed });
+    await createExecution(store);
+    await store.appendEvent("execution", "root", "invocation.progress", { value: 1 }, "one");
+    await store.appendEvent("execution", "root", "invocation.progress", { value: 2 }, "two");
+    const original = await feed.read({ limit: 10 });
+    const first = original.items[0];
+    expect(first?.kind).toBe("event");
+
+    await expect(
+      feed.maintain({
+        safeThrough: { sequence: 1 },
+        retainAfter: "9999-01-01T00:00:00.000Z",
+        targetBytes: Number.MAX_SAFE_INTEGER,
+      }),
+    ).resolves.toMatchObject({ deletedEvents: 1, blockedBytes: 0 });
+    await expect(feed.inspect()).resolves.toMatchObject({
+      lastSequence: 2,
+      eventCount: 1,
+      receiptCount: 2,
+    });
+
+    if (first?.kind === "event") await feed.append([first.event]);
+    await expect(feed.inspect()).resolves.toMatchObject({ eventCount: 1, receiptCount: 2 });
+    feed.close();
+  });
+
+  it("reports payload pinned above the target instead of deleting unacknowledged events", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-canonical-pinned-"));
+    const feed = await createFileCanonicalEventFeed({ pragmaHome: home });
+    const store = createFileExecutionStore({ pragmaHome: home, canonicalEventFeed: feed });
+    await createExecution(store);
+    await store.appendEvent("execution", "root", "invocation.progress", {}, "pinned");
+    const result = await feed.maintain({
+      safeThrough: { sequence: 0 },
+      retainAfter: "9999-01-01T00:00:00.000Z",
+      targetBytes: 0,
+    });
+    expect(result.deletedEvents).toBe(0);
+    expect(result.blockedBytes).toBeGreaterThan(0);
+    feed.close();
+  });
+
+  it("upgrades a v1 Feed lazily and preserves replay idempotency after pruning", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-canonical-v1-"));
+    const path = new PragmaPaths({ pragmaHome: home }).canonicalEventFeed();
+    await mkdir(dirname(path), { recursive: true });
+    const legacy = new DatabaseSync(path);
+    legacy.exec(CANONICAL_EVENT_FEED_V1_SCHEMA_SQL);
+    const event = CanonicalEventEnvelopeSchema.parse({
+      schemaVersion: "pragma.canonical-event/v1",
+      eventId: "legacy-event",
+      topic: "pragma.test.event",
+      schemaRef: "pragma.test/v1",
+      sourceRef: { type: "pragma.test", id: "source" },
+      correlationId: "legacy-execution",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      payload: { value: "legacy" },
+    });
+    legacy
+      .prepare(
+        `INSERT INTO canonical_events(event_id, topic, schema_ref, occurred_at, envelope_json)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(event.eventId, event.topic, event.schemaRef, event.occurredAt, JSON.stringify(event));
+    legacy.close();
+
+    const feed = await createFileCanonicalEventFeed({ pragmaHome: home });
+    await expect(feed.inspect()).resolves.toMatchObject({ lastSequence: 1, eventCount: 1 });
+    await expect(readFile(`${path}.v1.backup`)).resolves.toBeInstanceOf(Buffer);
+    await feed.maintain({
+      safeThrough: { sequence: 1 },
+      retainAfter: "2027-01-01T00:00:00.000Z",
+      targetBytes: Number.MAX_SAFE_INTEGER,
+    });
+    await feed.append([event]);
+    await expect(feed.inspect()).resolves.toMatchObject({
+      lastSequence: 1,
+      eventCount: 0,
+      receiptCount: 1,
+    });
+    await expect(readFile(`${path}.v1.backup`)).rejects.toMatchObject({ code: "ENOENT" });
+    feed.close();
   });
 });
 

--- a/packages/memory/src/episodic/module.ts
+++ b/packages/memory/src/episodic/module.ts
@@ -82,38 +82,40 @@ export async function createEpisodicMemoryModule(
       const evidence = sanitizeEvidence(await store.readEvidence(job.executionId));
       try {
         if (evidence.some((item) => item.sensitivity === "restricted")) {
-          await store.completeRejected(job, "sensitive");
+          await store.completeRejected(job, "sensitive", now());
           return;
         }
         if (isLowValue(evidence)) {
-          await store.completeRejected(job, "low-value");
+          await store.completeRejected(job, "low-value", now());
           return;
         }
         const visibility = strictestVisibility(evidence);
         if (visibility === undefined) {
-          await store.completeRejected(job, "policy");
+          await store.completeRejected(job, "policy", now());
           return;
         }
         const previousEpisode = await store.getByExecution(job.executionId);
         if (previousEpisode?.terminalMessageId === job.terminalMessageId) {
-          await store.completeRetained({ job, record: previousEpisode, evidence });
+          await store.completeRetained({ job, record: previousEpisode, evidence, now: now() });
           return;
         }
         const input = EpisodicExtractionInputSchema.parse({
-          schemaVersion: "pragma.memory-episodic-extraction-input/v1",
+          schemaVersion: "pragma.memory-episodic-extraction-input/v2",
           jobId: job.id,
           executionId: job.executionId,
           ...(previousEpisode === undefined ? {} : { previousEpisode }),
           evidence,
+          omittedEvidence: await store.readOmissionStats(job.executionId),
         });
         const extracted = await extractor.extract(input);
         const output = EpisodicExtractionOutputSchema.parse(extracted.output);
         if (!output.retain) {
-          await store.completeRejected(job, output.reason);
+          await store.completeRejected(job, output.reason, now());
           return;
         }
         assertEvidenceRefs(output, new Set(evidence.map((item) => item.messageId)));
-        const timestamp = now().toISOString();
+        const completedAt = now();
+        const timestamp = completedAt.toISOString();
         const attribution = resolveAttribution(evidence);
         const record = EpisodicMemoryRecordSchema.parse({
           schemaVersion: "pragma.memory-episodic/v2",
@@ -147,7 +149,7 @@ export async function createEpisodicMemoryModule(
           createdAt: previousEpisode?.createdAt ?? timestamp,
           updatedAt: timestamp,
         });
-        await store.completeRetained({ job, record, evidence });
+        await store.completeRetained({ job, record, evidence, now: completedAt });
       } catch (error) {
         await store.fail({
           job,
@@ -159,7 +161,6 @@ export async function createEpisodicMemoryModule(
     },
     async setExtractor(next) {
       extractor = next;
-      if (next !== undefined) await store.wakeNeedsAttention(now());
     },
     store,
     close() {

--- a/packages/memory/src/episodic/schema.ts
+++ b/packages/memory/src/episodic/schema.ts
@@ -7,8 +7,10 @@ import {
 } from "@pragma/shared";
 import { z } from "zod";
 
+import { MemoryEvidenceOmissionStatsSchema } from "../storage/bounded-evidence.ts";
+
 export const EPISODIC_MEMORY_SCHEMA_VERSION = "pragma.memory-episodic/v2" as const;
-export const EPISODIC_JOB_SCHEMA_VERSION = "pragma.memory-extraction-job/v1" as const;
+export const EPISODIC_JOB_SCHEMA_VERSION = "pragma.memory-extraction-job/v2" as const;
 
 const EvidenceRefsSchema = z.array(z.string().min(1)).min(1).max(100);
 
@@ -74,11 +76,12 @@ export const EpisodicMemoryRecordSchema = z.object({
 });
 
 export const EpisodicExtractionInputSchema = z.object({
-  schemaVersion: z.literal("pragma.memory-episodic-extraction-input/v1"),
+  schemaVersion: z.literal("pragma.memory-episodic-extraction-input/v2"),
   jobId: z.string().min(1),
   executionId: z.string().min(1),
   previousEpisode: EpisodicMemoryRecordSchema.optional(),
   evidence: z.array(MemoryEvidenceEnvelopeSchema).min(1).max(2_000),
+  omittedEvidence: MemoryEvidenceOmissionStatsSchema,
 });
 
 const RetainedExtractionSchema = z.object({
@@ -105,13 +108,19 @@ export const EpisodicExtractionOutputSchema = z.discriminatedUnion("retain", [
 export const EpisodicExtractionJobSchema = z.object({
   schemaVersion: z.literal(EPISODIC_JOB_SCHEMA_VERSION),
   id: z.string().min(1),
+  revision: z.number().int().positive(),
   executionId: z.string().min(1),
   terminalMessageId: z.string().min(1),
-  status: z.enum(["pending", "running", "needs_attention", "completed"]),
+  status: z.enum(["pending", "running", "needs_attention", "completed", "expired"]),
   attempts: z.number().int().nonnegative(),
+  totalAttempts: z.number().int().nonnegative(),
   retryAt: z.string().datetime().optional(),
   leaseUntil: z.string().datetime().optional(),
   lastErrorCode: z.string().min(1).optional(),
+  failureClass: z.enum(["configuration", "transient-exhausted"]).optional(),
+  attentionSince: z.string().datetime().optional(),
+  completedAt: z.string().datetime().optional(),
+  expiredAt: z.string().datetime().optional(),
   completion: z.enum(["retained", "rejected"]).optional(),
   updatedAt: z.string().datetime(),
 });

--- a/packages/memory/src/episodic/store.ts
+++ b/packages/memory/src/episodic/store.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { PragmaPaths } from "@pragma/core";
+import { PragmaPaths, withFileLock } from "@pragma/core";
 import {
   MemoryEvidenceEnvelopeSchema,
   type MemoryEvidenceEnvelope,
@@ -22,6 +22,21 @@ import {
   createMemoryTombstone,
 } from "../governance/access-governance.ts";
 import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
+import {
+  EMPTY_MEMORY_EVIDENCE_OMISSION_STATS,
+  MemoryEvidenceOmissionStatsSchema,
+  mergeMemoryEvidenceOmissionStats,
+  selectBoundedMemoryEvidence,
+  type MemoryEvidenceOmissionStats,
+} from "../storage/bounded-evidence.ts";
+import { DEFAULT_MEMORY_STORAGE_POLICY } from "../storage/memory-storage-policy.ts";
+import { EPISODIC_DATA_STORAGE_MIGRATIONS } from "../storage/migrations/episodic-data/index.ts";
+import { EPISODIC_JOB_STORAGE_MIGRATIONS } from "../storage/migrations/episodic-jobs/index.ts";
+import {
+  assertFreshSqliteDatabase,
+  removeExpiredSqliteMigrationBackup,
+  runAdjacentSqliteMigrations,
+} from "../storage/sqlite-migration-backup.ts";
 
 export interface EpisodicGovernanceInput {
   readonly id: string;
@@ -36,6 +51,10 @@ export interface EpisodicMemoryStoreDiagnostic {
   readonly pending: number;
   readonly running: number;
   readonly needsAttention: number;
+  readonly expired: number;
+  readonly evidenceRecords: number;
+  readonly evidenceBytes: number;
+  readonly truncatedExecutions: number;
   readonly rejected: number;
   readonly rejectedByReason: Readonly<Record<EpisodicRejectionReason, number>>;
 }
@@ -47,6 +66,7 @@ export interface EpisodicMemoryStore {
   ingest(envelopes: readonly MemoryEvidenceEnvelope[]): Promise<void>;
   claimDueJob(now: Date): Promise<EpisodicExtractionJob | undefined>;
   readEvidence(executionId: string): Promise<readonly MemoryEvidenceEnvelope[]>;
+  readOmissionStats(executionId: string): Promise<MemoryEvidenceOmissionStats>;
   getByExecution(executionId: string): Promise<EpisodicMemoryRecord | undefined>;
   get(id: string): Promise<EpisodicMemoryRecord | undefined>;
   history(id: string): Promise<readonly EpisodicMemoryRecord[]>;
@@ -75,15 +95,28 @@ export interface EpisodicMemoryStore {
     readonly job: EpisodicExtractionJob;
     readonly record: EpisodicMemoryRecord;
     readonly evidence: readonly MemoryEvidenceEnvelope[];
+    readonly now: Date;
   }): Promise<void>;
-  completeRejected(job: EpisodicExtractionJob, reason: EpisodicRejectionReason): Promise<void>;
+  completeRejected(
+    job: EpisodicExtractionJob,
+    reason: EpisodicRejectionReason,
+    now: Date,
+  ): Promise<void>;
   fail(input: {
     readonly job: EpisodicExtractionJob;
     readonly errorCode: string;
     readonly now: Date;
     readonly retry: "transient" | "configuration";
   }): Promise<void>;
-  wakeNeedsAttention(now: Date): Promise<void>;
+  wakeNeedsAttention(now: Date, reason?: "configuration" | "manual"): Promise<void>;
+  retryJob(input: {
+    readonly id: string;
+    readonly expectedRevision: number;
+    readonly now: Date;
+  }): Promise<void>;
+  listExtractionJobs(): Promise<readonly EpisodicExtractionJob[]>;
+  maintain(now: Date): Promise<{ readonly expired: number; readonly deleted: number }>;
+  deleteExecutionState(executionIds: readonly string[], now?: Date): Promise<void>;
   inspect(): Promise<EpisodicMemoryStoreDiagnostic>;
   close(): void;
 }
@@ -102,8 +135,34 @@ export async function createEpisodicMemoryStore(
   const data = new DatabaseSync(dataPath);
   const state = new DatabaseSync(statePath);
   try {
-    initializeData(data);
-    initializeState(state);
+    await withFileLock(`${dataPath}.migration.lock`, async () => {
+      if (readVersion(data) === 0) {
+        assertFreshSqliteDatabase(data, "pragma.memory-episodic-store");
+      } else {
+        await runAdjacentSqliteMigrations({
+          database: data,
+          databasePath: dataPath,
+          family: "pragma.memory-episodic-store",
+          targetVersion: 2,
+          migrations: EPISODIC_DATA_STORAGE_MIGRATIONS,
+        });
+      }
+      initializeData(data);
+    });
+    await withFileLock(`${statePath}.migration.lock`, async () => {
+      if (readVersion(state) === 0) {
+        assertFreshSqliteDatabase(state, "pragma.memory-episodic-jobs");
+      } else {
+        await runAdjacentSqliteMigrations({
+          database: state,
+          databasePath: statePath,
+          family: "pragma.memory-episodic-jobs",
+          targetVersion: 2,
+          migrations: EPISODIC_JOB_STORAGE_MIGRATIONS,
+        });
+      }
+      initializeState(state);
+    });
   } catch (error) {
     tryClose(data);
     tryClose(state);
@@ -142,10 +201,13 @@ export async function createEpisodicMemoryStore(
       );
       state.exec("BEGIN IMMEDIATE;");
       try {
+        const touched = new Set<string>();
         for (const raw of envelopes) {
           const envelope = MemoryEvidenceEnvelopeSchema.parse(raw);
           const executionId = envelope.correlationId;
           if (executionId === undefined) continue;
+          if (isDeletedExecution(state, executionId)) continue;
+          touched.add(executionId);
           insertEvidence.run(
             envelope.messageId,
             executionId,
@@ -158,16 +220,19 @@ export async function createEpisodicMemoryStore(
           if (existing?.terminalMessageId === envelope.messageId) continue;
           writeJob(
             EpisodicExtractionJobSchema.parse({
-              schemaVersion: "pragma.memory-extraction-job/v1",
+              schemaVersion: "pragma.memory-extraction-job/v2",
               id,
+              revision: 1,
               executionId,
               terminalMessageId: envelope.messageId,
               status: "pending",
               attempts: 0,
+              totalAttempts: 0,
               updatedAt: envelope.occurredAt,
             }),
           );
         }
+        for (const executionId of touched) compactEvidence(state, executionId);
         state.exec("COMMIT;");
       } catch (error) {
         rollback(state);
@@ -194,8 +259,10 @@ export async function createEpisodicMemoryStore(
         const current = EpisodicExtractionJobSchema.parse(JSON.parse(row.jobJson));
         const claimed = EpisodicExtractionJobSchema.parse({
           ...current,
+          revision: current.revision + 1,
           status: "running",
           attempts: current.attempts + 1,
+          totalAttempts: current.totalAttempts + 1,
           retryAt: undefined,
           leaseUntil: new Date(now.getTime() + 5 * 60_000).toISOString(),
           updatedAt: now.toISOString(),
@@ -228,6 +295,10 @@ export async function createEpisodicMemoryStore(
         unique.set(envelope.messageId, envelope);
       }
       return [...unique.values()].slice(-2_000);
+    },
+
+    async readOmissionStats(executionId) {
+      return readOmissionStats(state, executionId);
     },
 
     async getByExecution(executionId) {
@@ -327,12 +398,13 @@ export async function createEpisodicMemoryStore(
     },
 
     async completeRetained(input) {
+      if (isDeletedExecution(state, input.job.executionId)) return;
       const record = EpisodicMemoryRecordSchema.parse(input.record);
       data.exec("BEGIN IMMEDIATE;");
       try {
         if (hasTombstone(data, record.id)) {
           data.exec("COMMIT;");
-          completeRetainedJob(state, input.job);
+          completeRetainedJob(state, input.job, input.now);
           return;
         }
         data
@@ -359,7 +431,9 @@ export async function createEpisodicMemoryStore(
           `INSERT OR REPLACE INTO episode_evidence(episode_id, evidence_id, occurred_at, envelope_json)
            VALUES (?, ?, ?, ?)`,
         );
+        const citedEvidence = new Set(record.evidenceRefs);
         for (const envelope of input.evidence) {
+          if (!citedEvidence.has(envelope.messageId)) continue;
           insert.run(record.id, envelope.messageId, envelope.occurredAt, JSON.stringify(envelope));
         }
         data.exec("COMMIT;");
@@ -367,7 +441,7 @@ export async function createEpisodicMemoryStore(
         rollback(data);
         throw error;
       }
-      completeRetainedJob(state, input.job);
+      completeRetainedJob(state, input.job, input.now);
     },
 
     async tightenAccess(input) {
@@ -421,10 +495,11 @@ export async function createEpisodicMemoryStore(
       }
     },
 
-    async completeRejected(job, reason) {
+    async completeRejected(job, reason, now) {
+      if (isDeletedExecution(state, job.executionId)) return;
       state.exec("BEGIN IMMEDIATE;");
       try {
-        finishJob(state, job, "rejected");
+        finishJob(state, job, "rejected", now);
         state.prepare("DELETE FROM evidence WHERE execution_id = ?").run(job.executionId);
         incrementCounter(state, "rejected_total");
         incrementCounter(state, `rejected_${reason.replaceAll("-", "_")}`);
@@ -436,39 +511,97 @@ export async function createEpisodicMemoryStore(
     },
 
     async fail(input) {
+      if (isDeletedExecution(state, input.job.executionId)) return;
       const attempts = input.job.attempts;
       const needsAttention = input.retry === "configuration" || attempts >= 3;
       const delay = attempts <= 1 ? 60_000 : attempts === 2 ? 5 * 60_000 : 15 * 60_000;
       writeJob(
         EpisodicExtractionJobSchema.parse({
           ...input.job,
+          revision: input.job.revision + 1,
           status: needsAttention ? "needs_attention" : "pending",
           leaseUntil: undefined,
           ...(needsAttention
             ? { retryAt: undefined }
             : { retryAt: new Date(input.now.getTime() + delay).toISOString() }),
           lastErrorCode: input.errorCode,
+          ...(needsAttention
+            ? {
+                failureClass:
+                  input.retry === "configuration" ? "configuration" : "transient-exhausted",
+                attentionSince: input.job.attentionSince ?? input.now.toISOString(),
+              }
+            : {}),
           updatedAt: input.now.toISOString(),
         }),
       );
     },
 
-    async wakeNeedsAttention(now) {
+    async wakeNeedsAttention(now, reason = "configuration") {
       const rows = state
         .prepare("SELECT job_json AS jobJson FROM jobs WHERE status = 'needs_attention'")
         .all() as unknown as readonly { readonly jobJson: string }[];
       for (const row of rows) {
         const job = EpisodicExtractionJobSchema.parse(JSON.parse(row.jobJson));
+        if (reason === "configuration" && job.failureClass !== "configuration") continue;
         writeJob(
           EpisodicExtractionJobSchema.parse({
             ...job,
+            revision: job.revision + 1,
             status: "pending",
+            attempts: 0,
             retryAt: now.toISOString(),
             lastErrorCode: undefined,
+            failureClass: undefined,
+            attentionSince: undefined,
             updatedAt: now.toISOString(),
           }),
         );
       }
+    },
+
+    async retryJob(input) {
+      const job = readJob(state, input.id);
+      if (job === undefined) throw new Error("memory_extraction_job_not_found");
+      if (job.revision !== input.expectedRevision) {
+        throw new Error("memory_extraction_job_revision_conflict");
+      }
+      if (job.status !== "needs_attention") throw new Error("memory_extraction_job_not_retryable");
+      writeJob(
+        EpisodicExtractionJobSchema.parse({
+          ...job,
+          revision: job.revision + 1,
+          status: "pending",
+          attempts: 0,
+          retryAt: input.now.toISOString(),
+          lastErrorCode: undefined,
+          failureClass: undefined,
+          attentionSince: undefined,
+          updatedAt: input.now.toISOString(),
+        }),
+      );
+    },
+
+    async listExtractionJobs() {
+      return readJobRows(state);
+    },
+
+    async maintain(now) {
+      const result = maintainJobs(state, now);
+      const cutoff = now.getTime() - DEFAULT_MEMORY_STORAGE_POLICY.jobRecordRetentionMs;
+      await Promise.all([
+        ...EPISODIC_DATA_STORAGE_MIGRATIONS.map((step) =>
+          removeExpiredSqliteMigrationBackup(dataPath, step.fromVersion, cutoff),
+        ),
+        ...EPISODIC_JOB_STORAGE_MIGRATIONS.map((step) =>
+          removeExpiredSqliteMigrationBackup(statePath, step.fromVersion, cutoff),
+        ),
+      ]);
+      return result;
+    },
+
+    async deleteExecutionState(executionIds, now = new Date()) {
+      deleteExecutionState(state, executionIds, now);
     },
 
     async inspect() {
@@ -488,6 +621,8 @@ export async function createEpisodicMemoryStore(
         pending: byStatus.get("pending") ?? 0,
         running: byStatus.get("running") ?? 0,
         needsAttention: byStatus.get("needs_attention") ?? 0,
+        expired: byStatus.get("expired") ?? 0,
+        ...inspectEvidenceState(state),
         rejected: counters.get("rejected_total") ?? 0,
         rejectedByReason: {
           "low-value": counters.get("rejected_low_value") ?? 0,
@@ -558,12 +693,15 @@ function initializeData(database: DatabaseSync): void {
       tombstone_json TEXT NOT NULL
     );
   `);
-  if (version === 1) migrateEpisodicDataV1ToV2(database);
+  if (version !== 0 && version !== 2) {
+    throw new Error(`missing-adjacent-migration:pragma.memory-episodic-store/v${version}`);
+  }
   database.exec("PRAGMA user_version = 2;");
 }
 
 function initializeState(database: DatabaseSync): void {
-  assertVersion(database, "pragma.memory-episodic-jobs", 1);
+  assertVersion(database, "pragma.memory-episodic-jobs", 2);
+  const version = readVersion(database);
   database.exec(`
     PRAGMA journal_mode = WAL;
     PRAGMA synchronous = FULL;
@@ -585,8 +723,19 @@ function initializeState(database: DatabaseSync): void {
     );
     CREATE INDEX IF NOT EXISTS jobs_due ON jobs(status, retry_at, lease_until);
     CREATE TABLE IF NOT EXISTS counters (name TEXT PRIMARY KEY, value INTEGER NOT NULL);
-    PRAGMA user_version = 1;
+    CREATE TABLE IF NOT EXISTS capture_stats (
+      execution_id TEXT PRIMARY KEY,
+      stats_json TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS deleted_executions (
+      execution_id TEXT PRIMARY KEY,
+      deleted_at TEXT NOT NULL
+    );
   `);
+  if (version !== 0 && version !== 2) {
+    throw new Error(`missing-adjacent-migration:pragma.memory-episodic-jobs/v${version}`);
+  }
+  database.exec("PRAGMA user_version = 2;");
 }
 
 function assertVersion(database: DatabaseSync, family: string, current: number): void {
@@ -604,33 +753,157 @@ function readVersion(database: DatabaseSync): number {
   return row.user_version;
 }
 
-function migrateEpisodicDataV1ToV2(database: DatabaseSync): void {
+function readJob(database: DatabaseSync, id: string): EpisodicExtractionJob | undefined {
+  const row = database.prepare("SELECT job_json AS jobJson FROM jobs WHERE id = ?").get(id) as
+    { readonly jobJson: string } | undefined;
+  return row === undefined ? undefined : EpisodicExtractionJobSchema.parse(JSON.parse(row.jobJson));
+}
+
+function readJobRows(database: DatabaseSync): EpisodicExtractionJob[] {
   const rows = database
-    .prepare("SELECT id, record_json AS recordJson FROM episodes")
-    .all() as unknown as readonly { readonly id: string; readonly recordJson: string }[];
+    .prepare("SELECT job_json AS jobJson FROM jobs ORDER BY rowid DESC")
+    .all() as unknown as readonly { readonly jobJson: string }[];
+  return rows.map((row) => EpisodicExtractionJobSchema.parse(JSON.parse(row.jobJson)));
+}
+
+function compactEvidence(database: DatabaseSync, executionId: string): void {
+  const rows = database
+    .prepare(
+      "SELECT envelope_json AS envelopeJson FROM evidence WHERE execution_id = ? ORDER BY occurred_at, message_id",
+    )
+    .all(executionId) as unknown as readonly { readonly envelopeJson: string }[];
+  const evidence = rows.map((row) =>
+    MemoryEvidenceEnvelopeSchema.parse(JSON.parse(row.envelopeJson)),
+  );
+  const selection = selectBoundedMemoryEvidence(evidence, {
+    maxRecords: DEFAULT_MEMORY_STORAGE_POLICY.evidenceMaxRecordsPerExecution,
+    maxBytes: DEFAULT_MEMORY_STORAGE_POLICY.evidenceMaxBytesPerExecution,
+  });
+  if (selection.omitted.length === 0) return;
+  const remove = database.prepare("DELETE FROM evidence WHERE message_id = ?");
+  for (const envelope of selection.omitted) remove.run(envelope.messageId);
+  const stats = mergeMemoryEvidenceOmissionStats(
+    readOmissionStats(database, executionId),
+    selection.omittedStats,
+  );
+  database
+    .prepare(
+      `INSERT INTO capture_stats(execution_id, stats_json) VALUES (?, ?)
+       ON CONFLICT(execution_id) DO UPDATE SET stats_json=excluded.stats_json`,
+    )
+    .run(executionId, JSON.stringify(stats));
+}
+
+function readOmissionStats(
+  database: DatabaseSync,
+  executionId: string,
+): MemoryEvidenceOmissionStats {
+  const row = database
+    .prepare("SELECT stats_json AS statsJson FROM capture_stats WHERE execution_id = ?")
+    .get(executionId) as { readonly statsJson: string } | undefined;
+  return row === undefined
+    ? EMPTY_MEMORY_EVIDENCE_OMISSION_STATS
+    : MemoryEvidenceOmissionStatsSchema.parse(JSON.parse(row.statsJson));
+}
+
+function inspectEvidenceState(database: DatabaseSync): {
+  readonly evidenceRecords: number;
+  readonly evidenceBytes: number;
+  readonly truncatedExecutions: number;
+} {
+  const evidence = database
+    .prepare(
+      "SELECT COUNT(*) AS records, COALESCE(SUM(length(CAST(envelope_json AS BLOB))), 0) AS bytes FROM evidence",
+    )
+    .get() as unknown as { readonly records: number; readonly bytes: number };
+  const truncated = database
+    .prepare("SELECT COUNT(*) AS count FROM capture_stats")
+    .get() as unknown as { readonly count: number };
+  return {
+    evidenceRecords: evidence.records,
+    evidenceBytes: evidence.bytes,
+    truncatedExecutions: truncated.count,
+  };
+}
+
+function maintainJobs(
+  database: DatabaseSync,
+  now: Date,
+): { readonly expired: number; readonly deleted: number } {
+  const timestamp = now.getTime();
+  let expired = 0;
+  let deleted = 0;
   database.exec("BEGIN IMMEDIATE;");
   try {
-    for (const row of rows) {
-      const previous = JSON.parse(row.recordJson) as Record<string, unknown>;
-      const refs = Array.isArray(previous["bindings"]) ? previous["bindings"] : [];
-      const migrated = EpisodicMemoryRecordSchema.parse({
-        ...previous,
-        schemaVersion: "pragma.memory-episodic/v2",
-        bindings: refs.map((consumerRef) => ({
-          consumerRef,
-          recall: "allow",
-          export: "deny",
-          permissionRevision: 1,
-        })),
-      });
-      database
-        .prepare("UPDATE episodes SET record_json = ? WHERE id = ?")
-        .run(JSON.stringify(migrated), row.id);
-      database
-        .prepare(
-          "INSERT OR IGNORE INTO episode_revisions(episode_id, revision, record_json) VALUES (?, ?, ?)",
-        )
-        .run(migrated.id, migrated.revision, JSON.stringify(migrated));
+    for (const job of readJobRows(database)) {
+      if (
+        job.status === "needs_attention" &&
+        job.attentionSince !== undefined &&
+        timestamp - Date.parse(job.attentionSince) >=
+          DEFAULT_MEMORY_STORAGE_POLICY.failedPayloadRetentionMs
+      ) {
+        const next = EpisodicExtractionJobSchema.parse({
+          ...job,
+          revision: job.revision + 1,
+          status: "expired",
+          expiredAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+        });
+        database.prepare("DELETE FROM evidence WHERE execution_id = ?").run(job.executionId);
+        database.prepare("DELETE FROM capture_stats WHERE execution_id = ?").run(job.executionId);
+        database
+          .prepare("UPDATE jobs SET status = 'expired', job_json = ? WHERE id = ?")
+          .run(JSON.stringify(next), next.id);
+        expired += 1;
+        continue;
+      }
+      const terminalAt = job.status === "completed" ? job.completedAt : job.expiredAt;
+      const retention =
+        job.status === "completed"
+          ? DEFAULT_MEMORY_STORAGE_POLICY.jobRecordRetentionMs
+          : DEFAULT_MEMORY_STORAGE_POLICY.expiredDiagnosticRetentionMs;
+      if (
+        terminalAt !== undefined &&
+        ["completed", "expired"].includes(job.status) &&
+        timestamp - Date.parse(terminalAt) >= retention
+      ) {
+        database.prepare("DELETE FROM jobs WHERE id = ?").run(job.id);
+        database.prepare("DELETE FROM capture_stats WHERE execution_id = ?").run(job.executionId);
+        deleted += 1;
+      }
+    }
+    database
+      .prepare("DELETE FROM deleted_executions WHERE deleted_at <= ?")
+      .run(
+        new Date(timestamp - DEFAULT_MEMORY_STORAGE_POLICY.failedPayloadRetentionMs).toISOString(),
+      );
+    database.exec("COMMIT;");
+    return { expired, deleted };
+  } catch (error) {
+    rollback(database);
+    throw error;
+  }
+}
+
+function deleteExecutionState(
+  database: DatabaseSync,
+  executionIds: readonly string[],
+  now: Date,
+): void {
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    const markDeleted = database.prepare(
+      `INSERT INTO deleted_executions(execution_id, deleted_at) VALUES (?, ?)
+       ON CONFLICT(execution_id) DO UPDATE SET deleted_at=excluded.deleted_at`,
+    );
+    const deleteEvidence = database.prepare("DELETE FROM evidence WHERE execution_id = ?");
+    const deleteStats = database.prepare("DELETE FROM capture_stats WHERE execution_id = ?");
+    const deleteJobs = database.prepare("DELETE FROM jobs WHERE execution_id = ?");
+    for (const executionId of new Set(executionIds)) {
+      markDeleted.run(executionId, now.toISOString());
+      deleteEvidence.run(executionId);
+      deleteStats.run(executionId);
+      deleteJobs.run(executionId);
     }
     database.exec("COMMIT;");
   } catch (error) {
@@ -639,25 +912,31 @@ function migrateEpisodicDataV1ToV2(database: DatabaseSync): void {
   }
 }
 
-function readJob(database: DatabaseSync, id: string): EpisodicExtractionJob | undefined {
-  const row = database.prepare("SELECT job_json AS jobJson FROM jobs WHERE id = ?").get(id) as
-    { readonly jobJson: string } | undefined;
-  return row === undefined ? undefined : EpisodicExtractionJobSchema.parse(JSON.parse(row.jobJson));
+function isDeletedExecution(database: DatabaseSync, executionId: string): boolean {
+  return (
+    database
+      .prepare("SELECT 1 AS found FROM deleted_executions WHERE execution_id = ?")
+      .get(executionId) !== undefined
+  );
 }
 
 function finishJob(
   database: DatabaseSync,
   job: EpisodicExtractionJob,
   completion: "retained" | "rejected",
+  now: Date,
 ): void {
+  const completedAt = now.toISOString();
   const completed = EpisodicExtractionJobSchema.parse({
     ...job,
+    revision: job.revision + 1,
     status: "completed",
     leaseUntil: undefined,
     retryAt: undefined,
     lastErrorCode: undefined,
     completion,
-    updatedAt: new Date().toISOString(),
+    completedAt,
+    updatedAt: completedAt,
   });
   database
     .prepare(
@@ -666,10 +945,10 @@ function finishJob(
     .run(completed.status, JSON.stringify(completed), completed.id);
 }
 
-function completeRetainedJob(database: DatabaseSync, job: EpisodicExtractionJob): void {
+function completeRetainedJob(database: DatabaseSync, job: EpisodicExtractionJob, now: Date): void {
   database.exec("BEGIN IMMEDIATE;");
   try {
-    finishJob(database, job, "retained");
+    finishJob(database, job, "retained", now);
     database.prepare("DELETE FROM evidence WHERE execution_id = ?").run(job.executionId);
     database.exec("COMMIT;");
   } catch (error) {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -17,3 +17,5 @@ export * from "./semantic/store.ts";
 export * from "./semantic/context.ts";
 export * from "./semantic/module.ts";
 export * from "./curator.ts";
+export * from "./storage/memory-storage-policy.ts";
+export * from "./storage/bounded-evidence.ts";

--- a/packages/memory/src/pipeline/pipeline-state-store.ts
+++ b/packages/memory/src/pipeline/pipeline-state-store.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 
 import { PragmaPaths, withFileLock } from "@pragma/core";
 import { MemoryEvidenceEnvelopeSchema } from "@pragma/shared";
 import { z } from "zod";
+
+import { DEFAULT_MEMORY_STORAGE_POLICY } from "../storage/memory-storage-policy.ts";
 
 const ConsumerStateSchema = z.object({
   schemaVersion: z.literal("pragma.memory-consumer-state/v1"),
@@ -57,6 +60,11 @@ export interface MemoryDeadLetterStore {
   list(consumerId: string): Promise<readonly MemoryDeadLetter[]>;
 }
 
+export interface MemoryPipelineMaintenanceStore {
+  maintain(now: Date): Promise<{ readonly deletedDeadLetters: number }>;
+  inspectDeadLetters(): Promise<{ readonly entries: number; readonly bytes: number }>;
+}
+
 export interface MemoryDerivedEventOutboxStore {
   enqueue(entry: MemoryDerivedEventOutboxEntry): Promise<void>;
   listPending(consumerId: string): Promise<readonly MemoryDerivedEventOutboxEntry[]>;
@@ -68,23 +76,35 @@ export function createFileMemoryPipelineStateStore(
     readonly pragmaHome?: string | undefined;
     readonly now?: (() => Date) | undefined;
   } = {},
-): MemoryConsumerCheckpointStore & MemoryDeadLetterStore & MemoryDerivedEventOutboxStore {
+): MemoryConsumerCheckpointStore &
+  MemoryDeadLetterStore &
+  MemoryDerivedEventOutboxStore &
+  MemoryPipelineMaintenanceStore {
   const paths = new PragmaPaths(options);
   const now = options.now ?? (() => new Date());
   const statePath = (consumerId: string) =>
     join(paths.memoryModuleStateRoot(consumerId), "consumer.json");
-  const deadLetterPath = (consumerId: string) =>
+  const legacyDeadLetterPath = (consumerId: string) =>
     join(paths.memoryModuleStateRoot(consumerId), "dead-letters.json");
+  const deadLetterPath = (consumerId: string) =>
+    join(paths.memoryModuleStateRoot(consumerId), "dead-letters.sqlite");
   const lockPath = (consumerId: string) => join(paths.memoryModuleStateRoot(consumerId), ".lock");
   const outboxPath = (consumerId: string) =>
     join(paths.memoryModuleStateRoot(consumerId), "derived-event-outbox.json");
+  const knownConsumers = new Set<string>();
+
+  const remember = (consumerId: string): void => {
+    knownConsumers.add(consumerId);
+  };
 
   return {
     async read(consumerId) {
+      remember(consumerId);
       return await readState(statePath(consumerId), consumerId, now);
     },
 
     async update(consumerId, updater) {
+      remember(consumerId);
       return await withFileLock(lockPath(consumerId), async () => {
         const current = await readState(statePath(consumerId), consumerId, now);
         const next = ConsumerStateSchema.parse(updater(current));
@@ -98,19 +118,42 @@ export function createFileMemoryPipelineStateStore(
 
     async put(input) {
       const entry = DeadLetterSchema.parse(input);
+      remember(entry.consumerId);
       await withFileLock(lockPath(entry.consumerId), async () => {
-        const existing = await readDeadLetters(deadLetterPath(entry.consumerId));
-        if (existing.some((candidate) => candidate.messageId === entry.messageId)) return;
-        await writeJsonAtomic(deadLetterPath(entry.consumerId), [...existing, entry]);
+        const database = await openDeadLetterDatabase(
+          deadLetterPath(entry.consumerId),
+          legacyDeadLetterPath(entry.consumerId),
+        );
+        try {
+          database
+            .prepare(
+              `INSERT OR IGNORE INTO dead_letters(message_id, failed_at, record_json)
+               VALUES (?, ?, ?)`,
+            )
+            .run(entry.messageId, entry.failedAt, JSON.stringify(entry));
+          pruneDeadLetters(database, now());
+        } finally {
+          database.close();
+        }
       });
     },
 
     async list(consumerId) {
-      return await readDeadLetters(deadLetterPath(consumerId));
+      remember(consumerId);
+      const database = await openDeadLetterDatabase(
+        deadLetterPath(consumerId),
+        legacyDeadLetterPath(consumerId),
+      );
+      try {
+        return readDeadLetters(database);
+      } finally {
+        database.close();
+      }
     },
 
     async enqueue(input) {
       const entry = DerivedEventOutboxEntrySchema.parse(input);
+      remember(entry.consumerId);
       await withFileLock(lockPath(entry.consumerId), async () => {
         const existing = await readOutbox(outboxPath(entry.consumerId));
         const duplicate = existing.find((candidate) => candidate.deliveryId === entry.deliveryId);
@@ -125,16 +168,73 @@ export function createFileMemoryPipelineStateStore(
     },
 
     async listPending(consumerId) {
+      remember(consumerId);
       return await readOutbox(outboxPath(consumerId));
     },
 
     async acknowledge(consumerId, deliveryId) {
+      remember(consumerId);
       await withFileLock(lockPath(consumerId), async () => {
         const existing = await readOutbox(outboxPath(consumerId));
         const next = existing.filter((entry) => entry.deliveryId !== deliveryId);
         if (next.length === existing.length) return;
         await writeJsonAtomic(outboxPath(consumerId), next);
       });
+    },
+
+    async maintain(maintenanceNow) {
+      let deletedDeadLetters = 0;
+      for (const consumerId of knownConsumers) {
+        await withFileLock(lockPath(consumerId), async () => {
+          const database = await openDeadLetterDatabase(
+            deadLetterPath(consumerId),
+            legacyDeadLetterPath(consumerId),
+          );
+          try {
+            deletedDeadLetters += pruneDeadLetters(database, maintenanceNow);
+          } finally {
+            database.close();
+          }
+          const backup = `${legacyDeadLetterPath(consumerId)}.v1.backup`;
+          await stat(backup)
+            .then(async (details) => {
+              if (
+                maintenanceNow.getTime() - details.mtimeMs >=
+                DEFAULT_MEMORY_STORAGE_POLICY.deadLetterRetentionMs
+              ) {
+                await rm(backup, { force: true });
+              }
+            })
+            .catch((error: unknown) => {
+              if (!isNotFound(error)) throw error;
+            });
+          await removeStaleAtomicTemps(paths.memoryModuleStateRoot(consumerId), maintenanceNow);
+        });
+      }
+      return { deletedDeadLetters };
+    },
+
+    async inspectDeadLetters() {
+      let entries = 0;
+      let bytes = 0;
+      for (const consumerId of knownConsumers) {
+        const database = await openDeadLetterDatabase(
+          deadLetterPath(consumerId),
+          legacyDeadLetterPath(consumerId),
+        );
+        try {
+          const row = database
+            .prepare(
+              "SELECT COUNT(*) AS entries, COALESCE(SUM(length(CAST(record_json AS BLOB))), 0) AS bytes FROM dead_letters",
+            )
+            .get() as unknown as { readonly entries: number; readonly bytes: number };
+          entries += row.entries;
+          bytes += row.bytes;
+        } finally {
+          database.close();
+        }
+      }
+      return { entries, bytes };
     },
   };
 }
@@ -161,9 +261,11 @@ async function readState(
   return ConsumerStateSchema.parse(value);
 }
 
-async function readDeadLetters(path: string): Promise<MemoryDeadLetter[]> {
-  const value = await readJson(path);
-  return value === undefined ? [] : DeadLetterSchema.array().parse(value);
+function readDeadLetters(database: DatabaseSync): MemoryDeadLetter[] {
+  const rows = database
+    .prepare("SELECT record_json AS recordJson FROM dead_letters ORDER BY failed_at, message_id")
+    .all() as unknown as readonly { readonly recordJson: string }[];
+  return rows.map((row) => DeadLetterSchema.parse(JSON.parse(row.recordJson)));
 }
 
 async function readOutbox(path: string): Promise<MemoryDerivedEventOutboxEntry[]> {
@@ -183,8 +285,126 @@ async function readJson(path: string): Promise<unknown | undefined> {
 async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
   const temporary = `${path}.${randomUUID()}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 });
-  await rename(temporary, path);
+  try {
+    await writeFile(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+async function removeStaleAtomicTemps(root: string, now: Date): Promise<void> {
+  let names: string[];
+  try {
+    names = await readdir(root);
+  } catch (error) {
+    if (isNotFound(error)) return;
+    throw error;
+  }
+  const cutoff = now.getTime() - DEFAULT_MEMORY_STORAGE_POLICY.atomicTempRetentionMs;
+  for (const name of names.filter((value) => value.endsWith(".tmp"))) {
+    const path = join(root, name);
+    try {
+      if ((await stat(path)).mtimeMs <= cutoff) await rm(path, { force: true });
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+  }
+}
+
+async function openDeadLetterDatabase(path: string, legacyPath: string): Promise<DatabaseSync> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const database = new DatabaseSync(path);
+  const version = database.prepare("PRAGMA user_version").get() as unknown as {
+    readonly user_version: number;
+  };
+  if (version.user_version > 1) {
+    database.close();
+    throw new Error(
+      `unsupported-state-version:pragma.memory-dead-letter-store/v${version.user_version}`,
+    );
+  }
+  database.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = FULL;
+    CREATE TABLE IF NOT EXISTS dead_letters (
+      message_id TEXT PRIMARY KEY,
+      failed_at TEXT NOT NULL,
+      record_json TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS dead_letters_failed_at ON dead_letters(failed_at, message_id);
+    PRAGMA user_version = 1;
+  `);
+  const legacy = await readJson(legacyPath);
+  if (legacy !== undefined) {
+    try {
+      const entries = DeadLetterSchema.array().parse(legacy);
+      const insert = database.prepare(
+        "INSERT OR IGNORE INTO dead_letters(message_id, failed_at, record_json) VALUES (?, ?, ?)",
+      );
+      database.exec("BEGIN IMMEDIATE;");
+      for (const entry of entries) {
+        insert.run(entry.messageId, entry.failedAt, JSON.stringify(entry));
+      }
+      database.exec("COMMIT;");
+      await rename(legacyPath, `${legacyPath}.v1.backup`).catch((error: unknown) => {
+        if (!isNotFound(error)) throw error;
+      });
+    } catch (error) {
+      try {
+        database.exec("ROLLBACK;");
+      } catch {
+        // Parsing can fail before a transaction starts, or rename can fail after commit.
+      }
+      database.close();
+      throw error;
+    }
+  }
+  return database;
+}
+
+function pruneDeadLetters(database: DatabaseSync, now: Date): number {
+  let deleted = 0;
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    const cutoff = new Date(
+      now.getTime() - DEFAULT_MEMORY_STORAGE_POLICY.deadLetterRetentionMs,
+    ).toISOString();
+    deleted += Number(
+      database.prepare("DELETE FROM dead_letters WHERE failed_at < ?").run(cutoff).changes,
+    );
+    const rows = database
+      .prepare(
+        `SELECT message_id AS messageId, length(CAST(record_json AS BLOB)) AS bytes
+         FROM dead_letters ORDER BY failed_at DESC, message_id DESC`,
+      )
+      .all() as unknown as readonly { readonly messageId: string; readonly bytes: number }[];
+    let retainedBytes = 0;
+    const remove = database.prepare("DELETE FROM dead_letters WHERE message_id = ?");
+    for (const [index, row] of rows.entries()) {
+      retainedBytes += row.bytes;
+      if (
+        index < DEFAULT_MEMORY_STORAGE_POLICY.deadLetterMaxEntries &&
+        retainedBytes <= DEFAULT_MEMORY_STORAGE_POLICY.deadLetterMaxBytes
+      ) {
+        continue;
+      }
+      deleted += Number(remove.run(row.messageId).changes);
+    }
+    database.exec("COMMIT;");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK;");
+    } catch {
+      // No transaction remained active.
+    }
+    throw error;
+  }
+  if (deleted > 0) {
+    database.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+    database.exec("VACUUM;");
+  }
+  return deleted;
 }
 
 function isNotFound(error: unknown): boolean {

--- a/packages/memory/src/semantic/module.ts
+++ b/packages/memory/src/semantic/module.ts
@@ -79,23 +79,23 @@ export async function createSemanticMemoryModule(
       if (job === undefined) return;
       try {
         if (await store.hasAppliedJob(job.id)) {
-          await store.completePreviouslyApplied(job);
+          await store.completePreviouslyApplied(job, now());
           return;
         }
         const subjectContext = await store.getSubjectContext(job.executionId);
         if (subjectContext === undefined) throw new Error("semantic_subject_context_missing");
         const evidence = sanitizeEvidence(await store.readEvidence(job.executionId));
         if (evidence.some((item) => item.sensitivity === "restricted")) {
-          await store.completeRejected(job, "sensitive");
+          await store.completeRejected(job, "sensitive", now());
           return;
         }
         if (!hasTextEvidence(evidence)) {
-          await store.completeRejected(job, "insufficient-evidence");
+          await store.completeRejected(job, "insufficient-evidence", now());
           return;
         }
         const visibility = strictestVisibility(evidence);
         if (visibility === undefined) {
-          await store.completeRejected(job, "policy");
+          await store.completeRejected(job, "policy", now());
           return;
         }
         const attribution = resolveAttribution(evidence);
@@ -105,16 +105,17 @@ export async function createSemanticMemoryModule(
           ...attribution.producerRefs,
         ]);
         const input = SemanticExtractionInputSchema.parse({
-          schemaVersion: "pragma.memory-semantic-extraction-input/v1",
+          schemaVersion: "pragma.memory-semantic-extraction-input/v2",
           jobId: job.id,
           executionId: job.executionId,
           allowedSubjectRefs,
           evidence,
+          omittedEvidence: await store.readOmissionStats(job.executionId),
         });
         const extracted = await extractor.extract(input);
         const output = SemanticExtractionOutputSchema.parse(extracted.output);
         if (!output.retain) {
-          await store.completeRejected(job, output.reason);
+          await store.completeRejected(job, output.reason, now());
           return;
         }
         assertCandidateRefs(output.facts, evidence, allowedSubjectRefs);
@@ -140,7 +141,6 @@ export async function createSemanticMemoryModule(
     },
     async setExtractor(next) {
       extractor = next;
-      if (next !== undefined) await store.wakeNeedsAttention(now());
     },
     async registerExecutionSubjects(input) {
       await store.registerSubjectContext(

--- a/packages/memory/src/semantic/schema.ts
+++ b/packages/memory/src/semantic/schema.ts
@@ -6,7 +6,9 @@ import {
 } from "@pragma/shared";
 import { z } from "zod";
 
-export const SEMANTIC_JOB_SCHEMA_VERSION = "pragma.memory-semantic-job/v1" as const;
+import { MemoryEvidenceOmissionStatsSchema } from "../storage/bounded-evidence.ts";
+
+export const SEMANTIC_JOB_SCHEMA_VERSION = "pragma.memory-semantic-job/v2" as const;
 export const SEMANTIC_SUBJECT_CONTEXT_SCHEMA_VERSION =
   "pragma.memory-semantic-execution-subject-context/v1" as const;
 export const SEMANTIC_GOVERNANCE_EVENT_SCHEMA_VERSION =
@@ -31,11 +33,12 @@ export const SemanticFactCandidateSchema = z
 
 export const SemanticExtractionInputSchema = z
   .object({
-    schemaVersion: z.literal("pragma.memory-semantic-extraction-input/v1"),
+    schemaVersion: z.literal("pragma.memory-semantic-extraction-input/v2"),
     jobId: z.string().min(1),
     executionId: z.string().min(1),
     allowedSubjectRefs: z.array(MemorySubjectRefSchema).min(1).max(200),
     evidence: z.array(MemoryEvidenceEnvelopeSchema).min(1).max(2_000),
+    omittedEvidence: MemoryEvidenceOmissionStatsSchema,
   })
   .strict();
 
@@ -58,13 +61,19 @@ export const SemanticExtractionJobSchema = z
   .object({
     schemaVersion: z.literal(SEMANTIC_JOB_SCHEMA_VERSION),
     id: z.string().min(1),
+    revision: z.number().int().positive(),
     executionId: z.string().min(1),
     terminalMessageId: z.string().min(1),
-    status: z.enum(["pending", "running", "needs_attention", "completed"]),
+    status: z.enum(["pending", "running", "needs_attention", "completed", "expired"]),
     attempts: z.number().int().nonnegative(),
+    totalAttempts: z.number().int().nonnegative(),
     retryAt: z.string().datetime().optional(),
     leaseUntil: z.string().datetime().optional(),
     lastErrorCode: z.string().min(1).optional(),
+    failureClass: z.enum(["configuration", "transient-exhausted"]).optional(),
+    attentionSince: z.string().datetime().optional(),
+    completedAt: z.string().datetime().optional(),
+    expiredAt: z.string().datetime().optional(),
     completion: z.enum(["retained", "rejected"]).optional(),
     updatedAt: z.string().datetime(),
   })

--- a/packages/memory/src/semantic/store.ts
+++ b/packages/memory/src/semantic/store.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { PragmaPaths } from "@pragma/core";
+import { PragmaPaths, withFileLock } from "@pragma/core";
 import {
   MemoryEvidenceEnvelopeSchema,
   SemanticFactSchema,
@@ -30,6 +30,21 @@ import {
   createMemoryTombstone,
 } from "../governance/access-governance.ts";
 import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
+import {
+  EMPTY_MEMORY_EVIDENCE_OMISSION_STATS,
+  MemoryEvidenceOmissionStatsSchema,
+  mergeMemoryEvidenceOmissionStats,
+  selectBoundedMemoryEvidence,
+  type MemoryEvidenceOmissionStats,
+} from "../storage/bounded-evidence.ts";
+import { DEFAULT_MEMORY_STORAGE_POLICY } from "../storage/memory-storage-policy.ts";
+import { SEMANTIC_DATA_STORAGE_MIGRATIONS } from "../storage/migrations/semantic-data/index.ts";
+import { SEMANTIC_JOB_STORAGE_MIGRATIONS } from "../storage/migrations/semantic-jobs/index.ts";
+import {
+  assertFreshSqliteDatabase,
+  removeExpiredSqliteMigrationBackup,
+  runAdjacentSqliteMigrations,
+} from "../storage/sqlite-migration-backup.ts";
 
 export type SemanticRejectionReason =
   "no-stable-fact" | "insufficient-evidence" | "sensitive" | "policy";
@@ -39,6 +54,10 @@ export interface SemanticMemoryStoreDiagnostic {
   readonly pending: number;
   readonly running: number;
   readonly needsAttention: number;
+  readonly expired: number;
+  readonly evidenceRecords: number;
+  readonly evidenceBytes: number;
+  readonly truncatedExecutions: number;
   readonly rejected: number;
   readonly rejectedByReason: Readonly<Record<SemanticRejectionReason, number>>;
 }
@@ -86,17 +105,30 @@ export interface SemanticMemoryStore {
   getSubjectContext(executionId: string): Promise<SemanticExecutionSubjectContext | undefined>;
   claimDueJob(now: Date): Promise<SemanticExtractionJob | undefined>;
   readEvidence(executionId: string): Promise<readonly MemoryEvidenceEnvelope[]>;
+  readOmissionStats(executionId: string): Promise<MemoryEvidenceOmissionStats>;
   hasAppliedJob(jobId: string): Promise<boolean>;
-  completePreviouslyApplied(job: SemanticExtractionJob): Promise<void>;
+  completePreviouslyApplied(job: SemanticExtractionJob, now: Date): Promise<void>;
   completeRetained(input: SemanticFactMaterialization): Promise<readonly SemanticFact[]>;
-  completeRejected(job: SemanticExtractionJob, reason: SemanticRejectionReason): Promise<void>;
+  completeRejected(
+    job: SemanticExtractionJob,
+    reason: SemanticRejectionReason,
+    now: Date,
+  ): Promise<void>;
   fail(input: {
     readonly job: SemanticExtractionJob;
     readonly errorCode: string;
     readonly now: Date;
     readonly retry: "transient" | "configuration";
   }): Promise<void>;
-  wakeNeedsAttention(now: Date): Promise<void>;
+  wakeNeedsAttention(now: Date, reason?: "configuration" | "manual"): Promise<void>;
+  retryJob(input: {
+    readonly id: string;
+    readonly expectedRevision: number;
+    readonly now: Date;
+  }): Promise<void>;
+  listExtractionJobs(): Promise<readonly SemanticExtractionJob[]>;
+  maintain(now: Date): Promise<{ readonly expired: number; readonly deleted: number }>;
+  deleteExecutionState(executionIds: readonly string[], now?: Date): Promise<void>;
   list(): Promise<readonly SemanticFact[]>;
   search(query: string, limit: number): Promise<readonly SemanticFact[]>;
   get(id: string): Promise<SemanticFact | undefined>;
@@ -152,11 +184,39 @@ export async function createSemanticMemoryStore(
     mkdir(dataRoot, { recursive: true, mode: 0o700 }),
     mkdir(stateRoot, { recursive: true, mode: 0o700 }),
   ]);
-  const data = new DatabaseSync(join(dataRoot, "facts.sqlite"));
-  const state = new DatabaseSync(join(stateRoot, "jobs.sqlite"));
+  const dataPath = join(dataRoot, "facts.sqlite");
+  const statePath = join(stateRoot, "jobs.sqlite");
+  const data = new DatabaseSync(dataPath);
+  const state = new DatabaseSync(statePath);
   try {
-    initializeData(data);
-    initializeState(state);
+    await withFileLock(`${dataPath}.migration.lock`, async () => {
+      if (readDatabaseVersion(data) === 0) {
+        assertFreshSqliteDatabase(data, "pragma.memory-semantic-store");
+      } else {
+        await runAdjacentSqliteMigrations({
+          database: data,
+          databasePath: dataPath,
+          family: "pragma.memory-semantic-store",
+          targetVersion: 2,
+          migrations: SEMANTIC_DATA_STORAGE_MIGRATIONS,
+        });
+      }
+      initializeData(data);
+    });
+    await withFileLock(`${statePath}.migration.lock`, async () => {
+      if (readDatabaseVersion(state) === 0) {
+        assertFreshSqliteDatabase(state, "pragma.memory-semantic-jobs");
+      } else {
+        await runAdjacentSqliteMigrations({
+          database: state,
+          databasePath: statePath,
+          family: "pragma.memory-semantic-jobs",
+          targetVersion: 2,
+          migrations: SEMANTIC_JOB_STORAGE_MIGRATIONS,
+        });
+      }
+      initializeState(state);
+    });
   } catch (error) {
     tryClose(data);
     tryClose(state);
@@ -182,15 +242,22 @@ export async function createSemanticMemoryStore(
       );
   };
 
-  const finishJob = (job: SemanticExtractionJob, completion: "retained" | "rejected"): void => {
+  const finishJob = (
+    job: SemanticExtractionJob,
+    completion: "retained" | "rejected",
+    now: Date,
+  ): void => {
+    const completedAt = now.toISOString();
     const finished = SemanticExtractionJobSchema.parse({
       ...job,
+      revision: job.revision + 1,
       status: "completed",
       completion,
       retryAt: undefined,
       leaseUntil: undefined,
       lastErrorCode: undefined,
-      updatedAt: new Date().toISOString(),
+      completedAt,
+      updatedAt: completedAt,
     });
     writeJob(finished);
     state.prepare("DELETE FROM evidence WHERE execution_id = ?").run(job.executionId);
@@ -218,7 +285,7 @@ export async function createSemanticMemoryStore(
       assertNoDuplicate(data, next);
       persistFactRevision(data, next);
       const mutable = new Set([next.id]);
-      recomputeConflicts(data, mutable);
+      recomputeConflicts(data, mutable, input.now);
       next = readRequiredFact(data, next.id);
       const event = SemanticGovernanceEventSchema.parse({
         schemaVersion: "pragma.memory-semantic-governance-event/v1",
@@ -249,9 +316,12 @@ export async function createSemanticMemoryStore(
       );
       state.exec("BEGIN IMMEDIATE;");
       try {
+        const touched = new Set<string>();
         for (const raw of envelopes) {
           const envelope = MemoryEvidenceEnvelopeSchema.parse(raw);
           if (envelope.correlationId === undefined) continue;
+          if (isDeletedExecution(state, envelope.correlationId)) continue;
+          touched.add(envelope.correlationId);
           insertEvidence.run(
             envelope.messageId,
             envelope.correlationId,
@@ -263,16 +333,19 @@ export async function createSemanticMemoryStore(
           if (readJob(state, id) !== undefined) continue;
           writeJob(
             SemanticExtractionJobSchema.parse({
-              schemaVersion: "pragma.memory-semantic-job/v1",
+              schemaVersion: "pragma.memory-semantic-job/v2",
               id,
+              revision: 1,
               executionId: envelope.correlationId,
               terminalMessageId: envelope.messageId,
               status: "pending",
               attempts: 0,
+              totalAttempts: 0,
               updatedAt: envelope.occurredAt,
             }),
           );
         }
+        for (const executionId of touched) compactEvidence(state, executionId);
         state.exec("COMMIT;");
       } catch (error) {
         rollback(state);
@@ -282,6 +355,7 @@ export async function createSemanticMemoryStore(
 
     async registerSubjectContext(raw) {
       const context = SemanticExecutionSubjectContextSchema.parse(raw);
+      if (isDeletedExecution(state, context.executionId)) return;
       state
         .prepare(
           `INSERT INTO subject_contexts(execution_id, context_json) VALUES (?, ?)
@@ -299,9 +373,13 @@ export async function createSemanticMemoryStore(
         writeJob(
           SemanticExtractionJobSchema.parse({
             ...job,
+            revision: job.revision + 1,
             status: "pending",
+            attempts: 0,
             retryAt: context.registeredAt,
             lastErrorCode: undefined,
+            failureClass: undefined,
+            attentionSince: undefined,
             updatedAt: context.registeredAt,
           }),
         );
@@ -336,8 +414,10 @@ export async function createSemanticMemoryStore(
         const current = SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
         const claimed = SemanticExtractionJobSchema.parse({
           ...current,
+          revision: current.revision + 1,
           status: "running",
           attempts: current.attempts + 1,
+          totalAttempts: current.totalAttempts + 1,
           retryAt: undefined,
           leaseUntil: new Date(now.getTime() + 5 * 60_000).toISOString(),
           updatedAt: now.toISOString(),
@@ -379,6 +459,10 @@ export async function createSemanticMemoryStore(
         .slice(-2_000);
     },
 
+    async readOmissionStats(executionId) {
+      return readOmissionStats(state, executionId);
+    },
+
     async hasAppliedJob(jobId) {
       return (
         data.prepare("SELECT 1 AS found FROM applied_jobs WHERE job_id = ?").get(jobId) !==
@@ -386,10 +470,11 @@ export async function createSemanticMemoryStore(
       );
     },
 
-    async completePreviouslyApplied(job) {
+    async completePreviouslyApplied(job, now) {
+      if (isDeletedExecution(state, job.executionId)) return;
       state.exec("BEGIN IMMEDIATE;");
       try {
-        finishJob(job, "retained");
+        finishJob(job, "retained", now);
         state.exec("COMMIT;");
       } catch (error) {
         rollback(state);
@@ -398,6 +483,7 @@ export async function createSemanticMemoryStore(
     },
 
     async completeRetained(input) {
+      if (isDeletedExecution(state, input.job.executionId)) return [];
       const evidenceById = new Map(input.evidence.map((item) => [item.messageId, item]));
       const touched = new Set<string>();
       data.exec("BEGIN IMMEDIATE;");
@@ -475,7 +561,7 @@ export async function createSemanticMemoryStore(
                 .run(record.id, envelope.messageId);
             }
           }
-          recomputeConflicts(data, touched);
+          recomputeConflicts(data, touched, input.now);
           data
             .prepare(
               "INSERT INTO applied_jobs(job_id, terminal_message_id, applied_at) VALUES (?, ?, ?)",
@@ -489,7 +575,7 @@ export async function createSemanticMemoryStore(
       }
       state.exec("BEGIN IMMEDIATE;");
       try {
-        finishJob(input.job, "retained");
+        finishJob(input.job, "retained", input.now);
         state.exec("COMMIT;");
       } catch (error) {
         rollback(state);
@@ -498,10 +584,11 @@ export async function createSemanticMemoryStore(
       return [...touched].map((id) => readRequiredFact(data, id));
     },
 
-    async completeRejected(job, reason) {
+    async completeRejected(job, reason, now) {
+      if (isDeletedExecution(state, job.executionId)) return;
       state.exec("BEGIN IMMEDIATE;");
       try {
-        finishJob(job, "rejected");
+        finishJob(job, "rejected", now);
         incrementCounter(state, "rejected_total");
         incrementCounter(state, `rejected_${reason.replaceAll("-", "_")}`);
         state.exec("COMMIT;");
@@ -512,38 +599,96 @@ export async function createSemanticMemoryStore(
     },
 
     async fail(input) {
+      if (isDeletedExecution(state, input.job.executionId)) return;
       const needsAttention = input.retry === "configuration" || input.job.attempts >= 3;
       const delay = input.job.attempts <= 1 ? 60_000 : 5 * 60_000;
       writeJob(
         SemanticExtractionJobSchema.parse({
           ...input.job,
+          revision: input.job.revision + 1,
           status: needsAttention ? "needs_attention" : "pending",
           leaseUntil: undefined,
           ...(needsAttention
             ? { retryAt: undefined }
             : { retryAt: new Date(input.now.getTime() + delay).toISOString() }),
           lastErrorCode: input.errorCode,
+          ...(needsAttention
+            ? {
+                failureClass:
+                  input.retry === "configuration" ? "configuration" : "transient-exhausted",
+                attentionSince: input.job.attentionSince ?? input.now.toISOString(),
+              }
+            : {}),
           updatedAt: input.now.toISOString(),
         }),
       );
     },
 
-    async wakeNeedsAttention(now) {
+    async wakeNeedsAttention(now, reason = "configuration") {
       const rows = state
         .prepare("SELECT job_json AS jobJson FROM jobs WHERE status = 'needs_attention'")
         .all() as unknown as readonly { readonly jobJson: string }[];
       for (const row of rows) {
         const job = SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
+        if (reason === "configuration" && job.failureClass !== "configuration") continue;
         writeJob(
           SemanticExtractionJobSchema.parse({
             ...job,
+            revision: job.revision + 1,
             status: "pending",
+            attempts: 0,
             retryAt: now.toISOString(),
             lastErrorCode: undefined,
+            failureClass: undefined,
+            attentionSince: undefined,
             updatedAt: now.toISOString(),
           }),
         );
       }
+    },
+
+    async retryJob(input) {
+      const job = readJob(state, input.id);
+      if (job === undefined) throw new Error("memory_extraction_job_not_found");
+      if (job.revision !== input.expectedRevision) {
+        throw new Error("memory_extraction_job_revision_conflict");
+      }
+      if (job.status !== "needs_attention") throw new Error("memory_extraction_job_not_retryable");
+      writeJob(
+        SemanticExtractionJobSchema.parse({
+          ...job,
+          revision: job.revision + 1,
+          status: "pending",
+          attempts: 0,
+          retryAt: input.now.toISOString(),
+          lastErrorCode: undefined,
+          failureClass: undefined,
+          attentionSince: undefined,
+          updatedAt: input.now.toISOString(),
+        }),
+      );
+    },
+
+    async listExtractionJobs() {
+      return readJobRows(state);
+    },
+
+    async maintain(now) {
+      const result = maintainJobs(state, now);
+      const cutoff = now.getTime() - DEFAULT_MEMORY_STORAGE_POLICY.jobRecordRetentionMs;
+      await Promise.all([
+        ...SEMANTIC_DATA_STORAGE_MIGRATIONS.map((step) =>
+          removeExpiredSqliteMigrationBackup(dataPath, step.fromVersion, cutoff),
+        ),
+        ...SEMANTIC_JOB_STORAGE_MIGRATIONS.map((step) =>
+          removeExpiredSqliteMigrationBackup(statePath, step.fromVersion, cutoff),
+        ),
+      ]);
+      return result;
+    },
+
+    async deleteExecutionState(executionIds, now = new Date()) {
+      deleteExecutionState(state, executionIds, now);
     },
 
     async list() {
@@ -704,7 +849,7 @@ export async function createSemanticMemoryStore(
             input.now.toISOString(),
             JSON.stringify(createMemoryTombstone("semantic", current.id, current.revision, input)),
           );
-        recomputeConflicts(data, new Set());
+        recomputeConflicts(data, new Set(), input.now);
         data.exec("COMMIT;");
       } catch (error) {
         rollback(data);
@@ -740,6 +885,8 @@ export async function createSemanticMemoryStore(
         pending: byStatus.get("pending") ?? 0,
         running: byStatus.get("running") ?? 0,
         needsAttention: byStatus.get("needs_attention") ?? 0,
+        expired: byStatus.get("expired") ?? 0,
+        ...inspectEvidenceState(state),
         rejected: counters.get("rejected_total") ?? 0,
         rejectedByReason: {
           "no-stable-fact": counters.get("rejected_no_stable_fact") ?? 0,
@@ -829,11 +976,15 @@ function initializeData(database: DatabaseSync): void {
       tombstone_json TEXT NOT NULL
     );
   `);
+  if (version !== 0 && version !== 2) {
+    throw new Error(`missing-adjacent-migration:pragma.memory-semantic-store/v${version}`);
+  }
   database.exec("PRAGMA user_version = 2;");
 }
 
 function initializeState(database: DatabaseSync): void {
-  assertVersion(database, "pragma.memory-semantic-jobs", 1);
+  assertVersion(database, "pragma.memory-semantic-jobs", 2);
+  const version = readDatabaseVersion(database);
   database.exec(`
     PRAGMA journal_mode = WAL;
     PRAGMA synchronous = FULL;
@@ -860,8 +1011,19 @@ function initializeState(database: DatabaseSync): void {
       context_json TEXT NOT NULL
     );
     CREATE TABLE IF NOT EXISTS counters (name TEXT PRIMARY KEY, value INTEGER NOT NULL);
-    PRAGMA user_version = 1;
+    CREATE TABLE IF NOT EXISTS capture_stats (
+      execution_id TEXT PRIMARY KEY,
+      stats_json TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS deleted_executions (
+      execution_id TEXT PRIMARY KEY,
+      deleted_at TEXT NOT NULL
+    );
   `);
+  if (version !== 0 && version !== 2) {
+    throw new Error(`missing-adjacent-migration:pragma.memory-semantic-jobs/v${version}`);
+  }
+  database.exec("PRAGMA user_version = 2;");
 }
 
 function assertVersion(database: DatabaseSync, family: string, current: number): void {
@@ -883,6 +1045,175 @@ function readJob(database: DatabaseSync, id: string): SemanticExtractionJob | un
   const row = database.prepare("SELECT job_json AS jobJson FROM jobs WHERE id = ?").get(id) as
     { readonly jobJson: string } | undefined;
   return row === undefined ? undefined : SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
+}
+
+function readJobRows(database: DatabaseSync): SemanticExtractionJob[] {
+  const rows = database
+    .prepare("SELECT job_json AS jobJson FROM jobs ORDER BY rowid DESC")
+    .all() as unknown as readonly { readonly jobJson: string }[];
+  return rows.map((row) => SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson)));
+}
+
+function compactEvidence(database: DatabaseSync, executionId: string): void {
+  const rows = database
+    .prepare(
+      "SELECT envelope_json AS envelopeJson FROM evidence WHERE execution_id = ? ORDER BY occurred_at, message_id",
+    )
+    .all(executionId) as unknown as readonly { readonly envelopeJson: string }[];
+  const evidence = rows.map((row) =>
+    MemoryEvidenceEnvelopeSchema.parse(JSON.parse(row.envelopeJson)),
+  );
+  const selection = selectBoundedMemoryEvidence(evidence, {
+    maxRecords: DEFAULT_MEMORY_STORAGE_POLICY.evidenceMaxRecordsPerExecution,
+    maxBytes: DEFAULT_MEMORY_STORAGE_POLICY.evidenceMaxBytesPerExecution,
+  });
+  if (selection.omitted.length === 0) return;
+  const remove = database.prepare("DELETE FROM evidence WHERE message_id = ?");
+  for (const envelope of selection.omitted) remove.run(envelope.messageId);
+  const stats = mergeMemoryEvidenceOmissionStats(
+    readOmissionStats(database, executionId),
+    selection.omittedStats,
+  );
+  database
+    .prepare(
+      `INSERT INTO capture_stats(execution_id, stats_json) VALUES (?, ?)
+       ON CONFLICT(execution_id) DO UPDATE SET stats_json=excluded.stats_json`,
+    )
+    .run(executionId, JSON.stringify(stats));
+}
+
+function readOmissionStats(
+  database: DatabaseSync,
+  executionId: string,
+): MemoryEvidenceOmissionStats {
+  const row = database
+    .prepare("SELECT stats_json AS statsJson FROM capture_stats WHERE execution_id = ?")
+    .get(executionId) as { readonly statsJson: string } | undefined;
+  return row === undefined
+    ? EMPTY_MEMORY_EVIDENCE_OMISSION_STATS
+    : MemoryEvidenceOmissionStatsSchema.parse(JSON.parse(row.statsJson));
+}
+
+function inspectEvidenceState(database: DatabaseSync): {
+  readonly evidenceRecords: number;
+  readonly evidenceBytes: number;
+  readonly truncatedExecutions: number;
+} {
+  const evidence = database
+    .prepare(
+      "SELECT COUNT(*) AS records, COALESCE(SUM(length(CAST(envelope_json AS BLOB))), 0) AS bytes FROM evidence",
+    )
+    .get() as unknown as { readonly records: number; readonly bytes: number };
+  const truncated = database
+    .prepare("SELECT COUNT(*) AS count FROM capture_stats")
+    .get() as unknown as { readonly count: number };
+  return {
+    evidenceRecords: evidence.records,
+    evidenceBytes: evidence.bytes,
+    truncatedExecutions: truncated.count,
+  };
+}
+
+function maintainJobs(
+  database: DatabaseSync,
+  now: Date,
+): { readonly expired: number; readonly deleted: number } {
+  const timestamp = now.getTime();
+  let expired = 0;
+  let deleted = 0;
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    for (const job of readJobRows(database)) {
+      if (
+        job.status === "needs_attention" &&
+        job.attentionSince !== undefined &&
+        timestamp - Date.parse(job.attentionSince) >=
+          DEFAULT_MEMORY_STORAGE_POLICY.failedPayloadRetentionMs
+      ) {
+        const next = SemanticExtractionJobSchema.parse({
+          ...job,
+          revision: job.revision + 1,
+          status: "expired",
+          expiredAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+        });
+        database.prepare("DELETE FROM evidence WHERE execution_id = ?").run(job.executionId);
+        database.prepare("DELETE FROM capture_stats WHERE execution_id = ?").run(job.executionId);
+        database
+          .prepare("DELETE FROM subject_contexts WHERE execution_id = ?")
+          .run(job.executionId);
+        database
+          .prepare("UPDATE jobs SET status = 'expired', job_json = ? WHERE id = ?")
+          .run(JSON.stringify(next), next.id);
+        expired += 1;
+        continue;
+      }
+      const terminalAt = job.status === "completed" ? job.completedAt : job.expiredAt;
+      const retention =
+        job.status === "completed"
+          ? DEFAULT_MEMORY_STORAGE_POLICY.jobRecordRetentionMs
+          : DEFAULT_MEMORY_STORAGE_POLICY.expiredDiagnosticRetentionMs;
+      if (
+        terminalAt !== undefined &&
+        ["completed", "expired"].includes(job.status) &&
+        timestamp - Date.parse(terminalAt) >= retention
+      ) {
+        database.prepare("DELETE FROM jobs WHERE id = ?").run(job.id);
+        database.prepare("DELETE FROM capture_stats WHERE execution_id = ?").run(job.executionId);
+        database
+          .prepare("DELETE FROM subject_contexts WHERE execution_id = ?")
+          .run(job.executionId);
+        deleted += 1;
+      }
+    }
+    database
+      .prepare("DELETE FROM deleted_executions WHERE deleted_at <= ?")
+      .run(
+        new Date(timestamp - DEFAULT_MEMORY_STORAGE_POLICY.failedPayloadRetentionMs).toISOString(),
+      );
+    database.exec("COMMIT;");
+    return { expired, deleted };
+  } catch (error) {
+    rollback(database);
+    throw error;
+  }
+}
+
+function deleteExecutionState(
+  database: DatabaseSync,
+  executionIds: readonly string[],
+  now: Date,
+): void {
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    const markDeleted = database.prepare(
+      `INSERT INTO deleted_executions(execution_id, deleted_at) VALUES (?, ?)
+       ON CONFLICT(execution_id) DO UPDATE SET deleted_at=excluded.deleted_at`,
+    );
+    const deleteEvidence = database.prepare("DELETE FROM evidence WHERE execution_id = ?");
+    const deleteStats = database.prepare("DELETE FROM capture_stats WHERE execution_id = ?");
+    const deleteJobs = database.prepare("DELETE FROM jobs WHERE execution_id = ?");
+    const deleteSubjects = database.prepare("DELETE FROM subject_contexts WHERE execution_id = ?");
+    for (const executionId of new Set(executionIds)) {
+      markDeleted.run(executionId, now.toISOString());
+      deleteEvidence.run(executionId);
+      deleteStats.run(executionId);
+      deleteJobs.run(executionId);
+      deleteSubjects.run(executionId);
+    }
+    database.exec("COMMIT;");
+  } catch (error) {
+    rollback(database);
+    throw error;
+  }
+}
+
+function isDeletedExecution(database: DatabaseSync, executionId: string): boolean {
+  return (
+    database
+      .prepare("SELECT 1 AS found FROM deleted_executions WHERE execution_id = ?")
+      .get(executionId) !== undefined
+  );
 }
 
 function readFact(database: DatabaseSync, id: string): SemanticFact | undefined {
@@ -957,7 +1288,7 @@ function assertNoDuplicate(database: DatabaseSync, fact: SemanticFact): void {
   }
 }
 
-function recomputeConflicts(database: DatabaseSync, mutable: ReadonlySet<string>): void {
+function recomputeConflicts(database: DatabaseSync, mutable: ReadonlySet<string>, now: Date): void {
   const facts = readFactRows(
     database
       .prepare("SELECT record_json AS recordJson FROM current_facts WHERE status = 'active'")
@@ -995,7 +1326,7 @@ function recomputeConflicts(database: DatabaseSync, mutable: ReadonlySet<string>
         revision: fact.revision + 1,
         conflictsWith,
         supersedes: appendRevisionRef(fact.supersedes, fact.id, fact.revision),
-        updatedAt: new Date().toISOString(),
+        updatedAt: now.toISOString(),
       }),
     );
   }

--- a/packages/memory/src/storage/bounded-evidence.ts
+++ b/packages/memory/src/storage/bounded-evidence.ts
@@ -1,0 +1,182 @@
+import type { MemoryEvidenceEnvelope } from "@pragma/shared";
+import { z } from "zod";
+
+export const MemoryEvidenceOmissionStatsSchema = z.object({
+  records: z.number().int().nonnegative(),
+  bytes: z.number().int().nonnegative(),
+  byTopic: z.record(z.string(), z.number().int().nonnegative()),
+  firstOccurredAt: z.string().datetime().optional(),
+  lastOccurredAt: z.string().datetime().optional(),
+});
+
+export type MemoryEvidenceOmissionStats = z.infer<typeof MemoryEvidenceOmissionStatsSchema>;
+
+export interface BoundedEvidenceSelection {
+  readonly retained: readonly MemoryEvidenceEnvelope[];
+  readonly omitted: readonly MemoryEvidenceEnvelope[];
+  readonly omittedStats: MemoryEvidenceOmissionStats;
+}
+
+export function selectBoundedMemoryEvidence(
+  evidence: readonly MemoryEvidenceEnvelope[],
+  limits: { readonly maxRecords: number; readonly maxBytes: number },
+): BoundedEvidenceSelection {
+  const ordered = evidence.toSorted(compareChronological);
+  const firstUserId = ordered.find(isUserMessage)?.messageId;
+  const latestUserId = ordered.findLast(isUserMessage)?.messageId;
+  const latestAssistantId = ordered.findLast(isAssistantMessage)?.messageId;
+  const completedTools = new Set(
+    ordered
+      .filter(
+        (item) =>
+          item.topic === "execution.tool.completed" || item.topic === "execution.tool.failed",
+      )
+      .map(toolCallId)
+      .filter((value): value is string => value !== undefined),
+  );
+  const candidates = ordered
+    .filter(
+      (item) =>
+        item.topic !== "execution.tool.started" ||
+        toolCallId(item) === undefined ||
+        !completedTools.has(toolCallId(item)!),
+    )
+    .map((item) => ({
+      item,
+      bytes: evidenceBytes(item),
+      priority: evidencePriority(item, { firstUserId, latestUserId, latestAssistantId }),
+    }))
+    .toSorted(
+      (left, right) =>
+        right.priority - left.priority ||
+        right.item.occurredAt.localeCompare(left.item.occurredAt) ||
+        right.item.messageId.localeCompare(left.item.messageId),
+    );
+  const retained = new Set<string>();
+  let retainedBytes = 0;
+  for (const candidate of candidates) {
+    if (retained.size >= limits.maxRecords) continue;
+    if (retainedBytes + candidate.bytes > limits.maxBytes) continue;
+    retained.add(candidate.item.messageId);
+    retainedBytes += candidate.bytes;
+  }
+  const retainedItems = ordered.filter((item) => retained.has(item.messageId));
+  const omitted = ordered.filter((item) => !retained.has(item.messageId));
+  return { retained: retainedItems, omitted, omittedStats: omissionStats(omitted) };
+}
+
+export function mergeMemoryEvidenceOmissionStats(
+  left: MemoryEvidenceOmissionStats,
+  right: MemoryEvidenceOmissionStats,
+): MemoryEvidenceOmissionStats {
+  const byTopic: Record<string, number> = { ...left.byTopic };
+  for (const [topic, count] of Object.entries(right.byTopic)) {
+    byTopic[topic] = (byTopic[topic] ?? 0) + count;
+  }
+  return {
+    records: left.records + right.records,
+    bytes: left.bytes + right.bytes,
+    byTopic,
+    ...optionalRange("firstOccurredAt", [left.firstOccurredAt, right.firstOccurredAt], "first"),
+    ...optionalRange("lastOccurredAt", [left.lastOccurredAt, right.lastOccurredAt], "last"),
+  };
+}
+
+export const EMPTY_MEMORY_EVIDENCE_OMISSION_STATS: MemoryEvidenceOmissionStats = Object.freeze({
+  records: 0,
+  bytes: 0,
+  byTopic: {},
+});
+
+function evidencePriority(
+  item: MemoryEvidenceEnvelope,
+  special: {
+    readonly firstUserId?: string | undefined;
+    readonly latestUserId?: string | undefined;
+    readonly latestAssistantId?: string | undefined;
+  },
+): number {
+  if (item.topic === "execution.execution.terminal") return 1_000;
+  if (item.messageId === special.firstUserId) return 950;
+  if (item.messageId === special.latestUserId) return 940;
+  if (item.messageId === special.latestAssistantId) return 930;
+  if (item.topic === "execution.tool.failed" || isFailedToolMessage(item)) return 900;
+  if (item.topic.startsWith("artifact.")) return 850;
+  if (isSummary(item)) return 800;
+  if (isUserMessage(item)) return 700;
+  if (isAssistantMessage(item)) return 650;
+  if (item.topic === "execution.invocation.terminal") return 600;
+  if (item.topic === "execution.tool.completed") return 300;
+  if (item.topic === "execution.tool.started") return 100;
+  return 500;
+}
+
+function omissionStats(evidence: readonly MemoryEvidenceEnvelope[]): MemoryEvidenceOmissionStats {
+  const byTopic: Record<string, number> = {};
+  let bytes = 0;
+  for (const item of evidence) {
+    byTopic[item.topic] = (byTopic[item.topic] ?? 0) + 1;
+    bytes += evidenceBytes(item);
+  }
+  return {
+    records: evidence.length,
+    bytes,
+    byTopic,
+    ...(evidence[0] === undefined ? {} : { firstOccurredAt: evidence[0].occurredAt }),
+    ...(evidence.at(-1) === undefined ? {} : { lastOccurredAt: evidence.at(-1)!.occurredAt }),
+  };
+}
+
+function evidenceBytes(item: MemoryEvidenceEnvelope): number {
+  return Buffer.byteLength(JSON.stringify(item));
+}
+
+function isUserMessage(item: MemoryEvidenceEnvelope): boolean {
+  return messageRole(item) === "user";
+}
+
+function isAssistantMessage(item: MemoryEvidenceEnvelope): boolean {
+  return messageRole(item) === "assistant";
+}
+
+function isSummary(item: MemoryEvidenceEnvelope): boolean {
+  return messageRole(item) === "summary";
+}
+
+function isFailedToolMessage(item: MemoryEvidenceEnvelope): boolean {
+  return messageRole(item) === "tool" && messagePayload(item)?.["status"] === "failed";
+}
+
+function messageRole(item: MemoryEvidenceEnvelope): unknown {
+  return messagePayload(item)?.["role"];
+}
+
+function messagePayload(item: MemoryEvidenceEnvelope): Record<string, unknown> | undefined {
+  if (typeof item.payload !== "object" || item.payload === null) return undefined;
+  const message = (item.payload as Record<string, unknown>)["message"];
+  return typeof message === "object" && message !== null
+    ? (message as Record<string, unknown>)
+    : undefined;
+}
+
+function toolCallId(item: MemoryEvidenceEnvelope): string | undefined {
+  if (typeof item.payload !== "object" || item.payload === null) return undefined;
+  const value = (item.payload as Record<string, unknown>)["toolCallId"];
+  return typeof value === "string" ? value : undefined;
+}
+
+function compareChronological(left: MemoryEvidenceEnvelope, right: MemoryEvidenceEnvelope): number {
+  return (
+    left.occurredAt.localeCompare(right.occurredAt) || left.messageId.localeCompare(right.messageId)
+  );
+}
+
+function optionalRange(
+  key: "firstOccurredAt" | "lastOccurredAt",
+  values: readonly (string | undefined)[],
+  end: "first" | "last",
+): Partial<Record<typeof key, string>> {
+  const sorted = values.filter((value): value is string => value !== undefined).toSorted();
+  const value = end === "first" ? sorted[0] : sorted.at(-1);
+  return value === undefined ? {} : { [key]: value };
+}

--- a/packages/memory/src/storage/memory-storage-policy.ts
+++ b/packages/memory/src/storage/memory-storage-policy.ts
@@ -1,0 +1,40 @@
+export interface MemoryStoragePolicy {
+  readonly schemaVersion: "pragma.memory-storage-policy/v1";
+  readonly canonicalFeedRetentionMs: number;
+  readonly canonicalFeedTargetBytes: number;
+  readonly evidenceMaxRecordsPerExecution: number;
+  readonly evidenceMaxBytesPerExecution: number;
+  readonly extractionPromptMaxBytes: number;
+  readonly jobRecordRetentionMs: number;
+  readonly failedPayloadRetentionMs: number;
+  readonly expiredDiagnosticRetentionMs: number;
+  readonly deadLetterRetentionMs: number;
+  readonly deadLetterMaxEntries: number;
+  readonly deadLetterMaxBytes: number;
+  readonly maintenanceIntervalMs: number;
+  readonly curatorOrphanGraceMs: number;
+  readonly curatorRegistryMaxEntries: number;
+  readonly atomicTempRetentionMs: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const MIB = 1_024 * 1_024;
+
+export const DEFAULT_MEMORY_STORAGE_POLICY: MemoryStoragePolicy = Object.freeze({
+  schemaVersion: "pragma.memory-storage-policy/v1",
+  canonicalFeedRetentionMs: 30 * DAY_MS,
+  canonicalFeedTargetBytes: 512 * MIB,
+  evidenceMaxRecordsPerExecution: 2_000,
+  evidenceMaxBytesPerExecution: 16 * MIB,
+  extractionPromptMaxBytes: 78_000,
+  jobRecordRetentionMs: 30 * DAY_MS,
+  failedPayloadRetentionMs: 30 * DAY_MS,
+  expiredDiagnosticRetentionMs: 30 * DAY_MS,
+  deadLetterRetentionMs: 30 * DAY_MS,
+  deadLetterMaxEntries: 10_000,
+  deadLetterMaxBytes: 64 * MIB,
+  maintenanceIntervalMs: 60 * 60 * 1_000,
+  curatorOrphanGraceMs: DAY_MS,
+  curatorRegistryMaxEntries: 1_000,
+  atomicTempRetentionMs: DAY_MS,
+});

--- a/packages/memory/src/storage/migrations/episodic-data/index.ts
+++ b/packages/memory/src/storage/migrations/episodic-data/index.ts
@@ -1,0 +1,9 @@
+import { migrateEpisodicDataV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export { EpisodicMemoryRecordV1Schema } from "./schemas/v1.ts";
+export { EpisodicMemoryRecordV2Schema } from "./schemas/v2.ts";
+export { migrateEpisodicDataV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export const EPISODIC_DATA_STORAGE_MIGRATIONS = Object.freeze([
+  { fromVersion: 1, toVersion: 2, migrate: migrateEpisodicDataV1ToV2 },
+] as const);

--- a/packages/memory/src/storage/migrations/episodic-data/schemas/v1.ts
+++ b/packages/memory/src/storage/migrations/episodic-data/schemas/v1.ts
@@ -1,0 +1,11 @@
+import { MemorySubjectRefSchema } from "@pragma/shared";
+import { z } from "zod";
+
+export const EpisodicMemoryRecordV1Schema = z
+  .object({
+    schemaVersion: z.literal("pragma.memory-episodic/v1"),
+    id: z.string().min(1),
+    revision: z.number().int().positive(),
+    bindings: z.array(MemorySubjectRefSchema).min(1).max(100),
+  })
+  .passthrough();

--- a/packages/memory/src/storage/migrations/episodic-data/schemas/v2.ts
+++ b/packages/memory/src/storage/migrations/episodic-data/schemas/v2.ts
@@ -1,0 +1,1 @@
+export { EpisodicMemoryRecordSchema as EpisodicMemoryRecordV2Schema } from "../../../../episodic/schema.ts";

--- a/packages/memory/src/storage/migrations/episodic-data/steps/v1-to-v2.ts
+++ b/packages/memory/src/storage/migrations/episodic-data/steps/v1-to-v2.ts
@@ -1,0 +1,74 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { EpisodicMemoryRecordV1Schema } from "../schemas/v1.ts";
+import { EpisodicMemoryRecordV2Schema } from "../schemas/v2.ts";
+
+export function migrateEpisodicDataV1ToV2(database: DatabaseSync): void {
+  const rows = database
+    .prepare("SELECT id, record_json AS recordJson FROM episodes")
+    .all() as unknown as readonly { readonly id: string; readonly recordJson: string }[];
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    database.exec(`
+      CREATE TABLE IF NOT EXISTS episode_evidence (
+        episode_id TEXT NOT NULL,
+        evidence_id TEXT NOT NULL,
+        occurred_at TEXT NOT NULL,
+        envelope_json TEXT NOT NULL,
+        PRIMARY KEY (episode_id, evidence_id),
+        FOREIGN KEY (episode_id) REFERENCES episodes(id) ON DELETE CASCADE
+      );
+      CREATE TABLE IF NOT EXISTS episode_revisions (
+        episode_id TEXT NOT NULL,
+        revision INTEGER NOT NULL,
+        record_json TEXT NOT NULL,
+        PRIMARY KEY (episode_id, revision)
+      );
+      CREATE TABLE IF NOT EXISTS governance_events (
+        id TEXT PRIMARY KEY,
+        episode_id TEXT NOT NULL,
+        revision INTEGER NOT NULL,
+        event_json TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS tombstones (
+        id TEXT PRIMARY KEY,
+        last_revision INTEGER NOT NULL,
+        forgotten_at TEXT NOT NULL,
+        tombstone_json TEXT NOT NULL
+      );
+    `);
+    for (const row of rows) {
+      const previous = EpisodicMemoryRecordV1Schema.parse(JSON.parse(row.recordJson));
+      const migrated = EpisodicMemoryRecordV2Schema.parse({
+        ...previous,
+        schemaVersion: "pragma.memory-episodic/v2",
+        bindings: previous.bindings.map((consumerRef) => ({
+          consumerRef,
+          recall: "allow",
+          export: "deny",
+          permissionRevision: 1,
+        })),
+      });
+      database
+        .prepare("UPDATE episodes SET record_json = ? WHERE id = ?")
+        .run(JSON.stringify(migrated), row.id);
+      database
+        .prepare(
+          "INSERT OR IGNORE INTO episode_revisions(episode_id, revision, record_json) VALUES (?, ?, ?)",
+        )
+        .run(migrated.id, migrated.revision, JSON.stringify(migrated));
+    }
+    database.exec("PRAGMA user_version = 2; COMMIT;");
+  } catch (error) {
+    rollback(database);
+    throw error;
+  }
+}
+
+function rollback(database: DatabaseSync): void {
+  try {
+    database.exec("ROLLBACK;");
+  } catch {
+    // No migration transaction remained active.
+  }
+}

--- a/packages/memory/src/storage/migrations/episodic-jobs/index.ts
+++ b/packages/memory/src/storage/migrations/episodic-jobs/index.ts
@@ -1,0 +1,9 @@
+import { migrateEpisodicJobsV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export { EpisodicExtractionJobV1Schema } from "./schemas/v1.ts";
+export { EpisodicExtractionJobV2Schema } from "./schemas/v2.ts";
+export { migrateEpisodicJobsV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export const EPISODIC_JOB_STORAGE_MIGRATIONS = Object.freeze([
+  { fromVersion: 1, toVersion: 2, migrate: migrateEpisodicJobsV1ToV2 },
+] as const);

--- a/packages/memory/src/storage/migrations/episodic-jobs/schemas/v1.ts
+++ b/packages/memory/src/storage/migrations/episodic-jobs/schemas/v1.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const EpisodicExtractionJobV1Schema = z
+  .object({
+    schemaVersion: z.literal("pragma.memory-extraction-job/v1"),
+    id: z.string().min(1),
+    executionId: z.string().min(1),
+    terminalMessageId: z.string().min(1),
+    status: z.enum(["pending", "running", "needs_attention", "completed"]),
+    attempts: z.number().int().nonnegative(),
+    retryAt: z.string().datetime().optional(),
+    leaseUntil: z.string().datetime().optional(),
+    lastErrorCode: z.string().min(1).optional(),
+    completion: z.enum(["retained", "rejected"]).optional(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();

--- a/packages/memory/src/storage/migrations/episodic-jobs/schemas/v2.ts
+++ b/packages/memory/src/storage/migrations/episodic-jobs/schemas/v2.ts
@@ -1,0 +1,1 @@
+export { EpisodicExtractionJobSchema as EpisodicExtractionJobV2Schema } from "../../../../episodic/schema.ts";

--- a/packages/memory/src/storage/migrations/episodic-jobs/steps/v1-to-v2.ts
+++ b/packages/memory/src/storage/migrations/episodic-jobs/steps/v1-to-v2.ts
@@ -1,0 +1,55 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { EpisodicExtractionJobV1Schema } from "../schemas/v1.ts";
+import { EpisodicExtractionJobV2Schema } from "../schemas/v2.ts";
+
+export function migrateEpisodicJobsV1ToV2(database: DatabaseSync): void {
+  const rows = database
+    .prepare("SELECT id, job_json AS jobJson FROM jobs")
+    .all() as unknown as readonly { readonly id: string; readonly jobJson: string }[];
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    database.exec(`
+      CREATE TABLE IF NOT EXISTS capture_stats (
+        execution_id TEXT PRIMARY KEY,
+        stats_json TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS deleted_executions (
+        execution_id TEXT PRIMARY KEY,
+        deleted_at TEXT NOT NULL
+      );
+    `);
+    for (const row of rows) {
+      const previous = EpisodicExtractionJobV1Schema.parse(JSON.parse(row.jobJson));
+      const migrated = EpisodicExtractionJobV2Schema.parse({
+        ...previous,
+        schemaVersion: "pragma.memory-extraction-job/v2",
+        revision: 1,
+        totalAttempts: previous.attempts,
+        ...(previous.status === "completed"
+          ? { completedAt: previous.updatedAt }
+          : previous.status === "needs_attention"
+            ? {
+                attentionSince: previous.updatedAt,
+                failureClass: "transient-exhausted",
+              }
+            : {}),
+      });
+      database
+        .prepare("UPDATE jobs SET status = ?, job_json = ? WHERE id = ?")
+        .run(migrated.status, JSON.stringify(migrated), row.id);
+    }
+    database.exec("PRAGMA user_version = 2; COMMIT;");
+  } catch (error) {
+    rollback(database);
+    throw error;
+  }
+}
+
+function rollback(database: DatabaseSync): void {
+  try {
+    database.exec("ROLLBACK;");
+  } catch {
+    // No migration transaction remained active.
+  }
+}

--- a/packages/memory/src/storage/migrations/semantic-data/index.ts
+++ b/packages/memory/src/storage/migrations/semantic-data/index.ts
@@ -1,0 +1,9 @@
+import { migrateSemanticDataV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export { SemanticFactV1Schema } from "./schemas/v1.ts";
+export { SemanticFactV2StorageSchema } from "./schemas/v2.ts";
+export { migrateSemanticDataV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export const SEMANTIC_DATA_STORAGE_MIGRATIONS = Object.freeze([
+  { fromVersion: 1, toVersion: 2, migrate: migrateSemanticDataV1ToV2 },
+] as const);

--- a/packages/memory/src/storage/migrations/semantic-data/schemas/v1.ts
+++ b/packages/memory/src/storage/migrations/semantic-data/schemas/v1.ts
@@ -1,0 +1,1 @@
+export { SemanticFactSchema as SemanticFactV1Schema } from "@pragma/shared";

--- a/packages/memory/src/storage/migrations/semantic-data/schemas/v2.ts
+++ b/packages/memory/src/storage/migrations/semantic-data/schemas/v2.ts
@@ -1,0 +1,1 @@
+export { SemanticFactSchema as SemanticFactV2StorageSchema } from "@pragma/shared";

--- a/packages/memory/src/storage/migrations/semantic-data/steps/v1-to-v2.ts
+++ b/packages/memory/src/storage/migrations/semantic-data/steps/v1-to-v2.ts
@@ -1,0 +1,16 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export function migrateSemanticDataV1ToV2(database: DatabaseSync): void {
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    // v2 adds governance-side tables but does not change pragma.memory-semantic/v1 records.
+    database.exec("PRAGMA user_version = 2; COMMIT;");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK;");
+    } catch {
+      // No migration transaction remained active.
+    }
+    throw error;
+  }
+}

--- a/packages/memory/src/storage/migrations/semantic-jobs/index.ts
+++ b/packages/memory/src/storage/migrations/semantic-jobs/index.ts
@@ -1,0 +1,9 @@
+import { migrateSemanticJobsV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export { SemanticExtractionJobV1Schema } from "./schemas/v1.ts";
+export { SemanticExtractionJobV2Schema } from "./schemas/v2.ts";
+export { migrateSemanticJobsV1ToV2 } from "./steps/v1-to-v2.ts";
+
+export const SEMANTIC_JOB_STORAGE_MIGRATIONS = Object.freeze([
+  { fromVersion: 1, toVersion: 2, migrate: migrateSemanticJobsV1ToV2 },
+] as const);

--- a/packages/memory/src/storage/migrations/semantic-jobs/schemas/v1.ts
+++ b/packages/memory/src/storage/migrations/semantic-jobs/schemas/v1.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const SemanticExtractionJobV1Schema = z
+  .object({
+    schemaVersion: z.literal("pragma.memory-semantic-job/v1"),
+    id: z.string().min(1),
+    executionId: z.string().min(1),
+    terminalMessageId: z.string().min(1),
+    status: z.enum(["pending", "running", "needs_attention", "completed"]),
+    attempts: z.number().int().nonnegative(),
+    retryAt: z.string().datetime().optional(),
+    leaseUntil: z.string().datetime().optional(),
+    lastErrorCode: z.string().min(1).optional(),
+    completion: z.enum(["retained", "rejected"]).optional(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();

--- a/packages/memory/src/storage/migrations/semantic-jobs/schemas/v2.ts
+++ b/packages/memory/src/storage/migrations/semantic-jobs/schemas/v2.ts
@@ -1,0 +1,1 @@
+export { SemanticExtractionJobSchema as SemanticExtractionJobV2Schema } from "../../../../semantic/schema.ts";

--- a/packages/memory/src/storage/migrations/semantic-jobs/steps/v1-to-v2.ts
+++ b/packages/memory/src/storage/migrations/semantic-jobs/steps/v1-to-v2.ts
@@ -1,0 +1,55 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { SemanticExtractionJobV1Schema } from "../schemas/v1.ts";
+import { SemanticExtractionJobV2Schema } from "../schemas/v2.ts";
+
+export function migrateSemanticJobsV1ToV2(database: DatabaseSync): void {
+  const rows = database
+    .prepare("SELECT id, job_json AS jobJson FROM jobs")
+    .all() as unknown as readonly { readonly id: string; readonly jobJson: string }[];
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    database.exec(`
+      CREATE TABLE IF NOT EXISTS capture_stats (
+        execution_id TEXT PRIMARY KEY,
+        stats_json TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS deleted_executions (
+        execution_id TEXT PRIMARY KEY,
+        deleted_at TEXT NOT NULL
+      );
+    `);
+    for (const row of rows) {
+      const previous = SemanticExtractionJobV1Schema.parse(JSON.parse(row.jobJson));
+      const migrated = SemanticExtractionJobV2Schema.parse({
+        ...previous,
+        schemaVersion: "pragma.memory-semantic-job/v2",
+        revision: 1,
+        totalAttempts: previous.attempts,
+        ...(previous.status === "completed"
+          ? { completedAt: previous.updatedAt }
+          : previous.status === "needs_attention"
+            ? {
+                attentionSince: previous.updatedAt,
+                failureClass: "transient-exhausted",
+              }
+            : {}),
+      });
+      database
+        .prepare("UPDATE jobs SET status = ?, job_json = ? WHERE id = ?")
+        .run(migrated.status, JSON.stringify(migrated), row.id);
+    }
+    database.exec("PRAGMA user_version = 2; COMMIT;");
+  } catch (error) {
+    rollback(database);
+    throw error;
+  }
+}
+
+function rollback(database: DatabaseSync): void {
+  try {
+    database.exec("ROLLBACK;");
+  } catch {
+    // No migration transaction remained active.
+  }
+}

--- a/packages/memory/src/storage/sqlite-migration-backup.ts
+++ b/packages/memory/src/storage/sqlite-migration-backup.ts
@@ -1,0 +1,99 @@
+import { rename, rm, stat } from "node:fs/promises";
+import { backup, type DatabaseSync } from "node:sqlite";
+
+export interface SqliteMigrationStep {
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly migrate: (database: DatabaseSync) => void;
+}
+
+export async function runAdjacentSqliteMigrations(input: {
+  readonly database: DatabaseSync;
+  readonly databasePath: string;
+  readonly family: string;
+  readonly targetVersion: number;
+  readonly migrations: readonly SqliteMigrationStep[];
+}): Promise<void> {
+  let version = readVersion(input.database);
+  if (version > input.targetVersion) {
+    throw new Error(`unsupported-state-version:${input.family}/v${version}`);
+  }
+  while (version < input.targetVersion) {
+    const matches = input.migrations.filter((step) => step.fromVersion === version);
+    if (matches.length !== 1 || matches[0]!.toVersion !== version + 1) {
+      throw new Error(`missing-adjacent-migration:${input.family}/v${version}`);
+    }
+    const step = matches[0]!;
+    await ensureSqliteMigrationBackup(input.database, input.databasePath, version);
+    step.migrate(input.database);
+    const migratedVersion = readVersion(input.database);
+    if (migratedVersion !== step.toVersion) {
+      throw new Error(`invalid-migration-result:${input.family}/v${version}-to-v${step.toVersion}`);
+    }
+    version = migratedVersion;
+  }
+}
+
+export function assertFreshSqliteDatabase(database: DatabaseSync, family: string): void {
+  const row = database
+    .prepare(
+      `SELECT name FROM sqlite_master
+       WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+       ORDER BY name LIMIT 1`,
+    )
+    .get() as { readonly name: string } | undefined;
+  if (row !== undefined) {
+    throw new Error(`corrupt-state-version:${family}/v0-with-table:${row.name}`);
+  }
+}
+
+export async function ensureSqliteMigrationBackup(
+  database: DatabaseSync,
+  databasePath: string,
+  sourceVersion: number,
+): Promise<void> {
+  const destination = migrationBackupPath(databasePath, sourceVersion);
+  try {
+    await stat(destination);
+    return;
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+  }
+  const temporary = `${destination}.tmp`;
+  await rm(temporary, { force: true });
+  await backup(database, temporary);
+  await rename(temporary, destination);
+}
+
+export async function removeExpiredSqliteMigrationBackup(
+  databasePath: string,
+  sourceVersion: number,
+  cutoffMs: number,
+): Promise<void> {
+  const path = migrationBackupPath(databasePath, sourceVersion);
+  try {
+    if ((await stat(path)).mtimeMs <= cutoffMs) await rm(path, { force: true });
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+  }
+}
+
+export function migrationBackupPath(databasePath: string, sourceVersion: number): string {
+  return `${databasePath}.v${sourceVersion}.backup`;
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { readonly code?: unknown }).code === "ENOENT"
+  );
+}
+
+function readVersion(database: DatabaseSync): number {
+  const row = database.prepare("PRAGMA user_version").get() as unknown as {
+    readonly user_version: number;
+  };
+  return row.user_version;
+}

--- a/packages/memory/test/bounded-evidence.test.ts
+++ b/packages/memory/test/bounded-evidence.test.ts
@@ -1,0 +1,100 @@
+import { MemoryEvidenceEnvelopeSchema, type MemoryEvidenceEnvelope } from "@pragma/shared";
+import { describe, expect, it } from "vitest";
+
+import { selectBoundedMemoryEvidence } from "../src/index.ts";
+
+describe("bounded Memory Evidence", () => {
+  it("keeps the root goal and terminal result ahead of low-value tool events", () => {
+    const evidence = [
+      message("goal", "user", "Implement storage governance", 0),
+      tool("started", "execution.tool.started", "started", 1),
+      tool("completed", "execution.tool.completed", "completed", 2),
+      message("assistant", "assistant", "Done", 3),
+      terminal(4),
+    ];
+    const selection = selectBoundedMemoryEvidence(evidence, {
+      maxRecords: 2,
+      maxBytes: 1_000_000,
+    });
+
+    expect(selection.retained.map((item) => item.messageId)).toEqual(["goal", "terminal"]);
+    expect(selection.omittedStats).toMatchObject({ records: 3 });
+    expect(JSON.stringify(selection.omittedStats)).not.toContain("Implement storage governance");
+  });
+
+  it("deduplicates tool start when a terminal tool phase exists", () => {
+    const selection = selectBoundedMemoryEvidence(
+      [
+        tool("started", "execution.tool.started", "started", 1),
+        tool("failed", "execution.tool.failed", "failed", 2),
+      ],
+      { maxRecords: 10, maxBytes: 1_000_000 },
+    );
+    expect(selection.retained.map((item) => item.messageId)).toEqual(["failed"]);
+    expect(selection.omittedStats.byTopic["execution.tool.started"]).toBe(1);
+  });
+});
+
+function message(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+  second: number,
+): MemoryEvidenceEnvelope {
+  return envelope(
+    id,
+    "execution.message.appended",
+    role === "user" ? { message: { role, text } } : { message: { role, text, stopReason: "stop" } },
+    second,
+  );
+}
+
+function tool(
+  id: string,
+  topic: string,
+  phase: "started" | "completed" | "failed",
+  second: number,
+): MemoryEvidenceEnvelope {
+  return envelope(id, topic, { toolCallId: "tool-1", toolName: "shell", phase }, second);
+}
+
+function terminal(second: number): MemoryEvidenceEnvelope {
+  return envelope("terminal", "execution.execution.terminal", { outcome: "succeeded" }, second);
+}
+
+function envelope(
+  messageId: string,
+  topic: string,
+  payload: unknown,
+  second: number,
+): MemoryEvidenceEnvelope {
+  return MemoryEvidenceEnvelopeSchema.parse({
+    schemaVersion: "pragma.memory-evidence/v1",
+    messageId,
+    topic,
+    schemaRef:
+      topic === "execution.message.appended"
+        ? "pragma.memory.execution-message/v2"
+        : topic === "execution.execution.terminal"
+          ? "pragma.memory.execution-terminal/v2"
+          : "pragma.memory.tool-event/v2",
+    sourceRef: {
+      type: "pragma.execution-event",
+      id: messageId,
+      canonicalEventId: `canonical-${messageId}`,
+    },
+    subjectRefs: [{ type: "pragma.execution", id: "execution" }],
+    correlationId: "execution",
+    occurredAt: `2026-08-01T00:00:0${second}.000Z`,
+    visibility: { mode: "host-private" },
+    sensitivity: "internal",
+    bindings: [],
+    policySnapshot: {
+      capture: true,
+      recall: true,
+      learning: "local-candidates",
+      appliedRevisions: [],
+    },
+    payload,
+  });
+}

--- a/packages/memory/test/episodic-memory.test.ts
+++ b/packages/memory/test/episodic-memory.test.ts
@@ -31,8 +31,13 @@ afterEach(async () => {
 describe("Episodic Memory", () => {
   it("extracts a layered, evidence-traceable episode without WorkingState", async () => {
     const root = await temporaryRoot();
+    const now = new Date("2026-08-03T12:00:00.000Z");
     const extractor = fakeExtractor();
-    const module = await createEpisodicMemoryModule({ pragmaHome: root, extractor });
+    const module = await createEpisodicMemoryModule({
+      pragmaHome: root,
+      extractor,
+      now: () => now,
+    });
     const evidence = executionEvidence("execution-a");
 
     await module.consume(evidence);
@@ -47,6 +52,7 @@ describe("Episodic Memory", () => {
       outcome: { status: "succeeded" },
     });
     expect(extractor.extract).toHaveBeenCalledOnce();
+    expect((await module.store.listExtractionJobs())[0]?.completedAt).toBe(now.toISOString());
     const readEvidence = vi.spyOn(module.store, "readEvidence");
     const getEvidence = vi.spyOn(module.store, "getEvidenceForRecall");
 
@@ -69,11 +75,14 @@ describe("Episodic Memory", () => {
     expect(detail.ok && detail.value.content).toContain("## Evidence");
     expect(readEvidence).not.toHaveBeenCalled();
     expect(getEvidence).not.toHaveBeenCalled();
+    await expect(
+      context.readContext({ id: `episodic/evidence/${evidence[0]!.messageId}.md` }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "context_not_found" } });
     const evidenceDetail = await context.readContext({
-      id: `episodic/evidence/${evidence[0]!.messageId}.md`,
+      id: `episodic/evidence/${evidence.at(-1)!.messageId}.md`,
     });
-    expect(evidenceDetail.ok && evidenceDetail.value.content).toContain("Safe payload");
-    expect(getEvidence).toHaveBeenCalledOnce();
+    expect(evidenceDetail.ok && evidenceDetail.value.content).toContain("succeeded");
+    expect(getEvidence).toHaveBeenCalledTimes(2);
     const search = await context.searchContext({ query: evidence[0]!.messageId });
     expect(search.ok && search.value.some((match) => match.id.includes("/evidence/"))).toBe(false);
     module.close();
@@ -259,7 +268,7 @@ describe("Episodic Memory", () => {
     ).rejects.toThrow("memory_permission_expansion_denied");
     expect(await module.store.listForRecall(expertScope("expert-a"))).toEqual([]);
     expect(await module.store.history(initial.id)).toHaveLength(2);
-    expect(await module.store.getEvidence(evidence[0]!.messageId)).toBeDefined();
+    expect(await module.store.getEvidence(evidence.at(-1)!.messageId)).toBeDefined();
 
     await expect(
       module.store.forget({
@@ -281,7 +290,7 @@ describe("Episodic Memory", () => {
     });
     expect(await module.store.get(initial.id)).toBeUndefined();
     expect(await module.store.history(initial.id)).toEqual([]);
-    expect(await module.store.getEvidence(evidence[0]!.messageId)).toBeUndefined();
+    expect(await module.store.getEvidence(evidence.at(-1)!.messageId)).toBeUndefined();
 
     await module.consume([
       terminalEvidence("execution-governance", "terminal-after-forget", "2026-08-03T12:03:00.000Z"),
@@ -356,6 +365,12 @@ describe("Episodic Memory", () => {
         },
       ],
     });
+    const backup = new DatabaseSync(join(dataRoot, "episodes.sqlite.v1.backup"));
+    expect(
+      (backup.prepare("PRAGMA user_version").get() as unknown as { readonly user_version: number })
+        .user_version,
+    ).toBe(1);
+    backup.close();
     module.close();
   });
 
@@ -504,6 +519,208 @@ describe("Episodic Memory", () => {
     expect(await conflict.store.list()).toEqual([]);
     expect((await conflict.store.inspect()).needsAttention).toBe(1);
     conflict.close();
+  });
+
+  it("expires failed payloads after 30 days without startup-style retry", async () => {
+    const module = await createEpisodicMemoryModule({ pragmaHome: await temporaryRoot() });
+    await module.consume(executionEvidence("expiry"));
+    const job = await module.store.claimDueJob(new Date("2026-08-01T00:00:03.000Z"));
+    expect(job).toBeDefined();
+    await module.store.fail({
+      job: job!,
+      errorCode: "memory_extractor_profile_invalid",
+      now: new Date("2026-08-01T00:00:04.000Z"),
+      retry: "configuration",
+    });
+
+    await module.store.maintain(new Date("2026-09-01T00:00:05.000Z"));
+    const [expired] = await module.store.listExtractionJobs();
+    expect(expired).toMatchObject({ status: "expired", failureClass: "configuration" });
+    expect(await module.store.readEvidence("expiry")).toEqual([]);
+    await expect(
+      module.store.retryJob({
+        id: expired!.id,
+        expectedRevision: expired!.revision,
+        now: new Date(),
+      }),
+    ).rejects.toThrow("memory_extraction_job_not_retryable");
+    module.close();
+  });
+
+  it("does not recreate transient state or long-term memory after an Execution is deleted", async () => {
+    const module = await createEpisodicMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor: fakeExtractor(),
+    });
+    const evidence = executionEvidence("deleted-execution");
+    await module.consume(evidence);
+    const claimed = await module.store.claimDueJob(new Date("2026-08-04T00:00:00.000Z"));
+    expect(claimed).toBeDefined();
+    await module.store.deleteExecutionState(["deleted-execution"]);
+    await module.store.fail({
+      job: claimed!,
+      errorCode: "late_extractor_failure",
+      now: new Date("2026-08-04T00:01:00.000Z"),
+      retry: "transient",
+    });
+
+    await module.runBackgroundOnce?.();
+    await module.consume(evidence);
+    await module.runBackgroundOnce?.();
+
+    expect(await module.store.readEvidence("deleted-execution")).toEqual([]);
+    expect(await module.store.listExtractionJobs()).toEqual([]);
+    expect(await module.store.list()).toEqual([]);
+    module.close();
+  });
+
+  it("upgrades persisted extraction jobs from v1 to v2 on first access", async () => {
+    const root = await temporaryRoot();
+    const stateRoot = new PragmaPaths({ pragmaHome: root }).memoryModuleStateRoot(
+      "pragma.memory.episodic",
+    );
+    await mkdir(stateRoot, { recursive: true });
+    const database = new DatabaseSync(join(stateRoot, "jobs.sqlite"));
+    database.exec(`
+      CREATE TABLE jobs (
+        id TEXT PRIMARY KEY,
+        execution_id TEXT NOT NULL UNIQUE,
+        terminal_message_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        retry_at TEXT,
+        lease_until TEXT,
+        job_json TEXT NOT NULL
+      );
+      PRAGMA user_version = 1;
+    `);
+    const legacyJob = {
+      schemaVersion: "pragma.memory-extraction-job/v1",
+      id: "legacy-job",
+      executionId: "legacy-execution",
+      terminalMessageId: "legacy-terminal",
+      status: "needs_attention",
+      attempts: 3,
+      lastErrorCode: "legacy_failure",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    };
+    database
+      .prepare(
+        `INSERT INTO jobs(id, execution_id, terminal_message_id, status, retry_at, lease_until, job_json)
+         VALUES (?, ?, ?, ?, NULL, NULL, ?)`,
+      )
+      .run(
+        legacyJob.id,
+        legacyJob.executionId,
+        legacyJob.terminalMessageId,
+        legacyJob.status,
+        JSON.stringify(legacyJob),
+      );
+    database.close();
+
+    const module = await createEpisodicMemoryModule({ pragmaHome: root });
+    await expect(module.store.listExtractionJobs()).resolves.toEqual([
+      expect.objectContaining({
+        schemaVersion: "pragma.memory-extraction-job/v2",
+        id: "legacy-job",
+        revision: 1,
+        totalAttempts: 3,
+        status: "needs_attention",
+        failureClass: "transient-exhausted",
+      }),
+    ]);
+    const backup = new DatabaseSync(join(stateRoot, "jobs.sqlite.v1.backup"));
+    expect(
+      (backup.prepare("PRAGMA user_version").get() as unknown as { readonly user_version: number })
+        .user_version,
+    ).toBe(1);
+    backup.close();
+    module.close();
+
+    const future = new DatabaseSync(join(stateRoot, "jobs.sqlite"));
+    future.exec("PRAGMA user_version = 3;");
+    future.close();
+    await expect(createEpisodicMemoryModule({ pragmaHome: root })).rejects.toThrow(
+      "unsupported-state-version:pragma.memory-episodic-jobs/v3",
+    );
+  });
+
+  it("fails closed when an unversioned episodic database already contains tables", async () => {
+    const root = await temporaryRoot();
+    const stateRoot = new PragmaPaths({ pragmaHome: root }).memoryModuleStateRoot(
+      "pragma.memory.episodic",
+    );
+    await mkdir(stateRoot, { recursive: true });
+    const database = new DatabaseSync(join(stateRoot, "jobs.sqlite"));
+    database.exec("CREATE TABLE jobs (id TEXT PRIMARY KEY);");
+    database.close();
+
+    await expect(createEpisodicMemoryModule({ pragmaHome: root })).rejects.toThrow(
+      "corrupt-state-version:pragma.memory-episodic-jobs/v0-with-table:jobs",
+    );
+  });
+
+  it("preserves v1 state and replays the migration after a malformed job is repaired", async () => {
+    const root = await temporaryRoot();
+    const stateRoot = new PragmaPaths({ pragmaHome: root }).memoryModuleStateRoot(
+      "pragma.memory.episodic",
+    );
+    await mkdir(stateRoot, { recursive: true });
+    const statePath = join(stateRoot, "jobs.sqlite");
+    const database = new DatabaseSync(statePath);
+    database.exec(`
+      CREATE TABLE jobs (
+        id TEXT PRIMARY KEY,
+        execution_id TEXT NOT NULL UNIQUE,
+        terminal_message_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        retry_at TEXT,
+        lease_until TEXT,
+        job_json TEXT NOT NULL
+      );
+      PRAGMA user_version = 1;
+    `);
+    const malformed = {
+      schemaVersion: "pragma.memory-extraction-job/v1",
+      id: "repairable-job",
+      executionId: "repairable-execution",
+      terminalMessageId: "repairable-terminal",
+      status: "pending",
+      attempts: 0,
+    };
+    database
+      .prepare(
+        `INSERT INTO jobs(id, execution_id, terminal_message_id, status, retry_at, lease_until, job_json)
+         VALUES (?, ?, ?, ?, NULL, NULL, ?)`,
+      )
+      .run(
+        malformed.id,
+        malformed.executionId,
+        malformed.terminalMessageId,
+        malformed.status,
+        JSON.stringify(malformed),
+      );
+    database.close();
+
+    await expect(createEpisodicMemoryModule({ pragmaHome: root })).rejects.toThrow();
+    const preserved = new DatabaseSync(statePath);
+    expect(
+      (
+        preserved.prepare("PRAGMA user_version").get() as unknown as {
+          readonly user_version: number;
+        }
+      ).user_version,
+    ).toBe(1);
+    preserved
+      .prepare("UPDATE jobs SET job_json = ? WHERE id = ?")
+      .run(JSON.stringify({ ...malformed, updatedAt: "2026-08-01T00:00:00.000Z" }), malformed.id);
+    preserved.close();
+
+    const recovered = await createEpisodicMemoryModule({ pragmaHome: root });
+    expect((await recovered.store.listExtractionJobs())[0]).toMatchObject({
+      schemaVersion: "pragma.memory-extraction-job/v2",
+      id: malformed.id,
+    });
+    recovered.close();
   });
 });
 

--- a/packages/memory/test/memory-plane.test.ts
+++ b/packages/memory/test/memory-plane.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 
-import { createFileCanonicalEventFeed, createFileExecutionStore } from "@pragma/core";
+import { createFileCanonicalEventFeed, createFileExecutionStore, PragmaPaths } from "@pragma/core";
 import {
   CanonicalEventEnvelopeSchema,
   MemoryEvidenceEnvelopeSchema,
@@ -317,7 +318,7 @@ describe("Memory Plane phase one", () => {
 
     expect(consumeCount).toBe(expectedConsumes);
     await expect(state.listPending("pragma.memory.probe")).resolves.toEqual([]);
-    await expect(canonical.inspect()).resolves.toEqual({ lastSequence: 3, eventCount: 3 });
+    await expect(canonical.inspect()).resolves.toMatchObject({ lastSequence: 3, eventCount: 3 });
     expect(registry.diagnostic("pragma.memory.probe")).toMatchObject({
       status: "healthy",
       cursor: { sequence: 3 },
@@ -332,6 +333,57 @@ describe("Memory Plane phase one", () => {
     const record = await context.readContext({ id: "probe/items/entries.md" });
     expect(record.ok && record.value.content.match(/^- /gm)).toHaveLength(1);
     canonical.close();
+  });
+
+  it("migrates legacy dead letters and removes expired content", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-memory-dead-letters-"));
+    const consumerId = "pragma.memory.legacy-consumer";
+    const moduleRoot = new PragmaPaths({ pragmaHome: home }).memoryModuleStateRoot(consumerId);
+    await mkdir(moduleRoot, { recursive: true });
+    await writeFile(
+      join(moduleRoot, "dead-letters.json"),
+      JSON.stringify([
+        {
+          schemaVersion: "pragma.memory-dead-letter/v1",
+          consumerId,
+          messageId: "old-message",
+          sequence: 1,
+          errorCode: "old_failure",
+          failedAt: "2026-06-01T00:00:00.000Z",
+        },
+      ]),
+    );
+    const state = createFileMemoryPipelineStateStore({ pragmaHome: home });
+
+    await expect(state.list(consumerId)).resolves.toHaveLength(1);
+    await expect(state.maintain(new Date("2026-08-04T00:00:00.000Z"))).resolves.toEqual({
+      deletedDeadLetters: 1,
+    });
+    await expect(state.list(consumerId)).resolves.toEqual([]);
+    await expect(state.inspectDeadLetters()).resolves.toEqual({ entries: 0, bytes: 0 });
+  });
+
+  it("closes the SQLite handle when legacy dead-letter validation fails", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-memory-invalid-dead-letters-"));
+    const consumerId = "pragma.memory.invalid-legacy-consumer";
+    const moduleRoot = new PragmaPaths({ pragmaHome: home }).memoryModuleStateRoot(consumerId);
+    await mkdir(moduleRoot, { recursive: true });
+    await writeFile(
+      join(moduleRoot, "dead-letters.json"),
+      JSON.stringify([{ schemaVersion: "pragma.memory-dead-letter/v1", consumerId }]),
+    );
+    const state = createFileMemoryPipelineStateStore({ pragmaHome: home });
+
+    await expect(state.list(consumerId)).rejects.toThrow();
+    const database = new DatabaseSync(join(moduleRoot, "dead-letters.sqlite"));
+    expect(
+      (
+        database.prepare("PRAGMA user_version").get() as unknown as {
+          readonly user_version: number;
+        }
+      ).user_version,
+    ).toBe(1);
+    database.close();
   });
 });
 

--- a/packages/memory/test/semantic-memory.test.ts
+++ b/packages/memory/test/semantic-memory.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -80,6 +80,7 @@ describe("Semantic Memory", () => {
   });
 
   it("merges equivalent observations and preserves exclusive conflicts symmetrically", async () => {
+    const now = new Date("2026-08-03T12:00:00.000Z");
     const extractor = fakeExtractor((input) => {
       const text = evidenceText(input);
       return text.includes("light")
@@ -89,6 +90,7 @@ describe("Semantic Memory", () => {
     const module = await createSemanticMemoryModule({
       pragmaHome: await temporaryRoot(),
       extractor,
+      now: () => now,
     });
     for (const [executionId, text] of [
       ["execution-dark-1", "The theme is dark."],
@@ -112,6 +114,13 @@ describe("Semantic Memory", () => {
     expect(light.conflictsWith).toEqual([dark.id]);
     expect(dark.status).toBe("active");
     expect(light.status).toBe("active");
+    expect(dark.updatedAt).toBe(now.toISOString());
+    expect(light.updatedAt).toBe(now.toISOString());
+    expect(
+      (await module.store.listExtractionJobs()).every(
+        (job) => job.completedAt === now.toISOString(),
+      ),
+    ).toBe(true);
     module.close();
   });
 
@@ -404,6 +413,70 @@ describe("Semantic Memory", () => {
     await expect(
       createSemanticMemoryModule({ pragmaHome: root, extractor: fakeExtractor() }),
     ).rejects.toThrow("unsupported-state-version:pragma.memory-semantic-store/v3");
+  });
+
+  it("upgrades historical semantic jobs through the registered migration and keeps a backup", async () => {
+    const root = await temporaryRoot();
+    const stateRoot = new PragmaPaths({ pragmaHome: root }).memoryModuleStateRoot(
+      "pragma.memory.semantic",
+    );
+    await mkdir(stateRoot, { recursive: true });
+    const statePath = join(stateRoot, "jobs.sqlite");
+    const database = new DatabaseSync(statePath);
+    database.exec(`
+      CREATE TABLE jobs (
+        id TEXT PRIMARY KEY,
+        execution_id TEXT NOT NULL,
+        terminal_message_id TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL,
+        retry_at TEXT,
+        lease_until TEXT,
+        job_json TEXT NOT NULL
+      );
+      PRAGMA user_version = 1;
+    `);
+    const legacy = {
+      schemaVersion: "pragma.memory-semantic-job/v1",
+      id: "legacy-semantic-job",
+      executionId: "legacy-semantic-execution",
+      terminalMessageId: "legacy-semantic-terminal",
+      status: "needs_attention",
+      attempts: 3,
+      lastErrorCode: "legacy_failure",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    };
+    database
+      .prepare(
+        `INSERT INTO jobs(id, execution_id, terminal_message_id, status, retry_at, lease_until, job_json)
+         VALUES (?, ?, ?, ?, NULL, NULL, ?)`,
+      )
+      .run(
+        legacy.id,
+        legacy.executionId,
+        legacy.terminalMessageId,
+        legacy.status,
+        JSON.stringify(legacy),
+      );
+    database.close();
+
+    const module = await createSemanticMemoryModule({ pragmaHome: root });
+    await expect(module.store.listExtractionJobs()).resolves.toEqual([
+      expect.objectContaining({
+        schemaVersion: "pragma.memory-semantic-job/v2",
+        id: legacy.id,
+        revision: 1,
+        totalAttempts: 3,
+        status: "needs_attention",
+        failureClass: "transient-exhausted",
+      }),
+    ]);
+    const backup = new DatabaseSync(`${statePath}.v1.backup`);
+    expect(
+      (backup.prepare("PRAGMA user_version").get() as unknown as { readonly user_version: number })
+        .user_version,
+    ).toBe(1);
+    backup.close();
+    module.close();
   });
 
   it("rejects extractor subject and Evidence references outside the supplied allowlists", async () => {

--- a/packages/shared/src/memory/memory-plane.schema.ts
+++ b/packages/shared/src/memory/memory-plane.schema.ts
@@ -211,6 +211,10 @@ export const MemoryModuleDiagnosticSchema = z.object({
       running: z.number().int().nonnegative(),
       needsAttention: z.number().int().nonnegative(),
       rejected: z.number().int().nonnegative(),
+      expired: z.number().int().nonnegative().default(0),
+      evidenceRecords: z.number().int().nonnegative().default(0),
+      evidenceBytes: z.number().int().nonnegative().default(0),
+      truncatedExecutions: z.number().int().nonnegative().default(0),
     })
     .optional(),
   updatedAt: z.string().datetime(),


### PR DESCRIPTION
## What

- introduce versioned storage policies, bounded evidence snapshots, and SQLite migration backups for episodic and semantic memory
- add canonical event feed migrations, checkpoint-safe retention, and degraded/blocked capacity diagnostics
- make curator retries explicit and CAS-safe while bounding failed payloads, diagnostics, and dead letters
- add replayable Mission cleanup journals that remove transient execution state without deleting durable episodes or facts
- expose storage health and policy controls in Desktop IPC, settings, Memory UI, documentation, and localized copy

## Why

A failed or stalled extraction could retain feed events, evidence snapshots, curator payloads, and diagnostics without a complete lifecycle boundary. Exceptional cases could therefore grow local storage indefinitely, while startup recovery and Mission deletion did not have sufficiently explicit retry, visibility, and crash-recovery semantics.

## Impact

- feed cleanup never crosses the minimum registered consumer checkpoint
- lagging consumers report degraded or blocked state instead of silently losing evidence
- pending evidence, prompts, failures, diagnostics, and dead letters have fixed limits or retention windows
- `needs_attention` jobs are not automatically revived at startup
- Mission deletion cleans only associated transient state; curated episodes and facts remain durable
- schema upgrades are forward-only, backed up, journaled where multi-file cleanup is involved, and fail closed on unsupported versions

## Validation

- `pnpm check` — passed (21/21 tasks; Memory 41 tests; Desktop 630 tests)
- `pnpm build` — passed (21/21 tasks; Desktop preload self-containment verified)
- `git diff --check` — passed
- three code-review passes completed; verified findings were fixed and re-tested