### PR TITLE
fix mission compaction status lifecycle

### DIFF
--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -38,7 +38,11 @@ import {
 } from "../../../shared/contracts/index.ts";
 import type { CapabilityCredentialStore } from "../capabilities/capability-credential-store.ts";
 import type { CapabilityStore } from "../capabilities/capability-store.ts";
-import { compactExpertSessionContext, createMissionRunner } from "./mission-runner.ts";
+import {
+  compactExpertSessionContext,
+  createMissionRunner,
+  isRootMissionRuntimeOutput,
+} from "./mission-runner.ts";
 import { createMissionStore } from "./mission-store.ts";
 import { createPragmaProjectStore } from "../projects/pragma-project-store.ts";
 import type { DesktopUsageStore } from "../usage/usage-store.ts";
@@ -91,6 +95,29 @@ afterEach(async () => {
 });
 
 describe("MissionRunner", { timeout: 15_000 }, () => {
+  it("projects context compaction only from the root coordinator Runtime", () => {
+    const rootSource = { kind: "runtime" as const, runId: "root-run", path: [] };
+
+    expect(isRootMissionRuntimeOutput({ source: rootSource })).toBe(true);
+    expect(
+      isRootMissionRuntimeOutput({
+        parentInvocationId: "coordinator-invocation",
+        source: rootSource,
+      }),
+    ).toBe(false);
+    expect(
+      isRootMissionRuntimeOutput({
+        source: {
+          kind: "agent",
+          runId: "runtime-child-run",
+          sessionId: "runtime-child-session",
+          parentSessionId: "root-session",
+          path: [],
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("treats a restored Runtime with no compactable history as a normal no-op", async () => {
     const session = {
       canCompactRootContext: vi.fn(async () => undefined),
@@ -1721,6 +1748,24 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         },
       },
     });
+    await store.appendEvent(executionId, "nested-invocation", "runtime.event", {
+      schemaVersion: "pragma.stream/v1",
+      eventId: "nested-invocation-compaction-started",
+      sequence: 108,
+      runId: "nested-invocation-run",
+      parentRunId: "root-run",
+      emittedAt: new Date(childConversationStartedAt + 7).toISOString(),
+      source: compactionSource,
+      type: "progress",
+      payload: {
+        stage: "context.compaction.started",
+        data: {
+          operationId: "nested-invocation-compact",
+          trigger: "auto",
+          runtimeId: "codex-local",
+        },
+      },
+    });
     await store.appendEvent(executionId, executionId, "runtime.event", {
       schemaVersion: "pragma.stream/v1",
       eventId: "compaction-completed",
@@ -1733,6 +1778,24 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         stage: "context.compaction.completed",
         data: {
           operationId: "compact-1",
+          trigger: "auto",
+          runtimeId: "codex-local",
+        },
+      },
+    });
+    await store.appendEvent(executionId, executionId, "runtime.event", {
+      schemaVersion: "pragma.stream/v1",
+      eventId: "child-compaction-started",
+      sequence: 107,
+      runId: "child-turn",
+      parentRunId: "root-run",
+      emittedAt: new Date(childConversationStartedAt + 6).toISOString(),
+      source: childSource,
+      type: "progress",
+      payload: {
+        stage: "context.compaction.started",
+        data: {
+          operationId: "child-compact",
           trigger: "auto",
           runtimeId: "codex-local",
         },
@@ -1761,6 +1824,14 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         }),
       ]),
     });
+    expect((await runner.getChat({ id: mission.id, limit: 50 })).entries).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "context_operation",
+          operationId: expect.stringMatching(/^(child|nested-invocation)-compact$/),
+        }),
+      ]),
+    );
   });
 
   it("keeps an existing Mission on its original Runtime and ignores changed Expert defaults", async () => {

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -2313,7 +2313,11 @@ async function readMissionChatHistory(
     let activityEntries;
     try {
       histories = await view.getMessageHistory({ scope: { kind: "all" } });
-      activityEntries = await readHistoricalRuntimeActivityEntries(view, turn.sequence);
+      activityEntries = await readHistoricalRuntimeActivityEntries(
+        view,
+        turn.sequence,
+        state.rootInvocationId,
+      );
     } catch {
       const projection = await missions.readExecutionProjection(missionId, turn.executionId);
       if (projection !== undefined) {
@@ -2363,6 +2367,7 @@ async function readMissionChatHistory(
 async function readHistoricalRuntimeActivityEntries(
   view: StoredExecutionView,
   timelineSequence: number,
+  rootInvocationId: string,
 ): Promise<MissionChatEntry[]> {
   const events: Array<{
     readonly event: ExpertAgentStreamEvent;
@@ -2390,6 +2395,12 @@ async function readHistoricalRuntimeActivityEntries(
   for (const record of events) {
     const { event } = record;
     if (event.type === "progress") {
+      if (
+        record.invocationId !== rootInvocationId ||
+        !isRootMissionRuntimeSource(event.source)
+      ) {
+        continue;
+      }
       const data = readRuntimeContextCompactionProgressData(event.payload.data);
       if (data === undefined || !isRuntimeContextCompactionStage(event.payload.stage)) continue;
       const id = `context:${view.executionId}:${data.operationId}`;
@@ -2707,8 +2718,22 @@ function elapsedMissionMs(startedAt: number): number {
   return Math.round((performance.now() - startedAt) * 100) / 100;
 }
 
+export function isRootMissionRuntimeOutput(
+  item: Pick<ExecutionOutputItem, "parentInvocationId" | "source">,
+): boolean {
+  return item.parentInvocationId === undefined && isRootMissionRuntimeSource(item.source);
+}
+
+function isRootMissionRuntimeSource(
+  source: Pick<ExecutionOutputItem["source"], "parentSessionId">,
+): boolean {
+  return source.parentSessionId === undefined;
+}
+
 function isTerminalContextCompactionOutput(item: ExecutionOutputItem): boolean {
-  if (item.channel !== "progress") return false;
+  if (item.channel !== "progress" || !isRootMissionRuntimeOutput(item)) {
+    return false;
+  }
   const stage = asRecord(item.value)["stage"];
   return (
     stage === RUNTIME_CONTEXT_COMPACTION_STAGES.completed ||
@@ -2790,6 +2815,7 @@ function consumeLiveChatOutput(
     return [{ type: "entry.upsert", entry }];
   }
   if (item.channel === "progress") {
+    if (!isRootMissionRuntimeOutput(item)) return [];
     const payload = asRecord(item.value);
     const stage = payload["stage"];
     if (!isRuntimeContextCompactionStage(stage)) return [];

--- a/packages/runtime/codex/src/session.ts
+++ b/packages/runtime/codex/src/session.ts
@@ -414,7 +414,10 @@ function annotateCodexCompaction(
       ...(failed ? { errorMessage: readFailureMessage(item) } : {}),
     };
   }
-  if (notification.method === "thread/compacted" && session.pendingCompaction !== undefined) {
+  if (
+    (notification.method === "thread/compacted" || notification.method === "turn/completed") &&
+    session.pendingCompaction !== undefined
+  ) {
     const pending = session.pendingCompaction;
     session.pendingCompaction = undefined;
     return {

--- a/packages/runtime/codex/test/session.test.ts
+++ b/packages/runtime/codex/test/session.test.ts
@@ -293,7 +293,7 @@ describe("Codex turn completion", () => {
     );
   });
 
-  it("preserves the compaction trigger when thread completion is the only terminal event", async () => {
+  it("completes pending compaction when turn completion is the only terminal event", async () => {
     const notificationBus = createCodexNotificationBus();
     const writeNative = vi.fn();
     const client = {
@@ -308,10 +308,6 @@ describe("Codex turn completion", () => {
               trigger: "manual",
             },
           },
-        });
-        notificationBus.publish({
-          method: "thread/compacted",
-          params: { threadId: "thread-1" },
         });
         notificationBus.publish({
           method: "item/completed",

--- a/packages/runtime/pi/src/session.ts
+++ b/packages/runtime/pi/src/session.ts
@@ -68,6 +68,7 @@ export interface PiNativeSession {
   messageCountBeforeRun: number;
   pendingStartupMessages: readonly ExpertAgentStartupMessage[];
   pendingCompactionOperationId?: string | undefined;
+  pendingCompactionTrigger?: RuntimeContextCompactionTrigger | undefined;
   compactionTriggerOverride?: RuntimeContextCompactionTrigger | undefined;
 }
 
@@ -138,8 +139,13 @@ export async function startPiTurn(
   }
 
   const unsubscribe = nativeSession.session.subscribe((event) => {
+    const trigger =
+      event.type === "compaction_start" || event.type === "compaction_end"
+        ? (nativeSession.compactionTriggerOverride ?? mapPiCompactionTrigger(event.reason))
+        : undefined;
     if (event.type === "compaction_start") {
       nativeSession.pendingCompactionOperationId = randomUUID();
+      nativeSession.pendingCompactionTrigger = trigger ?? "unknown";
     }
     const operationId =
       event.type === "compaction_start" || event.type === "compaction_end"
@@ -151,12 +157,12 @@ export async function startPiTurn(
       ...(event.type !== "compaction_start" && event.type !== "compaction_end"
         ? {}
         : {
-            trigger:
-              nativeSession.compactionTriggerOverride ?? mapPiCompactionTrigger(event.reason),
+            trigger,
           }),
     });
     if (event.type === "compaction_end") {
       nativeSession.pendingCompactionOperationId = undefined;
+      nativeSession.pendingCompactionTrigger = undefined;
     }
   });
 
@@ -184,10 +190,33 @@ export async function startPiTurn(
       nativeSession.session.messages.slice(nativeSession.messageCountBeforeRun),
     );
   } finally {
-    unsubscribe();
-    nativeSession.streamState.runId = undefined;
-    nativeSession.streamState.source = undefined;
-    nativeSession.streamState.emitter = undefined;
+    const incompleteCompactionId = nativeSession.pendingCompactionOperationId;
+    try {
+      if (incompleteCompactionId !== undefined) {
+        const trigger = nativeSession.pendingCompactionTrigger ?? "unknown";
+        nativeSession.pendingCompactionOperationId = undefined;
+        nativeSession.pendingCompactionTrigger = undefined;
+        turn.stream.write({
+          runId: turn.runId,
+          source: turn.source,
+          type: "progress",
+          payload: {
+            stage: RUNTIME_CONTEXT_COMPACTION_STAGES.failed,
+            data: {
+              operationId: incompleteCompactionId,
+              trigger,
+              runtimeId: "cloud-pi-agent",
+              errorMessage: "PI Runtime turn ended before context compaction completed.",
+            },
+          },
+        });
+      }
+    } finally {
+      unsubscribe();
+      nativeSession.streamState.runId = undefined;
+      nativeSession.streamState.source = undefined;
+      nativeSession.streamState.emitter = undefined;
+    }
   }
 
   return {

--- a/packages/runtime/pi/test/startup-messages.test.ts
+++ b/packages/runtime/pi/test/startup-messages.test.ts
@@ -33,6 +33,55 @@ describe("PI startup messages", () => {
     expect(native.session.prompt).toHaveBeenCalledWith("always-on context\n\nuser prompt");
   });
 
+  it("fails an unfinished compaction when the turn ends", async () => {
+    const native = createNativeSession();
+    native.pendingCompactionOperationId = "compact-orphaned";
+    native.pendingCompactionTrigger = "auto";
+    const turn = createTurn([]);
+
+    await startPiTurn(native, turn);
+
+    expect(turn.stream.write).toHaveBeenCalledWith({
+      runId: "run-1",
+      source: { kind: "runtime", runId: "run-1", path: [] },
+      type: "progress",
+      payload: {
+        stage: "context.compaction.failed",
+        data: {
+          operationId: "compact-orphaned",
+          trigger: "auto",
+          runtimeId: "cloud-pi-agent",
+          errorMessage: "PI Runtime turn ended before context compaction completed.",
+        },
+      },
+    });
+    expect(native.pendingCompactionOperationId).toBeUndefined();
+    expect(native.pendingCompactionTrigger).toBeUndefined();
+  });
+
+  it("cleans up an unfinished compaction when publishing its failure throws", async () => {
+    const native = createNativeSession();
+    const unsubscribe = vi.fn();
+    vi.mocked(native.session.subscribe).mockReturnValue(unsubscribe);
+    native.pendingCompactionOperationId = "compact-orphaned";
+    native.pendingCompactionTrigger = "auto";
+    const turn = createTurn([]);
+    vi.mocked(turn.stream.write).mockImplementation(() => {
+      throw new Error("stream unavailable");
+    });
+
+    await expect(startPiTurn(native, turn)).rejects.toThrow("stream unavailable");
+
+    expect(native.pendingCompactionOperationId).toBeUndefined();
+    expect(native.pendingCompactionTrigger).toBeUndefined();
+    expect(native.streamState).toEqual({
+      runId: undefined,
+      source: undefined,
+      emitter: undefined,
+    });
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
   it("passes image blocks only when the selected model supports vision", async () => {
     const path = join(tmpdir(), `pragma-pi-image-${randomUUID()}.png`);
     await writeFile(path, "image-bytes");


### PR DESCRIPTION
## Summary

- scope Mission composer compaction state to the root invocation and root runtime session
- close Codex compaction state when a turn completes without a dedicated `thread/compacted` notification
- synthesize and safely publish a terminal PI compaction failure when a turn ends with compaction still pending
- add regression coverage for expert-team child invocations, runtime child sessions, missing terminal notifications, and cleanup failures

## Root cause

Mission runtime activity previously treated compaction progress from expert-team child invocations and nested runtime sessions as if it belonged to the coordinator's root chat. In addition, Codex and PI could leave a started compaction without a terminal event on valid or exceptional turn termination. The Mission composer therefore remained disabled until the whole task completed.

## Impact

The Mission detail composer now displays and enforces context compaction only for the root conversation. Child expert compaction no longer blocks coordinator input, and pending runtime compaction state is deterministically finalized.

## Validation

- Claude Code review completed; all accepted findings fixed
- focused Mission Runner tests: 20 passed
- focused Codex Runtime tests: 15 passed
- focused PI Runtime tests: 20 passed
- `pnpm check`
- `pnpm build` (22/22 packages)
- Desktop main/preload bundle verification
- `git diff --check`
