### PR TITLE
fix(runtime-antigravity): reuse host keyring for execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,11 +347,13 @@ Server 与 Agent 的关系：
   `~/.pragma/cache/runtimes/qodercli/external-commands/`；认证、Project、日志和 Session 状态继续私有。
   已有 Session 的本地 `external-commands` 目录不得在启动时扫描、迁移或替换；Pragma 只清理共享缓存中
   已完成的 `download-*` 与无活动锁保护的过期 `.tmp-*`。
-- Antigravity CLI 每个 Runtime Session 使用完整私有 `HOME`，其 `~/.gemini/config/`、
-  `~/.gemini/antigravity-cli/`、自定义 Agent、settings、hooks、MCP 配置、Skills、日志和 native Session
-  状态均不得与宿主或其他 Context 共享。认证只允许复用操作系统安全钥匙串或显式注入的受支持认证环境；
-  不复制宿主 `~/.gemini`。PreToolUse relay 凭据只能写入 Session 私有 hook 文件，不得暴露给 agy
-  进程环境及其子 shell。
+- Antigravity CLI 认证使用显式双模式：启用官方 `AGY_ADC_AUTH` 时使用完整私有 `HOME`；使用交互式
+  OAuth 时允许 `host-keyring` 兼容模式保留宿主 `HOME`，因为 agy 1.1.11 在替换 `HOME` 后不会读取操作系统
+  钥匙串。兼容模式不得由 Pragma 向宿主 `~/.gemini` 复制或物化配置；Pragma Agent、Hook、MCP 与 Skills 必须物化到
+  Runtime Session 私有的额外 `.agents` workspace，并使用唯一 namespace。兼容模式会按 agy 原生语义共享
+  宿主 settings、全局 customization 与 native Session 存储，必须在架构文档和诊断中明确披露；恢复只能按
+  已拥有的 conversation ID 定向读取，不得扫描宿主 Session 树。PreToolUse relay 凭据只能写入 Session
+  私有 hook 文件，不得暴露给 agy 进程环境及其子 shell。
 - Runtime 进程停止不等于持久数据删除。Mission 删除必须按 owner 图级联移动 ExpertSession、
   Execution、Runtime Session 和 ownership claim 到带 journal 的回收站。
 - 外部 ID 目录段统一通过 `@pragma/core` 的 `PragmaPaths` 编码和解析，具体 Runtime 或插件 loader 不自行拼接管理路径。

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.ts
@@ -350,6 +350,7 @@ export function createBuiltInRuntimeFactories(
             ? {}
             : { onModelCatalogUpdated: () => onModelCatalogUpdated(environment.id) }),
           permissionMode: antigravityRuntimePermissionForMode(permissionMode),
