### PR TITLE
Fix handoff context visibility across mission turns

### DIFF
--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -187,11 +187,48 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         snapshot.resources.find((resource) => resource.kind === "Expert")!,
       ),
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const historicalHandoff: { id: string | undefined } = { id: undefined };
+    const runtime = defineRuntimeDriver<
+      never,
+      { id: string; context: RuntimeDriverSessionContext }
+    >({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
-      createSession: (context) => ({ id: `runtime-${context.systemSessionId}` }),
+      createSession: (context) => ({ id: `runtime-${context.systemSessionId}`, context }),
+      restoreSession: (context) => ({ id: context.request.runtimeSession!.id, context }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
-      startTurn: () => ({ outputText: "done", runtimeSessionId: "runtime" }),
+      async startTurn(session, turn) {
+        if (turn.rawQuery === mission.goal) {
+          return {
+            outputText: "historical mission handoff\n".repeat(4_000),
+            runtimeSessionId: session.id,
+          };
+        }
+        const historicalHandoffId = historicalHandoff.id;
+        if (historicalHandoffId === undefined) throw new Error("Historical handoff id is missing.");
+        const read = session.context.agent
+          .createDefaultTools()
+          .find((tool) => tool.name === "read_expert_context");
+        if (read === undefined) throw new Error("read_expert_context is missing.");
+        const results = await Promise.all(
+          [0, 1].map(
+            async () =>
+              await read.call(
+                { namespace: "pragma.handoff", id: historicalHandoffId },
+                turn.signal,
+                { execution: session.context.request.executionContext },
+              ),
+          ),
+        );
+        const failed = results.find(
+          (result) =>
+            result.isError === true || !result.text.includes("historical mission handoff"),
+        );
+        return {
+          outputText:
+            failed === undefined ? "successor-read-ok" : `successor-read-failed:${failed.text}`,
+          runtimeSessionId: session.id,
+        };
+      },
       mapEvent: () => ({ events: [] }),
       closeSession: () => undefined,
     });
@@ -224,21 +261,25 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         dependencies: [],
       };
     });
-    const runner = createMissionRunner({
-      missions,
-      project,
-      capabilityStore: {} as CapabilityStore,
-      capabilityCredentials: {} as CapabilityCredentialStore,
-      capabilitiesPath: join(root, "capabilities"),
-      pragmaHome: join(root, "state"),
-      runtimes: createStaticRuntimeResolver({
-        runtimes: [runtime],
-        defaultRuntimeId: "fake",
-      }),
-      compileSystemExecutor,
-      getSystemExecutorFingerprint: () => `definition-${definitionVersion}`,
-      assertStorageWriteAllowed: async () => undefined,
-    });
+    const createRunner = (missionStore = missions) =>
+      createMissionRunner({
+        missions: missionStore,
+        project,
+        capabilityStore: {} as CapabilityStore,
+        capabilityCredentials: {} as CapabilityCredentialStore,
+        capabilitiesPath: join(root, "capabilities"),
+        pragmaHome: join(root, "state"),
+        executionStore: createFileExecutionStore({ pragmaHome: join(root, "state") }),
+        runtimes: createStaticRuntimeResolver({
+          runtimes: [runtime],
+          defaultRuntimeId: "fake",
+        }),
+        compileSystemExecutor,
+        getSystemExecutorFingerprint: () => `definition-${definitionVersion}`,
+        assertStorageWriteAllowed: async () => undefined,
+      });
+    let activeMissions = missions;
+    let runner = createRunner();
 
     await runner.run(mission.id);
     await vi.waitFor(
@@ -247,7 +288,23 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     );
     const originalSessionId = (await missions.get(mission.id)).execution?.sessionId;
     expect(originalSessionId).toMatch(/^[0-9a-f-]{36}$/);
+    if (originalSessionId === undefined) throw new Error("Original Session id is missing.");
+    const originalExecutionId = (await missions.get(mission.id)).execution!.id;
+    const originalExecution = await createFileExecutionStore({
+      pragmaHome: join(root, "state"),
+    }).get(originalExecutionId);
+    if (originalExecution?.output?.type !== "context") {
+      throw new Error("Expected the original Mission turn to produce a Context handoff.");
+    }
+    const originalHandoff = originalExecution.output.contexts[0];
+    if (originalHandoff === undefined) {
+      throw new Error("Expected the original Mission turn to produce a Context reference.");
+    }
+    historicalHandoff.id = originalHandoff.id;
     definitionVersion = 2;
+    activeMissions = createMissionStore({ missionsPath: join(root, "missions") });
+    const timelineRead = vi.spyOn(activeMissions, "readTimelinePage");
+    runner = createRunner(activeMissions);
 
     await runner.sendMessage({
       id: mission.id,
@@ -255,12 +312,28 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       requestId: "00000000-0000-4000-8000-000000000098",
     });
     await vi.waitFor(
-      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      async () =>
+        expect((await activeMissions.get(mission.id)).execution?.status).toBe("succeeded"),
       { timeout: settlementTimeoutMs },
     );
 
-    expect((await missions.get(mission.id)).execution?.sessionId).not.toBe(originalSessionId);
+    expect((await activeMissions.get(mission.id)).execution?.sessionId).not.toBe(originalSessionId);
     expect(compileSystemExecutor).toHaveBeenCalledTimes(2);
