### PR TITLE
Escape Memory Markdown link labels

### DIFF
--- a/packages/memory/src/context/markdown.ts
+++ b/packages/memory/src/context/markdown.ts
@@ -1,0 +1,3 @@
+export function escapeMarkdownLinkLabel(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("[", "\\[").replaceAll("]", "\\]");
+}

--- a/packages/memory/src/episodic/context.ts
+++ b/packages/memory/src/episodic/context.ts
@@ -7,6 +7,7 @@ import type { MemoryEvidenceEnvelope } from "@pragma/shared";
 
 import type { EpisodicMemoryRecord } from "./schema.ts";
 import type { EpisodicMemoryStore } from "./store.ts";
+import { escapeMarkdownLinkLabel } from "../context/markdown.ts";
 import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
 import { trimUtf8ToByteLimit } from "../storage/utf8.ts";
 
@@ -154,7 +155,7 @@ function renderSummary(
         ? ["- No episodes are available in this scope."]
         : recent.map(
             (episode) =>
-              `- [${oneLine(episode.goal.text, 60)}](episodic/items/${episode.id}.md) — ${viewLabel(episode, scope)} — ${episode.updatedAt} — ${episode.outcome.status}`,
+              `- [${escapeMarkdownLinkLabel(oneLine(episode.goal.text, 60))}](episodic/items/${episode.id}.md) — ${viewLabel(episode, scope)} — ${episode.updatedAt} — ${episode.outcome.status}`,
           )),
       "",
     ],
@@ -251,7 +252,7 @@ function renderIndexGroup(
           .toSorted(compareEpisode)
           .map(
             (episode) =>
-              `- [${oneLine(episode.goal.text, 120)}](episodic/items/${episode.id}.md) — ${label} | ${episode.updatedAt} | ${episode.outcome.status} | value ${episode.valueScore.toFixed(2)} | ${oneLine(episode.summary.text, 180)}`,
+              `- [${escapeMarkdownLinkLabel(oneLine(episode.goal.text, 120))}](episodic/items/${episode.id}.md) — ${label} | ${episode.updatedAt} | ${episode.outcome.status} | value ${episode.valueScore.toFixed(2)} | ${oneLine(episode.summary.text, 180)}`,
           )),
     "",
   ];