+          authenticationMode: "auto",
           env,
           tokenCounter: options.tokenCounter,
           ...(options.mcpToolRegistryPool === undefined

--- a/docs/architecture/antigravity-cli-runtime.md
+++ b/docs/architecture/antigravity-cli-runtime.md
@@ -7,7 +7,9 @@
 
 - Runtime id 为 `antigravity`，kind 为 `antigravity-local`，最低支持 `agy 1.1.11`。
 - Adapter 只依赖 `@pragma/core`、`@pragma/shared` 与运行时中立依赖，不依赖其他 Runtime。
-- 每个 Runtime Session 使用独立、可 checkpoint 的 HOME；不扫描、复制或修改宿主 `~/.gemini`。
+- 认证使用双模式：ADC 使用 Session 私有 HOME；交互式 OAuth 使用显式 `host-keyring` 兼容模式。
+- 两种模式都不由 Pragma 向宿主 `~/.gemini` 复制或物化配置；兼容模式由 agy 原生读取宿主 settings、
+  全局 customization，并使用宿主 native conversation 存储，Pragma 自己的配置仍保持 Session 私有。
 - 系统提示词通过 Markdown custom agent 注入；startup messages 只在 fresh conversation 的首轮注入。
 - Pragma 工具通过私有 HTTP MCP session 暴露；native tool 权限通过 fail-closed `PreToolUse` Hook
   回接 Core human interaction。
@@ -18,19 +20,23 @@
 
 `stream-json`、`init` / `step_update` / `result`、`tool_info`、`subagent_info` 和 usage 是 1.1.8
 引入的协议。1.1.10 修复了 `--model` 与 `--effort` 在 headless `-p` 中被忽略的问题；1.1.11 是当前
-global customization 路径与私有 HOME 的已验证基线，因此 Adapter 拒绝更早版本。开发时使用官方
-macOS x64 `agy 1.1.11` 验证了版本探测、参数面、配置发现、私有
-HOME 写入位置和未登录错误路径；当前开发机没有 Antigravity 登录态，因此真实模型成功响应仍由
-协议 fixture 覆盖，而不是宣称完成了账号侧在线调用。
+global customization 路径与认证行为的已验证基线，因此 Adapter 拒绝更早版本。开发时使用官方
+macOS x64 `agy 1.1.11` 验证了版本探测、参数面、配置发现、私有 HOME、宿主钥匙串登录、managed
+workspace Agent 发现和真实 `stream-json` 成功响应。
 
 可执行文件解析顺序为：显式 `executablePath`、`AGY_PATH`、`PATH`、官方用户安装目录，最后回退到
 `agy`/`agy.exe` 交给进程错误处理。Windows 必须指向原生 `.exe`，不接受无法直接 spawn 的 `.cmd`
 shim。版本探测与模型目录刷新都有有界缓存，并按 executable、environment 与 spawn implementation
 隔离。
 
-## Session 私有 HOME
+## 认证模式与 Session 布局
 
-每个 owned Runtime Session 在自己的持久目录中生成：
+Desktop 使用 `auto` 策略：`AGY_ADC_AUTH=true` 时选择 `isolated-environment`，否则选择
+`host-keyring`。前者适合官方 ADC；后者用于用户已通过交互式 `agy` 完成的 OAuth 登录。agy 1.1.11
+会在 `HOME` 被替换后跳过宿主系统钥匙串，因此 OAuth 模式必须保留真实 `HOME`/`USERPROFILE`。这是
+供应商 CLI 的认证约束，不是网络 fallback。
+
+`isolated-environment` 在 owned Runtime Session 中生成完整私有 HOME：
 
 ```text
 <runtime-session>/
@@ -49,20 +55,38 @@ shim。版本探测与模型目录刷新都有有界缓存，并按 executable�
 └── tmp/
 ```
 
-启动环境强制重定向 `HOME`、`USERPROFILE`、XDG 目录、Windows AppData 与临时目录，并移除宿主的
+`host-keyring` 不写宿主配置，而是在同一个 Runtime Session 中生成官方 workspace customization：
+
+```text
+<runtime-session>/
+├── managed-customizations/
+│   └── .agents/
+│       ├── agents/pragma-<expert-id>-<session-hash>/agent.md
+│       ├── hooks.json
+│       ├── mcp_config.json
+│       └── skills/pragma-<session-hash>-<skill>/SKILL.md
+├── hooks/pragma-pre-tool-use.mjs
+├── logs/turn-<run-id>.log
+└── tmp/
+```
+
+隔离模式强制重定向 `HOME`、`USERPROFILE`、XDG 目录、Windows AppData 与临时目录，并移除宿主的
 `AGY_APP_DATA_DIR`、`ANTIGRAVITY_HOME`、Gemini config override、Google log override、Antigravity
 conversation/project/sidecar 状态及旧的 Pragma Hook secret 变量。
 显式认证环境变量与其他业务环境保持透传。`AGY_CLI_DISABLE_AUTO_UPDATE=true`，避免一个受管 Session
-在执行中改写宿主安装。OAuth 登录态由 Antigravity 使用操作系统安全钥匙串管理；首次登录应在 Pragma
-外运行交互式 `agy`，Adapter 不复制凭据文件。
+在执行中改写宿主安装。
 
-同一策略也用于 `agy models`，但模型发现使用一次性临时 HOME，结束后立即删除，避免目录发现污染
-Runtime Session 或宿主配置。
+`host-keyring` 保留宿主 HOME/XDG/AppData，只移除可能串扰 Session 的 Antigravity sidecar、conversation、
+project、config override 和旧 Pragma secret 变量；临时目录和 Pragma turn 日志仍定向到 Runtime Session。
+agy 会按原生语义读取宿主 settings、全局 customization，并把 native conversation 保存在宿主目录。
+Pragma 只按当前拥有的 conversation ID 定向恢复，不扫描宿主 conversation 树；Mission 删除也不会删除
+agy 拥有的宿主 native conversation。首次 OAuth 登录仍在 Pragma 外运行交互式 `agy`，Adapter 不读取、
+复制或导出钥匙串凭据。模型发现同样保留宿主 HOME 和认证配置，但使用隔离 cwd/tmp 并移除 Session 变量。
 
 ## 系统提示词与 startup messages
 
-Antigravity 没有等价的 `--system-prompt` 参数。Adapter 在私有
-`~/.gemini/config/agents/pragma-<expert-id>-<session-hash>/agent.md` 写入一个 main custom agent：
+Antigravity 没有等价的 `--system-prompt` 参数。Adapter 在私有 HOME 的 global customization 或
+`host-keyring` 的 Session `managed-customizations/.agents/agents/` 中写入一个 main custom agent：
 
 ```markdown
 ---
@@ -96,7 +120,7 @@ user message，不把边界帧当作权威历史格式。
 ## MCP
 
 Adapter 从 Core 的 process-shared `McpToolRegistryPool` 获取连接，再为当前 Expert/Execution 注册独立
-MCP session。私有 `~/.gemini/config/mcp_config.json` 只写一个 Session-scoped
+MCP session。受管 global/workspace `mcp_config.json` 只写一个 Session-scoped
 `pragma<session-hash>` remote server：
 
 ```json
@@ -109,7 +133,8 @@ MCP session。私有 `~/.gemini/config/mcp_config.json` 只写一个 Session-sco
 }
 ```
 
-该不透明 namespace 只暴露当前 Expert allowlist 投影后的工具，且私有 HOME 不会继承宿主个人 MCP 配置。
+该不透明 namespace 只暴露当前 Expert allowlist 投影后的工具。私有 HOME 不继承宿主个人 MCP 配置；
+`host-keyring` 会按 agy 原生规则同时加载宿主全局配置，因此属于显式兼容性取舍。
 custom agent 的 `inheritMcp: true` 让上述受管 server 进入该 Agent。Antigravity 仍会按其原生语义发现
 workspace 内显式提交的 `.agents`、`.agent`、`_agents` 或 `_agent` customization；这些根可以在 Pragma
 `PreToolUse` relay 之前启动任意 shell Hook、stdio MCP 或第三方 Plugin，不能被名称 namespace 或同一个
@@ -123,8 +148,9 @@ registration、registry lease 与权限 relay；任一释放失败会聚合上�
 
 ## Skills
 
-Core 已解析的每个 local Skill 都复制到官方 global customization 路径
-`~/.gemini/config/skills/pragma-<session-hash>-<normalized-name>/`。复制规则为：
+Core 已解析的每个 local Skill 都复制到受管 customization 的
+`skills/pragma-<session-hash>-<normalized-name>/`。该根在隔离模式位于私有 HOME，在兼容模式位于 Session
+额外 workspace。复制规则为：
 
 - 复制整个 Skill 目录并解引用已选择的链接，保留 `scripts/`、`references/`、`resources/` 与其他文件；
 - 排除任何 `node_modules` 子树；
@@ -147,7 +173,7 @@ Desktop 的三种权限模式映射为：
 | auto-approve     | `proceed-in-sandbox` | 开启             | 禁止             | `--sandbox`                      |
 | full-access      | `always-proceed`     | 关闭             | 允许             | `--dangerously-skip-permissions` |
 
-`~/.gemini/config/hooks.json` 以 Session-scoped 名称注册匹配全部 native tools 的 `PreToolUse` command Hook。Hook runner 与本机
+受管 `hooks.json` 以 Session-scoped 名称注册匹配全部 native tools 的 `PreToolUse` command Hook。Hook runner 与本机
 loopback relay 使用每 Session 随机 bearer；URL 和 bearer 只写入权限为 `0600` 的私有脚本，不放入 agy
 进程环境，避免被 Agent 的 shell 子进程读取。
 
@@ -176,6 +202,7 @@ agy
   --disable-slash-commands
   --print-timeout 24h
   --add-dir <workspace>
+  [--add-dir <session-managed-customizations>]
   --agent <managed-agent>
   --log-file <private-turn-log>
   --mode accept-edits

--- a/packages/runtime/antigravity/src/adapter.ts
+++ b/packages/runtime/antigravity/src/adapter.ts
@@ -85,7 +85,7 @@ export function createAntigravityRuntime(
             "session.destroyed",
             "files.changed",
           ],
-          metadata: { format: "antigravity-private-home" },
+          metadata: { format: "antigravity-managed-session" },
         };
       },
       async createSession(ctx): Promise<AntigravityDriverSession> {
@@ -140,6 +140,7 @@ export function createAntigravityRuntime(
             mcpServerUrl: expertToolsMcpRegistration.url,
             hookRelay,
             permissionMode,
+            authenticationMode: options.authenticationMode,
             processEnvironment: ctx.processEnvironment,
             nodeExecutablePath: options.hookNodeExecutablePath,
           });
@@ -151,6 +152,7 @@ export function createAntigravityRuntime(
               systemPromptCharacters: ctx.agentContext.systemPrompt.length,
               skillCount: managedHome.skills.length,
               toolCount: mcpToolRegistryLease.registry.tools.length,
+              authenticationMode: managedHome.authenticationMode,
               mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
               mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
               mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,

--- a/packages/runtime/antigravity/src/managed-home.ts
+++ b/packages/runtime/antigravity/src/managed-home.ts
@@ -21,7 +21,7 @@ import {
   deleteEnvironmentValue,
 } from "./environment-variables.ts";
 import type { AntigravityHookRelay } from "./permission-hooks.ts";
-import type { AntigravityRuntimePermissionMode } from "./types.ts";
+import type { AntigravityAuthenticationMode, AntigravityRuntimePermissionMode } from "./types.ts";
 
 const FRONTMATTER_DELIMITER = "---";
 const NON_ALPHANUMERIC = /[^a-z0-9]+/g;
@@ -37,9 +37,11 @@ export interface ManagedAntigravityIdentity {
 }
 
 export interface ManagedAntigravityHome {
+  readonly authenticationMode: Exclude<AntigravityAuthenticationMode, "auto">;
   readonly homeDir: string;
   readonly appDataDir: string;
   readonly configDir: string;
+  readonly customizationWorkspace?: string | undefined;
   readonly agentName: string;
   readonly mcpServerName: string;
   readonly hookName: string;
@@ -55,15 +57,31 @@ export async function prepareManagedAntigravityHome(options: {
   readonly mcpServerUrl: string;
   readonly hookRelay: AntigravityHookRelay;
   readonly permissionMode: AntigravityRuntimePermissionMode;
+  readonly authenticationMode?: AntigravityAuthenticationMode | undefined;
   readonly processEnvironment: Readonly<NodeJS.ProcessEnv>;
   readonly nodeExecutablePath?: string | undefined;
   readonly platform?: NodeJS.Platform | undefined;
 }): Promise<ManagedAntigravityHome> {
   const platform = options.platform ?? process.platform;
-  const homeDir = join(options.sessionDir, "home");
+  const authenticationMode = resolveAntigravityAuthenticationMode(
+    options.authenticationMode ?? "isolated-environment",
+    options.processEnvironment,
+    platform,
+  );
+  const homeDir =
+    authenticationMode === "host-keyring"
+      ? resolveAntigravityHostHome(options.processEnvironment, platform)
+      : join(options.sessionDir, "home");
   const geminiDir = join(homeDir, ".gemini");
   const appDataDir = join(geminiDir, "antigravity-cli");
-  const configDir = join(geminiDir, "config");
+  const customizationWorkspace =
+    authenticationMode === "host-keyring"
+      ? join(options.sessionDir, "managed-customizations")
+      : undefined;
+  const configDir =
+    customizationWorkspace === undefined
+      ? join(geminiDir, "config")
+      : join(customizationWorkspace, ".agents");
   const logDir = join(options.sessionDir, "logs");
   const tmpDir = join(options.sessionDir, "tmp");
   const hookDir = join(options.sessionDir, "hooks");
@@ -72,7 +90,14 @@ export async function prepareManagedAntigravityHome(options: {
   const identity = createManagedAntigravityIdentity(options.agent.id, options.sessionDir);
   const managedAgentDir = join(agentsDir, identity.agentName);
 
-  for (const directory of [homeDir, appDataDir, configDir, logDir, tmpDir, hookDir]) {
+  if (customizationWorkspace !== undefined) {
+    await rm(customizationWorkspace, { recursive: true, force: true });
+  }
+  const managedDirectories =
+    customizationWorkspace === undefined
+      ? [homeDir, appDataDir, configDir, logDir, tmpDir, hookDir]
+      : [customizationWorkspace, configDir, logDir, tmpDir, hookDir];
+  for (const directory of managedDirectories) {
     await mkdir(directory, { recursive: true, mode: 0o700 });
     await chmod(directory, 0o700).catch(() => undefined);
   }
@@ -86,10 +111,14 @@ export async function prepareManagedAntigravityHome(options: {
 
   const skills = await materializeAntigravitySkills(options.agent, skillsDir, identity.namespace);
   await Promise.all([
-    writePrivateJson(
-      join(appDataDir, "settings.json"),
-      managedSettings(options.permissionMode, identity.mcpServerName),
-    ),
+    ...(authenticationMode === "isolated-environment"
+      ? [
+          writePrivateJson(
+            join(appDataDir, "settings.json"),
+            managedSettings(options.permissionMode, identity.mcpServerName),
+          ),
+        ]
+      : []),
     writePrivateJson(join(configDir, "mcp_config.json"), {
       mcpServers: {
         [identity.mcpServerName]: {
@@ -117,17 +146,26 @@ export async function prepareManagedAntigravityHome(options: {
       ),
     ),
   ]);
-  const env = createManagedAntigravityEnvironment({
-    base: options.processEnvironment,
-    homeDir,
-    tmpDir,
-    platform,
-  });
+  const env =
+    authenticationMode === "host-keyring"
+      ? createHostKeyringAntigravityEnvironment({
+          base: options.processEnvironment,
+          tmpDir,
+          platform,
+        })
+      : createManagedAntigravityEnvironment({
+          base: options.processEnvironment,
+          homeDir,
+          tmpDir,
+          platform,
+        });
 
   return {
+    authenticationMode,
     homeDir,
     appDataDir,
     configDir,
+    customizationWorkspace,
     agentName: identity.agentName,
     mcpServerName: identity.mcpServerName,
     hookName: identity.hookName,
@@ -135,6 +173,74 @@ export async function prepareManagedAntigravityHome(options: {
     env,
     skills,
   };
+}
+
+export function resolveAntigravityAuthenticationMode(
+  requested: AntigravityAuthenticationMode,
+  environment: Readonly<NodeJS.ProcessEnv>,
+  platform: NodeJS.Platform = process.platform,
+): Exclude<AntigravityAuthenticationMode, "auto"> {
+  if (requested !== "auto") return requested;
+  const adc = readEnvironmentValue(environment, "AGY_ADC_AUTH", platform)?.trim().toLowerCase();
+  return adc === "1" || adc === "true" || adc === "yes" || adc === "on"
+    ? "isolated-environment"
+    : "host-keyring";
+}
+
+export function resolveAntigravityHostHome(
+  environment: Readonly<NodeJS.ProcessEnv>,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const direct =
+    platform === "win32"
+      ? (readEnvironmentValue(environment, "USERPROFILE", platform) ??
+        readEnvironmentValue(environment, "HOME", platform))
+      : readEnvironmentValue(environment, "HOME", platform);
+  const windowsParts =
+    platform === "win32"
+      ? `${readEnvironmentValue(environment, "HOMEDRIVE", platform) ?? ""}${readEnvironmentValue(environment, "HOMEPATH", platform) ?? ""}`
+      : "";
+  const candidate = (direct ?? windowsParts).trim();
+  const environmentPath = platform === "win32" ? win32 : posix;
+  if (candidate === "" || !environmentPath.isAbsolute(candidate)) {
+    throw new Error(
+      "Antigravity host-keyring authentication requires an absolute host HOME/USERPROFILE in the Runtime process environment.",
+    );
+  }
+  return environmentPath.resolve(candidate);
+}
+
+export function createHostKeyringAntigravityEnvironment(options: {
+  readonly base: Readonly<NodeJS.ProcessEnv>;
+  readonly tmpDir: string;
+  readonly platform?: NodeJS.Platform | undefined;
+}): NodeJS.ProcessEnv {
+  const platform = options.platform ?? process.platform;
+  const env: NodeJS.ProcessEnv = { ...options.base };
+  for (const key of [
+    "AGY_ADC_AUTH",
+    "AGY_APP_DATA_DIR",
+    "ANTIGRAVITY_HOME",
+    "ANTIGRAVITY_AGENTAPI_EXE",
+    "ANTIGRAVITY_CONVERSATION_ID",
+    "ANTIGRAVITY_CSRF_TOKEN",
+    "ANTIGRAVITY_EXECUTABLE_DATA_DIR",
+    "ANTIGRAVITY_LS_ADDRESS",
+    "ANTIGRAVITY_PROJECT_ID",
+    "ANTIGRAVITY_SIDECAR_UI_TOKEN",
+    "ANTIGRAVITY_SIDECAR_WEB_PORT",
+    "GEMINI_CLI_HOME",
+    "GEMINI_CONFIG_DIR",
+    "GOOGLE_LOG_DIR",
+    "GOOGLE_STATUS_DIR",
+    "PRAGMA_AGY_HOOK_URL",
+    "PRAGMA_AGY_HOOK_AUTHORIZATION",
+    "ELECTRON_RUN_AS_NODE",
+  ]) {
+    deleteEnvironmentValue(env, key, platform);
+  }
+  applyCommonAntigravityEnvironment({ env, tmpDir: options.tmpDir, platform });
+  return env;
 }
 
 export function createManagedAntigravityEnvironment(options: {
@@ -193,6 +299,16 @@ export function createManagedAntigravityEnvironment(options: {
     env["LOCALAPPDATA"] = environmentPath.join(options.homeDir, "AppData", "Local");
   }
   return env;
+}
+
+function readEnvironmentValue(
+  environment: Readonly<NodeJS.ProcessEnv>,
+  name: string,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (platform !== "win32") return environment[name];
+  const matched = Object.keys(environment).find((key) => key.toLowerCase() === name.toLowerCase());
+  return matched === undefined ? undefined : environment[matched];
 }
 
 export function createManagedAntigravityIdentity(

--- a/packages/runtime/antigravity/src/session.ts
+++ b/packages/runtime/antigravity/src/session.ts
@@ -218,6 +218,7 @@ export async function startAntigravityTurn(
         sessionId: session.sessionId,
         modelName,
         thinkingLevel,
+        customizationWorkspace: session.managedHome.customizationWorkspace,
       }),
       cwd: session.agent.workspace,
       env: session.env,
@@ -339,6 +340,7 @@ export function createAntigravityArgs(options: {
   readonly sessionId?: string | undefined;
   readonly modelName?: string | undefined;
   readonly thinkingLevel?: string | undefined;
+  readonly customizationWorkspace?: string | undefined;
 }): readonly string[] {
   const sessionArgs =
     options.sessionId === undefined || options.sessionId === ""
@@ -352,6 +354,9 @@ export function createAntigravityArgs(options: {
     PRINT_TIMEOUT,
     "--add-dir",
     options.workspace,
+    ...(options.customizationWorkspace === undefined
+      ? []
+      : ["--add-dir", options.customizationWorkspace]),
     "--agent",
     options.agentName,
     "--log-file",

--- a/packages/runtime/antigravity/src/types.ts
+++ b/packages/runtime/antigravity/src/types.ts
@@ -11,6 +11,8 @@ import type {
 
 export type AntigravityRuntimePermissionMode = "request-approval" | "auto-approve" | "full-access";
 
+export type AntigravityAuthenticationMode = "auto" | "isolated-environment" | "host-keyring";
+
 export type AntigravityRuntimeSpawn = RuntimeCommandSpawn;
 
 export interface AntigravityRuntimeAdapterOptions {
@@ -22,6 +24,12 @@ export interface AntigravityRuntimeAdapterOptions {
   readonly listModels?: (() => Promise<readonly RuntimeModel[]>) | undefined;
   readonly onModelCatalogUpdated?: (() => void) | undefined;
   readonly permissionMode?: AntigravityRuntimePermissionMode | undefined;
+  /**
+   * `host-keyring` preserves the real user HOME so agy can reuse its OS-keyring
+   * OAuth profile. `isolated-environment` keeps a private HOME and therefore
+   * requires an explicit supported authentication environment such as ADC.
+   */
+  readonly authenticationMode?: AntigravityAuthenticationMode | undefined;
   readonly spawn?: AntigravityRuntimeSpawn | undefined;
   readonly canUse?: (() => Promise<RuntimeCanUseResult> | RuntimeCanUseResult) | undefined;
   readonly outputRetryLimit?: number | undefined;

--- a/packages/runtime/antigravity/test/adapter-lifecycle.test.ts
+++ b/packages/runtime/antigravity/test/adapter-lifecycle.test.ts
@@ -81,6 +81,9 @@ describe("Antigravity Runtime adapter lifecycle", () => {
       mcpToolRegistryPool,
     });
     const driver = runtimeMocks.driver as RuntimeDriver<unknown, AntigravityNativeSession>;
+    expect(driver.resolvePersistence?.(createSessionContext(sessionDir))).toMatchObject({
+      metadata: { format: "antigravity-managed-session" },
+    });
     const readContext = {
       agent: createSessionContext(sessionDir).agent,
       runContext: {},
@@ -167,6 +170,37 @@ describe("Antigravity Runtime adapter lifecycle", () => {
     expect(closeRelay).toHaveBeenCalledTimes(1);
   });
 
+  it("materializes host-keyring customizations without replacing the host HOME", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-agy-host-keyring-adapter-"));
+    temporaryDirectories.push(root);
+    const sessionDir = join(root, "session");
+    const hostHome = join(root, "host-home");
+    await mkdir(hostHome, { recursive: true });
+    createAntigravityRuntime({
+      executablePath: "/opt/agy",
+      canUse: () => ({ usable: true }),
+      listModels: async () => [],
+      authenticationMode: "host-keyring",
+    });
+    const driver = runtimeMocks.driver as RuntimeDriver<unknown, AntigravityNativeSession>;
+    const session = await driver.createSession(
+      createSessionContext(sessionDir, undefined, "/workspace/project", { HOME: hostHome }),
+    );
+
+    expect(session.env["HOME"]).toBe(hostHome);
+    expect(session.managedHome.authenticationMode).toBe("host-keyring");
+    expect(session.managedHome.customizationWorkspace).toBe(
+      join(sessionDir, "managed-customizations"),
+    );
+    await expect(
+      readFile(
+        join(session.managedHome.configDir, "agents", session.managedHome.agentName, "agent.md"),
+        "utf8",
+      ),
+    ).resolves.toContain("system prompt");
+    await driver.closeSession?.(session, closeContext());
+  });
+
   it("rejects workspace customizations before allocating MCP or spawning agy", async () => {
     const sessionDir = await mkdtemp(join(tmpdir(), "pragma-agy-unsafe-workspace-session-"));
     const workspace = await mkdtemp(join(tmpdir(), "pragma-agy-unsafe-workspace-"));
@@ -195,6 +229,7 @@ function createSessionContext(
   sessionDir: string,
   restoredRuntimeSessionId?: string,
   workspace = "/workspace/project",
+  processEnvironment: NodeJS.ProcessEnv = { API_KEY: "preserved" },
 ): RuntimeDriverSessionContext {
   const agent = {
     id: "expert-1",
@@ -229,7 +264,7 @@ function createSessionContext(
       systemSessionDir: sessionDir,
       runtimeSessionDir: () => sessionDir,
     },
-    processEnvironment: { API_KEY: "preserved" },
+    processEnvironment,
     agentContext: {
       systemPrompt: "system prompt",
       startupMessages: [{ role: "user", content: "always-on context" }],

--- a/packages/runtime/antigravity/test/managed-home.test.ts
+++ b/packages/runtime/antigravity/test/managed-home.test.ts
@@ -6,10 +6,13 @@ import type { Expert } from "@pragma/core";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  createHostKeyringAntigravityEnvironment,
   createManagedAntigravityIdentity,
   createManagedAntigravityEnvironment,
   managedAgentName,
   prepareManagedAntigravityHome,
+  resolveAntigravityAuthenticationMode,
+  resolveAntigravityHostHome,
 } from "../src/managed-home.ts";
 
 const temporaryDirectories: string[] = [];
@@ -23,6 +26,111 @@ afterEach(async () => {
 });
 
 describe("managed Antigravity HOME", () => {
+  it("uses a Session customization workspace while preserving host HOME for keyring OAuth", async () => {
+    const root = await temporaryRoot();
+    const hostHome = join(root, "host-home");
+    const sessionDir = join(root, "session");
+    await mkdir(hostHome, { recursive: true });
+    const managed = await prepareManagedAntigravityHome({
+      agent: createExpert(root),
+      sessionDir,
+      systemPrompt: "host-keyring system",
+      mcpServerUrl: "http://127.0.0.1/host-keyring/mcp",
+      hookRelay: relay(),
+      permissionMode: "request-approval",
+      authenticationMode: "host-keyring",
+      processEnvironment: {
+        HOME: hostHome,
+        XDG_CONFIG_HOME: join(hostHome, ".config"),
+        ANTIGRAVITY_CONVERSATION_ID: "stale-host-session",
+        PRAGMA_AGY_HOOK_AUTHORIZATION: "stale-secret",
+      },
+      platform: "linux",
+    });
+
+    expect(managed).toMatchObject({
+      authenticationMode: "host-keyring",
+      homeDir: hostHome,
+      configDir: join(sessionDir, "managed-customizations", ".agents"),
+      customizationWorkspace: join(sessionDir, "managed-customizations"),
+    });
+    expect(managed.env).toMatchObject({
+      HOME: hostHome,
+      XDG_CONFIG_HOME: join(hostHome, ".config"),
+      TMPDIR: join(sessionDir, "tmp"),
+    });
+    expect(managed.env["ANTIGRAVITY_CONVERSATION_ID"]).toBeUndefined();
+    expect(managed.env["PRAGMA_AGY_HOOK_AUTHORIZATION"]).toBeUndefined();
+    await expect(
+      stat(join(hostHome, ".gemini", "antigravity-cli", "settings.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readJson(join(managed.configDir, "mcp_config.json"))).resolves.toEqual({
+      mcpServers: {
+        [managed.mcpServerName]: { serverUrl: "http://127.0.0.1/host-keyring/mcp" },
+      },
+    });
+    await expect(
+      readFile(join(managed.configDir, "agents", managed.agentName, "agent.md"), "utf8"),
+    ).resolves.toContain("host-keyring system");
+    await expect(readJson(join(managed.configDir, "hooks.json"))).resolves.toHaveProperty(
+      managed.hookName,
+    );
+  });
+
+  it("auto-selects private HOME only when the official ADC switch is enabled", () => {
+    expect(resolveAntigravityAuthenticationMode("auto", { HOME: "/host" }, "linux")).toBe(
+      "host-keyring",
+    );
+    expect(
+      resolveAntigravityAuthenticationMode(
+        "auto",
+        { HOME: "/host", AGY_ADC_AUTH: "true" },
+        "linux",
+      ),
+    ).toBe("isolated-environment");
+    expect(
+      resolveAntigravityAuthenticationMode(
+        "auto",
+        { HOME: "/host", AGY_ADC_AUTH: "false" },
+        "linux",
+      ),
+    ).toBe("host-keyring");
+  });
+
+  it("resolves Windows host HOME case-insensitively and rejects missing host identity", () => {
+    expect(resolveAntigravityHostHome({ UserProfile: "C:\\Users\\Pragma" }, "win32")).toBe(
+      "C:\\Users\\Pragma",
+    );
+    expect(
+      resolveAntigravityHostHome({ HomeDrive: "C:", HomePath: "\\Users\\Pragma" }, "win32"),
+    ).toBe("C:\\Users\\Pragma");
+    expect(() => resolveAntigravityHostHome({}, "linux")).toThrow(/host HOME\/USERPROFILE/i);
+    expect(() =>
+      resolveAntigravityHostHome({ HomeDrive: "C:", HomePath: "Users\\Pragma" }, "win32"),
+    ).toThrow(/absolute host HOME\/USERPROFILE/i);
+    const env = createHostKeyringAntigravityEnvironment({
+      base: {
+        Home: "C:\\Users\\Pragma",
+        UserProfile: "C:\\Users\\Pragma",
+        Agy_Adc_Auth: "true",
+        Antigravity_Conversation_Id: "stale",
+        API_KEY: "preserved",
+      },
+      tmpDir: "C:\\Pragma\\tmp",
+      platform: "win32",
+    });
+    expect(env).toMatchObject({
+      Home: "C:\\Users\\Pragma",
+      UserProfile: "C:\\Users\\Pragma",
+      API_KEY: "preserved",
+      TMP: "C:\\Pragma\\tmp",
+    });
+    expect(
+      Object.keys(env).some((key) => key.toLowerCase() === "antigravity_conversation_id"),
+    ).toBe(false);
+    expect(Object.keys(env).some((key) => key.toLowerCase() === "agy_adc_auth")).toBe(false);
+  });
+
   it("materializes the exact system prompt, MCP bridge, approval hook, and complete skills", async () => {
     const root = await temporaryRoot();
     const skillRoot = join(root, "source-skill");

--- a/packages/runtime/antigravity/test/session.test.ts
+++ b/packages/runtime/antigravity/test/session.test.ts
@@ -39,6 +39,7 @@ describe("Antigravity CLI invocation", () => {
         sessionId: conversation1,
         modelName: "gemini-3.1-pro",
         thinkingLevel: "high",
+        customizationWorkspace: "/state/managed-customizations",
       }),
     ).toEqual([
       "--output-format",
@@ -48,6 +49,8 @@ describe("Antigravity CLI invocation", () => {
       "24h",
       "--add-dir",
       "/workspace/project",
+      "--add-dir",
+      "/state/managed-customizations",
       "--agent",
       "pragma-review",
       "--log-file",
@@ -914,6 +917,7 @@ function createSession(
       error: vi.fn(),
     } as unknown as AntigravityNativeSession["logger"],
     managedHome: {
+      authenticationMode: "isolated-environment",
       homeDir,
       appDataDir: join(homeDir, ".gemini", "antigravity-cli"),
       configDir: join(homeDir, ".gemini", "config"),


### PR DESCRIPTION
## What changed

- Add explicit isolated-environment and host-keyring authentication modes for Antigravity execution.
- Make Desktop auto-select isolated HOME for official ADC and preserve the real HOME for interactive OAuth/keyring login.
- Keep Pragma Agent, Hook, MCP, Skills, logs, and temporary files in the owned Runtime Session. Host-keyring mode exposes managed customizations through a Session-private --add-dir workspace.
- Remove stale Antigravity sidecar/session/config overrides and Pragma relay secrets before spawning agy.
- Document the compatibility tradeoff: agy itself reads host settings/global customizations and uses host native-conversation storage in host-keyring mode.

## Root cause

PR #152 fixed model discovery, but real execution still replaced HOME with the Runtime Session private HOME. agy 1.1.11 then skipped the host OS-keyring OAuth profile and reported that it was not signed in.

## Result

Actual headless execution now reuses an existing interactive agy OAuth login. Explicit AGY_ADC_AUTH environments retain the stronger private-HOME isolation path.

## Review

Claude Code completed the requested CR and reported no blocking issues. Each finding was independently checked. Two real clarity issues were fixed: redundant host-HOME resolution and misleading antigravity-private-home persistence metadata. Suggestions that duplicated mode state or weakened fail-closed handling for malformed Windows HOME values were rejected.

## Validation

- pnpm --filter @pragma/runtime-antigravity test — 10 files, 76 tests passed
- pnpm --filter @pragma/runtime-antigravity typecheck
- pnpm --filter @pragma/runtime-antigravity lint
- pnpm --filter @pragma/desktop typecheck
- pnpm check
- pnpm build — 22/22 packages passed
- Real headless agy execution through the new host-keyring managed environment returned the expected response without an authentication error
- Managed Agent discovery and PreToolUse Hook invocation verified against agy 1.1.11
- git diff --check and credential-pattern scan