### PR TITLE
Show names for memory subject references

### DIFF
--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -608,7 +608,11 @@ export async function createDesktopApplicationContainer(
       }
     },
   });
-  installMemoryPolicyHandlers(memoryPlane, { missions: missionStore, project: pragmaProjectStore });
+  installMemoryPolicyHandlers(memoryPlane, {
+    missions: missionStore,
+    project: pragmaProjectStore,
+    systemExperts,
+  });
   installModelProviderHandlers(modelProviderStore, {
     isProviderReferenced: async (providerId) =>
       (await pragmaProjectStore.get()).resources.some(

--- a/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
+++ b/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
@@ -38,11 +38,27 @@ import {
 import type { DesktopMemoryPlane } from "./desktop-memory-plane.ts";
 import type { MissionStore } from "../missions/mission-store.ts";
 import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
+import type { DesktopSystemExpertRegistry } from "../experts/system-expert-registry.ts";
+import {
+  loadMemorySubjectNameIndex,
+  selectMemorySubjectNames,
+  type MemorySubjectNameIndex,
+  type MemorySubjectReference,
+} from "./memory-subject-names.ts";
 
 export function installMemoryPolicyHandlers(
   plane: DesktopMemoryPlane,
-  options: { readonly missions: MissionStore; readonly project: PragmaProjectStore },
+  options: {
+    readonly missions: MissionStore;
+    readonly project: PragmaProjectStore;
+    readonly systemExperts: Pick<DesktopSystemExpertRegistry, "list">;
+  },
 ): void {
+  const loadSubjectNameIndex = (): Promise<MemorySubjectNameIndex> =>
+    loadMemorySubjectNameIndex({
+      getProject: () => options.project.get(),
+      listSystemExperts: () => options.systemExperts.list(),
+    });
   const globalSnapshot = async () => {
     const revision = await plane.policies.getGlobal();
     return DesktopGlobalMemoryPolicySnapshotSchema.parse({
@@ -181,16 +197,22 @@ export function installMemoryPolicyHandlers(
   });
   ipcMain.handle("memory-items:list", async (_event, input: unknown) => {
     const parsed = ListDesktopMemoryItemsSchema.parse(input ?? {});
+    const [episodes, facts, knowledge, subjectNameIndex] = await Promise.all([
+      parsed.module === "all" || parsed.module === "episodic"
+        ? plane.episodicStore.list()
+        : Promise.resolve([]),
+      parsed.module === "all" || parsed.module === "semantic"
+        ? plane.semanticStore.list()
+        : Promise.resolve([]),
+      parsed.module === "all" || parsed.module === "knowledge"
+        ? plane.knowledgeStore.list()
+        : Promise.resolve([]),
+      loadSubjectNameIndex(),
+    ]);
     const items = [
-      ...(parsed.module === "all" || parsed.module === "episodic"
-        ? (await plane.episodicStore.list()).map(toDesktopEpisode)
-        : []),
-      ...(parsed.module === "all" || parsed.module === "semantic"
-        ? (await plane.semanticStore.list()).map(toDesktopFact)
-        : []),
-      ...(parsed.module === "all" || parsed.module === "knowledge"
-        ? (await plane.knowledgeStore.list()).map(toDesktopKnowledge)
-        : []),
+      ...episodes.map((record) => toDesktopEpisode(record, subjectNameIndex)),
+      ...facts.map((record) => toDesktopFact(record, subjectNameIndex)),
+      ...knowledge.map((record) => toDesktopKnowledge(record, subjectNameIndex)),
     ]
       .filter((item) => parsed.status === "all" || item.status === parsed.status)
       .filter((item) => {
@@ -204,27 +226,54 @@ export function installMemoryPolicyHandlers(
   ipcMain.handle("memory-items:get", async (_event, input: unknown) => {
     const parsed = DesktopMemoryItemRefSchema.parse(input);
     if (parsed.module === "episodic") {
-      const record = await plane.episodicStore.get(parsed.id);
+      const [record, subjectNameIndex] = await Promise.all([
+        plane.episodicStore.get(parsed.id),
+        loadSubjectNameIndex(),
+      ]);
       if (record === undefined) throw new Error("memory_item_not_found");
-      return DesktopMemoryItemSchema.parse(toDesktopEpisode(record));
+      return DesktopMemoryItemSchema.parse(toDesktopEpisode(record, subjectNameIndex));
     }
     if (parsed.module === "semantic") {
-      const record = await plane.semanticStore.get(parsed.id);
+      const [record, subjectNameIndex] = await Promise.all([
+        plane.semanticStore.get(parsed.id),
+        loadSubjectNameIndex(),
+      ]);
       if (record === undefined) throw new Error("memory_item_not_found");
-      return DesktopMemoryItemSchema.parse(toDesktopFact(record));
+      return DesktopMemoryItemSchema.parse(toDesktopFact(record, subjectNameIndex));
     }
-    const record = await plane.knowledgeStore.get(parsed.id);
+    const [record, subjectNameIndex] = await Promise.all([
+      plane.knowledgeStore.get(parsed.id),
+      loadSubjectNameIndex(),
+    ]);
     if (record === undefined) throw new Error("memory_item_not_found");
-    return DesktopMemoryItemSchema.parse(toDesktopKnowledge(record));
+    return DesktopMemoryItemSchema.parse(toDesktopKnowledge(record, subjectNameIndex));
   });
   ipcMain.handle("memory-items:history", async (_event, input: unknown) => {
     const parsed = DesktopMemoryItemRefSchema.parse(input);
+    if (parsed.module === "episodic") {
+      const [records, subjectNameIndex] = await Promise.all([
+        plane.episodicStore.history(parsed.id),
+        loadSubjectNameIndex(),
+      ]);
+      return DesktopMemoryItemListSchema.parse(
+        records.map((record) => toDesktopEpisode(record, subjectNameIndex)),
+      );
+    }
+    if (parsed.module === "semantic") {
+      const [records, subjectNameIndex] = await Promise.all([
+        plane.semanticStore.history(parsed.id),
+        loadSubjectNameIndex(),
+      ]);
+      return DesktopMemoryItemListSchema.parse(
+        records.map((record) => toDesktopFact(record, subjectNameIndex)),
+      );
+    }
+    const [records, subjectNameIndex] = await Promise.all([
+      plane.knowledgeStore.history(parsed.id),
+      loadSubjectNameIndex(),
+    ]);
     return DesktopMemoryItemListSchema.parse(
-      parsed.module === "episodic"
-        ? (await plane.episodicStore.history(parsed.id)).map(toDesktopEpisode)
-        : parsed.module === "semantic"
-          ? (await plane.semanticStore.history(parsed.id)).map(toDesktopFact)
-          : (await plane.knowledgeStore.history(parsed.id)).map(toDesktopKnowledge),
+      records.map((record) => toDesktopKnowledge(record, subjectNameIndex)),
     );
   });
   ipcMain.handle("memory-items:evidence", async (_event, input: unknown) => {
@@ -245,24 +294,30 @@ export function installMemoryPolicyHandlers(
   });
   ipcMain.handle("memory-items:tighten", async (_event, input: unknown) => {
     const parsed = TightenDesktopMemoryAccessSchema.parse(input);
-    const result = await plane.tightenMemoryAccess(parsed);
+    const [result, subjectNameIndex] = await Promise.all([
+      plane.tightenMemoryAccess(parsed),
+      loadSubjectNameIndex(),
+    ]);
     return DesktopMemoryItemSchema.parse(
       result.module === "episodic"
-        ? toDesktopEpisode(result.record)
+        ? toDesktopEpisode(result.record, subjectNameIndex)
         : result.module === "semantic"
-          ? toDesktopFact(result.record)
-          : toDesktopKnowledge(result.record),
+          ? toDesktopFact(result.record, subjectNameIndex)
+          : toDesktopKnowledge(result.record, subjectNameIndex),
     );
   });
   ipcMain.handle("memory-items:invalidate", async (_event, input: unknown) => {
     const parsed = ReviewDesktopMemoryItemSchema.parse(input);
-    const result = await plane.invalidateMemoryItem(parsed);
+    const [result, subjectNameIndex] = await Promise.all([
+      plane.invalidateMemoryItem(parsed),
+      loadSubjectNameIndex(),
+    ]);
     return DesktopMemoryItemSchema.parse(
       result.module === "episodic"
-        ? toDesktopEpisode(result.record)
+        ? toDesktopEpisode(result.record, subjectNameIndex)
         : result.module === "semantic"
-          ? toDesktopFact(result.record)
-          : toDesktopKnowledge(result.record),
+          ? toDesktopFact(result.record, subjectNameIndex)
+          : toDesktopKnowledge(result.record, subjectNameIndex),
     );
   });
   ipcMain.handle("memory-items:forget", async (_event, input: unknown) => {
@@ -346,7 +401,10 @@ export function installMemoryPolicyHandlers(
   });
 }
 
-function toDesktopEpisode(record: import("@pragma/memory").EpisodicMemoryRecord) {
+function toDesktopEpisode(
+  record: import("@pragma/memory").EpisodicMemoryRecord,
+  subjectNameIndex: MemorySubjectNameIndex,
+) {
   return {
     module: "episodic" as const,
     id: record.id,
@@ -360,6 +418,7 @@ function toDesktopEpisode(record: import("@pragma/memory").EpisodicMemoryRecord)
     visibility: record.visibility,
     sensitivity: record.sensitivity,
     bindings: record.bindings,
+    subjectNames: memoryItemSubjectNames(record, subjectNameIndex),
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     executionId: record.executionId,
@@ -377,7 +436,10 @@ function toDesktopEpisode(record: import("@pragma/memory").EpisodicMemoryRecord)
   };
 }
 
-function toDesktopFact(record: import("@pragma/shared").SemanticFact) {
+function toDesktopFact(
+  record: import("@pragma/shared").SemanticFact,
+  subjectNameIndex: MemorySubjectNameIndex,
+) {
   return {
     module: "semantic" as const,
     id: record.id,
@@ -391,6 +453,7 @@ function toDesktopFact(record: import("@pragma/shared").SemanticFact) {
     visibility: record.visibility,
     sensitivity: record.sensitivity,
     bindings: record.bindings,
+    subjectNames: memoryItemSubjectNames(record, subjectNameIndex),
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     statement: record.statement,
@@ -405,7 +468,10 @@ function toDesktopFact(record: import("@pragma/shared").SemanticFact) {
   };
 }
 
-function toDesktopKnowledge(record: import("@pragma/shared").Knowledge) {
+function toDesktopKnowledge(
+  record: import("@pragma/shared").Knowledge,
+  subjectNameIndex: MemorySubjectNameIndex,
+) {
   return {
     module: "knowledge" as const,
     id: record.id,
@@ -419,6 +485,10 @@ function toDesktopKnowledge(record: import("@pragma/shared").Knowledge) {
     visibility: record.visibility,
     sensitivity: record.sensitivity,
     bindings: record.bindings,
+    subjectNames: memoryItemSubjectNames(
+      { rootRefs: [record.rootRef], producerRefs: record.producerRefs, bindings: record.bindings },
+      subjectNameIndex,
+    ),
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     guidance: record.content.guidance,
@@ -426,6 +496,21 @@ function toDesktopKnowledge(record: import("@pragma/shared").Knowledge) {
     sourceRefs: record.sourceRefs,
     origin: record.origin.kind,
   };
+}
+
+function memoryItemSubjectNames(
+  item: {
+    readonly rootRefs: readonly MemorySubjectReference[];
+    readonly producerRefs: readonly MemorySubjectReference[];
+    readonly bindings: readonly { readonly consumerRef: MemorySubjectReference }[];
+  },
+  subjectNameIndex: MemorySubjectNameIndex,
+): Record<string, string> {
+  return selectMemorySubjectNames(subjectNameIndex, [
+    ...item.rootRefs,
+    ...item.producerRefs,
+    ...item.bindings.map((binding) => binding.consumerRef),
+  ]);
 }
 
 function toEpisodeSource(record: import("@pragma/memory").EpisodicMemoryRecord) {

--- a/apps/desktop/src/main/features/memory/memory-subject-names.test.ts
+++ b/apps/desktop/src/main/features/memory/memory-subject-names.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createMemorySubjectNameIndex,
+  loadMemorySubjectNameIndex,
+  selectMemorySubjectNames,
+} from "./memory-subject-names.ts";
+
+describe("memory subject names", () => {
+  it("indexes current project assets and built-in Experts by memory subject reference", () => {
+    const names = createMemorySubjectNameIndex({
+      project: {
+        resources: [
+          { kind: "Expert", metadata: { id: "expert-a", name: "研发专家" } },
+          { kind: "ExpertTeam", metadata: { id: "team-a", name: "AI研发团队" } },
+          { kind: "Flow", metadata: { id: "flow-a", name: "发布流程" } },
+          { kind: "Capability", metadata: { id: "capability-a", name: "不应展示" } },
+        ],
+      },
+      systemExperts: [{ id: "system-a", name: "Pragma" }],
+    });
+
+    expect(names).toEqual({
+      "pragma.expert:expert-a": "研发专家",
+      "pragma.expert-team:team-a": "AI研发团队",
+      "pragma.flow:flow-a": "发布流程",
+      "pragma.expert:system-a": "Pragma",
+    });
+  });
+
+  it("selects only names used by the memory item and omits unresolved references", () => {
+    const selected = selectMemorySubjectNames(
+      {
+        "pragma.expert-team:team-a": "AI研发团队",
+        "pragma.expert:expert-a": "研发专家",
+      },
+      [
+        { type: "pragma.expert-team", id: "team-a" },
+        { type: "pragma.expert", id: "missing" },
+      ],
+    );
+
+    expect(selected).toEqual({ "pragma.expert-team:team-a": "AI研发团队" });
+  });
+
+  it("falls back to an empty index when the resource directory is unavailable", async () => {
+    await expect(
+      loadMemorySubjectNameIndex({
+        getProject: async () => {
+          throw new Error("project_unavailable");
+        },
+        listSystemExperts: () => {
+          throw new Error("system_experts_unavailable");
+        },
+      }),
+    ).resolves.toEqual({});
+  });
+});

--- a/apps/desktop/src/main/features/memory/memory-subject-names.ts
+++ b/apps/desktop/src/main/features/memory/memory-subject-names.ts
@@ -1,0 +1,74 @@
+export interface MemorySubjectReference {
+  readonly type: string;
+  readonly id: string;
+}
+
+export type MemorySubjectNameIndex = Readonly<Record<string, string>>;
+
+interface MemorySubjectNameProject {
+  readonly resources: readonly {
+    readonly kind: string;
+    readonly metadata: { readonly id: string; readonly name: string };
+  }[];
+}
+
+interface NamedSystemExpert {
+  readonly id: string;
+  readonly name: string;
+}
+
+export function memorySubjectReferenceKey(ref: MemorySubjectReference): string {
+  return `${ref.type}:${ref.id}`;
+}
+
+export function createMemorySubjectNameIndex(input: {
+  readonly project: MemorySubjectNameProject;
+  readonly systemExperts: readonly NamedSystemExpert[];
+}): MemorySubjectNameIndex {
+  const names: Record<string, string> = {};
+  for (const resource of input.project.resources) {
+    const type = memorySubjectType(resource.kind);
+    if (type === undefined) continue;
+    names[memorySubjectReferenceKey({ type, id: resource.metadata.id })] = resource.metadata.name;
+  }
+  for (const expert of input.systemExperts) {
+    names[memorySubjectReferenceKey({ type: "pragma.expert", id: expert.id })] = expert.name;
+  }
+  return names;
+}
+
+export async function loadMemorySubjectNameIndex(input: {
+  readonly getProject: () => Promise<MemorySubjectNameProject>;
+  readonly listSystemExperts: () => readonly NamedSystemExpert[];
+}): Promise<MemorySubjectNameIndex> {
+  try {
+    return createMemorySubjectNameIndex({
+      project: await input.getProject(),
+      systemExperts: input.listSystemExperts(),
+    });
+  } catch {
+    return {};
+  }
+}
+
+export function selectMemorySubjectNames(
+  index: MemorySubjectNameIndex,
+  refs: readonly MemorySubjectReference[],
+): Record<string, string> {
+  const names: Record<string, string> = {};
+  for (const ref of refs) {
+    const key = memorySubjectReferenceKey(ref);
+    const name = index[key];
+    if (name !== undefined) names[key] = name;
+  }
+  return names;
+}
+
+function memorySubjectType(
+  kind: string,
+): "pragma.expert" | "pragma.expert-team" | "pragma.flow" | undefined {
+  if (kind === "Expert") return "pragma.expert";
+  if (kind === "ExpertTeam") return "pragma.expert-team";
+  if (kind === "Flow") return "pragma.flow";
+  return undefined;
+}

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
@@ -7,6 +7,7 @@ import {
   MemoryDegradedAlert,
   MemoryExtractionJobs,
   MemoryPage,
+  formatMemorySubjectRefs,
   memoryExtractionPollDelay,
 } from "./MemoryPage.tsx";
 
@@ -15,6 +16,19 @@ afterEach(async () => {
 });
 
 describe("MemoryPage", () => {
+  it("shows human-readable subject names while preserving canonical memory references", () => {
+    expect(
+      formatMemorySubjectRefs(
+        [
+          { type: "pragma.expert-team", id: "r5pjstt2yftkg8dx" },
+          { type: "pragma.expert", id: "missing" },
+        ],
+        { "pragma.expert-team:r5pjstt2yftkg8dx": "AI研发团队" },
+      ),
+    ).toBe("AI研发团队(pragma.expert-team:r5pjstt2yftkg8dx), pragma.expert:missing");
+    expect(formatMemorySubjectRefs([])).toBe("—");
+  });
+
   it("polls active extraction work quickly and terminal boards at a lower idle cadence", () => {
     expect(
       memoryExtractionPollDelay({

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
@@ -456,9 +456,9 @@ export function MemoryPage() {
                     <dt>{t("id")}</dt>
                     <dd>{selected.id}</dd>
                     <dt>{t("root")}</dt>
-                    <dd>{refs(selected.rootRefs)}</dd>
+                    <dd>{formatMemorySubjectRefs(selected.rootRefs, selected.subjectNames)}</dd>
                     <dt>{t("producers")}</dt>
-                    <dd>{refs(selected.producerRefs)}</dd>
+                    <dd>{formatMemorySubjectRefs(selected.producerRefs, selected.subjectNames)}</dd>
                     <dt>{t("visibility")}</dt>
                     <dd>{selected.visibility.mode}</dd>
                     <dt>{t("sensitivity")}</dt>
@@ -474,7 +474,7 @@ export function MemoryPage() {
                       key={`${binding.consumerRef.type}:${binding.consumerRef.id}`}
                     >
                       <span>
-                        {binding.consumerRef.type}:{binding.consumerRef.id}
+                        {formatMemorySubjectRefs([binding.consumerRef], selected.subjectNames)}
                       </span>
                       <span>
                         {t("recall")} {binding.recall} · {t("export")} {binding.export} · p
@@ -585,7 +585,10 @@ export function MemoryPage() {
                         disabled={reason.trim() === "" || actionBusy}
                         label={t("disableRecall")}
                         tooltip={t("disableRecallTooltip", {
-                          consumer: refs([binding.consumerRef]),
+                          consumer: formatMemorySubjectRefs(
+                            [binding.consumerRef],
+                            selected.subjectNames,
+                          ),
                         })}
                         onClick={() =>
                           void run(
@@ -616,7 +619,10 @@ export function MemoryPage() {
                       disabled={reason.trim() === "" || actionBusy}
                       label={t("restrictVisibility")}
                       tooltip={t("restrictVisibilityTooltip", {
-                        principals: refs(selected.rootRefs),
+                        principals: formatMemorySubjectRefs(
+                          selected.rootRefs,
+                          selected.subjectNames,
+                        ),
                       })}
                       onClick={() =>
                         void run(
@@ -993,6 +999,17 @@ function key(item: DesktopMemoryItem): string {
   return `${item.module}:${item.id}`;
 }
 
-function refs(values: readonly { readonly type: string; readonly id: string }[]): string {
-  return values.map((value) => `${value.type}:${value.id}`).join(", ") || "—";
+export function formatMemorySubjectRefs(
+  values: readonly { readonly type: string; readonly id: string }[],
+  names: Readonly<Record<string, string>> = {},
+): string {
+  return (
+    values
+      .map((value) => {
+        const ref = `${value.type}:${value.id}`;
+        const name = names[ref];
+        return name === undefined ? ref : `${name}(${ref})`;
+      })
+      .join(", ") || "—"
+  );
 }

--- a/apps/desktop/src/shared/contracts/contracts.test.ts
+++ b/apps/desktop/src/shared/contracts/contracts.test.ts
@@ -32,6 +32,7 @@ import {
   DesktopGlobalMemoryPolicySnapshotSchema,
   DesktopAssetMemoryPolicySnapshotSchema,
   DesktopMemoryPlaneStatusSchema,
+  DesktopMemoryItemSchema,
   UpdateDesktopAssetMemoryPolicySchema,
 } from "./index.ts";
 
@@ -66,6 +67,33 @@ describe("desktop settings contracts", () => {
 });
 
 describe("desktop memory contracts", () => {
+  it("defaults missing subject names for backward-compatible memory item IPC", () => {
+    expect(
+      DesktopMemoryItemSchema.parse({
+        module: "episodic",
+        id: "episode-a",
+        revision: 1,
+        status: "active",
+        title: "Release",
+        summary: "Released successfully.",
+        rootRefs: [{ type: "pragma.expert-team", id: "team-a" }],
+        producerRefs: [{ type: "pragma.expert", id: "expert-a" }],
+        evidenceRefs: [],
+        visibility: { mode: "host-private" },
+        sensitivity: "internal",
+        bindings: [],
+        createdAt: "2026-08-05T00:00:00.000Z",
+        updatedAt: "2026-08-05T00:00:00.000Z",
+        executionId: "execution-a",
+        goal: "Release",
+        outcome: "succeeded",
+        valueScore: 0.9,
+        attempts: [],
+        failuresAndRecoveries: [],
+      }).subjectNames,
+    ).toEqual({});
+  });
+
   it("validates versioned global and asset policy snapshots", () => {
     expect(
       DesktopGlobalMemoryPolicySnapshotSchema.parse({

--- a/apps/desktop/src/shared/contracts/memory.ts
+++ b/apps/desktop/src/shared/contracts/memory.ts
@@ -205,6 +205,10 @@ export const ReviewDesktopSemanticFactSchema = z
 
 export const DesktopSemanticFactSchema = SemanticFactSchema;
 
+const DesktopMemorySubjectNamesSchema = z
+  .record(z.string().min(1), z.string().trim().min(1))
+  .default({});
+
 const DesktopMemoryCommonSchema = z.object({
   id: z.string().min(1),
   revision: z.number().int().positive(),
@@ -217,6 +221,7 @@ const DesktopMemoryCommonSchema = z.object({
   visibility: MemoryVisibilityPolicySchema,
   sensitivity: MemorySensitivitySchema,
   bindings: z.array(MemoryRevisionBindingSchema),
+  subjectNames: DesktopMemorySubjectNamesSchema,
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });
@@ -259,6 +264,7 @@ export const DesktopMemoryItemSchema = z.discriminatedUnion("module", [
       visibility: MemoryVisibilityPolicySchema,
       sensitivity: MemorySensitivitySchema,
       bindings: z.array(MemoryRevisionBindingSchema),
+      subjectNames: DesktopMemorySubjectNamesSchema,
       createdAt: z.string().datetime(),
       updatedAt: z.string().datetime(),
       guidance: z.array(z.string().min(1)),


### PR DESCRIPTION
## Summary

- resolve current Expert, ExpertTeam, and Flow names for memory root assets, producers, and recall bindings
- render references as `Name(type:id)` while preserving the canonical reference and falling back to raw `type:id` when a name is unavailable
- add a backward-compatible `subjectNames` field to the Desktop memory IPC projection without changing persisted memory data
- load the resource name index in parallel with memory store queries and degrade safely when the resource directory is unavailable

## Why

The Memory tab previously exposed opaque identifiers such as `pragma.expert-team:r5pjstt2yftkg8dx` directly. Users could not tell which real Expert, ExpertTeam, or Flow a memory belonged to.

## User impact

Root assets, producers, recall bindings, and related governance tooltips now show labels such as `AI研发团队(pragma.expert-team:r5pjstt2yftkg8dx)`. Historical or deleted resources continue to display their canonical reference safely.

## Validation

- `pnpm check`
- `pnpm build`
- focused Desktop memory tests: 54 passed
- Desktop full suite: 109 test files and 652 tests passed
- Claude Code review completed; all confirmed findings were fixed and revalidated
