### PR TITLE
Preserve tool call structure in memory extraction

### DIFF
--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
@@ -13,6 +13,7 @@ import {
   createKnowledgeMemoryModule,
   createKnowledgeSourceReader,
   createSemanticMemoryModule,
+  createFileMemoryExtractionSettingsStore,
   createFileMemoryExtractorProfileStore,
   createExecutionEvidenceAdapter,
   createFederatedMemoryContextStore,
@@ -29,6 +30,7 @@ import {
   type KnowledgeMemoryExtractor,
   type KnowledgeMemoryStore,
   type MemoryExtractorProfileStore,
+  type MemoryExtractionSettingsStore,
   type SemanticMemoryExtractor,
   type SemanticMemoryStore,
   type EpisodicMemoryStore,
@@ -58,6 +60,7 @@ export interface DesktopMemoryPlane {
   readonly executionStore: FileExecutionStore;
   readonly policies: MemoryPolicyStore;
   readonly extractorProfiles: MemoryExtractorProfileStore;
+  readonly extractionSettings: MemoryExtractionSettingsStore;
   readonly semanticStore: SemanticMemoryStore;
   readonly episodicStore: EpisodicMemoryStore;
   readonly knowledgeStore: KnowledgeMemoryStore;
@@ -168,10 +171,19 @@ export async function createDesktopMemoryPlane(options: {
   const extractorProfiles = createFileMemoryExtractorProfileStore({
     pragmaHome: options.pragmaHome,
   });
+  const extractionSettings = createFileMemoryExtractionSettingsStore({
+    pragmaHome: options.pragmaHome,
+  });
   const publisher = createMemoryEvidencePublisher(canonical);
   const registry = new MemoryModuleRegistry();
-  const episodic = await createEpisodicMemoryModule({ pragmaHome: options.pragmaHome });
-  const semantic = await createSemanticMemoryModule({ pragmaHome: options.pragmaHome });
+  const episodic = await createEpisodicMemoryModule({
+    pragmaHome: options.pragmaHome,
+    extractionSettings,
+  });
+  const semantic = await createSemanticMemoryModule({
+    pragmaHome: options.pragmaHome,
+    extractionSettings,
+  });
   const knowledge = await createKnowledgeMemoryModule({
     pragmaHome: options.pragmaHome,
     sourceReader: createKnowledgeSourceReader({
@@ -391,6 +403,7 @@ export async function createDesktopMemoryPlane(options: {
     executionStore,
     policies,
     extractorProfiles,
+    extractionSettings,
     semanticStore: semantic.store,
     episodicStore: episodic.store,
     knowledgeStore: knowledge.store,

--- a/apps/desktop/src/main/features/memory/memory-curator.ts
+++ b/apps/desktop/src/main/features/memory/memory-curator.ts
@@ -288,6 +288,7 @@ const CURATOR_INSTRUCTIONS = [
   "You are the hidden Pragma Memory Curator.",
   "You have no tools and must not request additional context.",
   "Extract only claims supported by the supplied Evidence ids.",
+  "A tool event with hidden input or output proves only that the call occurred; never infer hidden content from its name or status.",
   "Return exactly one JSON object matching the requested schema, without Markdown fences or commentary.",
   "Use the dominant language of the source task. Historical precedent is not current truth.",
 ].join("\n");

--- a/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
+++ b/apps/desktop/src/main/features/memory/memory-policy-ipc.ts
@@ -5,10 +5,12 @@ import {
   DesktopGlobalMemoryPolicySnapshotSchema,
   DesktopMemoryPlaneStatusSchema,
   DesktopMemoryExtractorProfileSchema,
+  DesktopMemoryExtractionSettingsSchema,
   GetDesktopAssetMemoryPolicySchema,
   UpdateDesktopAssetMemoryPolicySchema,
   UpdateDesktopGlobalMemoryPolicySchema,
   UpdateDesktopMemoryExtractorProfileSchema,
+  UpdateDesktopMemoryExtractionSettingsSchema,
   DesktopSemanticFactSchema,
   ReviseDesktopSemanticFactSchema,
   ReviewDesktopSemanticFactSchema,
@@ -170,6 +172,15 @@ export function installMemoryPolicyHandlers(
     const profile = await plane.extractorProfiles.update(parsed);
     await plane.wakeMemoryJobs();
     return DesktopMemoryExtractorProfileSchema.parse(profile);
+  });
+  ipcMain.handle("memory-extraction-settings:get", async () =>
+    DesktopMemoryExtractionSettingsSchema.parse(await plane.extractionSettings.get()),
+  );
+  ipcMain.handle("memory-extraction-settings:update", async (_event, input: unknown) => {
+    const parsed = UpdateDesktopMemoryExtractionSettingsSchema.parse(input);
+    return DesktopMemoryExtractionSettingsSchema.parse(
+      await plane.extractionSettings.update(parsed),
+    );
   });
   ipcMain.handle("memory-semantic:revise", async (_event, input: unknown) => {
     const parsed = ReviseDesktopSemanticFactSchema.parse(input);

--- a/apps/desktop/src/preload/api/memory.ts
+++ b/apps/desktop/src/preload/api/memory.ts
@@ -6,10 +6,12 @@ import {
   DesktopGlobalMemoryPolicySnapshotSchema,
   DesktopMemoryPlaneStatusSchema,
   DesktopMemoryExtractorProfileSchema,
+  DesktopMemoryExtractionSettingsSchema,
   GetDesktopAssetMemoryPolicySchema,
   UpdateDesktopAssetMemoryPolicySchema,
   UpdateDesktopGlobalMemoryPolicySchema,
   UpdateDesktopMemoryExtractorProfileSchema,
+  UpdateDesktopMemoryExtractionSettingsSchema,
   DesktopSemanticFactSchema,
   ReviseDesktopSemanticFactSchema,
   ReviewDesktopSemanticFactSchema,
@@ -83,6 +85,17 @@ export const memoryApi = {
       await ipcRenderer.invoke(
         "memory-extractor-profile:update",
         UpdateDesktopMemoryExtractorProfileSchema.parse(input),
+      ),
+    ),
+  getMemoryExtractionSettings: async () =>
+    DesktopMemoryExtractionSettingsSchema.parse(
+      await ipcRenderer.invoke("memory-extraction-settings:get"),
+    ),
+  updateMemoryExtractionSettings: async (input) =>
+    DesktopMemoryExtractionSettingsSchema.parse(
+      await ipcRenderer.invoke(
+        "memory-extraction-settings:update",
+        UpdateDesktopMemoryExtractionSettingsSchema.parse(input),
       ),
     ),
   reviseSemanticFact: async (input) =>
@@ -192,6 +205,8 @@ export const memoryApi = {
   | "manageMemoryExtractionTask"
   | "getMemoryExtractorProfile"
   | "updateMemoryExtractorProfile"
+  | "getMemoryExtractionSettings"
+  | "updateMemoryExtractionSettings"
   | "reviseSemanticFact"
   | "verifySemanticFact"
   | "listMemoryItems"

--- a/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
@@ -46,6 +46,12 @@ export const settings = {
     enabled: "Enabled",
     disabled: "Disabled",
     localCandidates: "Local candidates",
+    episodicToolAssistedExtraction: "Allow tool-assisted extraction: Episodic Memory",
+    episodicToolAssistedExtractionDescription:
+      "Tool names, status, and sequence are always preserved. Turn this on to use sanitized tool input and result content. Off by default.",
+    semanticToolAssistedExtraction: "Allow tool-assisted extraction: Fact Memory",
+    semanticToolAssistedExtractionDescription:
+      "Tool names, status, and sequence are always preserved. Turn this on to use sanitized tool input and result content. Off by default.",
     extractorMode: "Extraction model",
     extractorModeDescription: "Choose the Runtime and model used by the hidden Memory Curator.",
     inheritDefaultModel: "Inherit system default",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
@@ -43,6 +43,12 @@ export const settings = {
     enabled: "启用",
     disabled: "停用",
     localCandidates: "本地候选",
+    episodicToolAssistedExtraction: "允许从工具辅助记忆提炼：情景记忆",
+    episodicToolAssistedExtractionDescription:
+      "工具名、调用状态和时序始终保留；启用后可使用经过脱敏的工具输入与结果内容。默认停用。",
+    semanticToolAssistedExtraction: "允许从工具辅助记忆提炼：事实记忆",
+    semanticToolAssistedExtractionDescription:
+      "工具名、调用状态和时序始终保留；启用后可使用经过脱敏的工具输入与结果内容。默认停用。",
     extractorMode: "提炼模型",
     extractorModeDescription: "选择隐藏 Memory Curator 使用的 Runtime 和模型。",
     inheritDefaultModel: "继承系统默认",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
@@ -43,6 +43,12 @@ export const settings = {
     enabled: "啟用",
     disabled: "停用",
     localCandidates: "本機候選",
+    episodicToolAssistedExtraction: "允許從工具輔助記憶提煉：情境記憶",
+    episodicToolAssistedExtractionDescription:
+      "工具名稱、呼叫狀態和時序一律保留；啟用後可使用經過脫敏的工具輸入與結果內容。預設停用。",
+    semanticToolAssistedExtraction: "允許從工具輔助記憶提煉：事實記憶",
+    semanticToolAssistedExtractionDescription:
+      "工具名稱、呼叫狀態和時序一律保留；啟用後可使用經過脫敏的工具輸入與結果內容。預設停用。",
     extractorMode: "提煉模型",
     extractorModeDescription: "選擇隱藏 Memory Curator 使用的 Runtime 和模型。",
     inheritDefaultModel: "繼承系統預設",

--- a/apps/desktop/src/renderer/src/pages/settings/MemorySettingsFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/MemorySettingsFragment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import type {
   DesktopGlobalMemoryPolicySnapshot,
+  DesktopMemoryExtractionSettings,
   DesktopMemoryExtractorProfile,
   DesktopMemoryPlaneStatus,
   DesktopRuntimeAvailability,
@@ -15,6 +16,7 @@ export function MemorySettingsFragment() {
   const [snapshot, setSnapshot] = useState<DesktopGlobalMemoryPolicySnapshot>();
   const [status, setStatus] = useState<DesktopMemoryPlaneStatus>();
   const [extractor, setExtractor] = useState<DesktopMemoryExtractorProfile>();
+  const [extractionSettings, setExtractionSettings] = useState<DesktopMemoryExtractionSettings>();
   const [runtimes, setRuntimes] = useState<readonly DesktopRuntimeAvailability[]>([]);
   const [runtimeId, setRuntimeId] = useState("");
   const [modelKey, setModelKey] = useState("");
@@ -27,13 +29,15 @@ export function MemorySettingsFragment() {
       window.pragmaDesktop.getGlobalMemoryPolicy(),
       window.pragmaDesktop.getMemoryPlaneStatus(),
       window.pragmaDesktop.getMemoryExtractorProfile(),
+      window.pragmaDesktop.getMemoryExtractionSettings(),
       window.pragmaDesktop.getRuntimeAvailability(),
     ])
-      .then(([nextSnapshot, nextStatus, nextExtractor, nextRuntimes]) => {
+      .then(([nextSnapshot, nextStatus, nextExtractor, nextExtractionSettings, nextRuntimes]) => {
         if (cancelled) return;
         setSnapshot(nextSnapshot);
         setStatus(nextStatus);
         setExtractor(nextExtractor);
+        setExtractionSettings(nextExtractionSettings);
         setRuntimes(nextRuntimes);
         const selectedRuntime =
           nextExtractor.runtimeId ?? nextRuntimes.find((runtime) => runtime.isDefault)?.id ?? "";
@@ -97,6 +101,26 @@ export function MemorySettingsFragment() {
     }
   };
 
+  const updateExtractionSettings = async (
+    allowToolAssisted: DesktopMemoryExtractionSettings["allowToolAssisted"],
+  ) => {
+    if (extractionSettings === undefined) return;
+    setSaving(true);
+    setError(undefined);
+    try {
+      setExtractionSettings(
+        await window.pragmaDesktop.updateMemoryExtractionSettings({
+          expectedRevision: extractionSettings.revision,
+          allowToolAssisted,
+        }),
+      );
+    } catch {
+      setError(t("memory.saveError"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const selectedRuntime = runtimes.find((runtime) => runtime.id === runtimeId);
   const models = selectedRuntime?.models ?? [];
   return (
@@ -135,6 +159,30 @@ export function MemorySettingsFragment() {
             ["disabled", t("memory.disabled")],
           ]}
           onChange={(learning) => void update({ ...snapshot!.policy, learning })}
+        />
+        <MemoryGlobalSwitch
+          label={t("memory.episodicToolAssistedExtraction")}
+          description={t("memory.episodicToolAssistedExtractionDescription")}
+          value={extractionSettings?.allowToolAssisted.episodic ? "enabled" : "disabled"}
+          disabled={extractionSettings === undefined || saving}
+          onChange={(value) =>
+            void updateExtractionSettings({
+              ...extractionSettings!.allowToolAssisted,
+              episodic: value === "enabled",
+            })
+          }
+        />
+        <MemoryGlobalSwitch
+          label={t("memory.semanticToolAssistedExtraction")}
+          description={t("memory.semanticToolAssistedExtractionDescription")}
+          value={extractionSettings?.allowToolAssisted.semantic ? "enabled" : "disabled"}
+          disabled={extractionSettings === undefined || saving}
+          onChange={(value) =>
+            void updateExtractionSettings({
+              ...extractionSettings!.allowToolAssisted,
+              semantic: value === "enabled",
+            })
+          }
         />
         <MemorySelectRow
           label={t("memory.extractorMode")}

--- a/apps/desktop/src/renderer/src/pages/settings/SettingsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/SettingsPage.test.tsx
@@ -60,6 +60,8 @@ describe("SettingsPage", () => {
     expect(html).toContain("Capture");
     expect(html).toContain("Recall");
     expect(html).toContain("Learning");
+    expect(html).toContain("Allow tool-assisted extraction: Episodic Memory");
+    expect(html).toContain("Allow tool-assisted extraction: Fact Memory");
     expect(html).toContain("Memory plane health");
   });
 });

--- a/apps/desktop/src/shared/contracts/api.ts
+++ b/apps/desktop/src/shared/contracts/api.ts
@@ -122,7 +122,9 @@ import type {
   UpdateDesktopAssetMemoryPolicy,
   DesktopMemoryPlaneStatus,
   DesktopMemoryExtractorProfile,
+  DesktopMemoryExtractionSettings,
   UpdateDesktopMemoryExtractorProfile,
+  UpdateDesktopMemoryExtractionSettings,
   DesktopSemanticFact,
   ReviseDesktopSemanticFact,
   ReviewDesktopSemanticFact,
@@ -169,6 +171,10 @@ export interface PragmaDesktopAPI {
   updateMemoryExtractorProfile: (
     input: UpdateDesktopMemoryExtractorProfile,
   ) => Promise<DesktopMemoryExtractorProfile>;
+  getMemoryExtractionSettings: () => Promise<DesktopMemoryExtractionSettings>;
+  updateMemoryExtractionSettings: (
+    input: UpdateDesktopMemoryExtractionSettings,
+  ) => Promise<DesktopMemoryExtractionSettings>;
   reviseSemanticFact: (input: ReviseDesktopSemanticFact) => Promise<DesktopSemanticFact>;
   verifySemanticFact: (input: ReviewDesktopSemanticFact) => Promise<DesktopSemanticFact>;
   listMemoryItems: (input?: ListDesktopMemoryItems) => Promise<DesktopMemoryItem[]>;

--- a/apps/desktop/src/shared/contracts/memory.ts
+++ b/apps/desktop/src/shared/contracts/memory.ts
@@ -169,6 +169,27 @@ export const UpdateDesktopMemoryExtractorProfileSchema = z.object({
   ]),
 });
 
+export const DesktopMemoryExtractionSettingsSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.memory-extraction-settings/v1"),
+    revision: z.number().int().nonnegative(),
+    allowToolAssisted: z
+      .object({
+        episodic: z.boolean(),
+        semantic: z.boolean(),
+      })
+      .strict(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const UpdateDesktopMemoryExtractionSettingsSchema = z
+  .object({
+    expectedRevision: z.number().int().nonnegative(),
+    allowToolAssisted: DesktopMemoryExtractionSettingsSchema.shape.allowToolAssisted,
+  })
+  .strict();
+
 export const ReviseDesktopSemanticFactSchema = z
   .object({
     id: z.string().min(1),

--- a/apps/desktop/src/shared/contracts/types.ts
+++ b/apps/desktop/src/shared/contracts/types.ts
@@ -187,11 +187,13 @@ import {
   DesktopGlobalMemoryPolicySnapshotSchema,
   DesktopMemoryPlaneStatusSchema,
   DesktopMemoryExtractorProfileSchema,
+  DesktopMemoryExtractionSettingsSchema,
   DesktopMemoryPolicyTargetSchema,
   GetDesktopAssetMemoryPolicySchema,
   UpdateDesktopAssetMemoryPolicySchema,
   UpdateDesktopGlobalMemoryPolicySchema,
   UpdateDesktopMemoryExtractorProfileSchema,
+  UpdateDesktopMemoryExtractionSettingsSchema,
   DesktopSemanticFactSchema,
   ReviseDesktopSemanticFactSchema,
   ReviewDesktopSemanticFactSchema,
@@ -267,6 +269,10 @@ export type DesktopMemoryPlaneStatus = z.infer<typeof DesktopMemoryPlaneStatusSc
 export type DesktopMemoryExtractorProfile = z.infer<typeof DesktopMemoryExtractorProfileSchema>;
 export type UpdateDesktopMemoryExtractorProfile = z.infer<
   typeof UpdateDesktopMemoryExtractorProfileSchema
+>;
+export type DesktopMemoryExtractionSettings = z.infer<typeof DesktopMemoryExtractionSettingsSchema>;
+export type UpdateDesktopMemoryExtractionSettings = z.infer<
+  typeof UpdateDesktopMemoryExtractionSettingsSchema
 >;
 export type DesktopSemanticFact = z.infer<typeof DesktopSemanticFactSchema>;
 export type ReviseDesktopSemanticFact = z.infer<typeof ReviseDesktopSemanticFactSchema>;

--- a/packages/core/src/storage/pragma-paths.ts
+++ b/packages/core/src/storage/pragma-paths.ts
@@ -171,6 +171,10 @@ export class PragmaPaths {
     return join(this.memoryDataRoot(), "extractor-profile.json");
   }
 
+  memoryExtractionSettings(): string {
+    return join(this.memoryDataRoot(), "extraction-settings.json");
+  }
+
   memoryExecutionActivityRoot(executionId: string): string {
     return join(this.memoryStateRoot(), "executions", encodePragmaPathSegment(executionId));
   }

--- a/packages/core/test/pragma-paths.test.ts
+++ b/packages/core/test/pragma-paths.test.ts
@@ -49,6 +49,15 @@ describe("PragmaPaths", () => {
     expect(root.startsWith(paths.workspaceRoot())).toBe(false);
   });
 
+  it("keeps Memory extraction settings in the authoritative Memory data root", () => {
+    const paths = new PragmaPaths({ pragmaHome: join("", "pragma-home") });
+
+    expect(paths.memoryExtractionSettings()).toBe(
+      join(paths.memoryDataRoot(), "extraction-settings.json"),
+    );
+    expect(paths.memoryExtractionSettings().startsWith(paths.workspaceRoot())).toBe(false);
+  });
+
   it("places Qoder external commands in the shared rebuildable Runtime cache", () => {
     const paths = new PragmaPaths({ pragmaHome: join("", "pragma-home") });
 

--- a/packages/memory/src/curator.ts
+++ b/packages/memory/src/curator.ts
@@ -2,5 +2,5 @@ import { MissionExecutorRefSchema } from "@pragma/shared";
 
 export const MEMORY_CURATOR_ID = "0000000000mem0ry";
 export const MEMORY_CURATOR_REF = MissionExecutorRefSchema.parse(`expert:${MEMORY_CURATOR_ID}`);
-export const MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator/v1";
-export const SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator.semantic/v1";
+export const MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator/v2";
+export const SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION = "pragma.memory-curator.semantic/v2";

--- a/packages/memory/src/episodic/module.ts
+++ b/packages/memory/src/episodic/module.ts
@@ -9,7 +9,12 @@ import {
 } from "./schema.ts";
 import { createEpisodicMemoryStore, episodicMemoryId, type EpisodicMemoryStore } from "./store.ts";
 import { extractionErrorCode } from "../pipeline/extraction-error-code.ts";
+import {
+  selectMemoryExtractionEvidence,
+  type MemoryExtractionSettingsStore,
+} from "../pipeline/extraction-settings.ts";
 import type { MemoryModule } from "../pipeline/memory-module.ts";
+import { mergeMemoryEvidenceOmissionStats } from "../storage/bounded-evidence.ts";
 
 export interface EpisodicMemoryModule extends MemoryModule {
   setExtractor(extractor: EpisodicMemoryExtractor | undefined): Promise<void>;
@@ -36,6 +41,7 @@ export async function createEpisodicMemoryModule(
   options: {
     readonly pragmaHome?: string | undefined;
     readonly extractor?: EpisodicMemoryExtractor | undefined;
+    readonly extractionSettings?: Pick<MemoryExtractionSettingsStore, "get"> | undefined;
     readonly now?: (() => Date) | undefined;
   } = {},
 ): Promise<EpisodicMemoryModule> {
@@ -100,7 +106,22 @@ export async function createEpisodicMemoryModule(
       const controller = new AbortController();
       running.set(key, controller);
       try {
-        const evidence = sanitizeEvidence(await store.readEvidenceForJob(job));
+        const capturedEvidence = await store.readEvidenceForJob(job);
+        const allowToolAssisted =
+          (await options.extractionSettings?.get())?.allowToolAssisted.episodic ?? false;
+        const selectedEvidence = selectMemoryExtractionEvidence(
+          capturedEvidence,
+          allowToolAssisted,
+        );
+        const evidence = sanitizeEvidence(selectedEvidence.retained);
+        const omittedEvidence = mergeMemoryEvidenceOmissionStats(
+          await store.readOmissionStatsForJob(job),
+          selectedEvidence.omittedStats,
+        );
+        if (evidence.length === 0) {
+          await store.completeRejected(job, "insufficient-evidence", now());
+          return;
+        }
         if (evidence.some((item) => item.sensitivity === "restricted")) {
           await store.completeRejected(job, "sensitive", now());
           return;
@@ -125,7 +146,7 @@ export async function createEpisodicMemoryModule(
           executionId: job.executionId,
           ...(previousEpisode === undefined ? {} : { previousEpisode }),
           evidence,
-          omittedEvidence: await store.readOmissionStatsForJob(job),
+          omittedEvidence,
         });
         if (!(await store.isClaimCurrent(job))) return;
         controller.signal.throwIfAborted();

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -4,6 +4,7 @@ export * from "./pipeline/pipeline-state-store.ts";
 export * from "./pipeline/memory-module.ts";
 export * from "./pipeline/memory-schema-registry.ts";
 export * from "./pipeline/memory-pipeline-scheduler.ts";
+export * from "./pipeline/extraction-settings.ts";
 export * from "./policy/memory-policy-store.ts";
 export * from "./context/federated-memory-context-store.ts";
 export * from "./activity/memory-activity-store.ts";

--- a/packages/memory/src/pipeline/extraction-settings.ts
+++ b/packages/memory/src/pipeline/extraction-settings.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { PragmaPaths, withFileLock } from "@pragma/core";
+import {
+  MemorySafeExecutionMessagePayloadSchema,
+  MemorySafeToolEventPayloadSchema,
+  type MemoryEvidenceEnvelope,
+} from "@pragma/shared";
+import { z } from "zod";
+
+import {
+  EMPTY_MEMORY_EVIDENCE_OMISSION_STATS,
+  summarizeMemoryEvidenceOmissions,
+  type MemoryEvidenceOmissionStats,
+} from "../storage/bounded-evidence.ts";
+
+export const MemoryExtractionSettingsSchema = z
+  .object({
+    schemaVersion: z.literal("pragma.memory-extraction-settings/v1"),
+    revision: z.number().int().nonnegative(),
+    allowToolAssisted: z
+      .object({
+        episodic: z.boolean(),
+        semantic: z.boolean(),
+      })
+      .strict(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export type MemoryExtractionSettings = z.infer<typeof MemoryExtractionSettingsSchema>;
+
+export interface MemoryExtractionSettingsStore {
+  get(): Promise<MemoryExtractionSettings>;
+  update(input: {
+    readonly expectedRevision: number;
+    readonly allowToolAssisted: MemoryExtractionSettings["allowToolAssisted"];
+  }): Promise<MemoryExtractionSettings>;
+}
+
+export function createFileMemoryExtractionSettingsStore(
+  options: {
+    readonly pragmaHome?: string | undefined;
+    readonly now?: (() => Date) | undefined;
+  } = {},
+): MemoryExtractionSettingsStore {
+  const path = new PragmaPaths(options).memoryExtractionSettings();
+  const now = options.now ?? (() => new Date());
+  const initial = (): MemoryExtractionSettings =>
+    MemoryExtractionSettingsSchema.parse({
+      schemaVersion: "pragma.memory-extraction-settings/v1",
+      revision: 0,
+      allowToolAssisted: { episodic: false, semantic: false },
+      updatedAt: new Date(0).toISOString(),
+    });
+  const read = async (): Promise<MemoryExtractionSettings> => {
+    try {
+      return MemoryExtractionSettingsSchema.parse(JSON.parse(await readFile(path, "utf8")));
+    } catch (error) {
+      if (isNotFound(error)) return initial();
+      throw error;
+    }
+  };
+  return {
+    get: read,
+    async update(input) {
+      return await withFileLock(`${path}.lock`, async () => {
+        const current = await read();
+        if (current.revision !== input.expectedRevision) {
+          const error = new Error("memory_extraction_settings_revision_conflict");
+          Object.assign(error, { expected: input.expectedRevision, actual: current.revision });
+          throw error;
+        }
+        const next = MemoryExtractionSettingsSchema.parse({
+          schemaVersion: "pragma.memory-extraction-settings/v1",
+          revision: current.revision + 1,
+          allowToolAssisted: input.allowToolAssisted,
+          updatedAt: now().toISOString(),
+        });
+        await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        const temporary = `${path}.${randomUUID()}.tmp`;
+        await writeFile(temporary, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+        await rename(temporary, path);
+        return next;
+      });
+    },
+  };
+}
+
+export interface MemoryExtractionEvidenceSelection {
+  readonly retained: readonly MemoryEvidenceEnvelope[];
+  readonly omittedStats: MemoryEvidenceOmissionStats;
+}
+
+export function selectMemoryExtractionEvidence(
+  evidence: readonly MemoryEvidenceEnvelope[],
+  allowToolAssisted: boolean,
+): MemoryExtractionEvidenceSelection {
+  const retained: MemoryEvidenceEnvelope[] = [];
+  const omitted: MemoryEvidenceEnvelope[] = [];
+  for (const item of evidence) {
+    const prepared = prepareExtractionEvidence(item, allowToolAssisted);
+    if (prepared === undefined) omitted.push(item);
+    else retained.push(prepared);
+  }
+  return {
+    retained,
+    omittedStats:
+      omitted.length === 0
+        ? EMPTY_MEMORY_EVIDENCE_OMISSION_STATS
+        : summarizeMemoryEvidenceOmissions(omitted),
+  };
+}
+
+function prepareExtractionEvidence(
+  item: MemoryEvidenceEnvelope,
+  allowToolAssisted: boolean,
+): MemoryEvidenceEnvelope | undefined {
+  if (item.schemaRef === "pragma.memory.tool-event/v2") {
+    const structural = MemorySafeToolEventPayloadSchema.safeParse(item.payload);
+    if (!structural.success) return undefined;
+    return {
+      ...item,
+      payload: allowToolAssisted
+        ? toolAssistedEventPayload(structural.data, item.payload)
+        : structural.data,
+    };
+  }
+  if (item.schemaRef !== "pragma.memory.execution-message/v2") return item;
+  const structural = MemorySafeExecutionMessagePayloadSchema.safeParse(item.payload);
+  if (!structural.success) return undefined;
+  if (!allowToolAssisted || structural.data.message.role !== "tool") {
+    return { ...item, payload: structural.data };
+  }
+  const rawMessage = readRecord(readRecord(item.payload)?.["message"]);
+  return {
+    ...item,
+    payload: {
+      message: {
+        ...structural.data.message,
+        ...(rawMessage !== undefined && "content" in rawMessage
+          ? { content: rawMessage["content"] }
+          : {}),
+      },
+    },
+  };
+}
+
+function toolAssistedEventPayload(
+  structural: ReturnType<typeof MemorySafeToolEventPayloadSchema.parse>,
+  payload: unknown,
+) {
+  const raw = readRecord(payload);
+  if (raw === undefined) return structural;
+  return {
+    ...structural,
+    ...(structural.phase === "started" && "inputPreview" in raw
+      ? { inputPreview: raw["inputPreview"] }
+      : {}),
+    ...(structural.phase === "completed" && "outputPreview" in raw
+      ? { outputPreview: raw["outputPreview"] }
+      : {}),
+    ...(structural.phase === "failed" && typeof raw["message"] === "string"
+      ? { errorMessage: raw["message"] }
+      : {}),
+  };
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { readonly code?: unknown }).code === "ENOENT"
+  );
+}

--- a/packages/memory/src/semantic/module.ts
+++ b/packages/memory/src/semantic/module.ts
@@ -9,7 +9,12 @@ import {
 } from "./schema.ts";
 import { createSemanticMemoryStore, type SemanticMemoryStore } from "./store.ts";
 import { extractionErrorCode } from "../pipeline/extraction-error-code.ts";
+import {
+  selectMemoryExtractionEvidence,
+  type MemoryExtractionSettingsStore,
+} from "../pipeline/extraction-settings.ts";
 import type { MemoryModule } from "../pipeline/memory-module.ts";
+import { mergeMemoryEvidenceOmissionStats } from "../storage/bounded-evidence.ts";
 
 export interface SemanticMemoryModule extends MemoryModule {
   readonly store: SemanticMemoryStore;
@@ -41,6 +46,7 @@ export async function createSemanticMemoryModule(
   options: {
     readonly pragmaHome?: string | undefined;
     readonly extractor?: SemanticMemoryExtractor | undefined;
+    readonly extractionSettings?: Pick<MemoryExtractionSettingsStore, "get"> | undefined;
     readonly now?: (() => Date) | undefined;
   } = {},
 ): Promise<SemanticMemoryModule> {
@@ -104,7 +110,18 @@ export async function createSemanticMemoryModule(
         }
         const subjectContext = await store.getSubjectContext(job.executionId);
         if (subjectContext === undefined) throw new Error("semantic_subject_context_missing");
-        const evidence = sanitizeEvidence(await store.readEvidenceForJob(job));
+        const capturedEvidence = await store.readEvidenceForJob(job);
+        const allowToolAssisted =
+          (await options.extractionSettings?.get())?.allowToolAssisted.semantic ?? false;
+        const selectedEvidence = selectMemoryExtractionEvidence(
+          capturedEvidence,
+          allowToolAssisted,
+        );
+        const evidence = sanitizeEvidence(selectedEvidence.retained);
+        const omittedEvidence = mergeMemoryEvidenceOmissionStats(
+          await store.readOmissionStatsForJob(job),
+          selectedEvidence.omittedStats,
+        );
         if (evidence.some((item) => item.sensitivity === "restricted")) {
           await store.completeRejected(job, "sensitive", now());
           return;
@@ -130,7 +147,7 @@ export async function createSemanticMemoryModule(
           executionId: job.executionId,
           allowedSubjectRefs,
           evidence,
-          omittedEvidence: await store.readOmissionStatsForJob(job),
+          omittedEvidence,
         });
         if (!(await store.isClaimCurrent(job))) return;
         controller.signal.throwIfAborted();

--- a/packages/memory/src/storage/bounded-evidence.ts
+++ b/packages/memory/src/storage/bounded-evidence.ts
@@ -62,7 +62,11 @@ export function selectBoundedMemoryEvidence(
   }
   const retainedItems = ordered.filter((item) => retained.has(item.messageId));
   const omitted = ordered.filter((item) => !retained.has(item.messageId));
-  return { retained: retainedItems, omitted, omittedStats: omissionStats(omitted) };
+  return {
+    retained: retainedItems,
+    omitted,
+    omittedStats: summarizeMemoryEvidenceOmissions(omitted),
+  };
 }
 
 export function mergeMemoryEvidenceOmissionStats(
@@ -111,7 +115,9 @@ function evidencePriority(
   return 500;
 }
 
-function omissionStats(evidence: readonly MemoryEvidenceEnvelope[]): MemoryEvidenceOmissionStats {
+export function summarizeMemoryEvidenceOmissions(
+  evidence: readonly MemoryEvidenceEnvelope[],
+): MemoryEvidenceOmissionStats {
   const byTopic: Record<string, number> = {};
   let bytes = 0;
   for (const item of evidence) {

--- a/packages/memory/test/extraction-settings.test.ts
+++ b/packages/memory/test/extraction-settings.test.ts
@@ -1,0 +1,189 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { MemoryEvidenceEnvelopeSchema, type MemoryEvidenceEnvelope } from "@pragma/shared";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createFileMemoryExtractionSettingsStore,
+  selectMemoryExtractionEvidence,
+} from "../src/index.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Memory extraction settings", () => {
+  it("defaults tool-assisted Episodic and Semantic extraction to off and persists independently", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-memory-extraction-settings-"));
+    roots.push(root);
+    const store = createFileMemoryExtractionSettingsStore({
+      pragmaHome: root,
+      now: () => new Date("2026-08-05T00:00:00.000Z"),
+    });
+
+    await expect(store.get()).resolves.toMatchObject({
+      revision: 0,
+      allowToolAssisted: { episodic: false, semantic: false },
+    });
+    await expect(
+      store.update({
+        expectedRevision: 0,
+        allowToolAssisted: { episodic: true, semantic: false },
+      }),
+    ).resolves.toMatchObject({
+      revision: 1,
+      allowToolAssisted: { episodic: true, semantic: false },
+    });
+    await expect(
+      store.update({
+        expectedRevision: 0,
+        allowToolAssisted: { episodic: false, semantic: true },
+      }),
+    ).rejects.toThrow("memory_extraction_settings_revision_conflict");
+    await expect(
+      createFileMemoryExtractionSettingsStore({ pragmaHome: root }).get(),
+    ).resolves.toMatchObject({
+      revision: 1,
+      allowToolAssisted: { episodic: true, semantic: false },
+    });
+  });
+
+  it("preserves tool-call structure while hiding tool input and result content", () => {
+    const evidence = [
+      envelope("user", "execution.message.appended", {
+        message: {
+          role: "user",
+          text: "Remember this preference",
+          providerDiagnostics: "private diagnostic",
+        },
+      }),
+      envelope("tool-started", "execution.tool.started", {
+        toolCallId: "call-1",
+        toolName: "search",
+        phase: "started",
+        inputPreview: { query: "private query" },
+        providerDiagnostics: "private diagnostic",
+      }),
+      envelope("tool-result", "execution.message.appended", {
+        message: {
+          role: "tool",
+          toolCallId: "call-1",
+          toolName: "search",
+          status: "succeeded",
+          content: "private result",
+          details: "private diagnostic",
+        },
+      }),
+      envelope("assistant", "execution.message.appended", {
+        message: {
+          role: "assistant",
+          text: "Saved",
+          stopReason: "stop",
+          reasoning: "private reasoning",
+        },
+      }),
+    ];
+
+    const filtered = selectMemoryExtractionEvidence(evidence, false);
+    expect(filtered.retained.map((item) => item.messageId)).toEqual([
+      "user",
+      "tool-started",
+      "tool-result",
+      "assistant",
+    ]);
+    expect(filtered.retained[1]?.payload).toEqual({
+      toolCallId: "call-1",
+      toolName: "search",
+      phase: "started",
+    });
+    expect(filtered.retained[2]?.payload).toEqual({
+      message: {
+        role: "tool",
+        toolCallId: "call-1",
+        toolName: "search",
+        status: "succeeded",
+      },
+    });
+    expect(filtered.retained[0]?.payload).toEqual({
+      message: { role: "user", text: "Remember this preference" },
+    });
+    expect(filtered.retained[3]?.payload).toEqual({
+      message: { role: "assistant", text: "Saved", stopReason: "stop" },
+    });
+    expect(filtered.omittedStats.records).toBe(0);
+
+    const enabled = selectMemoryExtractionEvidence(evidence, true);
+    expect(enabled.retained[1]?.payload).toEqual({
+      toolCallId: "call-1",
+      toolName: "search",
+      phase: "started",
+      inputPreview: { query: "private query" },
+    });
+    expect(enabled.retained[2]?.payload).toEqual({
+      message: {
+        role: "tool",
+        toolCallId: "call-1",
+        toolName: "search",
+        status: "succeeded",
+        content: "private result",
+      },
+    });
+    expect(enabled.retained[0]?.payload).toEqual(filtered.retained[0]?.payload);
+    expect(enabled.retained[3]?.payload).toEqual(filtered.retained[3]?.payload);
+  });
+
+  it("omits malformed safe-projection payloads instead of leaking their content", () => {
+    const malformed = [
+      envelope("malformed-tool", "execution.tool.completed", {
+        output: "private result without structural fields",
+      }),
+      envelope("malformed-assistant", "execution.message.appended", {
+        message: { role: "assistant", reasoning: "private reasoning without safe text" },
+      }),
+    ];
+
+    const selected = selectMemoryExtractionEvidence(malformed, true);
+
+    expect(selected.retained).toEqual([]);
+    expect(selected.omittedStats).toMatchObject({
+      records: 2,
+      byTopic: { "execution.tool.completed": 1, "execution.message.appended": 1 },
+    });
+  });
+});
+
+function envelope(messageId: string, topic: string, payload: unknown): MemoryEvidenceEnvelope {
+  return MemoryEvidenceEnvelopeSchema.parse({
+    schemaVersion: "pragma.memory-evidence/v1",
+    messageId,
+    topic,
+    schemaRef:
+      topic === "execution.message.appended"
+        ? "pragma.memory.execution-message/v2"
+        : "pragma.memory.tool-event/v2",
+    sourceRef: {
+      type: "pragma.execution-event",
+      id: messageId,
+      canonicalEventId: `canonical-${messageId}`,
+    },
+    subjectRefs: [{ type: "pragma.execution", id: "execution" }],
+    correlationId: "execution",
+    occurredAt: "2026-08-05T00:00:00.000Z",
+    visibility: { mode: "host-private" },
+    sensitivity: "internal",
+    bindings: [],
+    policySnapshot: {
+      capture: true,
+      recall: true,
+      learning: "local-candidates",
+      appliedRevisions: [],
+    },
+    payload,
+  });
+}


### PR DESCRIPTION
## Summary

- add per-memory-type settings for tool-assisted extraction, defaulting to disabled for episodic and semantic memory
- preserve the structural tool-call timeline while hiding tool inputs, outputs, and error details by default
- expose the settings through Desktop IPC, preload contracts, and localized Settings UI
- normalize evidence through the memory-safe schemas and omit malformed projections with omission accounting
- update curator prompts and tests for the new privacy boundary

## Why

Dropping tool events entirely breaks the conversational timeline used by memory extraction. Keeping only their safe structural fields preserves context without exposing tool payloads unless the user explicitly enables tool-assisted extraction for that memory type.

## Root cause

The previous pipeline treated tool evidence as all-or-nothing and did not have a persisted per-memory-type policy. It therefore could not retain call structure independently from potentially sensitive tool content.

## Impact

By default, episodic and semantic extraction can see that a tool was invoked and how it progressed, but cannot see its arguments or returned content. Users can opt in independently for each memory type.

## Validation

- `pnpm check` — 23/23 tasks passed
- `pnpm build` — 23/23 packages passed
- Desktop tests — 108 files, 647 tests passed
- focused memory extraction tests — 38 tests passed
- Prettier check and `git diff --check` passed
