### PR TITLE
fix(desktop): support Qwen multimodal attachments

### DIFF
--- a/apps/desktop/src/main/bootstrap/application.ts
+++ b/apps/desktop/src/main/bootstrap/application.ts
@@ -12,8 +12,10 @@ import { createDesktopWindowManager } from "../platform/window/desktop-window.ts
 import { configureDesktopApplicationIdentity } from "./application-identity.ts";
 import { createDesktopApplicationContainer } from "./application-container.ts";
 import { startDesktopWindowWithServices } from "./startup-sequence.ts";
+import { registerMissionAttachmentScheme } from "../features/missions/mission-attachment-protocol.ts";
 
 export function startDesktopApplication(): void {
+  registerMissionAttachmentScheme();
   configureDesktopApplicationIdentity(app);
   const paths = new PragmaPaths();
   const logging = createDesktopLogging(paths);

--- a/apps/desktop/src/main/features/missions/mission-attachment-preview.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-attachment-preview.test.ts
@@ -1,0 +1,113 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ExpertPromptAttachment } from "@pragma/shared";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseMissionAttachmentPreviewUrl,
+  resolveMissionAttachmentImage,
+} from "./mission-attachment-preview.ts";
+
+const roots: string[] = [];
+const missionId = "00000000-0000-4000-8000-000000000001";
+const attachmentId = "00000000-0000-4000-8000-000000000002";
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Mission attachment previews", () => {
+  it("accepts only canonical preview URLs", () => {
+    expect(
+      parseMissionAttachmentPreviewUrl(
+        `pragma-mission-attachment://preview/${missionId}/${attachmentId}`,
+      ),
+    ).toEqual({ missionId, attachmentId });
+    expect(() =>
+      parseMissionAttachmentPreviewUrl(
+        `pragma-mission-attachment://other/${missionId}/${attachmentId}`,
+      ),
+    ).toThrow("Invalid Mission attachment preview URL");
+    expect(() =>
+      parseMissionAttachmentPreviewUrl(
+        `pragma-mission-attachment://preview/${missionId}/${attachmentId}/extra`,
+      ),
+    ).toThrow("Invalid Mission attachment preview URL");
+    expect(() =>
+      parseMissionAttachmentPreviewUrl(
+        `pragma-mission-attachment://preview/${missionId}//${attachmentId}`,
+      ),
+    ).toThrow("Invalid Mission attachment preview URL");
+    expect(() =>
+      parseMissionAttachmentPreviewUrl(
+        `pragma-mission-attachment://preview/${missionId}/${attachmentId}?download=true`,
+      ),
+    ).toThrow("Invalid Mission attachment preview URL");
+    expect(() =>
+      parseMissionAttachmentPreviewUrl(
+        `pragma-mission-attachment://preview/not-a-mission/${attachmentId}`,
+      ),
+    ).toThrow();
+  });
+
+  it("serves only image files owned by the Mission attachment directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-preview-"));
+    roots.push(root);
+    const missionPath = join(root, missionId);
+    const imagePath = join(missionPath, "attachments", "images", `${attachmentId}.png`);
+    await mkdir(join(missionPath, "attachments", "images"), { recursive: true });
+    await writeFile(imagePath, "image-bytes");
+    const attachments: ExpertPromptAttachment[] = [
+      {
+        id: attachmentId,
+        kind: "image",
+        name: "screen.png",
+        path: imagePath,
+        mimeType: "image/png",
+      },
+    ];
+    const store = {
+      storagePath: () => missionPath,
+      getAttachments: async () => attachments,
+    };
+
+    await expect(resolveMissionAttachmentImage(store, missionId, attachmentId)).resolves.toEqual({
+      path: await realpath(imagePath),
+      mimeType: "image/png",
+    });
+
+    const outsidePath = join(root, "outside.png");
+    await writeFile(outsidePath, "outside");
+    attachments[0] = { ...attachments[0]!, path: outsidePath };
+    await expect(resolveMissionAttachmentImage(store, missionId, attachmentId)).rejects.toThrow(
+      "escaped its owner directory",
+    );
+  });
+
+  it("rejects non-image attachments and unknown identifiers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-preview-"));
+    roots.push(root);
+    const missionPath = join(root, missionId);
+    await mkdir(join(missionPath, "attachments", "images"), { recursive: true });
+    const store = {
+      storagePath: () => missionPath,
+      getAttachments: async () => [
+        {
+          id: attachmentId,
+          kind: "file" as const,
+          name: "notes.txt",
+          path: join(root, "notes.txt"),
+        },
+      ],
+    };
+
+    await expect(resolveMissionAttachmentImage(store, missionId, attachmentId)).rejects.toThrow(
+      "not found",
+    );
+    await expect(
+      resolveMissionAttachmentImage(store, missionId, "00000000-0000-4000-8000-000000000003"),
+    ).rejects.toThrow("not found");
+  });
+});

