### PR TITLE
fix(desktop): separate team and member memory scopes

### DIFF
--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.test.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.test.ts
@@ -237,26 +237,31 @@ describe("DesktopMemoryPlane", () => {
     await plane.stop();
   });
 
-  it("checks ContextStore view availability without constructing a view", async () => {
+  it("checks a personal data scope against the combined Team and Expert policy", async () => {
     const pragmaHome = await temporaryRoot("pragma-desktop-memory-context-view-");
     const plane = await createDesktopMemoryPlane({
       pragmaHome,
       logger: createPragmaLogger(undefined, { component: "desktop.memory-test" }),
     });
     const input = {
-      rootRef: { type: "pragma.expert-team" as const, id: "vyv9pwwzaksth2dd" },
+      rootRef: { type: "pragma.expert" as const, id: "1xddvess309a6gme" },
       expertRef: { type: "pragma.expert" as const, id: "1xddvess309a6gme" },
       projectId: "pragma",
+      policyScope: {
+        rootRef: { type: "pragma.expert-team" as const, id: "vyv9pwwzaksth2dd" },
+        producerRefs: [{ type: "pragma.expert" as const, id: "1xddvess309a6gme" }],
+      },
     };
 
-    await expect(plane.isContextStoreViewAvailable(input)).resolves.toBe(true);
-    await expect(plane.hasContextStoreViewContent(input)).resolves.toBe(false);
-    const global = await plane.policies.getGlobal();
-    await plane.policies.updateGlobal({
-      expectedRevision: global.revision,
-      policy: { capture: "enabled", recall: "disabled", learning: "local-candidates" },
+    await expect(plane.getContextStoreViewStatus(input)).resolves.toBe("empty");
+    const teamRef = { type: "pragma.expert-team" as const, id: "vyv9pwwzaksth2dd" };
+    const team = await plane.policies.getOverride(teamRef);
+    await plane.policies.updateOverride({
+      targetRef: teamRef,
+      expectedRevision: team.revision,
+      policy: { capture: "inherit", recall: "disabled", learning: "inherit" },
     });
-    await expect(plane.isContextStoreViewAvailable(input)).resolves.toBe(false);
+    await expect(plane.getContextStoreViewStatus(input)).resolves.toBe("recall_disabled");
     await expect(plane.createContextStoreView(input)).rejects.toMatchObject({
       code: "memory_recall_disabled",
     });

--- a/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
+++ b/apps/desktop/src/main/features/memory/desktop-memory-plane.ts
@@ -63,7 +63,15 @@ export interface DesktopMemoryContextStoreViewInput {
   readonly rootRef: MemoryRecallScope["rootRef"];
   readonly expertRef?: MemoryRecallScope["expertRef"] | undefined;
   readonly projectId: string;
+  readonly policyScope?:
+    | {
+        readonly rootRef: MemoryRecallScope["rootRef"];
+        readonly producerRefs?: readonly NonNullable<MemoryRecallScope["expertRef"]>[] | undefined;
+      }
+    | undefined;
 }
+
+export type DesktopMemoryContextStoreViewStatus = "available" | "empty" | "recall_disabled";
 
 export interface DesktopMemoryPlane {
   readonly executionStore: FileExecutionStore;
@@ -76,8 +84,9 @@ export interface DesktopMemoryPlane {
   readonly skillLearningStore: SkillMemoryModule["store"];
   readonly activity: MemoryActivityStore;
   readonly contextStore: import("@pragma/core").ExpertAgentContextStore;
-  isContextStoreViewAvailable(input: DesktopMemoryContextStoreViewInput): Promise<boolean>;
-  hasContextStoreViewContent(input: DesktopMemoryContextStoreViewInput): Promise<boolean>;
+  getContextStoreViewStatus(
+    input: DesktopMemoryContextStoreViewInput,
+  ): Promise<DesktopMemoryContextStoreViewStatus>;
   createContextStoreView(
     input: DesktopMemoryContextStoreViewInput,
   ): Promise<import("@pragma/core").ExpertAgentContextStore>;
@@ -457,9 +466,13 @@ export async function createDesktopMemoryPlane(options: {
       expertRef: input.expertRef,
       principalRefs: [localUser, { type: "pragma.project", id: input.projectId }],
     });
+    const policyRootRef = input.policyScope?.rootRef ?? scope.rootRef;
+    const producerRefs =
+      input.policyScope?.producerRefs ??
+      (scope.expertRef === undefined ? undefined : [scope.expertRef]);
     const policy = await policies.resolveAt({
-      rootRef: scope.rootRef,
-      ...(scope.expertRef === undefined ? {} : { producerRefs: [scope.expertRef] }),
+      rootRef: policyRootRef,
+      ...(producerRefs === undefined ? {} : { producerRefs }),
       occurredAt: new Date().toISOString(),
     });
     return { scope, available: policy.recall };
@@ -476,17 +489,14 @@ export async function createDesktopMemoryPlane(options: {
     skillLearningStore: skill.store,
     activity,
     contextStore,
-    async isContextStoreViewAvailable(input) {
-      return (await resolveContextStoreViewScope(input)).available;
-    },
-    async hasContextStoreViewContent(input) {
+    async getContextStoreViewStatus(input) {
       const resolved = await resolveContextStoreViewScope(input);
-      if (!resolved.available) return false;
+      if (!resolved.available) return "recall_disabled";
       const [episodes, facts] = await Promise.all([
         episodic.store.listForRecall(resolved.scope),
         semantic.store.listForRecall(resolved.scope, new Date()),
       ]);
-      return episodes.length > 0 || facts.length > 0;
+      return episodes.length > 0 || facts.length > 0 ? "available" : "empty";
     },
     async createContextStoreView(input) {
       const resolved = await resolveContextStoreViewScope(input);

--- a/apps/desktop/src/main/features/memory/expert-memory-context-store-browser.test.ts
+++ b/apps/desktop/src/main/features/memory/expert-memory-context-store-browser.test.ts
@@ -29,8 +29,7 @@ const expertResource: PragmaExpertResource = {
 
 describe("ExpertMemoryContextStoreBrowserService", () => {
   it("exposes the selected Expert's read-only memory view", async () => {
-    const isContextStoreViewAvailable = vi.fn(async () => true);
-    const hasContextStoreViewContent = vi.fn(async () => true);
+    const getContextStoreViewStatus = vi.fn(async () => "available" as const);
     const createContextStoreView = vi.fn(
       async () =>
         new StaticContextStore([
@@ -50,8 +49,7 @@ describe("ExpertMemoryContextStoreBrowserService", () => {
         getResource: vi.fn(() => undefined),
       } as unknown as Pick<DesktopSystemExpertRegistry, "getResource">,
       memory: {
-        isContextStoreViewAvailable,
-        hasContextStoreViewContent,
+        getContextStoreViewStatus,
         createContextStoreView,
       } as unknown as DesktopMemoryPlane,
     });
@@ -72,12 +70,7 @@ describe("ExpertMemoryContextStoreBrowserService", () => {
         },
       ],
     });
-    expect(isContextStoreViewAvailable).toHaveBeenCalledWith({
-      rootRef: { type: "pragma.expert", id: expertResource.metadata.id },
-      expertRef: { type: "pragma.expert", id: expertResource.metadata.id },
-      projectId: "pragma",
-    });
-    expect(hasContextStoreViewContent).toHaveBeenCalledWith({
+    expect(getContextStoreViewStatus).toHaveBeenCalledWith({
       rootRef: { type: "pragma.expert", id: expertResource.metadata.id },
       expertRef: { type: "pragma.expert", id: expertResource.metadata.id },
       projectId: "pragma",
@@ -104,8 +97,7 @@ describe("ExpertMemoryContextStoreBrowserService", () => {
         getResource: vi.fn(() => undefined),
       } as unknown as Pick<DesktopSystemExpertRegistry, "getResource">,
       memory: {
-        isContextStoreViewAvailable: vi.fn(async () => true),
-        hasContextStoreViewContent: vi.fn(async () => false),
+        getContextStoreViewStatus: vi.fn(async () => "empty" as const),
         createContextStoreView: vi.fn(async () => new StaticContextStore()),
       } as unknown as DesktopMemoryPlane,
     });

--- a/apps/desktop/src/main/features/memory/expert-memory-context-store-browser.ts
+++ b/apps/desktop/src/main/features/memory/expert-memory-context-store-browser.ts
@@ -74,12 +74,10 @@ export function createExpertMemoryContextStoreBrowserService(options: {
         expertRef: { type: "pragma.expert", id: expert.metadata.id },
         projectId: options.project.projectId,
       } as const;
-      const available = await options.memory.isContextStoreViewAvailable(viewInput);
-      const hasMemory = available
-        ? await options.memory.hasContextStoreViewContent(viewInput)
-        : false;
+      const status = await options.memory.getContextStoreViewStatus(viewInput);
+      const hasMemory = status === "available";
       return ExpertMemoryContextStoreDescriptorSchema.parse({
-        schemaVersion: "pragma.desktop-expert-memory-context-store/v1",
+        schemaVersion: "pragma.desktop-expert-memory-context-store/v2",
         expertRef: input.expertRef,
         storeId: MEMORY_STORE_ID,
         namespace: MEMORY_STORE_ID,
@@ -100,7 +98,7 @@ export function createExpertMemoryContextStoreBrowserService(options: {
             name: expert.metadata.name,
             role: "root",
             participation: "available",
-            availability: available ? "available" : "recall_disabled",
+            availability: status,
           },
         ],
       });

--- a/apps/desktop/src/main/features/memory/team-memory-context-store-browser.test.ts
+++ b/apps/desktop/src/main/features/memory/team-memory-context-store-browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { PragmaExpertTeamResourceSchema } from "@pragma/interpreter/ast";
+import { PragmaExpertTeamResourceSchema, type PragmaExpertResource } from "@pragma/interpreter/ast";
 import { ok } from "@pragma/core";
 
 import { createTeamMemoryContextStoreBrowserService } from "./team-memory-context-store-browser.ts";
@@ -7,7 +7,9 @@ import type { DesktopMemoryPlane } from "./desktop-memory-plane.ts";
 import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
 
 describe("team Memory ContextStore browser", () => {
-  it("detects and opens only the ExpertTeam root scope", async () => {
+  it("exposes separate Team, coordinator, and member scopes", async () => {
+    const writer = expert("1xddvess309a6gme", "Writer");
+    const reviewer = expert("3sfd30h5017wd17d", "Reviewer");
     const team = PragmaExpertTeamResourceSchema.parse({
       apiVersion: "pragma/v3",
       kind: "ExpertTeam",
@@ -51,28 +53,33 @@ describe("team Memory ContextStore browser", () => {
       },
     }));
     const memory = {
-      isContextStoreViewAvailable: vi.fn(async () => true),
-      hasContextStoreViewContent: vi.fn(async () => true),
+      getContextStoreViewStatus: vi.fn(async () => "available" as const),
       createContextStoreView,
     } as unknown as DesktopMemoryPlane;
     const project = {
       projectId: "project-a",
-      get: async () => ({ resources: [team] }),
+      get: async () => ({ resources: [writer, reviewer, team] }),
     } as unknown as PragmaProjectStore;
     const service = createTeamMemoryContextStoreBrowserService({ project, memory });
 
     await expect(service.get({ teamRef: "team:vyv9pwwzaksth2dd" })).resolves.toMatchObject({
+      schemaVersion: "pragma.desktop-team-memory-context-store/v2",
       hasMemory: true,
       readOnly: true,
       root: { type: "pragma.expert-team", id: "vyv9pwwzaksth2dd" },
       defaultScopeId: "team:vyv9pwwzaksth2dd",
+      scopes: [
+        expect.objectContaining({ id: "team:vyv9pwwzaksth2dd", role: "root" }),
+        expect.objectContaining({ id: "expert:1xddvess309a6gme", role: "coordinator" }),
+        expect.objectContaining({ id: "expert:3sfd30h5017wd17d", role: "member" }),
+      ],
     });
     await service.list({
       teamRef: "team:vyv9pwwzaksth2dd",
       scopeId: "team:vyv9pwwzaksth2dd",
     });
 
-    expect(memory.hasContextStoreViewContent).toHaveBeenCalledWith({
+    expect(memory.getContextStoreViewStatus).toHaveBeenCalledWith({
       rootRef: { type: "pragma.expert-team", id: "vyv9pwwzaksth2dd" },
       projectId: "project-a",
     });
@@ -80,5 +87,86 @@ describe("team Memory ContextStore browser", () => {
       rootRef: { type: "pragma.expert-team", id: "vyv9pwwzaksth2dd" },
       projectId: "project-a",
     });
+
+    await service.list({
+      teamRef: "team:vyv9pwwzaksth2dd",
+      scopeId: "expert:3sfd30h5017wd17d",
+    });
+    expect(createContextStoreView).toHaveBeenLastCalledWith({
+      rootRef: { type: "pragma.expert", id: "3sfd30h5017wd17d" },
+      expertRef: { type: "pragma.expert", id: "3sfd30h5017wd17d" },
+      projectId: "project-a",
+      policyScope: {
+        rootRef: { type: "pragma.expert-team", id: "vyv9pwwzaksth2dd" },
+        producerRefs: [{ type: "pragma.expert", id: "3sfd30h5017wd17d" }],
+      },
+    });
+  });
+
+  it("marks empty scopes and reports content when any selectable scope has Memory", async () => {
+    const writer = expert("1xddvess309a6gme", "Writer");
+    const reviewer = expert("3sfd30h5017wd17d", "Reviewer");
+    const team = PragmaExpertTeamResourceSchema.parse({
+      apiVersion: "pragma/v3",
+      kind: "ExpertTeam",
+      metadata: {
+        id: "vyv9pwwzaksth2dd",
+        name: "Editorial Team",
+        description: "Coordinates editorial work.",
+        tags: [],
+      },
+      spec: {
+        coordinator: { ref: "expert:1xddvess309a6gme" },
+        members: [{ ref: "expert:3sfd30h5017wd17d" }],
+        contextStores: [],
+        delegation: {},
+      },
+    });
+    const memory = {
+      getContextStoreViewStatus: vi.fn(
+        async (input: { readonly rootRef: { readonly id: string } }) =>
+          input.rootRef.id === reviewer.metadata.id ? ("available" as const) : ("empty" as const),
+      ),
+      createContextStoreView: vi.fn(async () => {
+        throw new Error("not needed");
+      }),
+    } as unknown as DesktopMemoryPlane;
+    const service = createTeamMemoryContextStoreBrowserService({
+      project: {
+        projectId: "project-a",
+        get: async () => ({ resources: [writer, reviewer, team] }),
+      } as unknown as PragmaProjectStore,
+      memory,
+    });
+
+    await expect(service.get({ teamRef: "team:vyv9pwwzaksth2dd" })).resolves.toMatchObject({
+      hasMemory: true,
+      defaultScopeId: "team:vyv9pwwzaksth2dd",
+      scopes: [
+        expect.objectContaining({ id: "team:vyv9pwwzaksth2dd", availability: "empty" }),
+        expect.objectContaining({ id: "expert:1xddvess309a6gme", availability: "empty" }),
+        expect.objectContaining({
+          id: "expert:3sfd30h5017wd17d",
+          availability: "available",
+        }),
+      ],
+    });
   });
 });
+
+function expert(id: string, name: string): PragmaExpertResource {
+  return {
+    apiVersion: "pragma/v3",
+    kind: "Expert",
+    metadata: { id, name, description: name, tags: [] },
+    spec: {
+      scope: name,
+      instructions: `${name} instructions`,
+      capabilities: [],
+      toolApprovals: {},
+      contextStores: [],
+      plugins: [],
+      tools: [],
+    },
+  };
+}

--- a/apps/desktop/src/main/features/memory/team-memory-context-store-browser.ts
+++ b/apps/desktop/src/main/features/memory/team-memory-context-store-browser.ts
@@ -1,6 +1,9 @@
 import type { ExpertAgentContextStore } from "@pragma/core";
-import { canonicalPragmaResourceRef, type PragmaExpertTeamResource } from "@pragma/interpreter/ast";
-import { MemoryRecallScopeSchema } from "@pragma/memory";
+import {
+  canonicalPragmaResourceRef,
+  type PragmaExpertResource,
+  type PragmaExpertTeamResource,
+} from "@pragma/interpreter/ast";
 
 import {
   TeamMemoryContextStoreContentSchema,
@@ -18,6 +21,11 @@ import {
 } from "../../../shared/contracts/index.ts";
 import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
 import type { DesktopMemoryPlane } from "./desktop-memory-plane.ts";
+import {
+  defineTeamMemoryScopes,
+  inspectTeamMemoryScopes,
+  type TeamMemoryScopeDefinition,
+} from "./team-memory-scope-catalog.ts";
 
 const MEMORY_STORE_ID = "memory";
 
@@ -34,23 +42,48 @@ export function createTeamMemoryContextStoreBrowserService(options: {
   readonly project: PragmaProjectStore;
   readonly memory: DesktopMemoryPlane;
 }): TeamMemoryContextStoreBrowserService {
-  const resolveTeam = async (teamRef: string): Promise<PragmaExpertTeamResource> => {
+  const resolveTeamScopes = async (
+    teamRef: string,
+  ): Promise<{
+    readonly team: PragmaExpertTeamResource;
+    readonly definition: TeamMemoryScopeDefinition;
+  }> => {
     const project = await options.project.get();
     const team = project.resources.find(
       (resource): resource is PragmaExpertTeamResource =>
         resource.kind === "ExpertTeam" && canonicalPragmaResourceRef(resource) === teamRef,
     );
     if (team === undefined) throw codedError("team_not_found");
-    return team;
+    const expertsByRef = new Map(
+      project.resources
+        .filter((resource): resource is PragmaExpertResource => resource.kind === "Expert")
+        .map((resource) => [canonicalPragmaResourceRef(resource), resource]),
+    );
+    const expertScopes = [
+      { ref: team.spec.coordinator.ref, role: "coordinator" as const },
+      ...team.spec.members.map((member) => ({ ref: member.ref, role: "member" as const })),
+    ].map(({ ref, role }) => {
+      const expert = expertsByRef.get(ref);
+      if (expert === undefined)
+        throw codedError("team_expert_not_found", `Expert not found: ${ref}`);
+      return {
+        expertId: expert.metadata.id,
+        name: expert.metadata.name,
+        role,
+        participation: "available" as const,
+      };
+    });
+    return {
+      team,
+      definition: defineTeamMemoryScopes({
+        teamId: team.metadata.id,
+        teamName: team.metadata.name,
+        teamParticipation: "available",
+        experts: expertScopes,
+        projectId: options.project.projectId,
+      }),
+    };
   };
-
-  const viewInput = (team: PragmaExpertTeamResource) => ({
-    rootRef: MemoryRecallScopeSchema.shape.rootRef.parse({
-      type: "pragma.expert-team",
-      id: team.metadata.id,
-    }),
-    projectId: options.project.projectId,
-  });
 
   const open = async (
     input:
@@ -58,45 +91,32 @@ export function createTeamMemoryContextStoreBrowserService(options: {
       | ReadTeamMemoryContextStoreEntry
       | SearchTeamMemoryContextStore,
   ): Promise<ExpertAgentContextStore> => {
-    const team = await resolveTeam(input.teamRef);
-    if (input.scopeId !== `team:${team.metadata.id}`) {
-      throw codedError("context_store_scope_not_found");
-    }
-    return await options.memory.createContextStoreView(viewInput(team));
+    const { definition } = await resolveTeamScopes(input.teamRef);
+    const view = definition.views.get(input.scopeId);
+    if (view === undefined) throw codedError("context_store_scope_not_found");
+    return await options.memory.createContextStoreView(view);
   };
 
   return {
     async get(input) {
-      const team = await resolveTeam(input.teamRef);
-      const scopeId = `team:${team.metadata.id}`;
-      const target = viewInput(team);
-      const available = await options.memory.isContextStoreViewAvailable(target);
-      const hasMemory = available ? await options.memory.hasContextStoreViewContent(target) : false;
+      const { team, definition } = await resolveTeamScopes(input.teamRef);
+      const catalog = await inspectTeamMemoryScopes(definition, options.memory);
       return TeamMemoryContextStoreDescriptorSchema.parse({
-        schemaVersion: "pragma.desktop-team-memory-context-store/v1",
+        schemaVersion: "pragma.desktop-team-memory-context-store/v2",
         teamRef: input.teamRef,
         storeId: MEMORY_STORE_ID,
         namespace: MEMORY_STORE_ID,
         name: "Memory ContextStore",
         readOnly: true,
         searchable: true,
-        hasMemory,
+        hasMemory: catalog.hasMemory,
         root: {
           type: "pragma.expert-team",
           id: team.metadata.id,
           name: team.metadata.name,
         },
-        defaultScopeId: scopeId,
-        scopes: [
-          {
-            id: scopeId,
-            expertId: team.metadata.id,
-            name: team.metadata.name,
-            role: "root",
-            participation: "available",
-            availability: available ? "available" : "recall_disabled",
-          },
-        ],
+        defaultScopeId: catalog.defaultScopeId,
+        scopes: catalog.scopes,
       });
     },
 

--- a/apps/desktop/src/main/features/memory/team-memory-scope-catalog.ts
+++ b/apps/desktop/src/main/features/memory/team-memory-scope-catalog.ts
@@ -1,0 +1,112 @@
+import { MemoryRecallScopeSchema } from "@pragma/memory";
+
+import type { MissionContextStoreScope } from "../../../shared/contracts/index.ts";
+import type {
+  DesktopMemoryContextStoreViewInput,
+  DesktopMemoryPlane,
+} from "./desktop-memory-plane.ts";
+
+type ExpertScopeRole = Exclude<MissionContextStoreScope["role"], "root">;
+
+export interface TeamMemoryExpertScopeCandidate {
+  readonly expertId: string;
+  readonly name: string;
+  readonly role: ExpertScopeRole;
+  readonly participation: MissionContextStoreScope["participation"];
+}
+
+export interface TeamMemoryScopeCatalog {
+  readonly scopes: readonly MissionContextStoreScope[];
+  readonly defaultScopeId: string;
+  readonly hasMemory: boolean;
+  readonly views: ReadonlyMap<string, DesktopMemoryContextStoreViewInput>;
+}
+
+export interface TeamMemoryScopeDefinition {
+  readonly scopes: readonly Omit<MissionContextStoreScope, "availability">[];
+  readonly defaultScopeId: string;
+  readonly views: ReadonlyMap<string, DesktopMemoryContextStoreViewInput>;
+}
+
+export function defineTeamMemoryScopes(input: {
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly teamParticipation: MissionContextStoreScope["participation"];
+  readonly experts: readonly TeamMemoryExpertScopeCandidate[];
+  readonly projectId: string;
+}): TeamMemoryScopeDefinition {
+  const teamRootRef = MemoryRecallScopeSchema.shape.rootRef.parse({
+    type: "pragma.expert-team",
+    id: input.teamId,
+  });
+  const rootScopeId = `team:${input.teamId}`;
+  const views = new Map<string, DesktopMemoryContextStoreViewInput>();
+  views.set(rootScopeId, { rootRef: teamRootRef, projectId: input.projectId });
+
+  const uniqueExperts = new Map<string, TeamMemoryExpertScopeCandidate>();
+  for (const expert of input.experts) {
+    if (!uniqueExperts.has(expert.expertId)) uniqueExperts.set(expert.expertId, expert);
+  }
+  for (const expert of uniqueExperts.values()) {
+    const expertRef = MemoryRecallScopeSchema.shape.expertRef.unwrap().parse({
+      type: "pragma.expert",
+      id: expert.expertId,
+    });
+    views.set(`expert:${expert.expertId}`, {
+      rootRef: expertRef,
+      expertRef,
+      projectId: input.projectId,
+      policyScope: { rootRef: teamRootRef, producerRefs: [expertRef] },
+    });
+  }
+
+  const scopes: Omit<MissionContextStoreScope, "availability">[] = [
+    {
+      id: rootScopeId,
+      expertId: input.teamId,
+      name: input.teamName,
+      role: "root",
+      participation: input.teamParticipation,
+    },
+    ...[...uniqueExperts.values()].map((expert) => ({
+      id: `expert:${expert.expertId}`,
+      expertId: expert.expertId,
+      name: expert.name,
+      role: expert.role,
+      participation: expert.participation,
+    })),
+  ];
+  return { scopes, defaultScopeId: rootScopeId, views };
+}
+
+export async function inspectTeamMemoryScopes(
+  definition: TeamMemoryScopeDefinition,
+  memory: Pick<DesktopMemoryPlane, "getContextStoreViewStatus">,
+): Promise<TeamMemoryScopeCatalog> {
+  const statuses = new Map<string, MissionContextStoreScope["availability"]>();
+  await Promise.all(
+    [...definition.views].map(async ([scopeId, view]) => {
+      statuses.set(scopeId, await memory.getContextStoreViewStatus(view));
+    }),
+  );
+
+  const scopes = definition.scopes.map((scope) => ({
+    ...scope,
+    availability: requireStatus(statuses, scope.id),
+  }));
+  return {
+    scopes,
+    defaultScopeId: definition.defaultScopeId,
+    hasMemory: scopes.some((scope) => scope.availability === "available"),
+    views: definition.views,
+  };
+}
+
+function requireStatus(
+  statuses: ReadonlyMap<string, MissionContextStoreScope["availability"]>,
+  scopeId: string,
+): MissionContextStoreScope["availability"] {
+  const status = statuses.get(scopeId);
+  if (status === undefined) throw new Error(`Memory scope status was not resolved: ${scopeId}`);
+  return status;
+}

--- a/apps/desktop/src/main/features/missions/mission-context-store-browser.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-context-store-browser.test.ts
@@ -87,7 +87,7 @@ describe("MissionContextStoreBrowserService", () => {
         getAdditionalResources: () => [],
       } as unknown as DesktopSystemExpertRegistry,
       memory: {
-        isContextStoreViewAvailable: vi.fn(async () => true),
+        getContextStoreViewStatus: vi.fn(async () => "available" as const),
         createContextStoreView: vi.fn(async () => new StaticContextStore()),
       } as unknown as DesktopMemoryPlane,
       runner: {
@@ -186,8 +186,8 @@ describe("MissionContextStoreBrowserService", () => {
     }
   });
 
-  it("exposes exact per-Expert scopes while preserving the Team root", async () => {
-    const isContextStoreViewAvailable = vi.fn(async () => true);
+  it("separates the Team root from each Expert's personal Memory scope", async () => {
+    const getContextStoreViewStatus = vi.fn(async () => "available" as const);
     const createContextStoreView = vi.fn(
       async () =>
         new StaticContextStore([
@@ -213,7 +213,7 @@ describe("MissionContextStoreBrowserService", () => {
         getAdditionalResources: () => [],
       } as unknown as DesktopSystemExpertRegistry,
       memory: {
-        isContextStoreViewAvailable,
+        getContextStoreViewStatus,
         createContextStoreView,
       } as unknown as DesktopMemoryPlane,
       runner: {
@@ -240,8 +240,15 @@ describe("MissionContextStoreBrowserService", () => {
     });
 
     const descriptor = await service.get({ missionId: mission.id, storeId: "memory" });
-    expect(descriptor.defaultScopeId).toBe(`expert:${writer.metadata.id}`);
+    expect(descriptor.schemaVersion).toBe("pragma.desktop-mission-context-store/v2");
+    expect(descriptor.defaultScopeId).toBe(`team:${team.metadata.id}`);
     expect(descriptor.scopes).toEqual([
+      expect.objectContaining({
+        id: `team:${team.metadata.id}`,
+        expertId: team.metadata.id,
+        role: "root",
+        availability: "available",
+      }),
       expect.objectContaining({ expertId: writer.metadata.id, role: "coordinator" }),
       expect.objectContaining({
         expertId: reviewer.metadata.id,
@@ -249,21 +256,35 @@ describe("MissionContextStoreBrowserService", () => {
         participation: "participated",
       }),
     ]);
-    expect(isContextStoreViewAvailable).toHaveBeenCalledTimes(2);
+    expect(getContextStoreViewStatus).toHaveBeenCalledTimes(3);
     expect(createContextStoreView).not.toHaveBeenCalled();
 
-    isContextStoreViewAvailable.mockClear();
+    getContextStoreViewStatus.mockClear();
+    await service.list({
+      missionId: mission.id,
+      storeId: "memory",
+      scopeId: `team:${team.metadata.id}`,
+    });
+    expect(createContextStoreView).toHaveBeenLastCalledWith({
+      rootRef: { type: "pragma.expert-team", id: team.metadata.id },
+      projectId: mission.project.id,
+    });
+
     await service.list({
       missionId: mission.id,
       storeId: "memory",
       scopeId: `expert:${reviewer.metadata.id}`,
     });
     expect(createContextStoreView).toHaveBeenLastCalledWith({
-      rootRef: { type: "pragma.expert-team", id: team.metadata.id },
+      rootRef: { type: "pragma.expert", id: reviewer.metadata.id },
       expertRef: { type: "pragma.expert", id: reviewer.metadata.id },
       projectId: mission.project.id,
+      policyScope: {
+        rootRef: { type: "pragma.expert-team", id: team.metadata.id },
+        producerRefs: [{ type: "pragma.expert", id: reviewer.metadata.id }],
+      },
     });
-    expect(isContextStoreViewAvailable).not.toHaveBeenCalled();
+    expect(getContextStoreViewStatus).not.toHaveBeenCalled();
   });
 
   it("rejects a renderer-provided Expert outside the Mission catalog", async () => {
@@ -277,7 +298,7 @@ describe("MissionContextStoreBrowserService", () => {
         getAdditionalResources: () => [],
       } as unknown as DesktopSystemExpertRegistry,
       memory: {
-        isContextStoreViewAvailable: vi.fn(async () => true),
+        getContextStoreViewStatus: vi.fn(async () => "available" as const),
         createContextStoreView: vi.fn(async () => new StaticContextStore()),
       } as unknown as DesktopMemoryPlane,
       runner: {
@@ -305,7 +326,7 @@ describe("MissionContextStoreBrowserService", () => {
         getAdditionalResources: () => [],
       } as unknown as DesktopSystemExpertRegistry,
       memory: {
-        isContextStoreViewAvailable: vi.fn(async () => true),
+        getContextStoreViewStatus: vi.fn(async () => "available" as const),
         createContextStoreView: vi.fn(async () => new StaticContextStore()),
       } as unknown as DesktopMemoryPlane,
       runner: {
@@ -335,7 +356,7 @@ describe("MissionContextStoreBrowserService", () => {
         getAdditionalResources: () => [],
       } as unknown as DesktopSystemExpertRegistry,
       memory: {
-        isContextStoreViewAvailable: vi.fn(async () => true),
+        getContextStoreViewStatus: vi.fn(async () => "available" as const),
         createContextStoreView: vi.fn(async () => new StaticContextStore()),
       } as unknown as DesktopMemoryPlane,
       runner: {

--- a/apps/desktop/src/main/features/missions/mission-context-store-browser.ts
+++ b/apps/desktop/src/main/features/missions/mission-context-store-browser.ts
@@ -30,6 +30,10 @@ import {
 } from "../../../shared/contracts/index.ts";
 import type { DesktopSystemExpertRegistry } from "../experts/system-expert-registry.ts";
 import type { DesktopMemoryPlane } from "../memory/desktop-memory-plane.ts";
+import {
+  defineTeamMemoryScopes,
+  inspectTeamMemoryScopes,
+} from "../memory/team-memory-scope-catalog.ts";
 import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
 import type { MissionRunner } from "./mission-runner.ts";
 import type { MissionStore } from "./mission-store.ts";
@@ -92,11 +96,35 @@ export function createMissionContextStoreBrowserService(options: {
   readonly memory: DesktopMemoryPlane;
   readonly runner: Pick<MissionRunner, "getWork">;
 }): MissionContextStoreBrowserService {
+  const resolveMemoryScopes = async (mission: Mission) => {
+    const { candidates, participated } = await collectScopeCandidates(mission, options);
+    const rootRef = missionRootRef(mission);
+    const teamDefinition =
+      rootRef.type === "pragma.expert-team"
+        ? defineTeamMemoryScopes({
+            teamId: rootRef.id,
+            teamName: mission.executor.name,
+            teamParticipation: "participated",
+            experts: candidates.map((candidate) => ({
+              ...candidate,
+              role: teamExpertScopeRole(candidate.role),
+              participation: participated.has(candidate.expertId) ? "participated" : "available",
+            })),
+            projectId: mission.project.id,
+          })
+        : undefined;
+    return { candidates, participated, rootRef, teamDefinition };
+  };
+
   const memoryCatalog = async (input: GetMissionContextStore) => {
     assertSupportedStore(input.storeId);
     const mission = await userMission(options.missions, input.missionId);
-    const { candidates, participated } = await collectScopeCandidates(mission, options);
-    const rootRef = missionRootRef(mission);
+    const { candidates, participated, rootRef, teamDefinition } =
+      await resolveMemoryScopes(mission);
+    if (teamDefinition !== undefined) {
+      const catalog = await inspectTeamMemoryScopes(teamDefinition, options.memory);
+      return { mission, rootRef, scopes: catalog.scopes, defaultScopeId: catalog.defaultScopeId };
+    }
     const scopes = await Promise.all(
       candidates.map(async (candidate) => ({
         id: `expert:${candidate.expertId}`,
@@ -114,7 +142,7 @@ export function createMissionContextStoreBrowserService(options: {
     const defaultScope =
       scopes.find((scope) => scope.role === "root" || scope.role === "coordinator") ?? scopes[0];
     if (defaultScope === undefined) throw codedError("context_store_scope_unavailable");
-    return { mission, rootRef, scopes, defaultScope };
+    return { mission, rootRef, scopes, defaultScopeId: defaultScope.id };
   };
 
   const openMemory = async (
@@ -123,11 +151,16 @@ export function createMissionContextStoreBrowserService(options: {
   ): Promise<ExpertAgentContextStore> => {
     if (input.storeId !== MEMORY_STORE_ID) throw codedError("context_store_not_found");
     const mission = await userMission(options.missions, input.missionId);
-    const { candidates } = await collectScopeCandidates(mission, options);
+    const { candidates, rootRef, teamDefinition } = await resolveMemoryScopes(mission);
+    if (teamDefinition !== undefined) {
+      const view = teamDefinition.views.get(input.scopeId);
+      if (view === undefined) throw codedError("context_store_scope_not_found");
+      return await options.memory.createContextStoreView(view);
+    }
     const scope = candidates.find((candidate) => `expert:${candidate.expertId}` === input.scopeId);
     if (scope === undefined) throw codedError("context_store_scope_not_found");
     return await options.memory.createContextStoreView({
-      rootRef: missionRootRef(mission),
+      rootRef,
       expertRef: { type: "pragma.expert", id: scope.expertId },
       projectId: mission.project.id,
     });
@@ -140,7 +173,7 @@ export function createMissionContextStoreBrowserService(options: {
         const mission = await userMission(options.missions, input.missionId);
         const rootRef = missionRootRef(mission);
         return MissionContextStoreDescriptorSchema.parse({
-          schemaVersion: "pragma.desktop-mission-context-store/v1",
+          schemaVersion: "pragma.desktop-mission-context-store/v2",
           missionId: mission.id,
           storeId: MISSION_BOARD_STORE_ID,
           namespace: MISSION_BOARD_SHARED_NAMESPACE,
@@ -164,7 +197,7 @@ export function createMissionContextStoreBrowserService(options: {
 
       const resolved = await memoryCatalog(input);
       return MissionContextStoreDescriptorSchema.parse({
-        schemaVersion: "pragma.desktop-mission-context-store/v1",
+        schemaVersion: "pragma.desktop-mission-context-store/v2",
         missionId: resolved.mission.id,
         storeId: MEMORY_STORE_ID,
         namespace: "memory",
@@ -175,7 +208,7 @@ export function createMissionContextStoreBrowserService(options: {
           ...resolved.rootRef,
           name: resolved.mission.executor.name,
         },
-        defaultScopeId: resolved.defaultScope.id,
+        defaultScopeId: resolved.defaultScopeId,
         scopes: resolved.scopes,
       });
     },
@@ -645,13 +678,13 @@ async function scopeAvailability(
     readonly expertId: string;
     readonly projectId: string;
   },
-): Promise<"available" | "recall_disabled"> {
-  const available = await memory.isContextStoreViewAvailable({
+): Promise<MissionContextStoreScope["availability"]> {
+  const view = {
     rootRef: input.rootRef,
     expertRef: { type: "pragma.expert", id: input.expertId },
     projectId: input.projectId,
-  });
-  return available ? "available" : "recall_disabled";
+  } as const;
+  return await memory.getContextStoreViewStatus(view);
 }
 
 async function userMission(missions: MissionStore, missionId: string): Promise<Mission> {
@@ -692,4 +725,14 @@ function isNodeErrorCode(error: unknown, code: string): boolean {
 
 function roleRank(role: ScopeRole): number {
   return SCOPE_ROLE_RANK[role];
+}
+
+function teamExpertScopeRole(role: ScopeRole): Exclude<ScopeRole, "root"> {
+  if (role === "root") {
+    throw codedError(
+      "invalid_team_scope_role",
+      "The root role is not valid for an Expert inside a Team Memory catalog.",
+    );
+  }
+  return role;
 }

--- a/apps/desktop/src/renderer/src/components/ContextStoreBrowser.test.ts
+++ b/apps/desktop/src/renderer/src/components/ContextStoreBrowser.test.ts
@@ -4,6 +4,8 @@ import type { MissionContextStoreEntry } from "../../../shared/contracts/index.t
 import {
   buildTreeRows,
   entryPreviewKind,
+  isMemoryScopeSelectable,
+  memoryScopeDescriptionKey,
   normalizeInternalContextId,
   summaryFromContent,
 } from "./ContextStoreBrowser.tsx";
@@ -70,5 +72,50 @@ describe("ContextStoreBrowser tree", () => {
       mediaType: "image/png",
       previewKind: "image",
     });
+  });
+
+  it("describes Team and Expert scopes as separate Memory stores", () => {
+    const teamDescriptor = {
+      storeId: "memory",
+      namespace: "memory",
+      name: "Memory ContextStore",
+      readOnly: true,
+      searchable: true,
+      root: { type: "pragma.expert-team" as const, id: "team-a", name: "Team A" },
+      defaultScopeId: "team:team-a",
+      scopes: [
+        {
+          id: "team:team-a",
+          expertId: "team-a",
+          name: "Team A",
+          role: "root" as const,
+          participation: "available" as const,
+          availability: "empty" as const,
+        },
+        {
+          id: "expert:expert-a",
+          expertId: "expert-a",
+          name: "Expert A",
+          role: "member" as const,
+          participation: "available" as const,
+          availability: "available" as const,
+        },
+      ],
+    };
+
+    expect(memoryScopeDescriptionKey(teamDescriptor, teamDescriptor.scopes[0])).toBe(
+      "contextStoreTeamScopeDescription",
+    );
+    expect(memoryScopeDescriptionKey(teamDescriptor, teamDescriptor.scopes[1])).toBe(
+      "contextStoreExpertScopeDescription",
+    );
+    expect(isMemoryScopeSelectable(teamDescriptor.scopes[0]!)).toBe(false);
+    expect(isMemoryScopeSelectable(teamDescriptor.scopes[1]!)).toBe(true);
+    expect(
+      isMemoryScopeSelectable({
+        ...teamDescriptor.scopes[1]!,
+        availability: "recall_disabled",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/src/components/ContextStoreBrowser.tsx
+++ b/apps/desktop/src/renderer/src/components/ContextStoreBrowser.tsx
@@ -140,7 +140,7 @@ export function ContextStoreBrowser(props: {
     setChunks([]);
     setMatches([]);
     setQuery("");
-    if (scope?.availability === "recall_disabled") {
+    if (scope !== undefined && !isMemoryScopeSelectable(scope)) {
       setLoading(false);
       return;
     }
@@ -210,6 +210,7 @@ export function ContextStoreBrowser(props: {
   const content = chunks.map((chunk) => chunk.content).join("");
   const lastChunk = chunks.at(-1);
   const previewKind = selected === undefined ? undefined : entryPreviewKind(selected);
+  const scopeDescriptionKey = memoryScopeDescriptionKey(descriptor, selectedScope);
 
   if (loading && descriptor === undefined) {
     return (
@@ -239,14 +240,19 @@ export function ContextStoreBrowser(props: {
               {t("contextStoreViewingAs")}
               <select value={scopeId} onChange={(event) => setScopeId(event.target.value)}>
                 {descriptor.scopes.map((scope) => (
-                  <option key={scope.id} value={scope.id}>
+                  <option
+                    key={scope.id}
+                    value={scope.id}
+                    disabled={!isMemoryScopeSelectable(scope)}
+                  >
                     {scope.name} · {t(`contextStoreRole.${scope.role}`)} ·{" "}
-                    {t(`contextStoreParticipation.${scope.participation}`)}
+                    {t(`contextStoreParticipation.${scope.participation}`)} ·{" "}
+                    {t(`contextStoreAvailability.${scope.availability}`)}
                   </option>
                 ))}
               </select>
             </label>
-            <small>{t("contextStoreScopeFormula", { expert: selectedScope?.name ?? "" })}</small>
+            <small>{t(scopeDescriptionKey, { expert: selectedScope?.name ?? "" })}</small>
           </>
         )}
         <button
@@ -265,6 +271,18 @@ export function ContextStoreBrowser(props: {
           <WarningCircle size={28} weight="thin" aria-hidden="true" />
           <strong>{t("contextStoreRecallDisabled")}</strong>
           <span>{t("contextStoreRecallDisabledDescription")}</span>
+        </div>
+      ) : selectedScope?.availability === "empty" ? (
+        <div className="context-browser-state">
+          <FileText size={28} weight="thin" aria-hidden="true" />
+          <strong>{t("contextStoreEmpty")}</strong>
+          <span>
+            {descriptor.root.type === "pragma.expert-team" && selectedScope.role === "root"
+              ? t("contextStoreTeamEmptyDescription")
+              : t("contextStoreExpertEmptyDescription", {
+                  expert: selectedScope.name,
+                })}
+          </span>
         </div>
       ) : (
         <div className="context-browser-workspace">
@@ -424,6 +442,26 @@ export function ContextStoreBrowser(props: {
       )}
     </div>
   );
+}
+
+export function memoryScopeDescriptionKey(
+  descriptor: ContextStoreBrowserDescriptor | undefined,
+  scope: MissionContextStoreDescriptor["scopes"][number] | undefined,
+):
+  | "contextStoreTeamScopeDescription"
+  | "contextStoreExpertScopeDescription"
+  | "contextStoreFlowScopeDescription" {
+  if (descriptor?.root.type === "pragma.expert-team" && scope?.role === "root") {
+    return "contextStoreTeamScopeDescription";
+  }
+  if (descriptor?.root.type === "pragma.flow") return "contextStoreFlowScopeDescription";
+  return "contextStoreExpertScopeDescription";
+}
+
+export function isMemoryScopeSelectable(
+  scope: MissionContextStoreDescriptor["scopes"][number],
+): boolean {
+  return scope.availability === "available";
 }
 
 function ContextEntryIcon(props: { readonly entry: MissionContextStoreEntry }) {

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -170,11 +170,16 @@ export const missions = {
     "This file type is listed on the Mission Board, but only text and images can be previewed for now.",
   contextStoreRoot: "Root: {{name}}",
   contextStoreViewingAs: "View as",
-  contextStoreScopeFormula: "Root memory + {{expert}} personal memory",
+  contextStoreTeamScopeDescription: "Team memory only; no member's personal memory is included.",
+  contextStoreExpertScopeDescription: "{{expert}} personal memory only.",
+  contextStoreFlowScopeDescription: "Flow memory + {{expert}} personal memory.",
   contextStoreRecallDisabled: "Memory recall is disabled",
   contextStoreRecallDisabledDescription:
     "The current Memory policy does not allow this expert scope to read the store.",
-  contextStoreSearch: "Search this expert's store",
+  contextStoreEmpty: "No memory yet",
+  contextStoreTeamEmptyDescription: "This expert team has no team memory to preview yet.",
+  contextStoreExpertEmptyDescription: "{{expert}} has no personal memory to preview yet.",
+  contextStoreSearch: "Search the current memory store",
   contextStoreNoMatches: "No matching context found.",
   contextStoreAlwaysOn: "always on",
   contextStoreLine: "Line {{line}}",
@@ -182,7 +187,7 @@ export const missions = {
   contextStoreSelectEntry: "Select a context file to preview it.",
   contextStoreLoadMore: "Load more",
   contextStoreRole: {
-    root: "root expert",
+    root: "root resource",
     coordinator: "coordinator",
     member: "team member",
     "flow-step": "flow expert",
@@ -192,6 +197,11 @@ export const missions = {
   contextStoreParticipation: {
     participated: "participated",
     available: "available",
+  },
+  contextStoreAvailability: {
+    available: "has memory",
+    empty: "no memory",
+    recall_disabled: "recall disabled",
   },
   contextStorePriority: {
     critical: "critical",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -163,10 +163,15 @@ export const missions = {
     "该文件已收录在 Mission Board 中，但目前仅支持预览文本和图片类型。",
   contextStoreRoot: "根资源：{{name}}",
   contextStoreViewingAs: "查看视角",
-  contextStoreScopeFormula: "根资源记忆 + {{expert}} 的个人记忆",
+  contextStoreTeamScopeDescription: "仅专家团记忆，不包含任何成员的个人记忆。",
+  contextStoreExpertScopeDescription: "仅 {{expert}} 的个人记忆。",
+  contextStoreFlowScopeDescription: "流程记忆 + {{expert}} 的个人记忆。",
   contextStoreRecallDisabled: "记忆召回已关闭",
   contextStoreRecallDisabledDescription: "当前 Memory 策略不允许这个专家视角读取 Store。",
-  contextStoreSearch: "搜索此专家的 Store",
+  contextStoreEmpty: "暂无记忆",
+  contextStoreTeamEmptyDescription: "这个专家团还没有可预览的团队记忆。",
+  contextStoreExpertEmptyDescription: "{{expert}} 还没有可预览的个人记忆。",
+  contextStoreSearch: "搜索当前记忆 Store",
   contextStoreNoMatches: "未找到匹配的上下文。",
   contextStoreAlwaysOn: "常驻",
   contextStoreLine: "第 {{line}} 行",
@@ -174,7 +179,7 @@ export const missions = {
   contextStoreSelectEntry: "请选择一个上下文文件进行预览。",
   contextStoreLoadMore: "加载更多",
   contextStoreRole: {
-    root: "根专家",
+    root: "根资源",
     coordinator: "协调者",
     member: "团队成员",
     "flow-step": "流程专家",
@@ -184,6 +189,11 @@ export const missions = {
   contextStoreParticipation: {
     participated: "参与过",
     available: "可用",
+  },
+  contextStoreAvailability: {
+    available: "有记忆",
+    empty: "无记忆",
+    recall_disabled: "召回已关闭",
   },
   contextStorePriority: {
     critical: "关键",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -163,10 +163,15 @@ export const missions = {
     "此檔案已收錄在 Mission Board 中，但目前僅支援預覽文字和圖片類型。",
   contextStoreRoot: "根資源：{{name}}",
   contextStoreViewingAs: "檢視視角",
-  contextStoreScopeFormula: "根資源記憶 + {{expert}} 的個人記憶",
+  contextStoreTeamScopeDescription: "僅專家團記憶，不包含任何成員的個人記憶。",
+  contextStoreExpertScopeDescription: "僅 {{expert}} 的個人記憶。",
+  contextStoreFlowScopeDescription: "流程記憶 + {{expert}} 的個人記憶。",
   contextStoreRecallDisabled: "記憶召回已關閉",
   contextStoreRecallDisabledDescription: "目前 Memory 策略不允許這個專家視角讀取 Store。",
-  contextStoreSearch: "搜尋此專家的 Store",
+  contextStoreEmpty: "暫無記憶",
+  contextStoreTeamEmptyDescription: "這個專家團尚無可預覽的團隊記憶。",
+  contextStoreExpertEmptyDescription: "{{expert}} 尚無可預覽的個人記憶。",
+  contextStoreSearch: "搜尋目前記憶 Store",
   contextStoreNoMatches: "找不到相符的上下文。",
   contextStoreAlwaysOn: "常駐",
   contextStoreLine: "第 {{line}} 行",
@@ -174,7 +179,7 @@ export const missions = {
   contextStoreSelectEntry: "請選擇一個上下文檔案進行預覽。",
   contextStoreLoadMore: "載入更多",
   contextStoreRole: {
-    root: "根專家",
+    root: "根資源",
     coordinator: "協調者",
     member: "團隊成員",
     "flow-step": "流程專家",
@@ -184,6 +189,11 @@ export const missions = {
   contextStoreParticipation: {
     participated: "參與過",
     available: "可用",
+  },
+  contextStoreAvailability: {
+    available: "有記憶",
+    empty: "無記憶",
+    recall_disabled: "召回已關閉",
   },
   contextStorePriority: {
     critical: "關鍵",

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -16622,6 +16622,10 @@ textarea:focus-visible,
   font: inherit;
 }
 
+.context-browser-scope-bar select option:disabled {
+  color: var(--muted);
+}
+
 .context-browser-workspace {
   display: grid;
   min-width: 0;

--- a/apps/desktop/src/shared/contracts/context-store-browser.test.ts
+++ b/apps/desktop/src/shared/contracts/context-store-browser.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   MissionContextStoreContentSchema,
+  MissionContextStoreDescriptorSchema,
   MissionContextStoreEntrySchema,
+  TeamMemoryContextStoreDescriptorSchema,
   ReadMissionContextStoreEntrySchema,
   SearchMissionContextStoreSchema,
 } from "./context-store-browser.ts";
@@ -64,5 +66,50 @@ describe("mission ContextStore browser contracts", () => {
       SearchMissionContextStoreSchema.safeParse({ ...target, query: "failure", maxResults: 51 })
         .success,
     ).toBe(false);
+  });
+
+  it("represents empty multi-scope Team Memory browsers in the v2 IPC contract", () => {
+    const scopes = [
+      {
+        id: "team:vyv9pwwzaksth2dd",
+        expertId: "vyv9pwwzaksth2dd",
+        name: "Editorial Team",
+        role: "root" as const,
+        participation: "available" as const,
+        availability: "empty" as const,
+      },
+      {
+        id: "expert:1xddvess309a6gme",
+        expertId: "1xddvess309a6gme",
+        name: "Writer",
+        role: "coordinator" as const,
+        participation: "available" as const,
+        availability: "available" as const,
+      },
+    ];
+    expect(
+      TeamMemoryContextStoreDescriptorSchema.parse({
+        schemaVersion: "pragma.desktop-team-memory-context-store/v2",
+        teamRef: "team:vyv9pwwzaksth2dd",
+        storeId: "memory",
+        namespace: "memory",
+        name: "Memory ContextStore",
+        readOnly: true,
+        searchable: true,
+        hasMemory: true,
+        root: {
+          type: "pragma.expert-team",
+          id: "vyv9pwwzaksth2dd",
+          name: "Editorial Team",
+        },
+        defaultScopeId: scopes[0]!.id,
+        scopes,
+      }).scopes,
+    ).toHaveLength(2);
+    expect(
+      MissionContextStoreDescriptorSchema.shape.schemaVersion.parse(
+        "pragma.desktop-mission-context-store/v2",
+      ),
+    ).toBe("pragma.desktop-mission-context-store/v2");
   });
 });

--- a/apps/desktop/src/shared/contracts/context-store-browser.ts
+++ b/apps/desktop/src/shared/contracts/context-store-browser.ts
@@ -19,11 +19,11 @@ export const MissionContextStoreScopeSchema = z.object({
   name: z.string().trim().min(1).max(200),
   role: z.enum(["root", "coordinator", "member", "flow-step", "delegated", "observed"]),
   participation: z.enum(["participated", "available"]),
-  availability: z.enum(["available", "recall_disabled"]),
+  availability: z.enum(["available", "empty", "recall_disabled"]),
 });
 
 export const MissionContextStoreDescriptorSchema = z.object({
-  schemaVersion: z.literal("pragma.desktop-mission-context-store/v1"),
+  schemaVersion: z.literal("pragma.desktop-mission-context-store/v2"),
   missionId: MissionIdSchema,
   storeId: MissionContextStoreIdSchema,
   namespace: z.string().trim().min(1).max(100),
@@ -40,7 +40,7 @@ export const MissionContextStoreDescriptorSchema = z.object({
 });
 
 export const ExpertMemoryContextStoreDescriptorSchema = z.object({
-  schemaVersion: z.literal("pragma.desktop-expert-memory-context-store/v1"),
+  schemaVersion: z.literal("pragma.desktop-expert-memory-context-store/v2"),
   expertRef: PragmaExpertRefSchema,
   storeId: z.literal("memory"),
   namespace: z.literal("memory"),
@@ -58,7 +58,7 @@ export const ExpertMemoryContextStoreDescriptorSchema = z.object({
 });
 
 export const TeamMemoryContextStoreDescriptorSchema = z.object({
-  schemaVersion: z.literal("pragma.desktop-team-memory-context-store/v1"),
+  schemaVersion: z.literal("pragma.desktop-team-memory-context-store/v2"),
   teamRef: PragmaExpertTeamRefSchema,
   storeId: z.literal("memory"),
   namespace: z.literal("memory"),
@@ -72,7 +72,7 @@ export const TeamMemoryContextStoreDescriptorSchema = z.object({
     name: z.string().trim().min(1).max(200),
   }),
   defaultScopeId: MissionContextStoreScopeIdSchema,
-  scopes: z.array(MissionContextStoreScopeSchema).min(1).max(1),
+  scopes: z.array(MissionContextStoreScopeSchema).min(1).max(500),
 });
 
 const MissionContextStoreTargetShape = {


### PR DESCRIPTION
## What changed

- Reuse one team Memory scope catalog in both ExpertTeam details and Mission details.
- Show the team root store and each coordinator/member store as separate scopes.
- Disable empty or recall-disabled stores instead of merging their content.
- Centralize Memory store availability checks and add localized empty-state UI.
- Add contract, service, and renderer coverage for the new scope behavior.

## Why

The two Memory Store Browser entry points exposed different data for the same ExpertTeam. Mission details omitted the team root store, while ExpertTeam details omitted other team members. The existing wording also implied that team and member memories were merged.

## Impact

Users now see the same ExpertTeam Memory scopes from either entry point. Team memory and individual expert memory remain independent, and unavailable scopes are visible but cannot be selected.

## Root cause

The Mission and ExpertTeam browsers built their scope lists independently, and the availability API split policy and content checks across separate calls.

## Validation

- Related tests: 27/27 passed
- `pnpm check`
- `pnpm --filter @pragma/desktop build`
- `git diff --check`
