### PR TITLE
Add version label to Desktop Home

### DIFF
--- a/apps/desktop/src/renderer/src/pages/home/HomePage.tsx
+++ b/apps/desktop/src/renderer/src/pages/home/HomePage.tsx
@@ -74,10 +74,24 @@ export function HomePage(props: {
   const [modelError, setModelError] = useState<string | null>(null);
   const [modelResetRequired, setModelResetRequired] = useState(false);
   const [persistenceReady, setPersistenceReady] = useState(false);
+  const [appVersion, setAppVersion] = useState<string>();
   const modelRuntimeIdRef = useRef<string | undefined>(undefined);
   const inputExecutorRef = useRef(props.initialExecutorRef ?? "");
   const pendingModelOverrideRef = useRef<MissionModelOverride | undefined>(undefined);
   const workspaceAssociationRequestRef = useRef(props.initialExecutorRef ?? "");
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.pragmaDesktop
+      .getBridgeSnapshot()
+      .then((snapshot) => {
+        if (!cancelled) setAppVersion(snapshot.app.version);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -513,6 +527,7 @@ export function HomePage(props: {
         ) : null}
       </section>
       <ExpertConstellation focused={composerFocused} submitting={saving} />
+      {appVersion !== undefined ? <p className="home-app-version">v{appVersion}</p> : null}
     </section>
   );
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -17266,6 +17266,20 @@ textarea:focus-visible,
   padding: 0;
 }
 
+.home-app-version {
+  position: absolute;
+  z-index: 4;
+  right: 20px;
+  bottom: 16px;
+  margin: 0;
+  color: var(--ui-text-disabled);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
 .home-mission-create
   > .mission-create:has(.mission-executor-picker.is-open, .mission-executor-manager-backdrop) {
   z-index: 4;


### PR DESCRIPTION
## What changed

- Show the Desktop app version in the Home screen’s bottom-right corner.
- Read the version from the Desktop bridge so it stays aligned with the packaged app.

## Why

The Home screen previously did not expose the installed app version, making it less convenient to identify a build.

## Validation

- `pnpm --filter @pragma/desktop typecheck:web`
- `pnpm --filter @pragma/desktop exec vitest run src/renderer/src/pages/home/HomePage.test.tsx`