### PR TITLE
feat(desktop): Team instructions Markdown preview

### DIFF
--- a/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.test.tsx
@@ -7,6 +7,7 @@ import {
   PragmaExpertTeamResourceSchema,
   type PragmaFlowResource,
   type PragmaExpertResource,
+  type PragmaExpertTeamResource,
 } from "@pragma/interpreter/ast";
 import type {
   DesktopRuntimeAvailability,
@@ -360,7 +361,31 @@ describe("PragmaResourceDetailFragment", () => {
       spec: {
         coordinator: { ref: "expert:0000000000000001" },
         members: [{ ref: "expert:0000000000000002" }],
-        instructions: "Check evidence.",
+        instructions: `# Evidence review
+
+**Verify** evidence before declaring work complete.
+
+> *Important note:* keep evidence traceable.
+
+- [x] Read evidence
+- Summarize findings
+
+Use \`team:quality\` for the handoff.
+
+| Check | Status |
+| --- | --- |
+| Evidence | Complete |
+
+[Open evidence](https://example.com)
+
+![evidence diagram](https://example.com/evidence.png)
+
+\`\`\`ts
+const complete = true;
+\`\`\`
+
+<script>window.alert("unsafe")</script>
+<img src=x onerror="window.alert('unsafe-image')">`,
         delegation: { maxConcurrency: 2, maxDepth: 5 },
       },
     });
@@ -400,6 +425,67 @@ describe("PragmaResourceDetailFragment", () => {
     expect(html).not.toContain("expert:0000000000000002");
     expect(html).toContain("2 members");
     expect(html).toContain("Delete");
+    expect(html).toContain("<h1>Evidence review</h1>");
+    expect(html).toContain("<strong>Verify</strong>");
+    expect(html).toContain("<blockquote");
+    expect(html).toContain("<em>Important note:</em>");
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("<code>team:quality</code>");
+    expect(html).toContain("<table>");
+    expect(html).toContain("<thead>");
+    expect(html).toContain("<tbody>");
+    expect(html).toContain("<th>Check</th>");
+    expect(html).toContain("<td>Complete</td>");
+    expect(html).toContain('href="https://example.com" target="_blank" rel="noreferrer"');
+    expect(html).toContain('class="markdown-image-placeholder"');
+    expect(html).toContain("[Image: evidence diagram]");
+    expect(html).toContain('<code class="language-ts">const complete = true;</code>');
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("src=");
+    expect(html).not.toContain("onerror");
+    expect(html).not.toContain('window.alert("unsafe")');
+    expect(html).not.toContain("unsafe-image");
+
+    const teamWithoutInstructions = PragmaExpertTeamResourceSchema.parse({
+      ...team,
+      spec: { ...team.spec, instructions: undefined },
+    });
+    const emptyInstructionsHtml = renderToStaticMarkup(
+      <PragmaResourceDetailFragment
+        resource={teamWithoutInstructions}
+        project={{ ...project, resources: [...experts, teamWithoutInstructions] }}
+        experts={studioExperts}
+        runtimes={runtimes}
+        onOpenExpert={() => undefined}
+        onBack={() => undefined}
+        onEdit={() => undefined}
+        onDelete={async () => undefined}
+      />,
+    );
+
+    expect(emptyInstructionsHtml).toContain("No instructions provided.");
+    expect(emptyInstructionsHtml).not.toContain("team-instructions-markdown");
+
+    const whitespaceTeam = {
+      ...team,
+      spec: { ...team.spec, instructions: "   \n  " },
+    } as unknown as PragmaExpertTeamResource;
+    const whitespaceInstructionsHtml = renderToStaticMarkup(
+      <PragmaResourceDetailFragment
+        resource={whitespaceTeam}
+        project={{ ...project, resources: [...experts, whitespaceTeam] }}
+        experts={studioExperts}
+        runtimes={runtimes}
+        onOpenExpert={() => undefined}
+        onBack={() => undefined}
+        onEdit={() => undefined}
+        onDelete={async () => undefined}
+      />,
+    );
+
+    expect(whitespaceInstructionsHtml).toContain("No instructions provided.");
+    expect(whitespaceInstructionsHtml).not.toContain("team-instructions-markdown");
   });
 
   it("shows Flow details before opening the Flow editor", () => {

--- a/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../../../shared/contracts/index.ts";
 
 import { CharacterCount } from "../../components/CharacterCount.tsx";
+import { MarkdownContent } from "../../components/MarkdownContent.tsx";
 import { errorMessage } from "../../lib/errors.ts";
 import { AssetMemoryPolicySection } from "../settings/AssetMemoryPolicySection.tsx";
 import { StudioScreenFrame } from "./StudioScreenFrame.tsx";
@@ -507,6 +508,7 @@ function TeamDetail(props: {
   const members = uniqueMemberRefs
     .filter((ref) => ref !== coordinatorRef)
     .map((ref) => buildExpert(ref));
+  const instructions = props.resource.spec.instructions?.trim();
 
   return (
     <div className="team-detail-content">
@@ -568,7 +570,13 @@ function TeamDetail(props: {
             <CaretDown size={18} aria-hidden="true" />
           </span>
         </summary>
-        <p>{props.resource.spec.instructions?.trim() || t("noInstructions")}</p>
+        {instructions ? (
+          <div className="team-instructions-markdown">
+            <MarkdownContent source={instructions} />
+          </div>
+        ) : (
+          <p className="team-instructions-empty">{t("noInstructions")}</p>
+        )}
       </details>
     </div>
   );

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -21042,7 +21042,7 @@ textarea:focus-visible,
   transform: rotate(180deg);
 }
 
-.team-instructions-disclosure > p {
+.team-instructions-empty {
   margin: 0;
   padding: 0 20px 20px;
   color: #3e4a42;
@@ -21050,6 +21050,148 @@ textarea:focus-visible,
   line-height: 1.75;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+.team-instructions-markdown {
+  min-width: 0;
+  padding: 0 20px 20px;
+  color: #3e4a42;
+  font-size: 13px;
+  line-height: 1.75;
+  overflow-wrap: anywhere;
+}
+
+.team-instructions-markdown > :first-child {
+  margin-top: 0;
+}
+
+.team-instructions-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.team-instructions-markdown h1,
+.team-instructions-markdown h2,
+.team-instructions-markdown h3,
+.team-instructions-markdown h4,
+.team-instructions-markdown h5,
+.team-instructions-markdown h6 {
+  margin: 1.25em 0 0.5em;
+  color: var(--text);
+  font-weight: 680;
+  line-height: 1.3;
+}
+
+.team-instructions-markdown h1 {
+  font-size: 1.45em;
+}
+
+.team-instructions-markdown h2 {
+  font-size: 1.28em;
+}
+
+.team-instructions-markdown h3 {
+  font-size: 1.12em;
+}
+
+.team-instructions-markdown h4,
+.team-instructions-markdown h5,
+.team-instructions-markdown h6 {
+  font-size: 1em;
+}
+
+.team-instructions-markdown p,
+.team-instructions-markdown ul,
+.team-instructions-markdown ol,
+.team-instructions-markdown blockquote,
+.team-instructions-markdown pre,
+.team-instructions-markdown table {
+  margin: 0.72em 0;
+}
+
+.team-instructions-markdown ul,
+.team-instructions-markdown ol {
+  padding-left: 1.5em;
+}
+
+.team-instructions-markdown li + li {
+  margin-top: 0.22em;
+}
+
+.team-instructions-markdown li > p {
+  margin: 0.2em 0;
+}
+
+.team-instructions-markdown :not(pre) > code {
+  padding: 0.14em 0.38em;
+  border: 1px solid rgb(76 91 82 / 10%);
+  border-radius: 5px;
+  background: rgb(69 84 75 / 8%);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.88em;
+}
+
+.team-instructions-markdown blockquote {
+  padding: 0.08em 0 0.08em 0.85em;
+  border-left: 3px solid #bdc9c1;
+  color: var(--muted);
+}
+
+.team-instructions-markdown blockquote > :first-child {
+  margin-top: 0;
+}
+
+.team-instructions-markdown blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.team-instructions-markdown hr {
+  margin: 1.25em 0;
+  border: 0;
+  border-top: 1px solid #d4dbd7;
+}
+
+.team-instructions-markdown .markdown-image-placeholder {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.team-instructions-markdown pre {
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 12px;
+  border: 1px solid #dfe4e1;
+  border-radius: 8px;
+  background: #f6f7f6;
+  color: #26312a;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  tab-size: 2;
+  white-space: pre;
+}
+
+.team-instructions-markdown pre code {
+  font: inherit;
+}
+
+.team-instructions-markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.team-instructions-markdown th,
+.team-instructions-markdown td {
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  text-align: left;
+  white-space: normal;
+}
+
+.team-instructions-markdown th {
+  background: rgb(70 85 76 / 5%);
+  font-weight: 650;
 }
 
 @media (max-width: 1180px) {


### PR DESCRIPTION
## 概述

专家团队详情页 `Team instructions (optional)` 展开区域改为 Markdown preview 渲染，替代原有纯文本展示。

## 改动

| 文件 | 说明 |
|------|------|
| `PragmaResourceDirectoryFragment.tsx` | 引入 MarkdownContent 组件，有内容时渲染 Markdown，空态保持不变 |
| `styles.css` | 新增 Team 专属 `.team-instructions-markdown` 排版样式，隔离于现有 `.mission-markdown` |
| `PragmaResourceDirectoryFragment.test.tsx` | 扩展测试：GFM 表格、事件属性过滤、外链/图片策略 |

## 技术决策

- **复用已有 MarkdownContent 组件**（基于 marked lexer，Token → React 节点），安全无 XSS
- 无新增 npm 依赖，无 schema/协议变更
- 仅 Desktop 端改动，不涉及 Web 端

## 质量

- Typecheck ✅
- 全量测试 119 files / 702 tests ✅
- 安全：XSS 已防护，外链 noreferrer，图片不加载

## 手动验收

- [ ] 折叠/展开交互正常
- [ ] 编辑保存语义不变