### PR TITLE
Fix mission detail memory tab scroll issue

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -15383,7 +15383,9 @@ textarea:focus-visible,
 }
 
 .mission-memory-activity {
-  overflow: auto;
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
   padding: 28px 32px 48px;
 }
 


### PR DESCRIPTION
## 变更说明
- 修复 mission 详情页“记忆”Tab 内容过多时无法滚动的问题。
- 调整对应样式容器为可滚动区域：
  - `height: 100%`
  - `min-height: 0`
  - `overflow-y: auto`

## 影响文件
- `apps/desktop/src/renderer/src/styles.css`

## Commit
- `aa65358`