--- a/packages/memory/src/semantic/context.ts
+++ b/packages/memory/src/semantic/context.ts
@@ -6,6 +6,7 @@ import {
 import type { MemoryEvidenceEnvelope, SemanticFact } from "@pragma/shared";
 
 import type { SemanticMemoryStore } from "./store.ts";
+import { escapeMarkdownLinkLabel } from "../context/markdown.ts";
 import type { MemoryRecallScope } from "../pipeline/memory-module.ts";
 import { trimUtf8ToByteLimit } from "../storage/utf8.ts";
 
@@ -153,7 +154,8 @@ function renderIndexLine(fact: SemanticFact): string {
     fact.conflictsWith.length === 0 ? undefined : `conflicts:${fact.conflictsWith.length}`,
     fact.reviewAt === undefined ? undefined : `review:${fact.reviewAt}`,
   ].filter((value): value is string => value !== undefined);
-  return `- [${oneLine(fact.statement, 180)}](semantic/items/${fact.id}.md) — confidence ${fact.confidence.toFixed(2)}${flags.length === 0 ? "" : ` | ${flags.join(", ")}`}`;
+  const label = escapeMarkdownLinkLabel(oneLine(fact.statement, 180));
+  return `- [${label}](semantic/items/${fact.id}.md) — confidence ${fact.confidence.toFixed(2)}${flags.length === 0 ? "" : ` | ${flags.join(", ")}`}`;
 }
 
 function renderFact(fact: SemanticFact): string {

--- a/packages/memory/test/episodic-memory.test.ts
+++ b/packages/memory/test/episodic-memory.test.ts
@@ -92,6 +92,27 @@ describe("Episodic Memory", () => {
     module.close();
   });
 
+  it("escapes episode goals used as Markdown link labels", async () => {
+    const goal = "Click](https://example.com)[Episode";
+    const module = await createEpisodicMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor: fakeExtractor(undefined, 0.9, goal),
+    });
+    await module.consume(executionEvidence("markdown-link-label"));
+    await module.runBackgroundOnce?.();
+
+    const [episode] = await module.store.list();
+    const registry = new MemoryModuleRegistry();
+    registry.register(module);
+    const context = scopedContext(registry, expertScope("expert-a"));
+    const expectedLink = `[Click\\](https://example.com)\\[Episode](episodic/items/${episode!.id}.md)`;
+    for (const id of ["episodic/summary.md", "episodic/index.md"]) {
+      const item = await context.readContext({ id });
+      expect(item.ok && item.value.content).toContain(expectedLink);
+    }
+    module.close();
+  });
+
   it("fails closed when recall is disabled for the current asset", async () => {
     const registry = new MemoryModuleRegistry();
     const module = await createEpisodicMemoryModule({ pragmaHome: await temporaryRoot() });
@@ -1116,6 +1137,7 @@ describe("Episodic Memory", () => {
 function fakeExtractor(
   forcedRef?: string,
   valueScore = 0.9,
+  goalText = "完成记忆架构实现",
 ): EpisodicMemoryExtractor & { extract: ReturnType<typeof vi.fn> } {
   const extract = vi.fn(async (input: EpisodicExtractionInput) => {
     const ref = forcedRef ?? input.evidence.at(-1)!.messageId;
@@ -1123,7 +1145,7 @@ function fakeExtractor(
       output: {
         retain: true as const,
         language: "zh-Hans",
-        goal: { text: "完成记忆架构实现", evidenceRefs: [ref] },
+        goal: { text: goalText, evidenceRefs: [ref] },
         summary: { text: `实现并验证了分层记忆 ${input.executionId}。`, evidenceRefs: [ref] },
         attempts: [{ description: "实现 Episodic 模块", result: "成功", evidenceRefs: [ref] }],
         failuresAndRecoveries: [],

--- a/packages/memory/test/semantic-memory.test.ts
+++ b/packages/memory/test/semantic-memory.test.ts
@@ -80,6 +80,31 @@ describe("Semantic Memory", () => {
     module.close();
   });
 
+  it("escapes fact statements used as Markdown link labels", async () => {
+    const statement = "Click](https://example.com)[Fact";
+    const module = await createSemanticMemoryModule({
+      pragmaHome: await temporaryRoot(),
+      extractor: fakeExtractor(() => ({ statement })),
+    });
+    await module.registerExecutionSubjects({
+      executionId: "markdown-link-label",
+      subjectRefs: [ref("pragma.user", "local-user")],
+    });
+    await module.consume(executionEvidence("markdown-link-label", "Remember this fact."));
+    await module.runBackgroundOnce?.();
+
+    const [fact] = await module.store.list();
+    const registry = new MemoryModuleRegistry();
+    registry.register(module);
+    const context = scopedContext(registry, expertScope("expert-a"));
+    const expectedLink = `[Click\\](https://example.com)\\[Fact](semantic/items/${fact!.id}.md)`;
+    for (const id of ["semantic/summary.md", "semantic/index.md"]) {
+      const item = await context.readContext({ id });
+      expect(item.ok && item.value.content).toContain(expectedLink);
+    }
+    module.close();
+  });
+
   it("merges equivalent observations and preserves exclusive conflicts symmetrically", async () => {
     const now = new Date("2026-08-03T18:00:01.000Z");
     const extractor = fakeExtractor((input) => {


### PR DESCRIPTION
## What changed

- escape backslashes and square brackets in Semantic Memory statement link labels
- apply the same protection to Episodic Memory summary and index goal links
- add regression coverage for crafted Memory text containing external-link Markdown syntax

## Why

Memory extractor output is untrusted text. It was interpolated directly into Markdown link labels, so text such as `Click](https://example.com)[Fact` could break the intended internal item link and create an attacker-controlled external link in the Desktop Context Store browser.

## Impact

Semantic and Episodic indexes continue to navigate to their internal Memory items, while dynamic labels are rendered as text instead of being interpreted as additional Markdown links.

## Validation

- `pnpm --filter @pragma/memory test -- --reporter=dot` (83 tests)
- `pnpm --filter @pragma/memory typecheck`
- `pnpm --filter @pragma/memory lint`
- `pnpm --filter @pragma/memory build`
- Prettier and `git diff --check`

Follow-up to the Codex review on #135.
