### PR TITLE
Fix memory extraction observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,19 @@ import { HealthResponseSchema } from "../../../shared/contracts/src/index.ts";
 
 禁止对内部依赖使用 `"*"`、固定 semver 或 npm registry 版本。
 
+## 语义资源 ID 与后台任务可观测性
+
+- Expert、ExpertTeam、Flow、Automation、Capability、ContextStore、RuntimeProfile 和 Evaluation
+  的 ID 必须是 16 位小写 Crockford Base32；允许 `0-9`、`a-h`、`j-k`、`m-n`、`p-t`、`v-z`，
+  禁止易混淆字符 `i`、`l`、`o`、`u`。
+- 内置或系统资源 ID 不得只靠人工检查字符串。必须在常量声明处通过权威运行时 Schema 构造 canonical ref，
+  并在第一个持久化或跨进程消费边界补集成测试；只 mock 掉边界的单元测试不算覆盖。
+- Evidence 捕获/发布不等于成功生成 Memory。计数器、日志和 UI 必须使用准确阶段名称，禁止把 Evidence
+  数量展示为记忆生成成功数量。
+- 后台任务进入 `needs_attention`、Module unavailable 或投递隔离时，所属子系统必须报告 degraded，日志和
+  用户界面必须展示 Module 与稳定错误码。可重试 Evidence 必须保留，修复配置或升级应用后可直接唤醒，
+  不要求用户重跑原任务。
+
 ## 协议与版本升级治理
 
 以下规则适用于所有持久化和跨进程协议，包括 DSL `apiVersion`、状态 `schemaVersion`、

--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.test.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.test.ts
@@ -2,12 +2,19 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createPragmaLogger, EXECUTION_CURRENT_EXPERT_ID_ATTR, PragmaPaths } from "@pragma/core";
+import {
+  createLoggerProvider,
+  createPragmaLogger,
+  EXECUTION_CURRENT_EXPERT_ID_ATTR,
+  PragmaPaths,
+} from "@pragma/core";
+import { MemoryEvidenceEnvelopeSchema, type PragmaLogRecord } from "@pragma/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   createDesktopMemoryPlane,
   resolveDesktopMemoryRecallScope,
+  resolveMemoryModuleHealthStatus,
 } from "./desktop-memory-plane.ts";
 
 const roots: string[] = [];
@@ -62,6 +69,114 @@ describe("DesktopMemoryPlane", () => {
       });
     });
     await plane.stop();
