### PR TITLE
Show expert names for memory candidates

### DIFF
--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
@@ -9,6 +9,7 @@ import {
   MemoryHealth,
   MemoryPage,
   canRunMemoryAction,
+  formatMemoryCandidateExpert,
   formatMemorySubjectRefs,
   memoryExtractionPollDelay,
 } from "./MemoryPage.tsx";
@@ -18,6 +19,15 @@ afterEach(async () => {
 });
 
 describe("MemoryPage", () => {
+  it("formats candidate experts with the expert name and id", () => {
+    expect(
+      formatMemoryCandidateExpert("expert:r5pjstt2yftkg8dx", {
+        "expert:r5pjstt2yftkg8dx": "Release reviewer",
+      }),
+    ).toBe("Release reviewer (r5pjstt2yftkg8dx)");
+    expect(formatMemoryCandidateExpert("expert:missing", {})).toBe("expert:missing");
+  });
+
   it("shows human-readable subject names while preserving canonical memory references", () => {
     expect(
       formatMemorySubjectRefs(

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
@@ -55,6 +55,7 @@ export function MemoryPage() {
     [],
   );
   const [skillCandidates, setSkillCandidates] = useState<readonly MemorySkillCandidate[]>([]);
+  const [expertNames, setExpertNames] = useState<Readonly<Record<string, string>>>({});
   const [reason, setReason] = useState("");
   const [dialog, setDialog] = useState<"revise" | "forget">();
   const [revisionDraft, setRevisionDraft] = useState("");
@@ -74,7 +75,7 @@ export function MemoryPage() {
       const requestVersion = (extractionRequestVersion.current += 1);
       if (!silent && !hasLoaded.current) setLoading(true);
       try {
-        const [records, status, extractionJobs, candidateRecords, skillCandidateRecords] =
+        const [records, status, extractionJobs, candidateRecords, skillCandidateRecords, experts] =
           await Promise.all([
             view === "extractions" || view === "candidates" || view === "skillCandidates"
               ? Promise.resolve([])
@@ -93,6 +94,9 @@ export function MemoryPage() {
               : Promise.resolve([]),
             view === "skillCandidates"
               ? window.pragmaDesktop.listMemorySkillCandidates()
+              : Promise.resolve([]),
+            view === "candidates" || view === "skillCandidates"
+              ? window.pragmaDesktop.listExperts()
               : Promise.resolve([]),
           ]);
         setItems(records);
@@ -117,6 +121,9 @@ export function MemoryPage() {
         }
         setCandidates(candidateRecords);
         setSkillCandidates(skillCandidateRecords);
+        if (view === "candidates" || view === "skillCandidates") {
+          setExpertNames(Object.fromEntries(experts.map((expert) => [expert.ref, expert.name])));
+        }
         const selectableIds =
           view === "candidates"
             ? candidateRecords.map((candidate) => candidate.id)
@@ -298,6 +305,7 @@ export function MemoryPage() {
       ) : view === "skillCandidates" ? (
         <MemorySkillCandidates
           candidates={skillCandidates}
+          expertNames={expertNames}
           selectedId={selectedId}
           busy={actionBusy}
           onSelect={setSelectedId}
@@ -321,6 +329,12 @@ export function MemoryPage() {
               >
                 <span>{t("candidates")}</span>
                 <strong>{candidate.name}</strong>
+                <small
+                  className="memory-candidate-expert"
+                  title={formatMemoryCandidateExpert(candidate.expertRef, expertNames)}
+                >
+                  {formatMemoryCandidateExpert(candidate.expertRef, expertNames)}
+                </small>
                 <small>{t("revision", { revision: candidate.revision })}</small>
               </button>
             ))}
@@ -334,7 +348,9 @@ export function MemoryPage() {
                   <header className="memory-candidate-header">
                     <div className="memory-candidate-meta">
                       <span className="memory-status is-pending_review">pending_review</span>
-                      <small title={candidate.expertRef}>{candidate.expertRef}</small>
+                      <small title={formatMemoryCandidateExpert(candidate.expertRef, expertNames)}>
+                        {formatMemoryCandidateExpert(candidate.expertRef, expertNames)}
+                      </small>
                     </div>
                     <label className="memory-candidate-field is-name">
                       <span>{t("candidateName")}</span>
@@ -1147,6 +1163,7 @@ function formatHealthBytes(bytes: number): string {
 
 function MemorySkillCandidates(props: {
   readonly candidates: readonly MemorySkillCandidate[];
+  readonly expertNames: Readonly<Record<string, string>>;
   readonly selectedId?: string | undefined;
   readonly busy: boolean;
   readonly onSelect: (id: string) => void;
@@ -1183,6 +1200,12 @@ function MemorySkillCandidates(props: {
           >
             <span>{t("skillCandidate")}</span>
             <strong>{item.package.name}</strong>
+            <small
+              className="memory-candidate-expert"
+              title={formatMemoryCandidateExpert(item.expertRef, props.expertNames)}
+            >
+              {formatMemoryCandidateExpert(item.expertRef, props.expertNames)}
+            </small>
             <small>
               {item.state} · {t("revision", { revision: item.revision })}
             </small>
@@ -1197,7 +1220,9 @@ function MemorySkillCandidates(props: {
             <header className="memory-candidate-header">
               <div className="memory-candidate-meta">
                 <span className={`memory-status is-${candidate.state}`}>{candidate.state}</span>
-                <small title={candidate.expertRef}>{candidate.expertRef}</small>
+                <small title={formatMemoryCandidateExpert(candidate.expertRef, props.expertNames)}>
+                  {formatMemoryCandidateExpert(candidate.expertRef, props.expertNames)}
+                </small>
               </div>
               <label className="memory-candidate-field is-name">
                 <span>{t("skillName")}</span>
@@ -1478,4 +1503,13 @@ export function formatMemorySubjectRefs(
       })
       .join(", ") || "—"
   );
+}
+
+export function formatMemoryCandidateExpert(
+  expertRef: string,
+  names: Readonly<Record<string, string>>,
+): string {
+  const name = names[expertRef];
+  if (name === undefined) return expertRef;
+  return `${name} (${expertRef.replace(/^expert:/u, "")})`;
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -17230,6 +17230,13 @@ textarea:focus-visible,
   font-size: 12px;
 }
 
+.memory-list-item .memory-candidate-expert {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .memory-detail > header h2,
 .memory-detail > header p {
   margin: 8px 0 0;


### PR DESCRIPTION
## What changed

- Resolve expert names while loading knowledge and skill candidates.
- Show candidates as `Expert name (Expert ID)` in both the list and detail header.
- Keep expert labels to one line with ellipsis and preserve the full value in the hover title.
- Fall back to the canonical expert reference if the expert can no longer be resolved.

## Why

Memory candidates previously displayed only the expert ID, which made it difficult to identify which expert produced a candidate.

## Impact

Users can identify the originating expert without leaving the Memory page. No persisted data or protocol changes are required.

## Validation

- `pnpm --filter @pragma/desktop typecheck`
- `pnpm --filter @pragma/desktop exec vitest run src/renderer/src/pages/memory/MemoryPage.test.tsx`
- `pnpm --filter @pragma/desktop exec eslint src/renderer/src/pages/memory/MemoryPage.tsx src/renderer/src/pages/memory/MemoryPage.test.tsx`
- Prettier check for the changed TypeScript files
- `git diff --check`