--- a/apps/desktop/src/main/features/missions/mission-attachment-preview.ts
+++ b/apps/desktop/src/main/features/missions/mission-attachment-preview.ts
@@ -1,0 +1,82 @@
+import { realpath, stat } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import {
+  MISSION_ATTACHMENT_PREVIEW_SCHEME,
+  MissionIdSchema,
+} from "../../../shared/contracts/index.ts";
+import type { MissionStore } from "./mission-store.ts";
+
+const SUPPORTED_IMAGE_TYPES = new Set(["image/gif", "image/jpeg", "image/png", "image/webp"]);
+const MAX_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+export async function resolveMissionAttachmentImage(
+  missions: {
+    readonly getAttachments: MissionStore["getAttachments"];
+    readonly storagePath: NonNullable<MissionStore["storagePath"]>;
+  },
+  missionIdInput: string,
+  attachmentId: string,
+): Promise<{ readonly path: string; readonly mimeType: string }> {
+  const missionId = MissionIdSchema.parse(missionIdInput);
+  const attachment = (await missions.getAttachments(missionId)).find(
+    (candidate) => candidate.id === attachmentId,
+  );
+  if (
+    attachment?.kind !== "image" ||
+    attachment.mimeType === undefined ||
+    !SUPPORTED_IMAGE_TYPES.has(attachment.mimeType)
+  ) {
+    throw new Error("Mission image attachment not found.");
+  }
+
+  const missionRoot = await realpath(missions.storagePath(missionId));
+  const imageRoot = await realpath(resolve(missionRoot, "attachments", "images"));
+  const imagePath = await realpath(attachment.path);
+  const relativePath = relative(imageRoot, imagePath);
+  if (
+    relativePath === "" ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error("Mission image attachment escaped its owner directory.");
+  }
+  const metadata = await stat(imagePath);
+  if (!metadata.isFile() || metadata.size > MAX_IMAGE_ATTACHMENT_BYTES) {
+    throw new Error("Mission image attachment is unavailable.");
+  }
+  return { path: imagePath, mimeType: attachment.mimeType };
+}
+
+export function parseMissionAttachmentPreviewUrl(url: string): {
+  readonly missionId: string;
+  readonly attachmentId: string;
+} {
+  const parsed = new URL(url);
+  if (
+    parsed.protocol !== `${MISSION_ATTACHMENT_PREVIEW_SCHEME}:` ||
+    parsed.hostname !== "preview" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.port !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new Error("Invalid Mission attachment preview URL.");
+  }
+  const rawSegments = parsed.pathname.split("/");
+  if (
+    rawSegments.length !== 3 ||
+    rawSegments[0] !== "" ||
+    rawSegments[1] === "" ||
+    rawSegments[2] === ""
+  ) {
+    throw new Error("Invalid Mission attachment preview URL.");
+  }
+  const segments = rawSegments.slice(1).map((segment) => decodeURIComponent(segment));
+  return {
+    missionId: MissionIdSchema.parse(segments[0]),
+    attachmentId: segments[1]!,
+  };
+}