+  });
+
+  it("reports extraction jobs that need attention as a degraded user-visible status", async () => {
+    const pragmaHome = await temporaryRoot("pragma-desktop-memory-extraction-failed-");
+    const logs: PragmaLogRecord[] = [];
+    const loggerProvider = createLoggerProvider({
+      handler: { write: (record) => logs.push(record) },
+      minimumLevel: "debug",
+    });
+    const plane = await createDesktopMemoryPlane({
+      pragmaHome,
+      logger: createPragmaLogger(loggerProvider, { component: "desktop.memory-test" }),
+      pollIntervalMs: 10,
+    });
+    const now = new Date("2026-08-04T00:00:00.000Z");
+    await plane.episodicStore.ingest([
+      MemoryEvidenceEnvelopeSchema.parse({
+        schemaVersion: "pragma.memory-evidence/v1",
+        messageId: "terminal-memory-extraction-failed",
+        topic: "execution.execution.terminal",
+        schemaRef: "pragma.memory.execution-terminal/v2",
+        sourceRef: {
+          type: "pragma.execution",
+          id: "execution-memory-extraction-failed",
+          canonicalEventId: "canonical-memory-extraction-failed",
+        },
+        subjectRefs: [{ type: "pragma.expert", id: "7k2m9q4v8np6r3dt" }],
+        correlationId: "execution-memory-extraction-failed",
+        occurredAt: now.toISOString(),
+        visibility: { mode: "host-private" },
+        sensitivity: "internal",
+        bindings: [],
+        attribution: {
+          rootRef: { type: "pragma.expert", id: "7k2m9q4v8np6r3dt" },
+          producerRefs: [{ type: "pragma.expert", id: "7k2m9q4v8np6r3dt" }],
+        },
+        policySnapshot: {
+          capture: true,
+          recall: true,
+          learning: "local-candidates",
+          appliedRevisions: [],
+        },
+        payload: { outcome: "succeeded" },
+      }),
+    ]);
+    const job = await plane.episodicStore.claimDueJob(now);
+    if (job === undefined) throw new Error("Expected an episodic extraction job.");
+    await plane.episodicStore.fail({
+      job,
+      errorCode: "memory_curator_failed",
+      now,
+      retry: "configuration",
+    });
+
+    plane.start();
+    await vi.waitFor(async () => {
+      await expect(plane.getStatus()).resolves.toMatchObject({
+        state: "degraded",
+        lastError: { code: "memory_curator_failed" },
+        modules: expect.arrayContaining([
+          expect.objectContaining({
+            moduleId: "pragma.memory.episodic",
+            status: "degraded",
+            lastErrorCode: "memory_curator_failed",
+            work: expect.objectContaining({ needsAttention: 1 }),
+          }),
+        ]),
+      });
+    });
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        event: "desktop.memory_pipeline_degraded",
+        attributes: expect.objectContaining({ code: "memory_curator_failed" }),
+      }),
+    );
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        event: "desktop.memory_extraction_needs_attention",
+        attributes: expect.objectContaining({
+          moduleId: "pragma.memory.episodic",
+          code: "memory_curator_failed",
+          needsAttention: 1,
+        }),
+      }),
+    );
+
+    await plane.wakeMemoryJobs();
+    await vi.waitFor(async () => {
+      await expect(plane.getStatus()).resolves.toMatchObject({
+        state: "running",
+        modules: expect.arrayContaining([
+          expect.objectContaining({
+            moduleId: "pragma.memory.episodic",
+            status: "healthy",
+            work: expect.objectContaining({ pending: 1, needsAttention: 0 }),
+          }),
+        ]),
+      });
+    });
+    await plane.stop();
+  });
+
+  it("does not downgrade an unavailable module when extraction also needs attention", () => {
+    expect(resolveMemoryModuleHealthStatus("unavailable", 1)).toBe("unavailable");
+    expect(resolveMemoryModuleHealthStatus("degraded", 1)).toBe("degraded");
+    expect(resolveMemoryModuleHealthStatus("healthy", 1)).toBe("degraded");
   });
 
   it("registers stable local User and Project subjects without inventing a Repository", async () => {

--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
@@ -117,6 +117,13 @@ export interface DesktopMemoryPlane {
   stop(): Promise<void>;
 }
 
+export function resolveMemoryModuleHealthStatus(
+  status: "healthy" | "degraded" | "unavailable",
+  needsAttention: number,
+): "healthy" | "degraded" | "unavailable" {
+  return needsAttention > 0 && status === "healthy" ? "degraded" : status;
+}
+
 export async function createDesktopMemoryPlane(options: {
   readonly pragmaHome: string;
   readonly logger: PragmaLogger;
@@ -189,6 +196,7 @@ export async function createDesktopMemoryPlane(options: {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let running: Promise<void> | undefined;
   let lastError: { readonly code: string; readonly occurredAt: string } | undefined;
+  let reportedExtractionIssues = new Set<string>();
   let maintenanceRunning: Promise<void> | undefined;
   let lastMaintenanceAtMs = 0;
   let safeThroughSequence = 0;
@@ -272,6 +280,33 @@ export async function createDesktopMemoryPlane(options: {
     }, options.pollIntervalMs ?? 1_000);
   };
 
+  const reportExtractionIssues = (
+    issues: readonly {
+      readonly moduleId: string;
+      readonly work: {
+        readonly needsAttention: number;
+        readonly lastErrorCode?: string | undefined;
+      };
+    }[],
+  ): void => {
+    const current = new Set<string>();
+    for (const issue of issues) {
+      const code = issue.work.lastErrorCode ?? "memory_extraction_needs_attention";
+      const key = `${issue.moduleId}\0${code}`;
+      current.add(key);
+      if (reportedExtractionIssues.has(key)) continue;
+      options.logger.error(
+        "desktop.memory_extraction_needs_attention",
+        "A Memory extraction module has jobs that need attention.",
+        new Error(
+          `${issue.moduleId} has ${issue.work.needsAttention} extraction job(s) that need attention.`,
+        ),
+        { moduleId: issue.moduleId, code, needsAttention: issue.work.needsAttention },
+      );
+    }
+    reportedExtractionIssues = current;
+  };
+
   const tick = async (): Promise<void> => {
     try {
       const recovery = await executionStore.recoverPendingCanonicalEvents();
@@ -280,10 +315,28 @@ export async function createDesktopMemoryPlane(options: {
       if (Date.now() - lastMaintenanceAtMs >= DEFAULT_MEMORY_STORAGE_POLICY.maintenanceIntervalMs) {
         await maintainStorage();
       }
+      const [episodicWork, semanticWork] = await Promise.all([
+        episodic.store.inspect(),
+        semantic.store.inspect(),
+      ]);
+      const extractionIssues = [
+        { moduleId: episodic.descriptor.id, work: episodicWork },
+        { moduleId: semantic.descriptor.id, work: semanticWork },
+      ].filter((item) => item.work.needsAttention > 0);
+      reportExtractionIssues(extractionIssues);
       if (recovery.quarantined > 0) {
         markDegraded("canonical_event_handoff_quarantined");
       } else if (recovery.failed > 0) {
         markDegraded("canonical_event_delivery_failed");
+      } else if (extractionIssues[0] !== undefined) {
+        const extractionIssue = extractionIssues[0];
+        const code = extractionIssue.work.lastErrorCode ?? "memory_extraction_needs_attention";
+        markDegraded(
+          code,
+          new Error(
+            `${extractionIssue.moduleId} has ${extractionIssue.work.needsAttention} extraction job(s) that need attention.`,
+          ),
+        );
       } else {
         lastError = undefined;
       }
@@ -422,6 +475,8 @@ export async function createDesktopMemoryPlane(options: {
             : await semantic.store.inspect();
         modules.push({
           ...diagnostic,
+          status: resolveMemoryModuleHealthStatus(diagnostic.status, work.needsAttention),
+          ...(work.lastErrorCode === undefined ? {} : { lastErrorCode: work.lastErrorCode }),
           work: {
             records: "episodes" in work ? work.episodes : work.facts,
             pending: work.pending,
@@ -438,7 +493,10 @@ export async function createDesktopMemoryPlane(options: {
       return {
         state: stopped
           ? "stopped"
-          : lastError !== undefined || delivery.quarantined > 0 || blockedBytes > 0
+          : lastError !== undefined ||
+              delivery.quarantined > 0 ||
+              blockedBytes > 0 ||
+              modules.some((module) => module.status !== "healthy")
             ? "degraded"
             : "running",
         feed: {

--- a/apps/desktop/src/main/features/memory/memory-curator.test.ts
+++ b/apps/desktop/src/main/features/memory/memory-curator.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { MEMORY_CURATOR_ID, MEMORY_CURATOR_REF } from "@pragma/memory";
+import { MissionExecutorRefSchema } from "@pragma/shared";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createMissionStore } from "../missions/mission-store.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Desktop Memory Curator", () => {
+  it("crosses the real Mission persistence boundary with a valid hidden system identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-memory-curator-"));
+    roots.push(root);
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+
+    expect(MissionExecutorRefSchema.parse(MEMORY_CURATOR_REF)).toBe(`expert:${MEMORY_CURATOR_ID}`);
+    const mission = await missions.create({
+      workspace: { path: join(root, "workspace"), basename: "workspace" },
+      goal: "Extract a durable episodic memory from supplied evidence.",
+      title: "Memory extraction test",
+      project: { id: "studio", revision: 1 },
+      executor: { kind: "expert", ref: MEMORY_CURATOR_REF, name: "Memory Curator" },
+      origin: { type: "system-memory", jobId: "episodic-test" },
+    });
+
+    await expect(missions.get(mission.id)).resolves.toMatchObject({
+      executor: { ref: MEMORY_CURATOR_REF },
+      origin: { type: "system-memory", jobId: "episodic-test" },
+    });
+    await expect(missions.list()).resolves.toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
@@ -41,5 +41,14 @@ export const memory = {
   healthSummary: "{{state}} · {{modules}} modules · {{events}} canonical events",
   storageHealth:
     "Feed {{logical}} / {{target}} · safe through {{safe}} · {{blocked}} blocked by durable consumers",
+  extractionDegraded: "Memory extraction needs attention",
+  extractionDegradedDescription:
+    "{{count}} extraction job(s) could not produce memory. Captured evidence remains available for retry.",
+  memoryDegraded: "Memory is degraded",
+  memoryDegradedDescription:
+    "The memory pipeline is not operating normally. Check Health for the affected module or delivery stage.",
+  moduleHealthSummary:
+    "{{status}} · lag {{lag}} · {{records}} memories · {{pending}} extracting · {{attention}} need attention · {{rejected}} rejected",
+  lastExtractionError: "Latest extraction error: {{code}}",
   permissionNote: "Permissions can only be kept or tightened in this phase.",
 };

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -140,7 +140,7 @@ export const missions = {
   memory: "Memory",
   memoryActivity: "Memory activity",
   memoryActivityDescription:
-    "Capture and agent-initiated ContextStore recall activity for each execution.",
+    "Evidence publication and agent-initiated ContextStore recall activity for each execution. Evidence publication does not mean a memory was extracted.",
   memoryActivityLoading: "Loading memory activity…",
   memoryActivityUnavailable: "Memory activity is unavailable",
   noMemoryActivity: "No memory activity",

--- a/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
@@ -75,6 +75,8 @@ export const settings = {
       "{{status}} · {{attempts}} attempts · {{evidence}} Evidence retained · {{omitted}} omitted · {{error}}",
     retryExtraction: "Retry extraction",
     retryError: "The extraction job changed or can no longer be retried.",
+    extractionError: "Memory extraction failed: {{code}}",
+    pipelineError: "Memory pipeline error: {{code}}",
     assetTitle: "Memory policy",
     assetDescription:
       "This team asset may only narrow the global policy. Runtime restrictions are intersected with this setting.",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
@@ -42,5 +42,13 @@ export const memory = {
   actionError: "无法保存记忆变更。",
   healthSummary: "{{state}} · {{modules}} 个模块 · {{events}} 个规范事件",
   storageHealth: "Feed {{logical}} / {{target}} · 安全水位 {{safe}} · {{blocked}} 被持久消费者阻塞",
+  extractionDegraded: "记忆提取需要处理",
+  extractionDegradedDescription:
+    "{{count}} 个提取任务未能生成记忆；已捕获的证据仍保留，可在修复配置后重试。",
+  memoryDegraded: "记忆系统异常",
+  memoryDegradedDescription: "记忆流水线未正常工作，请在健康状态中检查受影响的模块或投递阶段。",
+  moduleHealthSummary:
+    "{{status}} · 延迟 {{lag}} · {{records}} 条记忆 · {{pending}} 条提取中 · {{attention}} 条需处理 · {{rejected}} 条已拒绝",
+  lastExtractionError: "最近提取错误：{{code}}",
   permissionNote: "本阶段只能保持或收紧权限。",
 } satisfies DesktopTranslationResource["memory"];

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -133,7 +133,8 @@ export const missions = {
   work: "工作",
   memory: "记忆",
   memoryActivity: "记忆活动",
-  memoryActivityDescription: "每次执行的捕获活动与 Agent 主动发起的 ContextStore 召回活动。",
+  memoryActivityDescription:
+    "每次执行的证据发布与 Agent 主动发起的 ContextStore 召回活动；发布证据不代表已经提取出记忆。",
   memoryActivityLoading: "正在加载记忆活动…",
   memoryActivityUnavailable: "无法读取记忆活动",
   noMemoryActivity: "暂无记忆活动",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
@@ -71,6 +71,8 @@ export const settings = {
       "{{status}} · 累计 {{attempts}} 次 · 保留 {{evidence}} 条 Evidence · 省略 {{omitted}} 条 · {{error}}",
     retryExtraction: "重试提炼",
     retryError: "提炼任务已经变化或不再允许重试。",
+    extractionError: "记忆提取失败：{{code}}",
+    pipelineError: "记忆流水线错误：{{code}}",
     assetTitle: "记忆策略",
     assetDescription: "此团队资产只能收紧全局策略；运行时限制还会与本设置取交集。",
     effectiveSummary: "当前生效：采集{{capture}}，召回{{recall}}，学习{{learning}}",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
@@ -42,5 +42,13 @@ export const memory = {
   actionError: "無法儲存記憶變更。",
   healthSummary: "{{state}} · {{modules}} 個模組 · {{events}} 個規範事件",
   storageHealth: "Feed {{logical}} / {{target}} · 安全水位 {{safe}} · {{blocked}} 被持久消費者阻塞",
+  extractionDegraded: "記憶提取需要處理",
+  extractionDegradedDescription:
+    "{{count}} 個提取任務未能產生記憶；已擷取的證據仍保留，可在修復設定後重試。",
+  memoryDegraded: "記憶系統異常",
+  memoryDegradedDescription: "記憶流水線未正常運作，請在健康狀態中檢查受影響的模組或投遞階段。",
+  moduleHealthSummary:
+    "{{status}} · 延遲 {{lag}} · {{records}} 筆記憶 · {{pending}} 筆提取中 · {{attention}} 筆需處理 · {{rejected}} 筆已拒絕",
+  lastExtractionError: "最近提取錯誤：{{code}}",
   permissionNote: "本階段只能維持或縮小權限。",
 } satisfies DesktopTranslationResource["memory"];

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -133,7 +133,8 @@ export const missions = {
   work: "工作",
   memory: "記憶",
   memoryActivity: "記憶活動",
-  memoryActivityDescription: "每次執行的擷取活動與 Agent 主動發起的 ContextStore 召回活動。",
+  memoryActivityDescription:
+    "每次執行的證據發布與 Agent 主動發起的 ContextStore 召回活動；發布證據不代表已經提取出記憶。",
   memoryActivityLoading: "正在載入記憶活動…",
   memoryActivityUnavailable: "無法讀取記憶活動",
   noMemoryActivity: "暫無記憶活動",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
@@ -71,6 +71,8 @@ export const settings = {
       "{{status}} · 累計 {{attempts}} 次 · 保留 {{evidence}} 筆 Evidence · 省略 {{omitted}} 筆 · {{error}}",
     retryExtraction: "重試提煉",
     retryError: "提煉任務已經變更或不再允許重試。",
+    extractionError: "記憶提取失敗：{{code}}",
+    pipelineError: "記憶流水線錯誤：{{code}}",
     assetTitle: "記憶策略",
     assetDescription: "此團隊資產只能收緊全域策略；執行階段限制還會與本設定取交集。",
     effectiveSummary: "目前生效：採集{{capture}}，召回{{recall}}，學習{{learning}}",

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { i18n } from "../../i18n/index.ts";
-import { MemoryPage } from "./MemoryPage.tsx";
+import { MemoryDegradedAlert, MemoryPage } from "./MemoryPage.tsx";
 
 afterEach(async () => {
   await i18n.changeLanguage("en");
@@ -26,5 +26,128 @@ describe("MemoryPage", () => {
     expect(html).toContain("<h1>记忆</h1>");
     expect(html).toContain("情景记忆");
     expect(html).toContain("健康状态");
+  });
+
+  it("shows extraction failures without requiring the Health tab", async () => {
+    await i18n.changeLanguage("zh-Hans");
+    const html = renderToStaticMarkup(
+      <MemoryDegradedAlert
+        health={{
+          state: "degraded",
+          feed: {
+            lastSequence: 4,
+            eventCount: 4,
+            logicalBytes: 0,
+            fileBytes: 0,
+            receiptCount: 0,
+            safeThroughSequence: 0,
+            blockedBytes: 0,
+          },
+          delivery: { pending: 0, quarantined: 0 },
+          lastError: {
+            code: "memory_curator_failed",
+            occurredAt: "2026-08-04T00:00:00.000Z",
+          },
+          modules: [
+            {
+              moduleId: "pragma.memory.episodic",
+              moduleVersion: "1.0.0",
+              status: "degraded",
+              lag: 0,
+              processed: 4,
+              retried: 0,
+              deadLettered: 0,
+              skipped: 0,
+              lastErrorCode: "memory_curator_failed",
+              work: {
+                records: 0,
+                pending: 0,
+                running: 0,
+                needsAttention: 1,
+                rejected: 0,
+                expired: 0,
+                evidenceRecords: 2,
+                evidenceBytes: 512,
+                truncatedExecutions: 0,
+              },
+              updatedAt: "2026-08-04T00:00:00.000Z",
+            },
+          ],
+          maintenance: {
+            deletedEvents: 0,
+            reclaimedBytes: 0,
+            deletedDeadLetters: 0,
+            deadLetterEntries: 0,
+            deadLetterBytes: 0,
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("记忆提取需要处理");
+    expect(html).toContain("memory_curator_failed");
+  });
+
+  it("does not hide a concurrent delivery failure behind extraction wording", async () => {
+    await i18n.changeLanguage("zh-Hans");
+    const html = renderToStaticMarkup(
+      <MemoryDegradedAlert
+        health={{
+          state: "degraded",
+          feed: {
+            lastSequence: 4,
+            eventCount: 4,
+            logicalBytes: 0,
+            fileBytes: 0,
+            receiptCount: 0,
+            safeThroughSequence: 0,
+            blockedBytes: 0,
+          },
+          delivery: { pending: 1, quarantined: 1 },
+          lastError: {
+            code: "canonical_event_handoff_quarantined",
+            occurredAt: "2026-08-04T00:00:00.000Z",
+          },
+          modules: [
+            {
+              moduleId: "pragma.memory.episodic",
+              moduleVersion: "1.0.0",
+              status: "degraded",
+              lag: 0,
+              processed: 4,
+              retried: 0,
+              deadLettered: 0,
+              skipped: 0,
+              lastErrorCode: "memory_curator_failed",
+              work: {
+                records: 0,
+                pending: 0,
+                running: 0,
+                needsAttention: 1,
+                rejected: 0,
+                expired: 0,
+                evidenceRecords: 2,
+                evidenceBytes: 512,
+                truncatedExecutions: 0,
+              },
+              updatedAt: "2026-08-04T00:00:00.000Z",
+            },
+          ],
+          maintenance: {
+            deletedEvents: 0,
+            reclaimedBytes: 0,
+            deletedDeadLetters: 0,
+            deadLetterEntries: 0,
+            deadLetterBytes: 0,
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("记忆系统异常");
+    expect(html).not.toContain("记忆提取需要处理");
+    expect(html).toContain("canonical_event_handoff_quarantined");
+    expect(html).toContain("memory_curator_failed");
   });
 });

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
@@ -120,6 +120,7 @@ export function MemoryPage() {
           <WarningCircle size={18} aria-hidden="true" /> {error}
         </div>
       ) : null}
+      <MemoryDegradedAlert health={health} />
 
       {view === "health" ? (
         <MemoryHealth health={health} />
@@ -455,7 +456,20 @@ function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus | unde
             {module.moduleId}@{module.moduleVersion}
           </strong>
           <span>
-            {module.status} · lag {module.lag} · records {module.work?.records ?? 0}
+            {t("moduleHealthSummary", {
+              status: module.status,
+              lag: module.lag,
+              records: module.work?.records ?? 0,
+              pending: (module.work?.pending ?? 0) + (module.work?.running ?? 0),
+              attention: module.work?.needsAttention ?? 0,
+              rejected: module.work?.rejected ?? 0,
+            })}
+            {module.lastErrorCode === undefined ? null : (
+              <>
+                <br />
+                <code>{t("lastExtractionError", { code: module.lastErrorCode })}</code>
+              </>
+            )}
           </span>
         </article>
       ))}
@@ -465,6 +479,53 @@ function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus | unde
 
 function formatHealthBytes(bytes: number): string {
   return `${(bytes / (1_024 * 1_024)).toFixed(1)} MiB`;
+}
+
+export function MemoryDegradedAlert(props: {
+  readonly health?: DesktopMemoryPlaneStatus | undefined;
+}) {
+  const { t } = useTranslation("memory");
+  if (props.health?.state !== "degraded") return null;
+  const attention = props.health.modules.reduce(
+    (total, module) => total + (module.work?.needsAttention ?? 0),
+    0,
+  );
+  const codes = [
+    props.health.lastError?.code,
+    ...props.health.modules.map((module) => module.lastErrorCode),
+  ].filter(
+    (code, index, values): code is string => code !== undefined && values.indexOf(code) === index,
+  );
+  const extractionOnly =
+    attention > 0 &&
+    !props.health.modules.some((module) => module.status === "unavailable") &&
+    !isNonExtractionPipelineError(props.health.lastError?.code);
+  return (
+    <div className="memory-error" role="alert">
+      <WarningCircle size={20} aria-hidden="true" />
+      <span>
+        <strong>{t(extractionOnly ? "extractionDegraded" : "memoryDegraded")}</strong>
+        <br />
+        {extractionOnly
+          ? t("extractionDegradedDescription", { count: attention })
+          : t("memoryDegradedDescription")}
+        {codes.length === 0 ? null : (
+          <>
+            <br />
+            <code>{t("lastExtractionError", { code: codes.join(", ") })}</code>
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function isNonExtractionPipelineError(code: string | undefined): boolean {
+  return [
+    "canonical_event_handoff_quarantined",
+    "canonical_event_delivery_failed",
+    "memory_pipeline_iteration_failed",
+  ].includes(code ?? "");
 }
 
 function key(item: DesktopMemoryItem): string {

--- a/apps/desktop/src/renderer/src/pages/settings/MemorySettingsFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/MemorySettingsFragment.tsx
@@ -241,17 +241,29 @@ export function MemorySettingsFragment() {
                 })}
               </small>
             )}
+            {status?.lastError === undefined ? null : (
+              <small className="form-error" role="alert">
+                {t("memory.pipelineError", { code: status.lastError.code })}
+              </small>
+            )}
             {status?.modules.map((module) =>
               module.work === undefined ? null : (
-                <small key={module.moduleId}>
-                  {t("memory.moduleWorkSummary", {
-                    module: module.moduleId,
-                    records: module.work.records,
-                    pending: module.work.pending + module.work.running,
-                    attention: module.work.needsAttention,
-                    rejected: module.work.rejected,
-                  })}
-                </small>
+                <span className="memory-module-status" key={module.moduleId}>
+                  <small>
+                    {t("memory.moduleWorkSummary", {
+                      module: module.moduleId,
+                      records: module.work.records,
+                      pending: module.work.pending + module.work.running,
+                      attention: module.work.needsAttention,
+                      rejected: module.work.rejected,
+                    })}
+                  </small>
+                  {module.lastErrorCode === undefined ? null : (
+                    <small className="form-error" role="alert">
+                      {t("memory.extractionError", { code: module.lastErrorCode })}
+                    </small>
+                  )}
+                </span>
               ),
             )}
           </span>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2239,6 +2239,15 @@ html.is-resizing-sidebar * {
   background: color-mix(in srgb, #b7791f 10%, transparent);
 }
 
+.memory-module-status {
+  display: grid;
+  gap: 3px;
+}
+
+.setting-copy .memory-module-status .form-error {
+  color: var(--danger);
+}
+
 .asset-memory-policy {
   margin-top: 26px;
   padding: 22px;

--- a/docs/adr/023-semantic-resource-identity-and-project-revisions.md
+++ b/docs/adr/023-semantic-resource-identity-and-project-revisions.md
@@ -30,6 +30,10 @@ pinned revision.
 - Plugins, Runtime adapters, tool adapters, Context policies, and other independently shipped
   extensions retain explicit versions such as `plugin:pragma.memory@1.0.0` and
   `pragma.tool.call@v1`.
+- Reserved and built-in semantic IDs follow the same Crockford Base32 grammar as Host-allocated
+  IDs. Their canonical refs are runtime-Schema-validated where declared and covered at the first
+  persisted or cross-process consumer boundary; human-readable mnemonics do not bypass identity
+  validation.
 
 ## Migration
 
@@ -54,3 +58,5 @@ rewritten by compiler compatibility upgrades.
 - Two same-kind resources cannot share a normalized name.
 - Import and migration code must detect identity conflicts rather than preserving duplicate legacy
   versions.
+- TypeScript string types alone cannot prove the lexical validity of a built-in identity. Runtime
+  Schema validation and boundary integration tests are required for every built-in semantic ref.

--- a/docs/adr/033-layered-episodic-memory.md
+++ b/docs/adr/033-layered-episodic-memory.md
@@ -46,7 +46,7 @@ Expert 读取“当前 Team/Flow Store + 自己的个人 Store”。其他专家
 同一 Episode 的 restricted Evidence 若没有共同 authorized principal，则在调用 extractor 前以 policy
 reason 完成拒绝，不能降级成 `host-private`、扩大可见性，也不进入无意义的重试或 needs-attention。
 
-Desktop 通过隐藏系统 Expert `expert:0000000000memory` 运行 extractor。每个任务使用新的内部 Mission，
+Desktop 通过隐藏系统 Expert `expert:0000000000mem0ry` 运行 extractor。每个任务使用新的内部 Mission，
 Mission v6 以 `origin: system-memory` 标记并从普通列表排除，但仍沿用标准 Runtime、Execution、Usage
 和 ownership 链路。Evidence adapter 无条件排除 Memory Curator 作为 root Expert 的事件，避免递归记忆。
 

--- a/docs/architecture/memory-plane-implementation-plan.md
+++ b/docs/architecture/memory-plane-implementation-plan.md
@@ -201,7 +201,7 @@ Desktop 提供设置入口。
 
 #### 2D. Desktop Curator 与设置
 
-- 隐藏系统 Expert `expert:0000000000memory` 通过正常 Mission/ExpertSession/Runtime/Usage 链路执行；
+- 隐藏系统 Expert `expert:0000000000mem0ry` 通过正常 Mission/ExpertSession/Runtime/Usage 链路执行；
 - Mission 升级为 v6，显式记录 `origin: user | system-memory`；v5 首次读取相邻升级为 user；
 - Curator Mission 从普通列表排除，Curator 无工具、无 Memory Context，Evidence adapter 硬性排除其事件；
 - Memory Settings 保存 `pragma.memory-extractor-profile/v1`，支持继承默认或固定 Runtime/provider/model，

--- a/docs/conventions/coding-conventions.md
+++ b/docs/conventions/coding-conventions.md
@@ -21,6 +21,33 @@
 - Do not let shared packages import Node, React, Fastify, Prisma, or Agent Runtime APIs.
 - Define the target layer before creating a new package.
 
+## Semantic Resource Identities
+
+- Expert, ExpertTeam, Flow, Automation, Capability, ContextStore, RuntimeProfile, and Evaluation
+  identities are exactly 16 lowercase Crockford Base32 characters: `0-9`, `a-h`, `j-k`, `m-n`,
+  and `p-t`, `v-z`. The ambiguous letters `i`, `l`, `o`, and `u` are forbidden.
+- Never treat a readable mnemonic as proof that a reserved or built-in ID is valid. Define every
+  built-in semantic ref through the canonical runtime Schema at its declaration site so an invalid
+  literal fails during module initialization and tests.
+- A built-in identity must have an integration test at its first persisted or cross-process
+  consumer boundary. A unit test that mocks that boundary is not sufficient.
+- When an ID is used in both an unqualified and qualified form, keep one source literal and derive
+  the canonical `<kind>:<id>` ref through the Schema. Do not maintain two unchecked strings.
+- Background jobs must preserve a stable, bounded error code. Serialized validation errors and
+  stack text are diagnostics, not error codes. Stable error codes use lowercase ASCII and match
+  `[a-z][a-z0-9_.-]{0,199}`; normalize trustworthy external codes before persisting them.
+
+## Background Pipeline Observability
+
+- Capturing or publishing source Evidence is not equivalent to producing a derived record. UI copy
+  and counters must name the exact pipeline stage they represent.
+- A background job in `needs_attention`, an unavailable module, or an unprocessed quarantined item
+  makes the owning subsystem degraded. The health API, logs, and user-facing status must expose the
+  module and a stable latest error code.
+- Retriable Evidence must remain available while a job needs attention. Changing the relevant
+  configuration or installing a corrected build must be able to wake the preserved job without
+  rerunning the source task.
+
 ## Runtime Adapters
 
 - Runtime usage events are snapshots unless explicitly documented as deltas.

--- a/packages/memory/src/curator.ts
+++ b/packages/memory/src/curator.ts
@@ -1,4 +1,6 @@
-export const MEMORY_CURATOR_ID = "0000000000memory";
-export const MEMORY_CURATOR_REF = `expert:${MEMORY_CURATOR_ID}`;
+import { MissionExecutorRefSchema } from "@pragma/shared";
+
+export const MEMORY_CURATOR_ID = "0000000000mem0ry";
+export const MEMORY_CURATOR_REF = MissionExecutorRefSchema.parse(`expert:${MEMORY_CURATOR_ID}`);
 export const MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator/v1";
 export const SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator.semantic/v1";

--- a/packages/memory/src/episodic/module.ts
+++ b/packages/memory/src/episodic/module.ts
@@ -8,6 +8,7 @@ import {
   type EpisodicMemoryExtractor,
 } from "./schema.ts";
 import { createEpisodicMemoryStore, episodicMemoryId, type EpisodicMemoryStore } from "./store.ts";
+import { extractionErrorCode } from "../pipeline/extraction-error-code.ts";
 import type { MemoryModule } from "../pipeline/memory-module.ts";
 
 export interface EpisodicMemoryModule extends MemoryModule {
@@ -153,7 +154,7 @@ export async function createEpisodicMemoryModule(
       } catch (error) {
         await store.fail({
           job,
-          errorCode: errorCode(error),
+          errorCode: extractionErrorCode(error, "episodic_extraction"),
           now: now(),
           retry: isConfigurationError(error) ? "configuration" : "transient",
         });
@@ -338,12 +339,7 @@ function refKey(ref: MemorySubjectRef): string {
   return `${ref.type}\0${ref.id}`;
 }
 
-function errorCode(error: unknown): string {
-  if (error instanceof Error) return error.message.split(":", 1)[0] || "episodic_extraction_failed";
-  return "episodic_extraction_failed";
-}
-
 function isConfigurationError(error: unknown): boolean {
-  const code = errorCode(error);
+  const code = extractionErrorCode(error, "episodic_extraction");
   return code.includes("unavailable") || code.includes("configuration") || code.includes("profile");
 }

--- a/packages/memory/src/episodic/store.ts
+++ b/packages/memory/src/episodic/store.ts
@@ -21,6 +21,10 @@ import {
   assertMemoryVisibilityTightened,
   createMemoryTombstone,
 } from "../governance/access-governance.ts";
+import {
+  latestExtractionJobErrorCode,
+  parseExtractionJobJson,
+} from "../pipeline/extraction-job-diagnostic.ts";
 import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
 import {
   EMPTY_MEMORY_EVIDENCE_OMISSION_STATS,
@@ -56,6 +60,7 @@ export interface EpisodicMemoryStoreDiagnostic {
   readonly evidenceBytes: number;
   readonly truncatedExecutions: number;
   readonly rejected: number;
+  readonly lastErrorCode?: string | undefined;
   readonly rejectedByReason: Readonly<Record<EpisodicRejectionReason, number>>;
 }
 
@@ -542,7 +547,8 @@ export async function createEpisodicMemoryStore(
         .prepare("SELECT job_json AS jobJson FROM jobs WHERE status = 'needs_attention'")
         .all() as unknown as readonly { readonly jobJson: string }[];
       for (const row of rows) {
-        const job = EpisodicExtractionJobSchema.parse(JSON.parse(row.jobJson));
+        const job = parseExtractionJobJson(row.jobJson, EpisodicExtractionJobSchema);
+        if (job === undefined) continue;
         if (reason === "configuration" && job.failureClass !== "configuration") continue;
         writeJob(
           EpisodicExtractionJobSchema.parse({
@@ -616,6 +622,14 @@ export async function createEpisodicMemoryStore(
       const episodes = data.prepare("SELECT COUNT(*) AS count FROM episodes").get() as unknown as {
         readonly count: number;
       };
+      const attentionRows = state
+        .prepare("SELECT job_json AS jobJson FROM jobs WHERE status = 'needs_attention'")
+        .all() as unknown as readonly { readonly jobJson: string }[];
+      const lastErrorCode = latestExtractionJobErrorCode(
+        attentionRows,
+        EpisodicExtractionJobSchema,
+        "episodic_extraction_job_invalid",
+      );
       return {
         episodes: episodes.count,
         pending: byStatus.get("pending") ?? 0,
@@ -624,6 +638,7 @@ export async function createEpisodicMemoryStore(
         expired: byStatus.get("expired") ?? 0,
         ...inspectEvidenceState(state),
         rejected: counters.get("rejected_total") ?? 0,
+        ...(lastErrorCode === undefined ? {} : { lastErrorCode }),
         rejectedByReason: {
           "low-value": counters.get("rejected_low_value") ?? 0,
           "insufficient-evidence": counters.get("rejected_insufficient_evidence") ?? 0,

--- a/packages/memory/src/pipeline/extraction-error-code.ts
+++ b/packages/memory/src/pipeline/extraction-error-code.ts
@@ -1,0 +1,22 @@
+import { ZodError } from "zod";
+
+const STABLE_ERROR_CODE = /^[a-z][a-z0-9_.-]{0,199}$/;
+
+export function extractionErrorCode(
+  error: unknown,
+  family: "episodic_extraction" | "semantic_extraction",
+): string {
+  if (error instanceof ZodError) return `${family}_validation_failed`;
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { readonly code?: unknown }).code;
+    if (typeof code === "string") {
+      const normalized = code.trim().toLowerCase();
+      if (STABLE_ERROR_CODE.test(normalized)) return normalized;
+    }
+  }
+  if (error instanceof Error) {
+    const prefix = error.message.split(":", 1)[0]?.trim().toLowerCase();
+    if (prefix !== undefined && STABLE_ERROR_CODE.test(prefix)) return prefix;
+  }
+  return `${family}_failed`;
+}

--- a/packages/memory/src/pipeline/extraction-job-diagnostic.ts
+++ b/packages/memory/src/pipeline/extraction-job-diagnostic.ts
@@ -1,0 +1,28 @@
+import type { z } from "zod";
+
+export function parseExtractionJobJson<T>(jobJson: string, schema: z.ZodType<T>): T | undefined {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(jobJson);
+  } catch {
+    return undefined;
+  }
+  const parsed = schema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function latestExtractionJobErrorCode<
+  T extends { readonly updatedAt: string; readonly lastErrorCode?: string | undefined },
+>(
+  rows: readonly { readonly jobJson: string }[],
+  schema: z.ZodType<T>,
+  invalidCode: string,
+): string | undefined {
+  let latest: T | undefined;
+  for (const row of rows) {
+    const job = parseExtractionJobJson(row.jobJson, schema);
+    if (job === undefined) return invalidCode;
+    if (latest === undefined || job.updatedAt > latest.updatedAt) latest = job;
+  }
+  return latest?.lastErrorCode;
+}

--- a/packages/memory/src/semantic/module.ts
+++ b/packages/memory/src/semantic/module.ts
@@ -8,6 +8,7 @@ import {
   type SemanticMemoryExtractor,
 } from "./schema.ts";
 import { createSemanticMemoryStore, type SemanticMemoryStore } from "./store.ts";
+import { extractionErrorCode } from "../pipeline/extraction-error-code.ts";
 import type { MemoryModule } from "../pipeline/memory-module.ts";
 
 export interface SemanticMemoryModule extends MemoryModule {
@@ -133,7 +134,7 @@ export async function createSemanticMemoryModule(
       } catch (error) {
         await store.fail({
           job,
-          errorCode: errorCode(error),
+          errorCode: extractionErrorCode(error, "semantic_extraction"),
           now: now(),
           retry: isConfigurationError(error) ? "configuration" : "transient",
         });
@@ -276,14 +277,8 @@ function refKey(ref: MemorySubjectRef): string {
   return `${ref.type}\0${ref.id}`;
 }
 
-function errorCode(error: unknown): string {
-  return error instanceof Error
-    ? error.message.split(":", 1)[0] || "semantic_extraction_failed"
-    : "semantic_extraction_failed";
-}
-
 function isConfigurationError(error: unknown): boolean {
-  const code = errorCode(error);
+  const code = extractionErrorCode(error, "semantic_extraction");
   return (
     code.includes("unavailable") ||
     code.includes("configuration") ||

--- a/packages/memory/src/semantic/store.ts
+++ b/packages/memory/src/semantic/store.ts
@@ -29,6 +29,10 @@ import {
   assertMemoryVisibilityTightened,
   createMemoryTombstone,
 } from "../governance/access-governance.ts";
+import {
+  latestExtractionJobErrorCode,
+  parseExtractionJobJson,
+} from "../pipeline/extraction-job-diagnostic.ts";
 import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
 import {
   EMPTY_MEMORY_EVIDENCE_OMISSION_STATS,
@@ -59,6 +63,7 @@ export interface SemanticMemoryStoreDiagnostic {
   readonly evidenceBytes: number;
   readonly truncatedExecutions: number;
   readonly rejected: number;
+  readonly lastErrorCode?: string | undefined;
   readonly rejectedByReason: Readonly<Record<SemanticRejectionReason, number>>;
 }
 
@@ -629,7 +634,8 @@ export async function createSemanticMemoryStore(
         .prepare("SELECT job_json AS jobJson FROM jobs WHERE status = 'needs_attention'")
         .all() as unknown as readonly { readonly jobJson: string }[];
       for (const row of rows) {
-        const job = SemanticExtractionJobSchema.parse(JSON.parse(row.jobJson));
+        const job = parseExtractionJobJson(row.jobJson, SemanticExtractionJobSchema);
+        if (job === undefined) continue;
         if (reason === "configuration" && job.failureClass !== "configuration") continue;
         writeJob(
           SemanticExtractionJobSchema.parse({
@@ -880,6 +886,14 @@ export async function createSemanticMemoryStore(
         .get() as unknown as {
         readonly count: number;
       };
+      const attentionRows = state
+        .prepare("SELECT job_json AS jobJson FROM jobs WHERE status = 'needs_attention'")
+        .all() as unknown as readonly { readonly jobJson: string }[];
+      const lastErrorCode = latestExtractionJobErrorCode(
+        attentionRows,
+        SemanticExtractionJobSchema,
+        "semantic_extraction_job_invalid",
+      );
       return {
         facts: facts.count,
         pending: byStatus.get("pending") ?? 0,
@@ -888,6 +902,7 @@ export async function createSemanticMemoryStore(
         expired: byStatus.get("expired") ?? 0,
         ...inspectEvidenceState(state),
         rejected: counters.get("rejected_total") ?? 0,
+        ...(lastErrorCode === undefined ? {} : { lastErrorCode }),
         rejectedByReason: {
           "no-stable-fact": counters.get("rejected_no_stable_fact") ?? 0,
           "insufficient-evidence": counters.get("rejected_insufficient_evidence") ?? 0,

--- a/packages/memory/test/curator-identity.test.ts
+++ b/packages/memory/test/curator-identity.test.ts
@@ -1,0 +1,11 @@
+import { MissionExecutorRefSchema } from "@pragma/shared";
+import { describe, expect, it } from "vitest";
+
+import { MEMORY_CURATOR_ID, MEMORY_CURATOR_REF } from "../src/index.ts";
+
+describe("Memory Curator identity", () => {
+  it("is a valid canonical Mission executor reference", () => {
+    expect(MEMORY_CURATOR_ID).toMatch(/^[0-9a-hjkmnp-tv-z]{16}$/);
+    expect(MissionExecutorRefSchema.parse(MEMORY_CURATOR_REF)).toBe(`expert:${MEMORY_CURATOR_ID}`);
+  });
+});

--- a/packages/memory/test/episodic-memory.test.ts
+++ b/packages/memory/test/episodic-memory.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createEpisodicMemoryModule,
   createFederatedMemoryContextStore,
+  MEMORY_CURATOR_REF,
   MemoryModuleRegistry,
   type EpisodicExtractionInput,
   type EpisodicMemoryExtractor,
@@ -444,8 +445,32 @@ describe("Episodic Memory", () => {
     clock = new Date(clock.getTime() + 5 * 60_000 + 1_000);
     await module.runBackgroundOnce?.();
     const diagnostic = await module.store.inspect();
-    expect(diagnostic.needsAttention).toBe(1);
+    expect(diagnostic).toMatchObject({
+      needsAttention: 1,
+      lastErrorCode: "extractor_evidence_ref_invalid",
+    });
     expect(await module.store.list()).toEqual([]);
+
+    const database = new DatabaseSync(
+      join(
+        new PragmaPaths({ pragmaHome: root }).memoryModuleStateRoot("pragma.memory.episodic"),
+        "jobs.sqlite",
+      ),
+    );
+    database
+      .prepare("UPDATE jobs SET job_json = ? WHERE status = 'needs_attention'")
+      .run("{invalid-json");
+    database.close();
+
+    await expect(module.store.inspect()).resolves.toMatchObject({
+      needsAttention: 1,
+      lastErrorCode: "episodic_extraction_job_invalid",
+    });
+    await expect(module.store.wakeNeedsAttention(clock)).resolves.toBeUndefined();
+    await expect(module.store.inspect()).resolves.toMatchObject({
+      needsAttention: 1,
+      lastErrorCode: "episodic_extraction_job_invalid",
+    });
     module.close();
   });
 
@@ -741,7 +766,7 @@ function fakeExtractor(
         valueScore: 0.9,
       },
       provenance: {
-        curatorRef: "expert:0000000000memory",
+        curatorRef: MEMORY_CURATOR_REF,
         promptVersion: "pragma.memory-curator/v1",
         profileRevision: 0,
         runtimeId: "test-runtime",

--- a/packages/memory/test/extraction-error-code.test.ts
+++ b/packages/memory/test/extraction-error-code.test.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { describe, expect, it } from "vitest";
+
+import { extractionErrorCode } from "../src/pipeline/extraction-error-code.ts";
+
+describe("extractionErrorCode", () => {
+  it("turns structured validation failures into a stable diagnostic code", () => {
+    const validation = z.object({ value: z.string() }).safeParse({ value: 1 });
+    if (validation.success) throw new Error("Expected the fixture to fail validation.");
+
+    expect(extractionErrorCode(validation.error, "episodic_extraction")).toBe(
+      "episodic_extraction_validation_failed",
+    );
+  });
+
+  it("keeps an explicit stable error prefix and rejects serialized error text", () => {
+    expect(
+      extractionErrorCode(
+        new Error("memory_curator_failed:runtime unavailable"),
+        "episodic_extraction",
+      ),
+    ).toBe("memory_curator_failed");
+    expect(extractionErrorCode(new Error('[{"origin":"string"}]'), "semantic_extraction")).toBe(
+      "semantic_extraction_failed",
+    );
+  });
+
+  it("normalizes external error codes to the documented lowercase format", () => {
+    expect(
+      extractionErrorCode(
+        Object.assign(new Error("Invalid API key"), { code: " API_KEY_INVALID " }),
+        "semantic_extraction",
+      ),
+    ).toBe("api_key_invalid");
+  });
+});

--- a/packages/memory/test/fixtures/README.md
+++ b/packages/memory/test/fixtures/README.md
@@ -1,0 +1,9 @@
+# Memory Compatibility Fixtures
+
+`episodic-v1-record.json` preserves the historical v1 representation verbatim. Its
+`expert:0000000000memory` provenance value predates enforcement of the canonical 16-character
+Crockford Base32 semantic-resource ID format and is intentionally not corrected in place.
+
+Current built-in declarations use the validated `expert:0000000000mem0ry` ref. Keeping the old
+fixture unchanged verifies that readers remain able to inspect already-persisted history without
+reintroducing the invalid value into current writes.

--- a/packages/memory/test/semantic-memory.test.ts
+++ b/packages/memory/test/semantic-memory.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   MemoryModuleRegistry,
+  MEMORY_CURATOR_REF,
   SemanticExtractionOutputSchema,
   createFederatedMemoryContextStore,
   createSemanticMemoryModule,
@@ -535,7 +536,7 @@ function fakeExtractor(
         ],
       }),
       provenance: {
-        curatorRef: "expert:0000000000memory",
+        curatorRef: MEMORY_CURATOR_REF,
         promptVersion: "pragma.memory-curator.semantic/v1",
         profileRevision: 0,
         runtimeId: "runtime",


### PR DESCRIPTION
## What changed

- replace the invalid hidden Memory Curator semantic ID with a schema-validated canonical ref
- distinguish Evidence publication counters from successfully extracted Memory in Desktop copy
- surface extraction `needs_attention` state, module IDs, and stable error codes in health APIs, logs, Memory, and Settings UI
- preserve and re-wake retryable extraction jobs without requiring the source task to run again
- handle malformed persisted extraction jobs without crashing diagnostics or Desktop startup
- add integration and regression coverage for identity validation, degraded/recovery states, concurrent pipeline failures, error-code normalization, and historical fixtures
- document semantic ID and background pipeline observability rules

## Root cause

The built-in Memory Curator ID contained `o`, which is forbidden by the project's 16-character lowercase Crockford Base32 identity schema. The failure occurred when the internal Mission crossed its persistence boundary. Separately, the UI labeled published Evidence as captured Memory and did not promote extraction jobs requiring attention into user-visible degraded health.

## Impact

Desktop now reports the actual stage of the Memory pipeline. Users can distinguish published Evidence from derived Memory, see actionable module/error diagnostics, and retry preserved extraction jobs after configuration or application fixes.

## Validation

- `pnpm check` — all 21 workspaces passed lint, typecheck, and tests
- Desktop — 108 test files / 641 tests passed
- Memory — 9 test files / 45 tests passed
- `pnpm build` — all 21 workspaces passed
- Desktop preload bundle verification passed
