### PR TITLE
Optimize expert detail layout and Markdown preview

### DIFF
--- a/apps/desktop/src/renderer/src/pages/studio/ExpertDirectoryFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/ExpertDirectoryFragment.test.tsx
@@ -214,10 +214,13 @@ describe("ExpertDetailFragment", () => {
     expect(html).not.toContain("<li");
   });
 
-  it("uses compact metadata and bounded content previews", () => {
+  it("uses compact metadata and renders full Markdown instructions last", () => {
     const html = renderToStaticMarkup(
       <ExpertDetailFragment
-        expert={expert}
+        expert={{
+          ...expert,
+          instructions: "## Workflow\n\n- Inspect the input\n- **Verify** the result",
+        }}
         contextStores={[]}
         capabilities={[]}
         plugins={[]}
@@ -239,10 +242,21 @@ describe("ExpertDetailFragment", () => {
     );
     expect(html).not.toContain("Callable expert resources");
     expect(html).not.toContain("Availability");
-    expect(html).toContain('aria-expanded="false"');
-    expect(html).toContain("Show more");
     expect(html).not.toContain("d".repeat(201));
-    expect(html).not.toContain("i".repeat(421));
+    expect(html).toContain('<div class="expert-instructions-markdown markdown-preview">');
+    expect(html).toContain("<h2>Workflow</h2>");
+    expect(html).toContain("<li>Inspect the input</li>");
+    expect(html).toContain("<strong>Verify</strong>");
+    expect(html.indexOf('id="expert-scope-heading"')).toBeLessThan(
+      html.indexOf('id="expert-capabilities-heading"'),
+    );
+    expect(html.indexOf('id="expert-capabilities-heading"')).toBeLessThan(
+      html.indexOf('id="expert-context-heading"'),
+    );
+    expect(html.indexOf('id="expert-context-heading"')).toBeLessThan(
+      html.indexOf('id="expert-instructions-heading"'),
+    );
+    expect(html).toContain('<h2 id="expert-context-heading">Knowledge base</h2>');
     expect(html).toMatch(/studio-screen-header.*Back to Experts.*studio-screen-body.*Test Expert/s);
     expect(html).toContain("Delete expert");
     expect(html).not.toContain("Create new version");

--- a/apps/desktop/src/renderer/src/pages/studio/ExpertDirectoryFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/ExpertDirectoryFragment.tsx
@@ -32,6 +32,7 @@ import {
   MemoryStoreBrowser,
   type ContextStoreBrowserSource,
 } from "../../components/MemoryStoreBrowser.tsx";
+import { MarkdownContent } from "../../components/MarkdownContent.tsx";
 import { isBuiltInExpert, type ExpertRecord } from "./studio-model.ts";
 import { errorMessage } from "../../lib/errors.ts";
 import { runtimeDisplayName } from "../../lib/runtime-display.ts";
@@ -41,7 +42,6 @@ import {
 } from "../../lib/system-expert-copy.ts";
 
 const DESCRIPTION_PREVIEW_LENGTH = 200;
-const INSTRUCTIONS_PREVIEW_LENGTH = 420;
 
 function truncateText(value: string, maximumLength: number): string {
   const normalized = value.trim();
@@ -201,7 +201,6 @@ export function ExpertDetailFragment(props: {
     description: tCommon("builtInExperts.pragma.description"),
     scope: tCommon("builtInExperts.pragma.scope"),
   });
-  const [instructionsExpanded, setInstructionsExpanded] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -209,11 +208,8 @@ export function ExpertDetailFragment(props: {
   const [resetting, setResetting] = useState(false);
   const [memoryStoreOpen, setMemoryStoreOpen] = useState(false);
   const [memoryStoreHasContent, setMemoryStoreHasContent] = useState(false);
-  const hasLongInstructions = props.expert.instructions.trim().length > INSTRUCTIONS_PREVIEW_LENGTH;
-  const displayedInstructions =
-    hasLongInstructions && !instructionsExpanded
-      ? truncateText(props.expert.instructions, INSTRUCTIONS_PREVIEW_LENGTH)
-      : props.expert.instructions.trim();
+  const instructions = props.expert.instructions.trim();
+  const additionalInstructions = props.expert.additionalInstructions.trim();
   const runtime = props.runtimes.find((item) => item.id === props.expert.model?.runtimeId);
   const runtimeName =
     runtime === undefined
@@ -412,39 +408,10 @@ export function ExpertDetailFragment(props: {
         </div>
       </section>
       <div className="expert-detail-content">
-        <div className="expert-detail-reading-column">
-          <section className="expert-scope" aria-labelledby="expert-scope-heading">
-            <h2 id="expert-scope-heading">{t("scope")}</h2>
-            <p>{copy.scope}</p>
-          </section>
-          <section className="instructions-preview" aria-labelledby="expert-instructions-heading">
-            <header className="expert-detail-section-heading">
-              <h2 id="expert-instructions-heading">
-                {isBuiltInExpert(props.expert)
-                  ? t("builtInFoundationInstructions")
-                  : t("instructions")}
-              </h2>
-              {hasLongInstructions ? (
-                <button
-                  className="text-button instructions-toggle"
-                  type="button"
-                  aria-expanded={instructionsExpanded}
-                  aria-controls="expert-instructions-content"
-                  onClick={() => setInstructionsExpanded((expanded) => !expanded)}
-                >
-                  {instructionsExpanded ? t("showLess") : t("showMore")}
-                </button>
-              ) : null}
-            </header>
-            <p id="expert-instructions-content">{displayedInstructions || t("noInstructions")}</p>
-          </section>
-          {isBuiltInExpert(props.expert) ? (
-            <section className="instructions-preview" aria-labelledby="expert-additional-heading">
-              <h2 id="expert-additional-heading">{t("additionalInstructions")}</h2>
-              <p>{props.expert.additionalInstructions.trim() || t("noAdditionalInstructions")}</p>
-            </section>
-          ) : null}
-        </div>
+        <section className="expert-scope" aria-labelledby="expert-scope-heading">
+          <h2 id="expert-scope-heading">{t("scope")}</h2>
+          <p>{copy.scope}</p>
+        </section>
         <section className="expert-capabilities" aria-labelledby="expert-capabilities-heading">
           <header className="expert-detail-section-heading">
             <div>
@@ -475,66 +442,90 @@ export function ExpertDetailFragment(props: {
             />
           </div>
         </section>
-      </div>
-      <section className="expert-context-section" aria-labelledby="expert-context-heading">
-        <header>
-          <div>
-            <h2 id="expert-context-heading">{t("context")}</h2>
-            <p>{t("contextDescription")}</p>
-          </div>
-        </header>
-        {props.expert.contextStoreMounts.length === 0 && !memoryStoreHasContent ? (
-          <p className="expert-context-empty">{t("noContext")}</p>
-        ) : (
-          <div className="expert-context-list">
-            {props.expert.contextStoreMounts.map((mount) => {
-              const store = props.contextStores.find((item) => item.id === mount.storeId);
-              if (!store) return null;
-              const StoreIcon = Folder;
-              const loadingBehavior = "From Markdown metadata";
-              return (
+        <section className="expert-context-section" aria-labelledby="expert-context-heading">
+          <header>
+            <div>
+              <h2 id="expert-context-heading">{t("knowledgeBase")}</h2>
+              <p>{t("contextDescription")}</p>
+            </div>
+          </header>
+          {props.expert.contextStoreMounts.length === 0 && !memoryStoreHasContent ? (
+            <p className="expert-context-empty">{t("noContext")}</p>
+          ) : (
+            <div className="expert-context-list">
+              {props.expert.contextStoreMounts.map((mount) => {
+                const store = props.contextStores.find((item) => item.id === mount.storeId);
+                if (!store) return null;
+                const StoreIcon = Folder;
+                const loadingBehavior = "From Markdown metadata";
+                return (
+                  <button
+                    className="expert-context-link"
+                    key={mount.storeId}
+                    type="button"
+                    onClick={() => props.onOpenContextStore(store)}
+                  >
+                    <span className="store-icon">
+                      <StoreIcon size={20} />
+                    </span>
+                    <span>
+                      <strong>{store.name}</strong>
+                      <small>{t("knowledgeBase")}</small>
+                    </span>
+                    <em>{loadingBehavior}</em>
+                    <span className="store-status">
+                      <i className="is-ready" />
+                      {mount.enabled ? t("enabled") : t("disabled")}
+                    </span>
+                    <CaretRight size={17} aria-hidden="true" />
+                  </button>
+                );
+              })}
+              {memoryStoreSource !== undefined && memoryStoreHasContent ? (
                 <button
                   className="expert-context-link"
-                  key={mount.storeId}
                   type="button"
-                  onClick={() => props.onOpenContextStore(store)}
+                  onClick={() => setMemoryStoreOpen(true)}
                 >
                   <span className="store-icon">
-                    <StoreIcon size={20} />
+                    <Database size={20} />
                   </span>
                   <span>
-                    <strong>{store.name}</strong>
-                    <small>{t("knowledgeBase")}</small>
+                    <strong>{t("memoryStore")}</strong>
+                    <small>{t("readOnly")}</small>
                   </span>
-                  <em>{loadingBehavior}</em>
-                  <span className="store-status">
-                    <i className="is-ready" />
-                    {mount.enabled ? t("enabled") : t("disabled")}
-                  </span>
+                  <em>{t("browseMemoryStore")}</em>
                   <CaretRight size={17} aria-hidden="true" />
                 </button>
-              );
-            })}
-            {memoryStoreSource !== undefined && memoryStoreHasContent ? (
-              <button
-                className="expert-context-link"
-                type="button"
-                onClick={() => setMemoryStoreOpen(true)}
-              >
-                <span className="store-icon">
-                  <Database size={20} />
-                </span>
-                <span>
-                  <strong>{t("memoryStore")}</strong>
-                  <small>{t("readOnly")}</small>
-                </span>
-                <em>{t("browseMemoryStore")}</em>
-                <CaretRight size={17} aria-hidden="true" />
-              </button>
-            ) : null}
-          </div>
-        )}
-      </section>
+              ) : null}
+            </div>
+          )}
+        </section>
+        <section className="instructions-preview" aria-labelledby="expert-instructions-heading">
+          <h2 id="expert-instructions-heading">
+            {isBuiltInExpert(props.expert) ? t("builtInFoundationInstructions") : t("instructions")}
+          </h2>
+          {instructions ? (
+            <div className="expert-instructions-markdown markdown-preview">
+              <MarkdownContent source={instructions} />
+            </div>
+          ) : (
+            <p className="expert-instructions-empty">{t("noInstructions")}</p>
+          )}
+        </section>
+        {isBuiltInExpert(props.expert) ? (
+          <section className="instructions-preview" aria-labelledby="expert-additional-heading">
+            <h2 id="expert-additional-heading">{t("additionalInstructions")}</h2>
+            {additionalInstructions ? (
+              <div className="expert-instructions-markdown markdown-preview">
+                <MarkdownContent source={additionalInstructions} />
+              </div>
+            ) : (
+              <p className="expert-instructions-empty">{t("noAdditionalInstructions")}</p>
+            )}
+          </section>
+        ) : null}
+      </div>
       {props.expert.usesApproval ? (
         <p className="approval-note">
           <Info size={19} aria-hidden="true" /> {t("approvalNote")}

--- a/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.tsx
@@ -571,7 +571,7 @@ function TeamDetail(props: {
           </span>
         </summary>
         {instructions ? (
-          <div className="team-instructions-markdown">
+          <div className="team-instructions-markdown markdown-preview">
             <MarkdownContent source={instructions} />
           </div>
         ) : (

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -6107,17 +6107,6 @@ html.is-resizing-sidebar * {
   overflow-wrap: anywhere;
 }
 
-.instructions-toggle {
-  margin-top: 13px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--green-dark);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 680;
-}
-
 .expert-capabilities {
   display: grid;
   grid-template-columns: minmax(180px, 0.35fr) minmax(0, 1fr);
@@ -21265,7 +21254,7 @@ textarea:focus-visible,
   overflow-wrap: anywhere;
 }
 
-.team-instructions-markdown {
+.markdown-preview {
   min-width: 0;
   padding: 0 20px 20px;
   color: #3e4a42;
@@ -21274,67 +21263,67 @@ textarea:focus-visible,
   overflow-wrap: anywhere;
 }
 
-.team-instructions-markdown > :first-child {
+.markdown-preview > :first-child {
   margin-top: 0;
 }
 
-.team-instructions-markdown > :last-child {
+.markdown-preview > :last-child {
   margin-bottom: 0;
 }
 
-.team-instructions-markdown h1,
-.team-instructions-markdown h2,
-.team-instructions-markdown h3,
-.team-instructions-markdown h4,
-.team-instructions-markdown h5,
-.team-instructions-markdown h6 {
+.markdown-preview h1,
+.markdown-preview h2,
+.markdown-preview h3,
+.markdown-preview h4,
+.markdown-preview h5,
+.markdown-preview h6 {
   margin: 1.25em 0 0.5em;
   color: var(--text);
   font-weight: 680;
   line-height: 1.3;
 }
 
-.team-instructions-markdown h1 {
+.markdown-preview h1 {
   font-size: 1.45em;
 }
 
-.team-instructions-markdown h2 {
+.markdown-preview h2 {
   font-size: 1.28em;
 }
 
-.team-instructions-markdown h3 {
+.markdown-preview h3 {
   font-size: 1.12em;
 }
 
-.team-instructions-markdown h4,
-.team-instructions-markdown h5,
-.team-instructions-markdown h6 {
+.markdown-preview h4,
+.markdown-preview h5,
+.markdown-preview h6 {
   font-size: 1em;
 }
 
-.team-instructions-markdown p,
-.team-instructions-markdown ul,
-.team-instructions-markdown ol,
-.team-instructions-markdown blockquote,
-.team-instructions-markdown pre,
-.team-instructions-markdown table {
+.markdown-preview p,
+.markdown-preview ul,
+.markdown-preview ol,
+.markdown-preview blockquote,
+.markdown-preview pre,
+.markdown-preview table {
   margin: 0.72em 0;
 }
 
-.team-instructions-markdown ul,
-.team-instructions-markdown ol {
+.markdown-preview ul,
+.markdown-preview ol {
   padding-left: 1.5em;
 }
 
-.team-instructions-markdown li + li {
+.markdown-preview li + li {
   margin-top: 0.22em;
 }
 
-.team-instructions-markdown li > p {
+.markdown-preview li > p {
   margin: 0.2em 0;
 }
 
-.team-instructions-markdown :not(pre) > code {
+.markdown-preview :not(pre) > code {
   padding: 0.14em 0.38em;
   border: 1px solid rgb(76 91 82 / 10%);
   border-radius: 5px;
@@ -21343,32 +21332,32 @@ textarea:focus-visible,
   font-size: 0.88em;
 }
 
-.team-instructions-markdown blockquote {
+.markdown-preview blockquote {
   padding: 0.08em 0 0.08em 0.85em;
   border-left: 3px solid #bdc9c1;
   color: var(--muted);
 }
 
-.team-instructions-markdown blockquote > :first-child {
+.markdown-preview blockquote > :first-child {
   margin-top: 0;
 }
 
-.team-instructions-markdown blockquote > :last-child {
+.markdown-preview blockquote > :last-child {
   margin-bottom: 0;
 }
 
-.team-instructions-markdown hr {
+.markdown-preview hr {
   margin: 1.25em 0;
   border: 0;
   border-top: 1px solid #d4dbd7;
 }
 
-.team-instructions-markdown .markdown-image-placeholder {
+.markdown-preview .markdown-image-placeholder {
   color: var(--muted);
   font-style: italic;
 }
 
-.team-instructions-markdown pre {
+.markdown-preview pre {
   max-width: 100%;
   overflow-x: auto;
   padding: 12px;
@@ -21383,26 +21372,26 @@ textarea:focus-visible,
   white-space: pre;
 }
 
-.team-instructions-markdown pre code {
+.markdown-preview pre code {
   font: inherit;
 }
 
-.team-instructions-markdown table {
+.markdown-preview table {
   display: block;
   max-width: 100%;
   overflow-x: auto;
   border-collapse: collapse;
 }
 
-.team-instructions-markdown th,
-.team-instructions-markdown td {
+.markdown-preview th,
+.markdown-preview td {
   padding: 6px 9px;
   border: 1px solid var(--border);
   text-align: left;
   white-space: normal;
 }
 
-.team-instructions-markdown th {
+.markdown-preview th {
   background: rgb(70 85 76 / 5%);
   font-weight: 650;
 }
@@ -21513,16 +21502,9 @@ textarea:focus-visible,
 
 .expert-detail .expert-detail-content {
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(420px, 1.05fr);
-  align-items: start;
-  gap: 42px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
   margin-top: 28px;
-}
-
-.expert-detail .expert-detail-reading-column {
-  display: grid;
-  min-width: 0;
-  gap: 28px;
 }
 
 .expert-detail .expert-scope,
@@ -21555,7 +21537,7 @@ textarea:focus-visible,
 }
 
 .expert-detail .expert-scope p,
-.expert-detail .instructions-preview p {
+.expert-detail .expert-instructions-empty {
   max-width: 66ch;
   margin-top: 13px;
   color: var(--muted);
@@ -21563,9 +21545,20 @@ textarea:focus-visible,
   line-height: 1.75;
 }
 
+.expert-detail .expert-capabilities,
+.expert-detail .expert-context-section,
 .expert-detail .instructions-preview {
+  margin-top: 28px;
   padding-top: 27px;
   border-top: 1px solid var(--border);
+}
+
+.expert-detail .expert-instructions-markdown {
+  margin-top: 16px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--ui-surface);
 }
 
 .expert-detail .expert-detail-section-heading {
@@ -21592,13 +21585,6 @@ textarea:focus-visible,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.expert-detail .expert-detail-section-heading .instructions-toggle {
-  flex: 0 0 auto;
-  margin: 0;
-  padding: 0;
-  font-size: 12px;
 }
 
 .expert-detail .expert-capabilities > header {
@@ -21669,9 +21655,7 @@ textarea:focus-visible,
 }
 
 .expert-detail .expert-context-section {
-  margin-top: 36px;
-  padding-top: 27px;
-  border-top: 1px solid var(--border);
+  min-width: 0;
 }
 
 .expert-detail .expert-context-section > header {
@@ -21769,10 +21753,6 @@ textarea:focus-visible,
 }
 
 @media (max-width: 1120px) {
-  .expert-detail .expert-detail-content {
-    grid-template-columns: 1fr;
-  }
-
   .expert-detail .expert-capability-detail-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Summary

- reorganize the expert detail page into full-width sections ordered as scope, capabilities, knowledge base, and instructions
- rename the expert detail context heading to Knowledge base
- render expert foundation and additional instructions with the same Markdown preview used by expert team details
- extract reusable Markdown preview styling and remove the obsolete truncated-instructions toggle
- cover Markdown rendering, section order, and the knowledge-base heading in the expert detail tests

## Why

The previous two-column layout separated related expert configuration and rendered instructions as truncated plain text. The new layout gives each major section a predictable reading order and preserves authored Markdown in the final instructions section.

## Impact

Expert details are easier to scan, knowledge sources use product terminology consistently, and instructions now support headings, lists, emphasis, code, blockquotes, and tables without being truncated.

## Validation

- `pnpm exec vitest run src/renderer/src/pages/studio/ExpertDirectoryFragment.test.tsx src/renderer/src/pages/studio/PragmaResourceDirectoryFragment.test.tsx` — 21 tests passed
- `pnpm run typecheck:web` — passed
- targeted ESLint checks — passed
- Prettier checked the changed TS/TSX files; `git diff --check` passed
- visually verified the full-width section order and Markdown rendering in the in-app browser with no console warnings or horizontal overflow

The full Desktop test suite was also run: 697 of 699 tests passed. The two unrelated failures are environment-dependent Runtime availability tests caused by missing local Claude Code and Qoder CLI executables.