### PR TITLE
fix(runtime-antigravity): restore agy model discovery

### DIFF
--- a/packages/core/src/runtime/process-probe.ts
+++ b/packages/core/src/runtime/process-probe.ts
@@ -107,6 +107,11 @@ export function runRuntimeCommand(options: RuntimeCommandOptions): Promise<Runti
       cwd: options.cwd,
       env: options.env,
     });
+    // Runtime probes are non-interactive. Closing stdin is materially
+    // different from leaving Node's default pipe open: some CLIs wait for EOF
+    // before running a subcommand when they are launched without a TTY.
+    child.stdin.on("error", () => undefined);
+    child.stdin.end();
     let forceKillTimer: NodeJS.Timeout | undefined;
     const timeout = setTimeout(() => {
       finish(() => {

--- a/packages/core/test/process-probe.test.ts
+++ b/packages/core/test/process-probe.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { runRuntimeCommand } from "../src/runtime/process-probe.ts";
+
+describe("Runtime process probe", () => {
+  it("closes stdin so non-interactive commands waiting for EOF can start", async () => {
+    const result = await runRuntimeCommand({
+      executablePath: process.execPath,
+      args: [
+        "-e",
+        'process.stdin.once("end", () => process.stdout.write("ready\\n")); process.stdin.resume();',
+      ],
+      cwd: process.cwd(),
+      env: { ...process.env },
+      timeoutMs: 2_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      signal: null,
+      stdout: "ready\n",
+      stderr: "",
+    });
+  });
+});

--- a/packages/runtime/antigravity/src/environment-variables.ts
+++ b/packages/runtime/antigravity/src/environment-variables.ts
@@ -1,0 +1,37 @@
+export function deleteEnvironmentValue(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  platform: NodeJS.Platform,
+): void {
+  if (platform !== "win32") {
+    delete env[key];
+    return;
+  }
+  const normalized = key.toLowerCase();
+  for (const candidate of Object.keys(env)) {
+    if (candidate.toLowerCase() === normalized) delete env[candidate];
+  }
+}
+
+export function applyCommonAntigravityEnvironment(options: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly tmpDir: string;
+  readonly platform: NodeJS.Platform;
+}): void {
+  for (const key of [
+    "XDG_RUNTIME_DIR",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "AGY_CLI_DISABLE_AUTO_UPDATE",
+    "NO_COLOR",
+  ]) {
+    deleteEnvironmentValue(options.env, key, options.platform);
+  }
+  options.env["XDG_RUNTIME_DIR"] = options.tmpDir;
+  options.env["TMPDIR"] = options.tmpDir;
+  options.env["TMP"] = options.tmpDir;
+  options.env["TEMP"] = options.tmpDir;
+  options.env["AGY_CLI_DISABLE_AUTO_UPDATE"] = "true";
+  options.env["NO_COLOR"] = "1";
+}

--- a/packages/runtime/antigravity/src/managed-home.ts
+++ b/packages/runtime/antigravity/src/managed-home.ts
@@ -16,6 +16,10 @@ import { basename, dirname, isAbsolute, join, posix, resolve, win32 } from "node
 
 import type { Expert } from "@pragma/core";
 
+import {
+  applyCommonAntigravityEnvironment,
+  deleteEnvironmentValue,
+} from "./environment-variables.ts";
 import type { AntigravityHookRelay } from "./permission-hooks.ts";
 import type { AntigravityRuntimePermissionMode } from "./types.ts";
 
@@ -163,12 +167,6 @@ export function createManagedAntigravityEnvironment(options: {
     "XDG_CACHE_HOME",
     "XDG_DATA_HOME",
     "XDG_STATE_HOME",
-    "XDG_RUNTIME_DIR",
-    "TMPDIR",
-    "TMP",
-    "TEMP",
-    "AGY_CLI_DISABLE_AUTO_UPDATE",
-    "NO_COLOR",
     "PRAGMA_AGY_HOOK_URL",
     "PRAGMA_AGY_HOOK_AUTHORIZATION",
     "ELECTRON_RUN_AS_NODE",
@@ -186,12 +184,7 @@ export function createManagedAntigravityEnvironment(options: {
   env["XDG_CACHE_HOME"] = environmentPath.join(options.homeDir, ".cache");
   env["XDG_DATA_HOME"] = environmentPath.join(options.homeDir, ".local", "share");
   env["XDG_STATE_HOME"] = environmentPath.join(options.homeDir, ".local", "state");
-  env["XDG_RUNTIME_DIR"] = options.tmpDir;
-  env["TMPDIR"] = options.tmpDir;
-  env["TMP"] = options.tmpDir;
-  env["TEMP"] = options.tmpDir;
-  env["AGY_CLI_DISABLE_AUTO_UPDATE"] = "true";
-  env["NO_COLOR"] = "1";
+  applyCommonAntigravityEnvironment({ env, tmpDir: options.tmpDir, platform });
   if (platform === "win32") {
     const root = environmentPath.parse(options.homeDir).root;
     env["HOMEDRIVE"] = root.replace(/[\\/]$/, "");
@@ -567,18 +560,4 @@ function isReplaceError(error: unknown): boolean {
     "code" in error &&
     (error.code === "EEXIST" || error.code === "EPERM")
   );
-}
-
-function deleteEnvironmentValue(
-  env: NodeJS.ProcessEnv,
-  key: string,
-  platform: NodeJS.Platform,
-): void {
-  if (platform !== "win32") {
-    delete env[key];
-    return;
-  }
-  for (const candidate of Object.keys(env)) {
-    if (candidate.toLowerCase() === key.toLowerCase()) delete env[candidate];
-  }
 }

--- a/packages/runtime/antigravity/src/models.ts
+++ b/packages/runtime/antigravity/src/models.ts
@@ -5,8 +5,11 @@ import { join } from "node:path";
 
 import { runRuntimeCommand, type RuntimeCommandSpawn, type RuntimeModel } from "@pragma/core";
 
+import {
+  applyCommonAntigravityEnvironment,
+  deleteEnvironmentValue,
+} from "./environment-variables.ts";
 import { resolveAntigravityExecutablePath } from "./executable.ts";
-import { createManagedAntigravityEnvironment } from "./managed-home.ts";
 import type { AntigravityRuntimeAdapterOptions } from "./types.ts";
 
 const MODEL_CATALOG_TTL_MS = 10 * 60_000;
@@ -65,9 +68,8 @@ export function createAntigravityModelDiscovery(
           executablePath,
           args: ["models"],
           cwd: discoveryHome,
-          env: createManagedAntigravityEnvironment({
+          env: createAntigravityModelDiscoveryEnvironment({
             base: { ...process.env, ...(options.env ?? {}) },
-            homeDir: discoveryHome,
             tmpDir: discoveryTmp,
           }),
           timeoutMs: 20_000,
@@ -89,6 +91,41 @@ export function createAntigravityModelDiscovery(
       }
     }
   };
+}
+
+function createAntigravityModelDiscoveryEnvironment(options: {
+  readonly base: Readonly<NodeJS.ProcessEnv>;
+  readonly tmpDir: string;
+  readonly platform?: NodeJS.Platform | undefined;
+}): NodeJS.ProcessEnv {
+  const platform = options.platform ?? process.platform;
+  const env: NodeJS.ProcessEnv = { ...options.base };
+
+  // Model discovery must see the host's HOME/config paths because agy resolves
+  // the signed-in account and onboarding/project selection from that profile.
+  // Only discard volatile variables belonging to an already-running
+  // Antigravity session; inheriting those could attach discovery to an IDE or
+  // Runtime sidecar. Runtime execution still uses its fully private HOME.
+  for (const key of [
+    "ANTIGRAVITY_AGENTAPI_EXE",
+    "ANTIGRAVITY_CONVERSATION_ID",
+    "ANTIGRAVITY_CSRF_TOKEN",
+    "ANTIGRAVITY_EXECUTABLE_DATA_DIR",
+    "ANTIGRAVITY_LS_ADDRESS",
+    "ANTIGRAVITY_PROJECT_ID",
+    "ANTIGRAVITY_SIDECAR_UI_TOKEN",
+    "ANTIGRAVITY_SIDECAR_WEB_PORT",
+    "GOOGLE_LOG_DIR",
+    "GOOGLE_STATUS_DIR",
+    "PRAGMA_AGY_HOOK_URL",
+    "PRAGMA_AGY_HOOK_AUTHORIZATION",
+    "ELECTRON_RUN_AS_NODE",
+  ]) {
+    deleteEnvironmentValue(env, key, platform);
+  }
+
+  applyCommonAntigravityEnvironment({ env, tmpDir: options.tmpDir, platform });
+  return env;
 }
 
 export function parseAntigravityModels(output: string): readonly RuntimeModel[] {

--- a/packages/runtime/antigravity/test/environment-variables.test.ts
+++ b/packages/runtime/antigravity/test/environment-variables.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyCommonAntigravityEnvironment,
+  deleteEnvironmentValue,
+} from "../src/environment-variables.ts";
+
+describe("Antigravity environment variables", () => {
+  it("uses case-sensitive deletion on POSIX", () => {
+    const env = { TARGET: "remove", target: "preserve" };
+
+    deleteEnvironmentValue(env, "TARGET", "linux");
+
+    expect(env).toEqual({ target: "preserve" });
+  });
+
+  it("deletes every case variant on Windows", () => {
+    const env = { TARGET: "remove", Target: "also-remove", KEEP: "preserve" };
+
+    deleteEnvironmentValue(env, "target", "win32");
+
+    expect(env).toEqual({ KEEP: "preserve" });
+  });
+
+  it("replaces Windows case variants with canonical common overrides", () => {
+    const env = {
+      Tmp: "C:\\Host\\tmp",
+      no_color: "0",
+      AGY_CLI_DISABLE_AUTO_UPDATE: "false",
+    };
+
+    applyCommonAntigravityEnvironment({
+      env,
+      tmpDir: "C:\\Pragma\\tmp",
+      platform: "win32",
+    });
+
+    expect(env).toMatchObject({
+      XDG_RUNTIME_DIR: "C:\\Pragma\\tmp",
+      TMPDIR: "C:\\Pragma\\tmp",
+      TMP: "C:\\Pragma\\tmp",
+      TEMP: "C:\\Pragma\\tmp",
+      AGY_CLI_DISABLE_AUTO_UPDATE: "true",
+      NO_COLOR: "1",
+    });
+    expect(Object.keys(env).some((key) => key === "Tmp" || key === "no_color")).toBe(false);
+  });
+});

--- a/packages/runtime/antigravity/test/models.test.ts
+++ b/packages/runtime/antigravity/test/models.test.ts
@@ -89,29 +89,40 @@ describe("Antigravity model discovery", () => {
     ]);
   });
 
-  it("discovers inside a disposable private HOME and removes it afterwards", async () => {
+  it("inherits the authenticated host profile while isolating temporary discovery files", async () => {
     let discoveryHome = "";
     mocks.runRuntimeCommand.mockImplementation(async (options) => {
       discoveryHome = options.cwd as string;
       expect(options.args).toEqual(["models"]);
       expect(options.env).toMatchObject({
-        HOME: discoveryHome,
-        USERPROFILE: discoveryHome,
+        HOME: "/host/home",
+        USERPROFILE: "/host/profile",
         TMPDIR: `${discoveryHome}/tmp`,
         AGY_CLI_DISABLE_AUTO_UPDATE: "true",
+        NO_COLOR: "1",
         EXPLICIT_AUTH: "kept",
+        AGY_APP_DATA_DIR: "/host/agy",
+        ANTIGRAVITY_HOME: "/host/antigravity",
+        GEMINI_CLI_HOME: "/host/gemini-cli",
+        GEMINI_CONFIG_DIR: "/host/gemini",
       });
-      expect(options.env["AGY_APP_DATA_DIR"]).toBeUndefined();
-      expect(options.env["GEMINI_CONFIG_DIR"]).toBeUndefined();
+      expect(options.env["ANTIGRAVITY_CONVERSATION_ID"]).toBeUndefined();
+      expect(options.env["PRAGMA_AGY_HOOK_AUTHORIZATION"]).toBeUndefined();
       return { exitCode: 0, signal: null, stdout: MODEL_OUTPUT, stderr: "" };
     });
 
     const models = await createAntigravityModelDiscovery({
       executablePath: `/opt/agy-${randomUUID()}`,
       env: {
+        HOME: "/host/home",
+        USERPROFILE: "/host/profile",
         EXPLICIT_AUTH: "kept",
         AGY_APP_DATA_DIR: "/host/agy",
+        ANTIGRAVITY_HOME: "/host/antigravity",
+        GEMINI_CLI_HOME: "/host/gemini-cli",
         GEMINI_CONFIG_DIR: "/host/gemini",
+        ANTIGRAVITY_CONVERSATION_ID: "stale-conversation",
+        PRAGMA_AGY_HOOK_AUTHORIZATION: "secret",
       },
     })();
 


### PR DESCRIPTION
## What changed

- Close stdin for non-interactive Runtime probes so CLIs waiting for EOF can start.
- Let Antigravity model discovery inherit the signed-in host profile while keeping temporary files and Runtime session variables isolated.
- Centralize case-aware Antigravity environment cleanup and common process overrides.
- Add regression coverage for stdin EOF handling, host authentication paths, and POSIX/Windows environment semantics.

## Root cause

Pragma launched agy models with an open stdin pipe and a disposable empty HOME. Current agy releases wait for stdin EOF in this non-TTY mode, while the empty profile also hides the signed-in account and onboarding configuration. The probe therefore emitted no output and timed out after 20 seconds even though agy models worked in the terminal.

## Impact

Antigravity model discovery now reuses the authenticated host profile without weakening per-Runtime-session HOME isolation. On the reproduced machine the same Pragma discovery path returns 11 models in about 6.6 seconds instead of timing out after 20 seconds.

## Validation

- Two Claude Code review passes; no blocking findings remain.
- pnpm check
- pnpm build
- pnpm --filter @pragma/runtime-antigravity test (10 files, 72 tests)
- Real agy models discovery through createAntigravityModelDiscovery (11 models)
- git diff --check and Prettier