--- a/apps/desktop/src/main/features/missions/mission-attachment-protocol.ts
+++ b/apps/desktop/src/main/features/missions/mission-attachment-protocol.ts
@@ -1,0 +1,59 @@
+import { pathToFileURL } from "node:url";
+
+import { net, protocol } from "electron";
+
+import { MISSION_ATTACHMENT_PREVIEW_SCHEME } from "../../../shared/contracts/index.ts";
+import type { MissionStore } from "./mission-store.ts";
+import {
+  parseMissionAttachmentPreviewUrl,
+  resolveMissionAttachmentImage,
+} from "./mission-attachment-preview.ts";
+
+let schemeRegistered = false;
+let handlerInstalled = false;
+
+export function registerMissionAttachmentScheme(): void {
+  if (schemeRegistered) return;
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: MISSION_ATTACHMENT_PREVIEW_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+      },
+    },
+  ]);
+  schemeRegistered = true;
+}
+
+export function installMissionAttachmentProtocol(missions: MissionStore): void {
+  if (handlerInstalled) return;
+  if (missions.storagePath === undefined) {
+    throw new Error("Mission attachment previews require a persistent Mission store.");
+  }
+  const previewSource = {
+    getAttachments: missions.getAttachments.bind(missions),
+    storagePath: missions.storagePath,
+  };
+  protocol.handle(MISSION_ATTACHMENT_PREVIEW_SCHEME, async (request) => {
+    try {
+      const { missionId, attachmentId } = parseMissionAttachmentPreviewUrl(request.url);
+      const image = await resolveMissionAttachmentImage(previewSource, missionId, attachmentId);
+      const fileResponse = await net.fetch(pathToFileURL(image.path).toString());
+      if (!fileResponse.ok || fileResponse.body === null) {
+        throw new Error("Mission image attachment could not be streamed.");
+      }
+      return new Response(fileResponse.body, {
+        headers: {
+          "Cache-Control": "private, max-age=31536000, immutable",
+          "Content-Type": image.mimeType,
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } catch {
+      return new Response("Attachment preview unavailable.", { status: 404 });
+    }
+  });
+  handlerInstalled = true;
+}

--- a/apps/desktop/src/main/features/missions/mission-ipc.ts
+++ b/apps/desktop/src/main/features/missions/mission-ipc.ts
@@ -33,6 +33,7 @@ import { publishMissionUpdate } from "./mission-update-publisher.ts";
 import { availableRecentWorkspaces } from "../workspaces/workspace-history-store.ts";
 import { validateWorkspace } from "../workspaces/workspace-scope.ts";
 import type { HomeExecutorCatalog } from "./home-executor-catalog.ts";
+import { installMissionAttachmentProtocol } from "./mission-attachment-protocol.ts";
 
 export function installMissionHandlers(options: {
   readonly missions: MissionStore;
@@ -55,6 +56,7 @@ export function installMissionHandlers(options: {
       }) => Promise<void>)
     | undefined;
 }): void {
+  installMissionAttachmentProtocol(options.missions);
   const getCreationDefaults = async () => {
     const workspace = await options.getDefaultWorkspace();
     const recentWorkspaces = await availableRecentWorkspaces(

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -105,6 +105,69 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     expect(session.compactRootContext).toHaveBeenCalledOnce();
   });
 
+  it("projects initial Mission attachments onto the durable user chat entry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-chat-attachments-"));
+    temporaryPaths.push(root);
+    const sourceImage = join(root, "screen.png");
+    await writeFile(sourceImage, "image-bytes");
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Summarize the image",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(
+        snapshot.resources.find((resource) => resource.kind === "Expert")!,
+      ),
+      attachments: [
+        {
+          id: "00000000-0000-4000-8000-000000000002",
+          kind: "image",
+          name: "screen.png",
+          path: sourceImage,
+          mimeType: "image/png",
+        },
+      ],
+    });
+    const runtime = defineRuntimeDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      startTurn: () => ({ outputText: "done", runtimeSessionId: "runtime" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome: join(root, "state"),
+      runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
+    });
+
+    const chat = await runner.getChat({ id: mission.id, limit: 50 });
+    expect(chat.entries).toEqual([
+      expect.objectContaining({
+        id: mission.initialMessageId,
+        kind: "user",
+        content: "Summarize the image",
+        attachments: [
+          expect.objectContaining({
+            id: "00000000-0000-4000-8000-000000000002",
+            kind: "image",
+            name: "screen.png",
+            mimeType: "image/png",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("skips compilation for a follow-up on the live Mission Session", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-mission-followup-fast-path-"));
     temporaryPaths.push(root);

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -1508,7 +1508,10 @@ export function createMissionRunner(options: {
 
   const getChatSnapshot = async (input: MissionChatQuery): Promise<MissionChatSnapshot> => {
     const mission = await options.missions.get(input.id);
-    const timeline = await options.missions.readTimelinePage(mission.id, input);
+    const [timeline, missionAttachments] = await Promise.all([
+      options.missions.readTimelinePage(mission.id, input),
+      options.missions.getAttachments(mission.id),
+    ]);
     const capturedLive = liveChats.get(mission.id);
     const entries = await readMissionChatHistory(
       timeline.turns,
@@ -1536,10 +1539,16 @@ export function createMissionRunner(options: {
     const revision = chatRevisions.get(mission.id) ?? 0;
     const resolveExecutorName = createMissionExecutorNameResolver(mission, names);
     const namedEntries = entries.map((entry) => {
-      if (entry.executorName !== undefined || entry.executorId === undefined) return entry;
+      const withAttachments =
+        entry.kind === "user" && entry.id === mission.initialMessageId
+          ? { ...entry, attachments: [...missionAttachments] }
+          : entry;
+      if (withAttachments.executorName !== undefined || withAttachments.executorId === undefined) {
+        return withAttachments;
+      }
       return {
-        ...entry,
-        executorName: resolveExecutorName(entry.executorId) ?? entry.executorId,
+        ...withAttachments,
+        executorName: resolveExecutorName(withAttachments.executorId) ?? withAttachments.executorId,
       };
     });
     return {
@@ -1627,7 +1636,12 @@ export function createMissionRunner(options: {
     logger.info(
       "mission.get_work_snapshot",
       `Loaded Mission work snapshot for ${id} in ${(t1 - t0).toFixed(1)}ms.`,
-      { missionId: id, executionCount: executionIds.length, recordCount: records.length, elapsedMs: t1 - t0 },
+      {
+        missionId: id,
+        executionCount: executionIds.length,
+        recordCount: records.length,
+        elapsedMs: t1 - t0,
+      },
     );
     const names = await getExecutorNamesOrFallback(mission, "work");
     const runtimeAgentOrdinals = createRuntimeAgentOrdinals(records);

--- a/apps/desktop/src/main/features/model-providers/model-discovery.test.ts
+++ b/apps/desktop/src/main/features/model-providers/model-discovery.test.ts
@@ -62,6 +62,28 @@ describe("model discovery", () => {
     expect(failure).toMatchObject({ ok: false, source: "manual", models: [] });
   });
 
+  it("uses the Qwen capability catalog for Bailian model IDs", async () => {
+    const result = await discoverProviderModels({
+      presetId: "qwen",
+      protocol: "openai-completions",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      apiKey: "secret",
+      fetchImpl: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ data: [{ id: "qwen3.7-plus" }] }), { status: 200 }),
+        ),
+    });
+
+    expect(result.models).toEqual([
+      expect.objectContaining({
+        id: "qwen3.7-plus",
+        input: ["text", "image"],
+        capabilitiesSource: "provider",
+      }),
+    ]);
+  });
+
   it("rejects non-loopback HTTP endpoints before sending credentials", async () => {
     const fetchImpl = vi.fn<typeof fetch>();
 

--- a/apps/desktop/src/main/features/model-providers/model-discovery.ts
+++ b/apps/desktop/src/main/features/model-providers/model-discovery.ts
@@ -24,6 +24,7 @@ export async function discoverProviderModels(options: {
   readonly fetchImpl?: typeof fetch;
 }): Promise<ModelDiscoveryResult> {
   const preset = findModelProviderPreset(options.presetId);
+  const capabilityCatalogId = preset?.capabilityCatalogId ?? options.presetId;
   const baseUrl = normalizeModelProviderBaseUrl(options.baseUrl);
   const activeDrivers =
     options.fetchImpl === undefined
@@ -31,7 +32,7 @@ export async function discoverProviderModels(options: {
       : createBuiltInModelProviderDriverRegistry({ fetch: options.fetchImpl });
   const result = await discoverModelProviderModels({
     request: {
-      catalogId: options.presetId,
+      catalogId: capabilityCatalogId,
       api: options.protocol,
       baseUrl,
       apiKey: options.apiKey,
@@ -40,21 +41,15 @@ export async function discoverProviderModels(options: {
     drivers: activeDrivers,
     directory,
   });
-  const suggestedIds = new Set(directory.listModels(options.presetId).map((model) => model.id));
+  const suggestedIds = new Set(directory.listModels(capabilityCatalogId).map((model) => model.id));
   return {
     ...result,
     source: result.source === "catalog" ? "preset" : result.source,
-    models: result.models.map(
-      (model): ModelProviderModel => ({
-        ...model,
-        capabilitiesSource:
-          result.source === "catalog"
-            ? "preset"
-            : suggestedIds.has(model.id)
-              ? "provider"
-              : "manual",
-      }),
-    ),
+    models: result.models.map((model): ModelProviderModel => ({
+      ...model,
+      capabilitiesSource:
+        result.source === "catalog" ? "preset" : suggestedIds.has(model.id) ? "provider" : "manual",
+    })),
   };
 }
 

--- a/apps/desktop/src/main/features/model-providers/model-provider-store.test.ts
+++ b/apps/desktop/src/main/features/model-providers/model-provider-store.test.ts
@@ -118,6 +118,32 @@ describe("model provider store", () => {
     expect((await store.resolveProvider(created.id)).credentialFingerprint).not.toBe(before);
   });
 
+  it("persists image input overrides while exposing only the effective runtime modalities", async () => {
+    const { store } = await createStore();
+    const visionModel = {
+      ...model("qwen3.7-plus", "Qwen 3.7 Plus", true, "openai-completions"),
+      input: ["text", "image"] as ("text" | "image")[],
+      inputOverride: ["text", "image"] as ("text" | "image")[],
+    };
+    const provider = await store.create({
+      presetId: "qwen",
+      name: "Qwen / Bailian",
+      protocol: "openai-completions",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      apiKey: "secret",
+      requiresApiKey: true,
+      models: [visionModel],
+    });
+
+    expect(provider.models[0]).toMatchObject({
+      input: ["text", "image"],
+      inputOverride: ["text", "image"],
+    });
+    const runtimeModel = (await store.resolveProvider(provider.id)).models[0];
+    expect(runtimeModel).toMatchObject({ input: ["text", "image"] });
+    expect(runtimeModel).not.toHaveProperty("inputOverride");
+  });
+
   it("rejects duplicate model IDs and plaintext fallback when encryption is unavailable", async () => {
     const { configPath, store } = await createStore();
 
@@ -313,7 +339,6 @@ describe("model provider store", () => {
       }),
     ]);
   });
-
 });
 
 function model(

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -68,6 +68,12 @@ export const missions = {
   removeAttachment: "Remove {{name}}",
   attachmentLimit: "A mission can include up to 20 attachments.",
   attachmentUnavailableForFlow: "Attachments are available for experts and teams.",
+  attachmentPreviewAlt: "Preview of {{name}}",
+  attachmentKind: {
+    image: "Image",
+    file: "File",
+    directory: "Folder",
+  },
   flowInput: "Flow input",
   flowInputDescription: "Complete the fields required by this workflow.",
   flowInputEmpty: "This workflow does not require any input fields.",

--- a/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/settings.ts
@@ -175,6 +175,7 @@ export const settings = {
     searchModels: "Search model IDs",
     manualModelPlaceholder: "Enter a model ID manually",
     selectedModels: "Selected models ({{count}})",
+    imageInput: "Image input",
     reasoning: "Reasoning",
     adjustableThinking: "Adjustable depth",
     fixedThinking: "The model controls its own reasoning depth.",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -64,6 +64,12 @@ export const missions = {
   removeAttachment: "移除 {{name}}",
   attachmentLimit: "每个任务最多可添加 20 个附件。",
   attachmentUnavailableForFlow: "附件目前支持专家和专家团队。",
+  attachmentPreviewAlt: "{{name}} 的预览",
+  attachmentKind: {
+    image: "图片",
+    file: "文件",
+    directory: "文件夹",
+  },
   flowInput: "流程输入",
   flowInputDescription: "请填写此工作流要求的结构化字段。",
   flowInputEmpty: "此工作流不需要输入字段。",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/settings.ts
@@ -167,6 +167,7 @@ export const settings = {
     searchModels: "搜索模型 ID",
     manualModelPlaceholder: "手动输入模型 ID",
     selectedModels: "已选模型（{{count}}）",
+    imageInput: "图片输入",
     reasoning: "深度思考",
     adjustableThinking: "可调节思考深度",
     fixedThinking: "思考深度由模型自行控制。",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -64,6 +64,12 @@ export const missions = {
   removeAttachment: "移除 {{name}}",
   attachmentLimit: "每個任務最多可新增 20 個附件。",
   attachmentUnavailableForFlow: "附件目前支援專家和專家團隊。",
+  attachmentPreviewAlt: "{{name}} 的預覽",
+  attachmentKind: {
+    image: "圖片",
+    file: "檔案",
+    directory: "資料夾",
+  },
   flowInput: "流程輸入",
   flowInputDescription: "請填寫此工作流程要求的結構化欄位。",
   flowInputEmpty: "此工作流程不需要輸入欄位。",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/settings.ts
@@ -167,6 +167,7 @@ export const settings = {
     searchModels: "搜尋模型 ID",
     manualModelPlaceholder: "手動輸入模型 ID",
     selectedModels: "已選模型（{{count}}）",
+    imageInput: "圖片輸入",
     reasoning: "深度思考",
     adjustableThinking: "可調整思考深度",
     fixedThinking: "思考深度由模型自行控制。",

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -956,6 +956,42 @@ describe("Mission tool call grouping", () => {
 describe("Mission Expert output labels", () => {
   const createdAt = "2026-07-21T00:00:00.000Z";
 
+  it("renders Mission image previews and file attachment labels", () => {
+    const html = renderToStaticMarkup(
+      <MissionChatEntryView
+        missionId="00000000-0000-4000-8000-000000000001"
+        entry={{
+          id: "message",
+          kind: "user",
+          content: "Summarize these inputs.",
+          attachments: [
+            {
+              id: "00000000-0000-4000-8000-000000000002",
+              kind: "image",
+              name: "screen.png",
+              path: "/mission/attachments/images/screen.png",
+              mimeType: "image/png",
+            },
+            {
+              id: "00000000-0000-4000-8000-000000000003",
+              kind: "file",
+              name: "notes.txt",
+              path: "/workspace/notes.txt",
+            },
+          ],
+          createdAt,
+        }}
+      />,
+    );
+
+    expect(html).toContain(
+      "pragma-mission-attachment://preview/00000000-0000-4000-8000-000000000001/00000000-0000-4000-8000-000000000002",
+    );
+    expect(html).toContain("screen.png");
+    expect(html).toContain("notes.txt");
+    expect(html).toContain("mission-attachment-label");
+  });
+
   it("shows the friendly Expert name on answers, thinking, and tool groups", () => {
     const answer = renderToStaticMarkup(
       <MissionChatEntryView

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -18,9 +18,11 @@ import {
   CaretDown,
   CheckCircle,
   Database,
+  File,
   Folder,
   GitBranch,
   MagnifyingGlass,
+  ImageSquare,
   PaperPlaneTilt,
   Plus,
   Play,
@@ -36,7 +38,7 @@ import {
   X,
 } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
-import type { HumanInteractionResponse } from "@pragma/shared";
+import type { ExpertPromptAttachment, HumanInteractionResponse } from "@pragma/shared";
 
 import { ConfirmationDialog } from "../../components/Dialog.tsx";
 import {
@@ -55,6 +57,7 @@ import {
   type DesktopToolPermissionMode,
   type MissionModelOverride,
   type PragmaDesktopAPI,
+  missionAttachmentPreviewUrl,
 } from "../../../../shared/contracts/index.ts";
 import { errorMessage } from "../../lib/errors.ts";
 import { i18n } from "../../i18n/index.ts";
@@ -2094,6 +2097,7 @@ export function MissionDetailFragment(props: {
                     <MissionChatEntryView
                       entry={block.item.entry}
                       key={block.item.entry.id}
+                      missionId={props.mission.id}
                       paintExecutionId={block.item.entry.executionId ?? chat?.execution?.id}
                       showExecutorLabel
                     />
@@ -2330,8 +2334,15 @@ export function MissionDetailFragment(props: {
         ) : workLoading && workRecords.length === 0 ? (
           <div className="mission-work-empty">
             <SpinnerGap size={31} className="is-spinning" aria-hidden="true" />
-            <h2>{t("loadingWorkHistory", { ns: "missions", defaultValue: "正在加载工作纪录..." })}</h2>
-            <p>{t("loadingWorkHistoryDescription", { ns: "missions", defaultValue: "如果包含多个 Agent 或大量事件，可能需要稍等片刻" })}</p>
+            <h2>
+              {t("loadingWorkHistory", { ns: "missions", defaultValue: "正在加载工作纪录..." })}
+            </h2>
+            <p>
+              {t("loadingWorkHistoryDescription", {
+                ns: "missions",
+                defaultValue: "如果包含多个 Agent 或大量事件，可能需要稍等片刻",
+              })}
+            </p>
           </div>
         ) : workRecords.length === 0 ? (
           <div className="mission-work-empty">
@@ -2944,6 +2955,7 @@ function MissionThinkingPlaceholder(props: { readonly executorName: string }) {
 
 export const MissionChatEntryView = memo(function MissionChatEntryView(props: {
   readonly entry: MissionChatEntry;
+  readonly missionId?: string | undefined;
   readonly userLabel?: string | undefined;
   readonly paintExecutionId?: string | undefined;
   readonly showExecutorLabel?: boolean | undefined;
@@ -2955,6 +2967,10 @@ export const MissionChatEntryView = memo(function MissionChatEntryView(props: {
           {props.userLabel === undefined ? null : (
             <small className="mission-message-sender">{props.userLabel}</small>
           )}
+          <MissionMessageAttachments
+            attachments={props.entry.attachments ?? []}
+            missionId={props.missionId}
+          />
           <MissionMessageContent source={props.entry.content} />
         </div>
       </div>
@@ -2985,6 +3001,67 @@ export const MissionChatEntryView = memo(function MissionChatEntryView(props: {
     </div>
   );
 });
+
+function MissionMessageAttachments(props: {
+  readonly attachments: readonly ExpertPromptAttachment[];
+  readonly missionId?: string | undefined;
+}) {
+  if (props.attachments.length === 0) return null;
+  return (
+    <div className="mission-message-attachments">
+      {props.attachments.map((attachment) =>
+        attachment.kind === "image" && props.missionId !== undefined ? (
+          <MissionImageAttachment
+            attachment={attachment}
+            key={attachment.id}
+            missionId={props.missionId}
+          />
+        ) : (
+          <MissionAttachmentLabel attachment={attachment} key={attachment.id} />
+        ),
+      )}
+    </div>
+  );
+}
+
+function MissionImageAttachment(props: {
+  readonly attachment: ExpertPromptAttachment;
+  readonly missionId: string;
+}) {
+  const { t } = useTranslation("missions");
+  const [failed, setFailed] = useState(false);
+  if (failed) return <MissionAttachmentLabel attachment={props.attachment} />;
+  return (
+    <figure className="mission-image-attachment">
+      <img
+        alt={t("attachmentPreviewAlt", { name: props.attachment.name })}
+        loading="lazy"
+        src={missionAttachmentPreviewUrl(props.missionId, props.attachment.id)}
+        onError={() => setFailed(true)}
+      />
+      <figcaption>{props.attachment.name}</figcaption>
+    </figure>
+  );
+}
+
+function MissionAttachmentLabel(props: { readonly attachment: ExpertPromptAttachment }) {
+  const { t } = useTranslation("missions");
+  const Icon =
+    props.attachment.kind === "image"
+      ? ImageSquare
+      : props.attachment.kind === "directory"
+        ? Folder
+        : File;
+  return (
+    <span className="mission-attachment-label">
+      <Icon size={16} aria-hidden="true" />
+      <span>
+        <strong>{props.attachment.name}</strong>
+        <small>{t(`attachmentKind.${props.attachment.kind}`)}</small>
+      </span>
+    </span>
+  );
+}
 
 function MissionExecutorLabel(props: { readonly entry: MissionChatEntry }) {
   const label = missionChatEntryExecutorLabel(props.entry);

--- a/apps/desktop/src/renderer/src/pages/settings/ModelProvidersFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/ModelProvidersFragment.test.tsx
@@ -1,7 +1,11 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { ProviderEditor, supportedThinkingLevels } from "./ModelProvidersFragment.tsx";
+import {
+  ProviderEditor,
+  reconcileDiscoveredModelInputs,
+  supportedThinkingLevels,
+} from "./ModelProvidersFragment.tsx";
 
 describe("ProviderEditor", () => {
   it("renders configured models as removable cards in a responsive grid", () => {
@@ -36,6 +40,23 @@ describe("ProviderEditor", () => {
         thinking: { supportedLevels: ["off", "medium", "xhigh", "max"] },
       }),
     ).toEqual(["off", "medium", "xhigh", "max"]);
+  });
+
+  it("refreshes discovered image input unless the user explicitly overrode it", () => {
+    const discovered = {
+      ...model("qwen3.7-plus"),
+      input: ["text", "image"] as ("text" | "image")[],
+      capabilitiesSource: "provider" as const,
+    };
+    expect(reconcileDiscoveredModelInputs([model("qwen3.7-plus")], [discovered])).toEqual([
+      expect.objectContaining({ input: ["text", "image"], capabilitiesSource: "provider" }),
+    ]);
+    expect(
+      reconcileDiscoveredModelInputs(
+        [{ ...model("qwen3.7-plus"), inputOverride: ["text"] }],
+        [discovered],
+      ),
+    ).toEqual([expect.objectContaining({ input: ["text"], inputOverride: ["text"] })]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/pages/settings/ModelProvidersFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/ModelProvidersFragment.tsx
@@ -126,11 +126,14 @@ export function ProviderEditor(props: {
         ...(draft.apiKey.trim() === "" ? {} : { apiKey: draft.apiKey }),
         ...(draft.id === undefined ? {} : { providerId: draft.id }),
       });
-      const merged = mergeModels(draft.models, result.models);
+      const refreshedModels = reconcileDiscoveredModelInputs(draft.models, result.models);
+      const merged = mergeModels(refreshedModels, result.models);
       setAvailableModels(merged);
       setDiscoveryMessage(result.message);
       if (draft.models.length === 0 && result.models.length > 0) {
         setDraft({ ...draft, models: result.models.slice(0, 3) });
+      } else if (refreshedModels !== draft.models) {
+        setDraft({ ...draft, models: refreshedModels });
       }
       setStep(3);
     } catch (discoveryError) {
@@ -546,6 +549,14 @@ function ModelCapabilityEditor(props: {
       ...props.model,
       thinking: adjustable ? { supportedLevels: ["off", "high"], defaultLevel: "high" } : undefined,
     });
+  const setImageInput = (enabled: boolean) => {
+    const input: ModelProviderModel["input"] = enabled ? ["text", "image"] : ["text"];
+    props.onChange({
+      ...props.model,
+      input,
+      inputOverride: input,
+    });
+  };
   return (
     <div className="selected-model-row">
       <div className="model-identity">
@@ -553,6 +564,14 @@ function ModelCapabilityEditor(props: {
         <small>{props.model.id}</small>
       </div>
       <div className="model-capability-controls">
+        <label className="compact-check">
+          <input
+            type="checkbox"
+            checked={props.model.input.includes("image")}
+            onChange={(event) => setImageInput(event.target.checked)}
+          />
+          {t("models.imageInput")}
+        </label>
         <label className="compact-check">
           <input
             type="checkbox"
@@ -960,6 +979,33 @@ function mergeModels(
   const map = new Map(discovered.map((model) => [model.id, model]));
   for (const model of current) map.set(model.id, model);
   return [...map.values()];
+}
+
+export function reconcileDiscoveredModelInputs(
+  current: readonly ModelProviderModel[],
+  discovered: readonly ModelProviderModel[],
+): readonly ModelProviderModel[] {
+  const discoveredById = new Map(discovered.map((model) => [model.id, model]));
+  let changed = false;
+  const reconciled = current.map((model) => {
+    const fresh = discoveredById.get(model.id);
+    if (fresh === undefined) return model;
+    const input = model.inputOverride ?? fresh.input;
+    if (
+      model.capabilitiesSource === fresh.capabilitiesSource &&
+      input.length === model.input.length &&
+      input.every((modality, index) => modality === model.input[index])
+    ) {
+      return model;
+    }
+    changed = true;
+    return {
+      ...model,
+      input: [...input],
+      capabilitiesSource: fresh.capabilitiesSource,
+    };
+  });
+  return changed ? reconciled : current;
 }
 export function supportedThinkingLevels(
   model: ModelProviderModel,

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -18395,6 +18395,74 @@ textarea:focus-visible,
   background: var(--green-soft);
 }
 
+.mission-message-attachments {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 240px));
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.mission-image-attachment {
+  min-width: 0;
+  margin: 0;
+}
+
+.mission-image-attachment img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--ui-line);
+  border-radius: var(--ui-radius-md);
+  background: var(--ui-surface-subtle);
+  object-fit: contain;
+}
+
+.mission-image-attachment figcaption {
+  overflow: hidden;
+  margin-top: 4px;
+  color: var(--ui-text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mission-attachment-label {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-radius: var(--ui-radius-md);
+  background: var(--ui-surface-subtle);
+  color: var(--ui-text-secondary);
+}
+
+.mission-attachment-label > span {
+  min-width: 0;
+}
+
+.mission-attachment-label strong,
+.mission-attachment-label small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mission-attachment-label strong {
+  color: var(--ui-text);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.mission-attachment-label small {
+  margin-top: 2px;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .mission-message-sender {
   display: block;
   margin-bottom: 5px;

--- a/apps/desktop/src/shared/contracts/missions.ts
+++ b/apps/desktop/src/shared/contracts/missions.ts
@@ -368,6 +368,7 @@ export const MissionChatEntrySchema = z.discriminatedUnion("kind", [
   MissionChatEntryBaseSchema.extend({
     kind: z.literal("user"),
     content: z.string().max(200_000),
+    attachments: z.array(ExpertPromptAttachmentSchema).max(20).optional(),
   }),
   MissionChatEntryBaseSchema.extend({
     kind: z.literal("assistant"),
@@ -408,6 +409,12 @@ export const MissionChatEntrySchema = z.discriminatedUnion("kind", [
     error: z.string().max(10_000).optional(),
   }),
 ]);
+
+export const MISSION_ATTACHMENT_PREVIEW_SCHEME = "pragma-mission-attachment";
+
+export function missionAttachmentPreviewUrl(missionId: string, attachmentId: string): string {
+  return `${MISSION_ATTACHMENT_PREVIEW_SCHEME}://preview/${encodeURIComponent(missionId)}/${encodeURIComponent(attachmentId)}`;
+}
 
 export const MissionWorkConversationSnapshotSchema = z.object({
   missionId: MissionIdSchema,

--- a/apps/desktop/src/shared/contracts/model-provider.ts
+++ b/apps/desktop/src/shared/contracts/model-provider.ts
@@ -21,6 +21,15 @@ export const ModelCompatibilityProfileDescriptorSchema = z.object({
 
 export const ModelProviderModelSchema = ProviderModelDefinitionSchema.extend({
   capabilitiesSource: z.enum(["preset", "provider", "manual"]),
+  inputOverride: ProviderModelDefinitionSchema.shape.input.optional(),
+}).superRefine((model, context) => {
+  if (model.inputOverride !== undefined && !model.inputOverride.includes("text")) {
+    context.addIssue({
+      code: "custom",
+      path: ["inputOverride"],
+      message: "Model input overrides must retain text input.",
+    });
+  }
 });
 
 export const ModelProviderVerificationSchema = z.object({

--- a/apps/desktop/src/shared/model-provider-presets.ts
+++ b/apps/desktop/src/shared/model-provider-presets.ts
@@ -6,6 +6,7 @@ export interface ModelProviderPreset {
   readonly id: string;
   readonly name: string;
   readonly category: ModelProviderPresetCategory;
+  readonly capabilityCatalogId?: string | undefined;
   readonly protocol: ModelProvider["protocol"];
   readonly baseUrl: string;
   readonly requiresApiKey: boolean;
@@ -105,15 +106,18 @@ export const MODEL_PROVIDER_PRESETS = [
     true,
     true,
   ),
-  preset(
-    "qwen",
-    "Qwen / Bailian",
-    "gateway",
-    "openai-completions",
-    "https://dashscope.aliyuncs.com/compatible-mode/v1",
-    true,
-    true,
-  ),
+  {
+    ...preset(
+      "qwen",
+      "Qwen / Bailian",
+      "gateway",
+      "openai-completions",
+      "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      true,
+      true,
+    ),
+    capabilityCatalogId: "qwen-token-plan-cn",
+  },
   preset(
     "moonshotai",
     "Moonshot / Kimi",

--- a/docs/architecture/mission-attachments-and-multimodal-input.md
+++ b/docs/architecture/mission-attachments-and-multimodal-input.md
@@ -76,6 +76,11 @@ type ExpertPromptAttachment = {
 - 未识别或损坏的附件 manifest 会 fail closed，并报告 `config_invalid`。
 - 删除 Mission 时，Mission-owned 图片随 owner 图一起删除。
 
+Mission 聊天快照会在读取时把该 manifest 投影到首条用户消息的可选 `attachments` 字段，供详情页展示；
+投影不写回 `pragma.mission-message/v1`。图片缩略图通过只读
+`pragma-mission-attachment://` 协议按 Mission ID 与附件 ID 加载，主进程会重新校验 manifest、文件类型和
+Mission-owned 图片目录边界，Renderer 不能把任意本地路径转换成可读取 URL。
+
 ### Expert Core
 
 `PromptRequest` 继续保存纯文本，不升级 `pragma.expert-session/v5`。有附件时，既有 `ExecutionRecord.input` 和根 `Invocation.input` 的 `unknown` 插槽保存 `ExpertPromptInput`；没有附件时仍保存原来的字符串。这使旧数据保持原义，同时让崩溃恢复可以从 Invocation 重新取得附件。
@@ -113,6 +118,11 @@ Claude Code 的第三方映射端点在没有权威模态元数据时按 text-on
 
 此降级只处理输入模态能力。认证失败、网络失败或模型已经开始执行工具后的运行错误仍按真实错误报告，不自动重放整轮请求，避免重复副作用。
 
+Desktop 的模型发现将 Provider 模型 ID 与 Runtime 目录中的权威能力元数据合并。Qwen/Bailian 使用
+`qwen-token-plan-cn` 作为仅用于能力发现的目录别名，实际 Runtime provider identity 与 Qwen compatibility
+profile 不变。模型编辑器允许用户通过 `inputOverride` 显式开启或关闭图片输入；再次发现只刷新没有显式
+覆盖的输入模态。
+
 ## 安全与资源限制
 
 - 图片格式限 PNG、JPEG、GIF、WebP。
@@ -126,4 +136,4 @@ Claude Code 的第三方映射端点在没有权威模态元数据时按 text-on
 
 - 为 Mission 后续消息增加附件时，应新增带版本的消息附件协议和相邻迁移，不能直接修改 `pragma.mission-message/v1`。
 - 若需要离线、跨设备或云端 Mission，应把文件/目录引用升级为显式 artifact 上传协议；当前绝对路径语义只适用于 Desktop 本机 Runtime。
-- UI 后续可直接消费已标准化的 `inputModalities`，在发送前展示“原生视觉”或“路径上下文”提示。
+- UI 后续可消费已标准化的 `inputModalities`，在发送前展示“原生视觉”或“路径上下文”提示。


### PR DESCRIPTION
## Summary

- recognize `qwen3.7-plus` as a vision-capable model when discovering Qwen/Bailian models
- preserve explicit image-input overrides while refreshing discovered model capabilities
- project initial Mission attachments into chat snapshots and render image thumbnails with filenames
- serve Mission-owned images through a restricted, streaming Electron protocol
- add English, Simplified Chinese, and Traditional Chinese copy plus architecture documentation

## Root cause

The Qwen preset used `qwen` as its capability catalog identifier, but the Pi model directory exposes `qwen3.7-plus` under `qwen-token-plan-cn`. The discovered model therefore fell back to text-only metadata. Core then intentionally degraded the image attachment to path context, which led the Agent to use file-reading tools instead of receiving a native image block.

Mission attachments were persisted separately from the durable chat timeline and were not projected into the chat DTO, so the Mission detail page only rendered the prompt text.

## Implementation

- add a Qwen capability-catalog alias without changing the Runtime provider identity
- add persisted `inputOverride` metadata and an image-input editor control
- reconcile discovered image modalities unless the user explicitly overrides them
- attach the Mission manifest to the initial user chat entry at read time, without changing the timeline storage version
- register `pragma-mission-attachment://` before Electron becomes ready
- validate canonical preview URLs, Mission ownership, MIME allowlists, path boundaries, file type, and size
- stream preview files through Electron `net.fetch` instead of buffering up to 20 MiB per image
- render complete, uncropped thumbnails and filename/fallback cards without exposing local paths in tooltips

## User impact

Existing Qwen providers do not need to be deleted or re-imported. Users should edit the provider, rediscover models, and save once so `qwen3.7-plus` receives the refreshed `text + image` capability. New Missions will then send native image blocks to the Pi Runtime.

## Validation

- `pnpm --filter @pragma/desktop typecheck`
- `pnpm --filter @pragma/desktop lint`
- `pnpm --filter @pragma/desktop build`
- 82 focused Desktop tests passed
- 5 Core multimodal startup-message tests passed
- 10 Pi Runtime model/startup-message tests passed
- final UI/protocol regression: 46 tests passed
- `git diff --check`

Full Desktop suite result: 705/707 passed. The two remaining failures are pre-existing and outside this diff:
- Runtime availability cache/test isolation; the failing test passes when run alone
- CLI availability probe test depends on locally installed Claude Code and Qoder CLI executables