+    // One read restores Mission context; both concurrent handoff reads share one visibility load.
+    expect(timelineRead).toHaveBeenCalledTimes(2);
+    await expect(runner.getChat({ id: mission.id, limit: 50 })).resolves.toMatchObject({
+      entries: expect.arrayContaining([
+        expect.objectContaining({ kind: "assistant", content: "successor-read-ok" }),
+      ]),
+    });
+    await runner.delete(mission.id);
+    await expect(
+      readFile(
+        new PragmaPaths({ pragmaHome: join(root, "state") }).executionHandoffsManifest(
+          originalExecutionId,
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("limits deletion reconciliation to the target Mission and does not let analytics block deletion", async () => {
@@ -1069,8 +1142,8 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         createStaticRuntimeResolver({ runtimes: [runtimeForMode(mode)], defaultRuntimeId: "fake" }),
       ]),
     );
-    const runtimesForToolPermissionMode = vi.fn(
-      (mode: DesktopToolPermissionMode) => runtimeResolvers.get(mode)!,
+    const runtimesForToolPermissionMode = vi.fn((mode: DesktopToolPermissionMode) =>
+      runtimeResolvers.get(mode)!,
     );
     const runner = createMissionRunner({
       missions,

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -128,7 +128,7 @@ async function collectMissionExecutionIds(
   missions: MissionStore,
   missionId: string,
 ): Promise<ReadonlySet<string>> {
-  const executionIds = new Set<string>();
+  const executionTurns: { readonly sequence: number; readonly executionId: string }[] = [];
   let beforeSequence: number | undefined;
   while (true) {
     const page = await missions.readTimelinePage(missionId, {
@@ -136,9 +136,17 @@ async function collectMissionExecutionIds(
       limit: 500,
     });
     for (const turn of page.turns) {
-      if (turn.executionId !== undefined) executionIds.add(turn.executionId);
+      if (turn.executionId !== undefined) {
+        executionTurns.push({ sequence: turn.sequence, executionId: turn.executionId });
+      }
     }
-    if (page.nextBeforeSequence === undefined) return executionIds;
+    if (page.nextBeforeSequence === undefined) {
+      return new Set(
+        executionTurns
+          .toSorted((left, right) => left.sequence - right.sequence)
+          .map((turn) => turn.executionId),
+      );
+    }
     beforeSequence = page.nextBeforeSequence;
   }
 }
@@ -181,6 +189,7 @@ interface LiveMissionChat {
 interface MissionExecutionContext {
   readonly app: ReturnType<typeof createPragma>;
   readonly runtimes: RuntimeResolver;
+  readonly rememberHandoffExecution: (executionId: string) => void;
   readonly setToolPermissionMode: (mode: DesktopToolPermissionMode) => void;
 }
 
@@ -266,6 +275,26 @@ export function createMissionRunner(options: {
       resolve: async (request) =>
         await runtimeResolverForToolPermissionMode(toolPermissionMode).resolve(request),
     };
+    const pendingHandoffExecutionIds = new Set<string>();
+    let handoffExecutionIds: Set<string> | undefined;
+    let handoffExecutionIdsLoad: Promise<Set<string>> | undefined;
+    const resolveHandoffExecutionIds = async (): Promise<readonly string[]> => {
+      if (handoffExecutionIds !== undefined) return [...handoffExecutionIds];
+      const load =
+        handoffExecutionIdsLoad ??
+        (handoffExecutionIdsLoad = collectMissionExecutionIds(options.missions, mission.id).then(
+          (persisted) => new Set([...persisted, ...pendingHandoffExecutionIds]),
+        ));
+      try {
+        handoffExecutionIds = await load;
+        for (const executionId of pendingHandoffExecutionIds) {
+          handoffExecutionIds.add(executionId);
+        }
+        return [...handoffExecutionIds];
+      } finally {
+        if (handoffExecutionIdsLoad === load) handoffExecutionIdsLoad = undefined;
+      }
+    };
     const context = {
       runtimes,
       app: createPragma({
@@ -273,6 +302,7 @@ export function createMissionRunner(options: {
         runtimes,
         executionStore,
         expertSessionStore,
+        handoffContextVisibilityResolver: resolveHandoffExecutionIds,
         loggerProvider: options.loggerProvider?.withScope({ missionId: mission.id }),
         automaticHumanInteractionHandler: async (request) =>
           await automaticHumanInteractionHandlerForToolPermissionMode(toolPermissionMode)?.(
@@ -319,6 +349,10 @@ export function createMissionRunner(options: {
                 clearPreview: (observationId) => options.usage!.clearPreview(observationId),
               },
       }),
+      rememberHandoffExecution: (executionId: string) => {
+        pendingHandoffExecutionIds.add(executionId);
+        handoffExecutionIds?.add(executionId);
+      },
       setToolPermissionMode: (mode: DesktopToolPermissionMode) => {
         toolPermissionMode = mode;
       },
@@ -759,7 +793,7 @@ export function createMissionRunner(options: {
     const mission = await options.missions.get(id);
     await options.assertExecutorReady?.(mission.executor.ref);
     if (active.has(mission.id)) return mission;
-    const { app, runtimes: baseRuntimes } = executionContext(mission);
+    const { app, rememberHandoffExecution, runtimes: baseRuntimes } = executionContext(mission);
     const runtimes = withMissionRuntimeBinding(baseRuntimes, await readMissionRootContext(mission));
     let phaseStartedAt = performance.now();
     const compiled = await compileMissionExecutor(mission, runtimes);
@@ -809,6 +843,7 @@ export function createMissionRunner(options: {
           executionId: mission.execution!.id,
           createdAt: executionStartedAt,
         });
+        rememberHandoffExecution(mission.execution!.id);
         await notifyExecutionLinked(mission, mission.execution!.id);
       }
       const handle = recoverable
@@ -827,6 +862,7 @@ export function createMissionRunner(options: {
           executionId: handle.executionId,
           createdAt: executionStartedAt,
         });
+        rememberHandoffExecution(handle.executionId);
         await notifyExecutionLinked(mission, handle.executionId);
       }
       const recoveredWaiting = recoverable && (await hasPendingHumanInteraction(handle));
@@ -911,6 +947,7 @@ export function createMissionRunner(options: {
       executionId: turn.executionId,
       createdAt: executionStartedAt,
     });
+    rememberHandoffExecution(turn.executionId);
     await notifyExecutionLinked(mission, turn.executionId);
     const running = await options.missions.updateExecution(mission.id, {
       id: turn.executionId,
@@ -948,7 +985,7 @@ export function createMissionRunner(options: {
     logMissionPhase(logger, input.id, "storage_capacity_check", capacityCheckStartedAt, acceptedAt);
     const mission = await options.missions.get(input.id);
     await options.assertExecutorReady?.(mission.executor.ref);
-    const { app, runtimes: baseRuntimes } = executionContext(mission);
+    const { app, rememberHandoffExecution, runtimes: baseRuntimes } = executionContext(mission);
     const rootContext = await readMissionRootContext(mission);
     const runtimes = withMissionRuntimeBinding(baseRuntimes, rootContext);
     if (mission.executor.kind === "flow") {
@@ -1077,6 +1114,7 @@ export function createMissionRunner(options: {
       executionId: turn.executionId,
       createdAt: startedAt,
     });
+    rememberHandoffExecution(turn.executionId);
     await notifyExecutionLinked(mission, turn.executionId);
     const running = await options.missions.updateExecution(mission.id, {
       id: turn.executionId,

--- a/docs/Execution-SDK-Design.md
+++ b/docs/Execution-SDK-Design.md
@@ -44,3 +44,9 @@ Expert、ExpertTeam 成员和 Flow Expert step 的输出统一经过 Execution H
 Agent 已经在 workspace 中生成大型 UTF-8 文件时，使用 `register_handoff_file` 注册受控相对路径，
 不复制文件。Handoff 属于 Execution 可恢复状态，不是已发布 Artifact。Flow Task 和 HumanTask 的
 结构化内部数据不自动外置，Flow 最终结果仍应用同一 Handoff 规则。
+
+Handoff 文件由产出它的 Execution 持有，但读取视图按 owner 联邦：ExpertSession 默认包含其全部
+Execution，Desktop 进一步以持久 Mission timeline 覆盖 successor ExpertSession 和 Flow Execution。
+因此后续多轮和应用重启后仍可通过原 Context id 读取；不同 Mission 不共享视图。可见 Execution 中若
+出现重复 Context id，list、read、search 均返回 `context_conflict`，不隐式选择。workspace 注册项继续是
+实时路径引用，读取时反映文件后续修改；Mission 删除仍通过 timeline 删除实际持有 handoff 的 Execution。

--- a/docs/adr/018-execution-handoff-context.md
+++ b/docs/adr/018-execution-handoff-context.md
@@ -1,4 +1,4 @@
-# ADR 018: Execution-scoped handoff through Context System
+# ADR 018: Execution-owned handoff through Context System
 
 ## Status
 
@@ -21,8 +21,20 @@ The coordinator receives only a bounded summary and Context references.
 
 Core owns this behavior as an internal Execution module. Cross-process handoff schemas live in
 `@pragma/shared`; it is not an optional plugin or a separately installed package. Every
-Execution-scoped Expert receives the same Handoff Context Store, an always-on policy Context, and
-the `register_handoff_file` managed tool.
+Execution-scoped Expert receives the Handoff Context Store, an always-on policy Context, and the
+`register_handoff_file` managed tool.
+
+Each handoff remains physically owned by the Execution that produced it, but Context visibility is
+owner-scoped. Core federates all persisted Execution ids of an ExpertSession, so later turns and a
+reconstructed Session can read earlier handoffs. A Host may extend that visible set through a
+`HandoffContextVisibilityResolver`. Desktop uses the persistent Mission timeline for this purpose,
+which keeps handoffs visible after an incompatible Expert revision creates a successor
+ExpertSession and after the application restarts. Flow execution visibility remains limited to its
+own Execution unless the Host supplies a wider owner scope.
+
+Federation does not copy or rewrite handoff files. Duplicate Context ids in the visible Execution
+set fail with `context_conflict` instead of selecting one by iteration order. Writes and attempt
+cleanup always target the currently active Execution.
 
 `register_handoff_file` registers an existing UTF-8 regular file under the producing Expert's
 workspace without copying it. Registration validates the real path against the workspace root.
@@ -53,6 +65,8 @@ bounded summary and Context references before entering canonical message history
 - Small Expert results preserve their current SDK behavior.
 - Large results remain searchable and range-readable without entering the parent prompt.
 - Workspace-backed handoffs are mutable references; revision and etag changes reveal later edits.
-- Handoffs are Execution-scoped collaboration data, not durable published Artifacts.
-- Binary files, directories, cross-Execution sharing, CAS publication, and DSL Artifact contracts
+- Handoffs are Execution-owned, owner-visible collaboration data, not durable published Artifacts.
+- The persisted ExpertSession execution list and Desktop Mission timeline reconstruct visibility;
+  no Context contents or Runtime-session closures are the source of truth.
+- Binary files, directories, cross-Mission sharing, CAS publication, and DSL Artifact contracts
   remain outside this decision.

--- a/docs/architecture/agent-core-architecture.md
+++ b/docs/architecture/agent-core-architecture.md
@@ -66,7 +66,11 @@ Invocation 创建。Snapshot 只保存 `systemSessionId` 与 `RuntimeSessionRef`
 
 Invocation 输出通过 Core 内部的 Execution Handoff 模块进入 `inline` 或 `context` 交接。大型输出和
 已注册 workspace 文件以 `pragma.handoff` Context item 暴露；`wait_experts` 和自动续跑只传摘要与引用。
-Handoff Context Store 是 Execution-scoped 动态 overlay，不属于 Expert 定义，也不通过 Plugin 可选安装。
+Handoff 的物理 owner 是产出它的 Execution；Context Store 按 ExpertSession 的持久 executionIds 联邦读取，
+Host 可通过 `HandoffContextVisibilityResolver` 扩展 owner 可见范围。Desktop 以 Mission timeline 联邦
+successor Session 和 Flow Execution，因此重启后仍可重建同一读取视图。写入始终落到当前 Execution，
+不同 owner 不共享视图，重复 Context id fail closed。该 overlay 不属于 Expert 定义，也不通过 Plugin
+可选安装。
 
 ## Dispatcher 与通知边界
 

--- a/packages/core/src/execution/expert-session.ts
+++ b/packages/core/src/execution/expert-session.ts
@@ -42,6 +42,7 @@ import {
   runExpertInvocation,
 } from "./expert-runner.ts";
 import { HandoffService, unwrapInvocationHandoff } from "./handoff/handoff-service.ts";
+import type { HandoffContextVisibilityResolver } from "./handoff/handoff-visibility.ts";
 import { RuntimeSessionPool } from "./runtime-session-pool.ts";
 import type { ExecutionStore } from "./execution-store.ts";
 import {
@@ -153,8 +154,8 @@ export interface ExpertSessionManagerDependencies {
   readonly usageSink?: UsageSink | undefined;
   readonly pragmaHome?: string | undefined;
   readonly automaticHumanInteractionHandler?:
-    | ExpertAgentAutomaticHumanInteractionHandler
-    | undefined;
+    ExpertAgentAutomaticHumanInteractionHandler | undefined;
+  readonly handoffContextVisibilityResolver?: HandoffContextVisibilityResolver | undefined;
 }
 
 type SteerClaim =
@@ -490,6 +491,7 @@ export class ExpertSessionManager {
 
 class ExpertSessionImpl implements ExpertSession {
   private controller: ExecutionController | undefined;
+  private activeHandoffService: HandoffService | undefined;
   private processing: Promise<void> | undefined;
   private readonly runtimeSessions = new RuntimeSessionPool();
   private closePromise: Promise<void> | undefined;
@@ -1117,10 +1119,23 @@ class ExpertSessionImpl implements ExpertSession {
     const handoffs = new HandoffService({
       executionId: prompt.executionId,
       executions: this.dependencies.executions,
+      resolveVisibleExecutionIds: async (activeExecutionId) => {
+        const currentSession = await this.dependencies.sessions.get(this.sessionId);
+        const hostExecutionIds = await this.dependencies.handoffContextVisibilityResolver?.({
+          currentExecutionId: activeExecutionId,
+          owner: { type: "expert-session", ownerId: this.sessionId },
+        });
+        return [...(currentSession?.executionIds ?? []), ...(hostExecutionIds ?? [])];
+      },
+      resolveActiveService: (executionId) =>
+        this.activeHandoffService?.executionId === executionId
+          ? this.activeHandoffService
+          : undefined,
       ...(this.dependencies.pragmaHome === undefined
         ? {}
         : { pragmaHome: this.dependencies.pragmaHome }),
     });
+    this.activeHandoffService = handoffs;
     this.controller = controller;
     let status: "succeeded" | "failed" | "cancelled" = "succeeded";
     let output: ReturnType<typeof InvocationHandoffSchema.parse> | undefined;
@@ -1208,6 +1223,9 @@ class ExpertSessionImpl implements ExpertSession {
     }));
     if (this.controller === controller) {
       this.controller = undefined;
+    }
+    if (this.activeHandoffService === handoffs) {
+      this.activeHandoffService = undefined;
     }
     controller.finish();
   }

--- a/packages/core/src/execution/handoff/handoff-context-store.ts
+++ b/packages/core/src/execution/handoff/handoff-context-store.ts
@@ -33,6 +33,7 @@ import {
   type ExpertAgentStoredContextItemSearchInput,
   type ExpertAgentStoredContextRegisterInput,
 } from "../../context-system/context-system.ts";
+import { readExecutionRunScope } from "../../runtime/run-context.ts";
 import { withFileLock } from "../../storage/file-lock.ts";
 import { PragmaPaths } from "../../storage/pragma-paths.ts";
 
@@ -100,6 +101,166 @@ export interface RegisterWorkspaceHandoffInput {
   readonly mediaType: string;
   readonly description?: string | undefined;
   readonly idempotencyKey: string;
+}
+
+export interface FederatedExecutionHandoffContextStoreOptions {
+  readonly defaultExecutionId: string;
+  readonly defaultStore?: ExecutionHandoffContextStore | undefined;
+  readonly resolveVisibleExecutionIds: (
+    activeExecutionId: string,
+  ) => Promise<readonly string[]> | readonly string[];
+  readonly pragmaHome?: string | undefined;
+}
+
+export class FederatedExecutionHandoffContextStore implements ExpertAgentContextStore {
+  readonly namespace = HANDOFF_NAMESPACE;
+  private readonly paths: PragmaPaths;
+  private readonly stores = new Map<string, ExecutionHandoffContextStore>();
+
+  constructor(private readonly options: FederatedExecutionHandoffContextStoreOptions) {
+    this.paths = new PragmaPaths(options);
+    if (options.defaultStore !== undefined) {
+      if (options.defaultStore.executionId !== options.defaultExecutionId) {
+        throw new Error("Federated handoff default Store must match the default Execution id.");
+      }
+      this.stores.set(options.defaultExecutionId, options.defaultStore);
+    }
+  }
+
+  async listContext(
+    input: ExpertAgentContextItemListInput = {},
+  ): Promise<ExpertAgentContextResult<readonly ExpertAgentContextItemSummary[]>> {
+    try {
+      const stores = await this.resolveStores(input.context);
+      const conflict = findDuplicateEntryId(
+        await Promise.all(
+          stores.map(async (store) => ({
+            executionId: store.executionId,
+            ids: await store.listContextIds(),
+          })),
+        ),
+      );
+      if (conflict !== undefined) return duplicateContextError(conflict.id, conflict.executionIds);
+
+      const results = await Promise.all(
+        stores.map(async (store) => await store.listContext(input)),
+      );
+      const summaries: ExpertAgentContextItemSummary[] = [];
+      for (const result of results) {
+        if (!result.ok) return result;
+        summaries.push(...result.value);
+      }
+      return ok(summaries);
+    } catch (caught) {
+      return error("store_error", "Failed to list visible handoffs.", toErrorDetails(caught));
+    }
+  }
+
+  async readContext(
+    input: ExpertAgentStoredContextItemReadInput,
+  ): Promise<ExpertAgentContextResult<ExpertAgentStoredContextItemReadResult>> {
+    try {
+      const stores = await this.resolveStores(input.context);
+      const matches: ExecutionHandoffContextStore[] = [];
+      for (const store of stores) {
+        if (await store.hasContext(input.id)) matches.push(store);
+      }
+      if (matches.length === 0) {
+        return error("context_not_found", `Handoff context not found: ${input.id}`, {
+          id: input.id,
+        });
+      }
+      if (matches.length > 1) {
+        return duplicateContextError(
+          input.id,
+          matches.map((store) => store.executionId),
+        );
+      }
+      return await matches[0]!.readContext(input);
+    } catch (caught) {
+      return error(
+        "store_error",
+        `Failed to read visible handoff context: ${input.id}`,
+        toErrorDetails(caught),
+      );
+    }
+  }
+
+  async searchContext(
+    input: ExpertAgentStoredContextItemSearchInput,
+  ): Promise<ExpertAgentContextResult<readonly ExpertAgentContextItemSearchMatch[]>> {
+    const query = input.query.trim();
+    if (query === "") return error("invalid_input", "Context search query must not be empty.");
+    try {
+      const stores = await this.resolveStores(input.context);
+      const duplicate = findDuplicateEntryId(
+        await Promise.all(
+          stores.map(async (store) => ({
+            executionId: store.executionId,
+            ids: await store.listContextIds(),
+          })),
+        ),
+      );
+      if (duplicate !== undefined) {
+        return duplicateContextError(duplicate.id, duplicate.executionIds);
+      }
+
+      const maxResults = Math.max(1, Math.trunc(input.maxResults ?? 20));
+      const matches: ExpertAgentContextItemSearchMatch[] = [];
+      for (const store of stores.toReversed()) {
+        const result = await store.searchContext({
+          ...input,
+          maxResults: maxResults - matches.length,
+        });
+        if (!result.ok) return result;
+        matches.push(...result.value);
+        if (matches.length >= maxResults) break;
+      }
+      return ok(matches);
+    } catch (caught) {
+      return error("store_error", "Failed to search visible handoffs.", toErrorDetails(caught));
+    }
+  }
+
+  async addContext(
+    input: ExpertAgentStoredContextRegisterInput,
+  ): Promise<ExpertAgentContextResult<ExpertAgentStoredContextItem>> {
+    void input;
+    return error("permission_denied", "Execution handoffs are read-only.");
+  }
+
+  async editContext(
+    input: ExpertAgentStoredContextItemEditInput,
+  ): Promise<ExpertAgentContextResult<ExpertAgentStoredContextItemEditResult>> {
+    void input;
+    return error("permission_denied", "Execution handoffs are read-only.");
+  }
+
+  async deleteContext(
+    input: ExpertAgentStoredContextItemDeleteInput,
+  ): Promise<ExpertAgentContextResult<{ readonly id: string }>> {
+    void input;
+    return error("permission_denied", "Execution handoffs are read-only.");
+  }
+
+  private async resolveStores(
+    context: ExpertAgentContextItemListInput["context"],
+  ): Promise<readonly ExecutionHandoffContextStore[]> {
+    const activeExecutionId =
+      readExecutionRunScope(context).executionId ?? this.options.defaultExecutionId;
+    const configured = await this.options.resolveVisibleExecutionIds(activeExecutionId);
+    const executionIds = [...new Set([...configured, activeExecutionId])];
+    return executionIds.map((executionId) => this.getStore(executionId));
+  }
+
+  private getStore(executionId: string): ExecutionHandoffContextStore {
+    let store = this.stores.get(executionId);
+    if (store === undefined) {
+      store = new ExecutionHandoffContextStore(executionId, { pragmaHome: this.paths.root });
+      this.stores.set(executionId, store);
+    }
+    return store;
+  }
 }
 
 export class ExecutionHandoffContextStore implements ExpertAgentContextStore {
@@ -312,6 +473,14 @@ export class ExecutionHandoffContextStore implements ExpertAgentContextStore {
     );
   }
 
+  async hasContext(id: string): Promise<boolean> {
+    return (await this.readManifest()).entries.some((entry) => entry.id === id);
+  }
+
+  async listContextIds(): Promise<readonly string[]> {
+    return (await this.readManifest()).entries.map((entry) => entry.id);
+  }
+
   async addContext(
     input: ExpertAgentStoredContextRegisterInput,
   ): Promise<ExpertAgentContextResult<ExpertAgentStoredContextItem>> {
@@ -493,6 +662,30 @@ export class ExecutionHandoffContextStore implements ExpertAgentContextStore {
       throw caught;
     }
   }
+}
+
+function findDuplicateEntryId(
+  entries: readonly { readonly executionId: string; readonly ids: readonly string[] }[],
+): { readonly id: string; readonly executionIds: readonly string[] } | undefined {
+  const owners = new Map<string, string>();
+  for (const entry of entries) {
+    for (const id of entry.ids) {
+      const owner = owners.get(id);
+      if (owner !== undefined) return { id, executionIds: [owner, entry.executionId] };
+      owners.set(id, entry.executionId);
+    }
+  }
+  return undefined;
+}
+
+function duplicateContextError<TValue>(
+  id: string,
+  executionIds: readonly string[],
+): ExpertAgentContextResult<TValue> {
+  return error("context_conflict", `Handoff context id is ambiguous: ${id}`, {
+    id,
+    executionIds,
+  });
 }
 
 function createEntryMetadata(entry: HandoffEntry, stats: BigIntStats): HandoffEntryMetadata {

--- a/packages/core/src/execution/handoff/handoff-service.ts
+++ b/packages/core/src/execution/handoff/handoff-service.ts
@@ -16,7 +16,10 @@ import type {
   ExpertAgentToolCallResult,
 } from "../../tools/managed-tool.ts";
 import type { ExecutionStore } from "../execution-store.ts";
-import { ExecutionHandoffContextStore } from "./handoff-context-store.ts";
+import {
+  ExecutionHandoffContextStore,
+  FederatedExecutionHandoffContextStore,
+} from "./handoff-context-store.ts";
 
 export const DEFAULT_HANDOFF_INLINE_LIMIT_BYTES = 32 * 1024;
 export const DEFAULT_HANDOFF_SUMMARY_LIMIT_BYTES = 4 * 1024;
@@ -27,16 +30,29 @@ export interface HandoffServiceOptions {
   readonly pragmaHome?: string | undefined;
   readonly inlineLimitBytes?: number | undefined;
   readonly summaryLimitBytes?: number | undefined;
+  readonly resolveVisibleExecutionIds?:
+    ((activeExecutionId: string) => Promise<readonly string[]> | readonly string[]) | undefined;
+  readonly resolveActiveService?: ((executionId: string) => HandoffService | undefined) | undefined;
 }
 
 export class HandoffService {
+  readonly executionId: string;
   readonly store: ExecutionHandoffContextStore;
+  readonly contextStore: FederatedExecutionHandoffContextStore;
   readonly inlineLimitBytes: number;
   readonly summaryLimitBytes: number;
   private readonly attempts = new Map<string, string>();
 
   constructor(private readonly options: HandoffServiceOptions) {
+    this.executionId = options.executionId;
     this.store = new ExecutionHandoffContextStore(options.executionId, {
+      ...(options.pragmaHome === undefined ? {} : { pragmaHome: options.pragmaHome }),
+    });
+    this.contextStore = new FederatedExecutionHandoffContextStore({
+      defaultExecutionId: options.executionId,
+      defaultStore: this.store,
+      resolveVisibleExecutionIds:
+        options.resolveVisibleExecutionIds ?? ((activeExecutionId) => [activeExecutionId]),
       ...(options.pragmaHome === undefined ? {} : { pragmaHome: options.pragmaHome }),
     });
     this.inlineLimitBytes = normalizeLimit(
@@ -54,7 +70,7 @@ export class HandoffService {
     Object.defineProperties(clone, Object.getOwnPropertyDescriptors(expert));
     const contextSystem = expert.contextSystem.extend({
       stores: [
-        ["pragma.handoff", this.store],
+        ["pragma.handoff", this.contextStore],
         [
           "pragma.handoff-policy",
           new StaticContextStore([
@@ -62,7 +78,7 @@ export class HandoffService {
               id: "HANDOFF.md",
               content: createHandoffPolicy(this.inlineLimitBytes),
               metadata: {
-                description: "Execution-scoped output handoff rules.",
+                description: "Owner-scoped output handoff rules.",
                 trigger: "always_on",
                 priority: "critical",
                 trustLevel: "system",
@@ -187,14 +203,19 @@ export class HandoffService {
           const path = readRequiredString(record, "path");
           const execution = context?.execution;
           const invocationId = execution?.invocationId;
-          if (
-            invocationId === undefined ||
-            execution === undefined ||
-            execution.executionId !== this.options.executionId
-          ) {
+          if (invocationId === undefined || execution === undefined) {
             throw new Error("register_handoff_file requires the active Execution context.");
           }
-          const reference = await this.registerWorkspaceFile({
+          const activeService =
+            execution.executionId === this.options.executionId
+              ? this
+              : this.options.resolveActiveService?.(execution.executionId);
+          if (activeService === undefined) {
+            throw new Error(
+              `register_handoff_file cannot resolve the active Execution: ${execution.executionId}`,
+            );
+          }
+          const reference = await activeService.registerWorkspaceFile({
             invocationId,
             toolCallId: context?.toolCallId ?? `untracked-${encodePragmaPathSegment(path)}`,
             workspaceRoot: expert.workspace,

--- a/packages/core/src/execution/handoff/handoff-visibility.ts
+++ b/packages/core/src/execution/handoff/handoff-visibility.ts
@@ -1,0 +1,10 @@
+export interface HandoffContextVisibilityRequest {
+  readonly currentExecutionId: string;
+  readonly owner:
+    | { readonly type: "expert-session"; readonly ownerId: string }
+    | { readonly type: "flow-execution"; readonly ownerId: string };
+}
+
+export type HandoffContextVisibilityResolver = (
+  request: HandoffContextVisibilityRequest,
+) => Promise<readonly string[]> | readonly string[];

--- a/packages/core/src/flow/flow-execution.ts
+++ b/packages/core/src/flow/flow-execution.ts
@@ -28,6 +28,7 @@ import {
   runExpertInvocation,
 } from "../execution/expert-runner.ts";
 import { HandoffService, unwrapInvocationHandoff } from "../execution/handoff/handoff-service.ts";
+import type { HandoffContextVisibilityResolver } from "../execution/handoff/handoff-visibility.ts";
 import {
   ContextResolutionService,
   closeExecutionContexts,
@@ -86,11 +87,12 @@ export class FlowExecutionManager {
     private readonly executions: ExecutionStore,
     private readonly runtimes: RuntimeResolver,
     private readonly automaticHumanInteractionHandler?:
-      | ExpertAgentAutomaticHumanInteractionHandler
-      | undefined,
+      ExpertAgentAutomaticHumanInteractionHandler | undefined,
     private readonly pragmaHome?: string | undefined,
     private readonly loggerProvider?: PragmaLoggerProvider | undefined,
     private readonly usageSink?: UsageSink | undefined,
+    private readonly handoffContextVisibilityResolver?:
+      HandoffContextVisibilityResolver | undefined,
   ) {}
 
   async start<TInput>(
@@ -279,6 +281,11 @@ export class FlowExecutionManager {
     const handoffs = new HandoffService({
       executionId,
       executions: this.executions,
+      resolveVisibleExecutionIds: async (activeExecutionId) =>
+        (await this.handoffContextVisibilityResolver?.({
+          currentExecutionId: activeExecutionId,
+          owner: { type: "flow-execution", ownerId: executionId },
+        })) ?? [],
       ...(this.pragmaHome === undefined ? {} : { pragmaHome: this.pragmaHome }),
     });
     await handoffs.beginInvocationAttempt(executionId, `flow-execution-attempt:${randomUUID()}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export * from "./execution/execution-live-bus.ts";
 export * from "./execution/execution-output.ts";
 export * from "./execution/execution-work-history.ts";
 export * from "./execution/execution-view.ts";
+export * from "./execution/handoff/handoff-visibility.ts";
 export * from "./events/canonical-event-feed.ts";
 export * from "./execution/expert-session-store.ts";
 export * from "./execution/expert-session.ts";

--- a/packages/core/src/pragma-app.ts
+++ b/packages/core/src/pragma-app.ts
@@ -21,6 +21,7 @@ import type { RuntimeResolver } from "./runtime-resolver.ts";
 import type { UsageSink } from "./runtime/usage.ts";
 import { defaultPragmaLoggerProvider, type PragmaLoggerProvider } from "./logging/logger.ts";
 import type { ExpertAgentAutomaticHumanInteractionHandler } from "./tools/managed-tool.ts";
+import type { HandoffContextVisibilityResolver } from "./execution/handoff/handoff-visibility.ts";
 
 export interface CreatePragmaOptions {
   readonly pragmaHome?: string | undefined;
@@ -30,8 +31,8 @@ export interface CreatePragmaOptions {
   readonly loggerProvider?: PragmaLoggerProvider | undefined;
   readonly usageSink?: UsageSink | undefined;
   readonly automaticHumanInteractionHandler?:
-    | ExpertAgentAutomaticHumanInteractionHandler
-    | undefined;
+    ExpertAgentAutomaticHumanInteractionHandler | undefined;
+  readonly handoffContextVisibilityResolver?: HandoffContextVisibilityResolver | undefined;
 }
 
 export interface PragmaApp {
@@ -81,6 +82,7 @@ export function createPragma(options: CreatePragmaOptions): PragmaApp {
     pragmaHome: options.pragmaHome,
     automaticHumanInteractionHandler: options.automaticHumanInteractionHandler,
     usageSink: options.usageSink,
+    handoffContextVisibilityResolver: options.handoffContextVisibilityResolver,
   });
   const flows = new FlowExecutionManager(
     executions,
@@ -89,6 +91,7 @@ export function createPragma(options: CreatePragmaOptions): PragmaApp {
     options.pragmaHome,
     loggerProvider,
     options.usageSink,
+    options.handoffContextVisibilityResolver,
   );
   return {
     experts: {

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -683,6 +683,104 @@ describe("ExpertSession", () => {
     await session.close();
   });
 
+  it("reads an earlier turn handoff through a reused Runtime Session", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-session-handoff-"));
+    await writeFile(join(home, "report.md"), "workspace handoff\n", "utf8");
+    let createSessionCalls = 0;
+    const runtime = defineRuntimeDriver<never, FakeSession>({
+      descriptor: { id: "handoff-reader", kind: "fake", displayName: "Handoff Reader" },
+      createSession: (context) => {
+        createSessionCalls += 1;
+        return { context, id: `native-${context.systemSessionId}` };
+      },
+      restoreSession: (context) => ({ context, id: context.request.runtimeSession!.id }),
+      readSession: (nativeSession) => ({ runtimeSessionId: nativeSession.id }),
+      async startTurn(nativeSession, turn) {
+        let output: string;
+        if (turn.rawQuery === "produce") {
+          output = "historical handoff\n".repeat(4_000);
+        } else if (turn.rawQuery.startsWith("read:")) {
+          const id = turn.rawQuery.slice("read:".length);
+          const read = nativeSession.context.agent
+            .createDefaultTools()
+            .find((tool) => tool.name === "read_expert_context");
+          if (read === undefined) throw new Error("read_expert_context is missing.");
+          const result = await read.call({ namespace: "pragma.handoff", id }, turn.signal, {
+            execution: nativeSession.context.request.executionContext,
+          });
+          output =
+            result.isError === true ||
+            (!result.text.includes("historical handoff") &&
+              !result.text.includes("workspace handoff"))
+              ? `read-failed:${result.text}`
+              : "read-ok";
+        } else {
+          const register = nativeSession.context.agent.tools?.find(
+            (tool) => tool.name === "register_handoff_file",
+          );
+          if (register === undefined) throw new Error("register_handoff_file is missing.");
+          const result = await register.call({ path: "report.md" }, turn.signal, {
+            toolCallId: "register-report",
+            execution: nativeSession.context.request.executionContext,
+          });
+          output = result.isError === true ? `register-failed:${result.text}` : "registered";
+        }
+        return { outputText: output, runtimeSessionId: nativeSession.id };
+      },
+      mapEvent: () => ({ events: [] }),
+    });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: "handoff-reader",
+      }),
+    });
+    const expert = await defineExpert({
+      id: "handoff-expert",
+      name: "Handoff Expert",
+      description: "Reads earlier handoffs",
+      tags: [],
+      scope: "test",
+      workspace: home,
+      pragmaHome: home,
+    });
+    const session = await app.experts.createSession(expert);
+    const first = await (await session.prompt("produce", { requestId: "produce" })).result;
+    if (
+      typeof first !== "object" ||
+      first === null ||
+      !("type" in first) ||
+      first.type !== "context" ||
+      !("contexts" in first) ||
+      !Array.isArray(first.contexts)
+    ) {
+      throw new Error("Expected the first turn to return a Context handoff.");
+    }
+    const id = (first.contexts[0] as { id: string }).id;
+
+    await expect((await session.prompt(`read:${id}`, { requestId: "read" })).result).resolves.toBe(
+      "read-ok",
+    );
+    const registered = await (await session.prompt("register", { requestId: "register" })).result;
+    if (
+      typeof registered !== "object" ||
+      registered === null ||
+      !("type" in registered) ||
+      registered.type !== "context" ||
+      !("contexts" in registered) ||
+      !Array.isArray(registered.contexts)
+    ) {
+      throw new Error("Expected the registered file to return a Context handoff.");
+    }
+    const workspaceId = (registered.contexts[0] as { id: string }).id;
+    await expect(
+      (await session.prompt(`read:${workspaceId}`, { requestId: "read-workspace" })).result,
+    ).resolves.toBe("read-ok");
+    expect(createSessionCalls).toBe(1);
+    await session.close();
+  }, 15_000);
+
   it("keeps one Runtime Session alive across prompts and closes it with the ExpertSession", async () => {
     const { home, app, expert, stats } = await trackedFixture();
     const session = await app.experts.createSession(expert);

--- a/packages/core/test/handoff.test.ts
+++ b/packages/core/test/handoff.test.ts
@@ -9,6 +9,7 @@ import {
   HandoffService,
   unwrapInvocationHandoff,
 } from "../src/execution/handoff/handoff-service.ts";
+import { withExecutionRunScope } from "../src/runtime/run-context.ts";
 import { PragmaPaths } from "../src/storage/pragma-paths.ts";
 
 describe("Execution handoff", () => {
@@ -58,6 +59,92 @@ describe("Execution handoff", () => {
     );
     await expect(readFile(outputPath, "utf8")).resolves.toBe(largeText);
     expect(unwrapInvocationHandoff(handoff)).toEqual(handoff);
+  });
+
+  it("federates handoffs from every visible Execution", async () => {
+    const fixture = await createFixture();
+    const previousService = new HandoffService({
+      executionId: "previous-execution",
+      executions: fixture.executions,
+      pragmaHome: fixture.home,
+    });
+    await previousService.beginInvocationAttempt("child", "attempt-1");
+    const output = "previous handoff\n".repeat(4_000);
+    const handoff = await previousService.normalize("child", output);
+    if (handoff.type !== "context") throw new Error("Expected a Context handoff.");
+
+    const currentService = new HandoffService({
+      executionId: "current-execution",
+      executions: fixture.executions,
+      pragmaHome: fixture.home,
+      resolveVisibleExecutionIds: () => ["previous-execution", "current-execution"],
+    });
+    const context = withExecutionRunScope(undefined, { executionId: "current-execution" });
+
+    const read = await currentService.contextStore.readContext({
+      id: handoff.contexts[0]!.id,
+      context,
+    });
+    const list = await currentService.contextStore.listContext({ context });
+    const search = await currentService.contextStore.searchContext({
+      query: "previous handoff",
+      context,
+    });
+
+    expect(read).toMatchObject({ ok: true, value: { content: output } });
+    expect(list).toMatchObject({ ok: true, value: [{ id: handoff.contexts[0]!.id }] });
+    expect(search).toMatchObject({ ok: true });
+    if (!search.ok) throw new Error(search.error.message);
+    expect(search.value.some((match) => match.id === handoff.contexts[0]!.id)).toBe(true);
+
+    const isolatedService = new HandoffService({
+      executionId: "isolated-execution",
+      executions: fixture.executions,
+      pragmaHome: fixture.home,
+      resolveVisibleExecutionIds: () => ["isolated-execution"],
+    });
+    await expect(
+      isolatedService.contextStore.readContext({ id: handoff.contexts[0]!.id }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: "context_not_found" },
+    });
+  });
+
+  it("fails closed when visible Executions contain the same context id", async () => {
+    const fixture = await createFixture();
+    const services = ["execution-a", "execution-b"].map(
+      (executionId) =>
+        new HandoffService({
+          executionId,
+          executions: fixture.executions,
+          pragmaHome: fixture.home,
+        }),
+    );
+    for (const service of services) {
+      await service.beginInvocationAttempt("shared-invocation", "attempt-1");
+      await service.normalize("shared-invocation", "duplicate\n".repeat(5_000));
+    }
+    const reader = new HandoffService({
+      executionId: "current-execution",
+      executions: fixture.executions,
+      pragmaHome: fixture.home,
+      resolveVisibleExecutionIds: () => ["execution-a", "execution-b"],
+    });
+    const id = "invocations/c2hhcmVkLWludm9jYXRpb24/output.txt";
+
+    await expect(reader.contextStore.listContext()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "context_conflict" },
+    });
+    await expect(reader.contextStore.readContext({ id })).resolves.toMatchObject({
+      ok: false,
+      error: { code: "context_conflict" },
+    });
+    await expect(reader.contextStore.searchContext({ query: "duplicate" })).resolves.toMatchObject({
+      ok: false,
+      error: { code: "context_conflict" },
+    });
   });
 
   it("registers a workspace file without copying it and exposes revision changes", async () => {


### PR DESCRIPTION
## What changed

- Federate `pragma.handoff` reads across the persisted Executions visible to an ExpertSession.
- Add a Host visibility resolver and let Desktop scope it to the persistent Mission timeline.
- Preserve handoff visibility after app restart and after an incompatible Expert definition creates a successor Session.
- Route `register_handoff_file` to the currently active Execution when a native Runtime Session reuses tools created in an earlier turn.
- Keep workspace handoffs as live references, fail closed on duplicate Context IDs, and retain Execution-owned deletion semantics.
- Cache Mission handoff visibility and incrementally update it when execution references are persisted.
- Update architecture documentation and regression coverage.

## Why

A reused Runtime Session retained the Handoff Context Store and managed tools from the Execution that originally created it. Later turns therefore looked only in the old Execution or attempted to write through the wrong service, causing valid handoff IDs to return `context_not_found`. The original Execution-only visibility model also could not satisfy Mission-level lifetime across restarts or successor ExpertSessions.

The implementation keeps physical files owned by their producing Execution and federates only the read view. This avoids a new persistence schema or content-copy migration while preserving Mission isolation and cleanup.

## Impact

Experts in the same Mission can read earlier handoffs across turns, application restarts, Flow executions, and successor ExpertSessions. Different Missions remain isolated. Duplicate IDs return `context_conflict` rather than selecting an arbitrary file.

## Validation

- Independent Claude Code review completed; no blocking issues remained after verified fixes.
- `pnpm check` passed across all 21 packages.
- `pnpm build` passed across all 21 packages.
- Core: 35 test files / 232 tests passed.
- Desktop: 106 test files / 629 tests passed.
- Desktop preload self-containment verification passed.