### PR TITLE
Clarify memory governance actions

### DIFF
--- a/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
@@ -22,7 +22,11 @@ export const memory = {
   evidence: "Evidence",
   reason: "Reason for this change",
   disableRecall: "Disable recall",
+  disableRecallTooltip:
+    "Prevent {{consumer}} from recalling this memory. The memory is not deleted, and other bindings are unaffected.",
   restrictVisibility: "Restrict visibility",
+  restrictVisibilityTooltip:
+    "Make this memory visible only to its root asset principals ({{principals}}). Other principals will no longer be able to discover it.",
   verify: "Verify fact",
   revise: "Revise fact",
   invalidate: "Invalidate",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
@@ -24,7 +24,11 @@ export const memory = {
   evidence: "证据",
   reason: "本次变更原因",
   disableRecall: "关闭召回",
+  disableRecallTooltip:
+    "禁止绑定“{{consumer}}”继续召回这条记忆。记忆不会被删除，其他绑定不受影响。",
   restrictVisibility: "收紧可见性",
+  restrictVisibilityTooltip:
+    "将这条记忆改为仅根资产主体（{{principals}}）可见，其他主体将无法再发现它。",
   verify: "验证事实",
   revise: "修正事实",
   invalidate: "设为失效",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
@@ -24,7 +24,11 @@ export const memory = {
   evidence: "證據",
   reason: "本次變更原因",
   disableRecall: "關閉召回",
+  disableRecallTooltip:
+    "禁止綁定「{{consumer}}」繼續召回這筆記憶。記憶不會被刪除，其他綁定不受影響。",
   restrictVisibility: "縮小可見性",
+  restrictVisibilityTooltip:
+    "將這筆記憶改為僅根資產主體（{{principals}}）可見，其他主體將無法再發現它。",
   verify: "驗證事實",
   revise: "修正事實",
   invalidate: "設為失效",

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { i18n } from "../../i18n/index.ts";
-import { MemoryDegradedAlert, MemoryPage } from "./MemoryPage.tsx";
+import { MemoryActionWithTooltip, MemoryDegradedAlert, MemoryPage } from "./MemoryPage.tsx";
 
 afterEach(async () => {
   await i18n.changeLanguage("en");
@@ -26,6 +26,21 @@ describe("MemoryPage", () => {
     expect(html).toContain("<h1>记忆</h1>");
     expect(html).toContain("情景记忆");
     expect(html).toContain("健康状态");
+  });
+
+  it("describes governance actions with an accessible tooltip", () => {
+    const html = renderToStaticMarkup(
+      <MemoryActionWithTooltip
+        disabled={false}
+        label="Restrict visibility"
+        tooltip="Only root asset principals will be able to discover this memory."
+        onClick={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('aria-describedby="');
+    expect(html).toContain('role="tooltip"');
+    expect(html).toContain("Only root asset principals");
   });
 
   it("shows extraction failures without requiring the Health tab", async () => {

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { MagnifyingGlass, ShieldCheck, Trash, WarningCircle } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 
@@ -191,60 +191,8 @@ export function MemoryPage() {
                         {t("recall")} {binding.recall} · {t("export")} {binding.export} · p
                         {binding.permissionRevision}
                       </span>
-                      {binding.recall === "allow" ? (
-                        <button
-                          type="button"
-                          disabled={reason.trim() === "" || actionBusy}
-                          onClick={() =>
-                            void run(
-                              async () =>
-                                await window.pragmaDesktop.tightenMemoryAccess({
-                                  module: selected.module,
-                                  id: selected.id,
-                                  expectedRevision: selected.revision,
-                                  reason,
-                                  bindings: selected.bindings.map((candidate) =>
-                                    candidate === binding
-                                      ? {
-                                          ...candidate,
-                                          recall: "deny",
-                                          permissionRevision: candidate.permissionRevision + 1,
-                                        }
-                                      : candidate,
-                                  ),
-                                }),
-                            )
-                          }
-                        >
-                          {t("disableRecall")}
-                        </button>
-                      ) : null}
                     </div>
                   ))}
-                  {selected.visibility.mode === "restricted" ||
-                  selected.rootRefs.length === 0 ? null : (
-                    <button
-                      type="button"
-                      disabled={reason.trim() === "" || actionBusy}
-                      onClick={() =>
-                        void run(
-                          async () =>
-                            await window.pragmaDesktop.tightenMemoryAccess({
-                              module: selected.module,
-                              id: selected.id,
-                              expectedRevision: selected.revision,
-                              reason,
-                              visibility: {
-                                mode: "restricted",
-                                principals: selected.rootRefs,
-                              },
-                            }),
-                        )
-                      }
-                    >
-                      {t("restrictVisibility")}
-                    </button>
-                  )}
                 </section>
                 <section>
                   <h3>{t("evidence")}</h3>
@@ -334,6 +282,63 @@ export function MemoryPage() {
                   >
                     <Trash size={17} aria-hidden="true" /> {t("forget")}
                   </button>
+                  {selected.bindings.map((binding) =>
+                    binding.recall === "allow" ? (
+                      <MemoryActionWithTooltip
+                        key={`${binding.consumerRef.type}:${binding.consumerRef.id}`}
+                        disabled={reason.trim() === "" || actionBusy}
+                        label={t("disableRecall")}
+                        tooltip={t("disableRecallTooltip", {
+                          consumer: refs([binding.consumerRef]),
+                        })}
+                        onClick={() =>
+                          void run(
+                            async () =>
+                              await window.pragmaDesktop.tightenMemoryAccess({
+                                module: selected.module,
+                                id: selected.id,
+                                expectedRevision: selected.revision,
+                                reason,
+                                bindings: selected.bindings.map((candidate) =>
+                                  candidate === binding
+                                    ? {
+                                        ...candidate,
+                                        recall: "deny",
+                                        permissionRevision: candidate.permissionRevision + 1,
+                                      }
+                                    : candidate,
+                                ),
+                              }),
+                          )
+                        }
+                      />
+                    ) : null,
+                  )}
+                  {selected.visibility.mode === "restricted" ||
+                  selected.rootRefs.length === 0 ? null : (
+                    <MemoryActionWithTooltip
+                      disabled={reason.trim() === "" || actionBusy}
+                      label={t("restrictVisibility")}
+                      tooltip={t("restrictVisibilityTooltip", {
+                        principals: refs(selected.rootRefs),
+                      })}
+                      onClick={() =>
+                        void run(
+                          async () =>
+                            await window.pragmaDesktop.tightenMemoryAccess({
+                              module: selected.module,
+                              id: selected.id,
+                              expectedRevision: selected.revision,
+                              reason,
+                              visibility: {
+                                mode: "restricted",
+                                principals: selected.rootRefs,
+                              },
+                            }),
+                        )
+                      }
+                    />
+                  )}
                 </div>
               </>
             )}
@@ -424,6 +429,30 @@ export function MemoryPage() {
         />
       ) : null}
     </section>
+  );
+}
+
+export function MemoryActionWithTooltip(props: {
+  readonly disabled: boolean;
+  readonly label: string;
+  readonly tooltip: string;
+  readonly onClick: () => void;
+}) {
+  const tooltipId = useId();
+  return (
+    <span className="memory-action-with-tooltip">
+      <button
+        type="button"
+        aria-describedby={tooltipId}
+        disabled={props.disabled}
+        onClick={props.onClick}
+      >
+        {props.label}
+      </button>
+      <span id={tooltipId} className="memory-action-tooltip" role="tooltip">
+        {props.tooltip}
+      </span>
+    </span>
   );
 }
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -15606,7 +15606,6 @@ textarea:focus-visible,
   border-top: 1px solid var(--border);
 }
 
-.memory-binding button,
 .memory-evidence-list button,
 .memory-actions button {
   padding: 7px 10px;
@@ -15646,7 +15645,7 @@ textarea:focus-visible,
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 12px;
+  margin: 12px 0 48px;
 }
 
 .memory-actions button {
@@ -15658,6 +15657,53 @@ textarea:focus-visible,
 .memory-actions button.is-danger {
   border-color: #e3b1aa;
   color: #9a3f35;
+}
+
+.memory-action-with-tooltip {
+  position: relative;
+  display: inline-flex;
+}
+
+.memory-action-tooltip {
+  position: absolute;
+  z-index: 4;
+  top: calc(100% + 8px);
+  left: 50%;
+  width: max-content;
+  max-width: min(320px, calc(100vw - 80px));
+  padding: 7px 9px;
+  border-radius: 7px;
+  background: #35443b;
+  color: #fff;
+  font-size: 12px;
+  line-height: 1.45;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, -3px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  visibility: hidden;
+  white-space: normal;
+}
+
+.memory-action-with-tooltip:hover .memory-action-tooltip,
+.memory-action-with-tooltip:focus-within .memory-action-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  visibility: visible;
+}
+
+.memory-action-with-tooltip:last-child .memory-action-tooltip {
+  right: 0;
+  left: auto;
+  transform: translate(0, -3px);
+}
+
+.memory-action-with-tooltip:last-child:hover .memory-action-tooltip,
+.memory-action-with-tooltip:last-child:focus-within .memory-action-tooltip {
+  transform: translate(0, 0);
 }
 
 .memory-dialog-field {


### PR DESCRIPTION
## What changed

- Moved **Disable recall** and **Restrict visibility** into the shared memory governance action row after the existing fact and lifecycle actions.
- Added consistent button styling and below-button hover/focus tooltips that explain each permission change and its target.
- Added English, Simplified Chinese, and Traditional Chinese copy plus an accessibility-focused tooltip test.

## Why

The visibility controls were separated from the other memory governance actions, and the standalone visibility button did not inherit the intended action styling. The labels also did not explain whether the operations deleted memory or which principals and bindings they affected.

## User impact

Users can now find all memory governance actions in one place and understand that restricting visibility limits discovery to root asset principals, while disabling recall only affects the named binding and does not delete the memory.

## Validation

- `pnpm run typecheck:web`
- Targeted ESLint checks
- Targeted Prettier checks
- `pnpm exec vitest run src/renderer/src/pages/memory/MemoryPage.test.tsx` (5 tests passed)