### PR TITLE
Improve memory extraction error handling

### DIFF
--- a/apps/desktop/src/main/features/memory/memory-extraction-jobs.test.ts
+++ b/apps/desktop/src/main/features/memory/memory-extraction-jobs.test.ts
@@ -1,5 +1,5 @@
 import type { EpisodicExtractionJob, SemanticExtractionJob } from "@pragma/memory";
-import type { KnowledgeExtractionJob } from "@pragma/shared";
+import type { KnowledgeExtractionJob, SkillLearningJob } from "@pragma/shared";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ListDesktopMemoryExtractionJobs } from "../../../shared/contracts/index.ts";
@@ -167,6 +167,89 @@ describe("listDesktopMemoryExtractionJobs", () => {
       "Release mission",
       "Knowledge source",
     ]);
+  });
+
+  it("exposes a completed Skill rejection without an error code", async () => {
+    const completed = <T>(jobs: readonly T[]) =>
+      vi.fn(async (input: { readonly statuses: readonly string[] }) =>
+        input.statuses.includes("completed")
+          ? { jobs, total: jobs.length }
+          : { jobs: [] as readonly T[], total: 0 },
+      );
+    const emptyPage = completed([]);
+    const skill: SkillLearningJob = {
+      schemaVersion: "pragma.memory-skill-job/v1",
+      id: "skill-job",
+      revision: 5,
+      rootRef: { type: "pragma.expert", id: "resource-1" },
+      sourceDigest: "a".repeat(64),
+      status: "completed",
+      attempts: 3,
+      completion: "rejected",
+      createdAt: "2026-08-05T00:00:00.000Z",
+      updatedAt: "2026-08-05T00:00:03.000Z",
+    };
+
+    const board = await listDesktopMemoryExtractionJobs(
+      {
+        episodicStore: { listExtractionJobsPage: emptyPage },
+        semanticStore: { listExtractionJobsPage: emptyPage },
+        knowledgeLearningStore: { listJobsPage: emptyPage },
+        skillLearningStore: { listJobsPage: completed([skill]) },
+      } as unknown as Parameters<typeof listDesktopMemoryExtractionJobs>[0],
+      {
+        ...emptyTitleOptions(),
+        project: {
+          get: vi.fn(async () => ({
+            resources: [{ metadata: { id: "resource-1", name: "Research team" } }],
+          })),
+        },
+      } as unknown as Parameters<typeof listDesktopMemoryExtractionJobs>[1],
+      FIRST_PAGES,
+    );
+
+    expect(board.lanes.completed.tasks).toEqual([
+      expect.objectContaining({
+        module: "skill",
+        title: "Research team",
+        completion: "rejected",
+      }),
+    ]);
+    expect(board.lanes.completed.tasks[0]).not.toHaveProperty("lastErrorCode");
+  });
+
+  it("exposes a classified problem instead of a user-facing error code", async () => {
+    const failed: KnowledgeExtractionJob = {
+      ...knowledgeJob(1, "2026-08-05T00:00:01.000Z"),
+      status: "needs_attention",
+      attempts: 3,
+      lastErrorCode: "extractor_evidence_ref_invalid",
+      failureClass: "transient-exhausted",
+    };
+    const attention = vi.fn(async (input: { readonly statuses: readonly string[] }) =>
+      input.statuses.includes("needs_attention")
+        ? { jobs: [failed], total: 1 }
+        : { jobs: [], total: 0 },
+    );
+    const emptyPage = vi.fn(async () => ({ jobs: [], total: 0 }));
+
+    const board = await listDesktopMemoryExtractionJobs(
+      {
+        episodicStore: { listExtractionJobsPage: emptyPage },
+        semanticStore: { listExtractionJobsPage: emptyPage },
+        knowledgeLearningStore: { listJobsPage: attention },
+      } as unknown as Parameters<typeof listDesktopMemoryExtractionJobs>[0],
+      emptyTitleOptions(),
+      FIRST_PAGES,
+    );
+
+    expect(board.lanes.attention.tasks[0]).toMatchObject({
+      problem: {
+        kind: "invalid_output",
+        technicalCode: "extractor_evidence_ref_invalid",
+      },
+    });
+    expect(board.lanes.attention.tasks[0]).not.toHaveProperty("lastErrorCode");
   });
 });
 

--- a/apps/desktop/src/main/features/memory/memory-extraction-jobs.ts
+++ b/apps/desktop/src/main/features/memory/memory-extraction-jobs.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../shared/contracts/index.ts";
 import type { MissionStore } from "../missions/mission-store.ts";
 import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
+import { classifyDesktopMemoryProblem } from "../../../shared/memory-problem.ts";
 import type { DesktopMemoryPlane } from "./desktop-memory-plane.ts";
 
 const MEMORY_EXTRACTION_LANES = ["waiting", "attention", "running", "completed"] as const;
@@ -233,8 +234,13 @@ function toDesktopTask(
     revision: entry.job.revision,
     lane: entry.lane,
     ...(title === undefined ? {} : { title }),
+    ...(entry.job.status === "completed" && entry.job.completion !== undefined
+      ? { completion: entry.job.completion }
+      : {}),
     ...(entry.job.status === "needs_attention" && entry.job.lastErrorCode !== undefined
-      ? { lastErrorCode: entry.job.lastErrorCode }
+      ? {
+          problem: classifyDesktopMemoryProblem(entry.job.lastErrorCode, entry.job.failureClass),
+        }
       : {}),
     updatedAt: entry.job.updatedAt,
   };

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -52,6 +52,11 @@ export function App() {
     setActiveView("settings");
   };
 
+  const openMemorySettings = () => {
+    setSettingsView("memory");
+    setActiveView("settings");
+  };
+
   return (
     <main
       className={sidebarCollapsed ? "desktop-shell is-sidebar-collapsed" : "desktop-shell"}
@@ -114,7 +119,7 @@ export function App() {
       ) : activeView === "usage" ? (
         <UsagePage />
       ) : activeView === "memory" ? (
-        <MemoryPage />
+        <MemoryPage onConfigureExtraction={openMemorySettings} />
       ) : (
         <SettingsPage initialView={settingsView} />
       )}

--- a/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/memory.ts
@@ -66,6 +66,10 @@ export const memory = {
     knowledge: "Knowledge memory",
     skill: "Skill learning",
   },
+  extractionCompletions: {
+    retained: "Generated",
+    rejected: "Nothing generated this time",
+  },
   emptyExtractionLane: "No tasks in this state.",
   extractionPagination: "{{lane}} pagination",
   previousPage: "Previous",
@@ -75,12 +79,47 @@ export const memory = {
   unknownAsset: "Deleted asset",
   extractNow: "Extract now",
   retryExtraction: "Retry extraction",
+  configureExtraction: "Check extraction settings",
+  reviewCandidates: "Review candidates",
   interruptExtraction: "Interrupt",
-  deleteExtraction: "Delete",
-  deleteExtractionTitle: "Delete extraction task?",
-  deleteExtractionDescription:
-    "Delete “{{title}}” and its pending extraction data? Memories already created will remain.",
-  deletingExtraction: "Deleting…",
+  abandonExtraction: "Abandon this extraction",
+  abandonExtractionTitle: "Abandon this extraction?",
+  abandonExtractionDescription:
+    "Discard “{{title}}” and its retained extraction evidence? Memories already created will remain.",
+  abandoningExtraction: "Abandoning…",
+  technicalDetails: "Technical details",
+  copyDiagnostics: "Copy diagnostics",
+  extractionProblems: {
+    configuration: {
+      title: "Extraction settings need attention",
+      description: "The configured extraction model or provider is unavailable or invalid.",
+    },
+    capacity: {
+      title: "Candidate capacity is full",
+      description: "Review existing candidates to free capacity before retrying.",
+    },
+    dependency: {
+      title: "Waiting for execution context",
+      description: "The system will continue automatically when the missing context is restored.",
+    },
+    invalid_output: {
+      title: "The extraction result could not be verified",
+      description:
+        "The model returned invalid structure or source references. Evidence was retained.",
+    },
+    runtime: {
+      title: "The extraction service did not complete",
+      description: "A model, provider, network, or timeout failure interrupted extraction.",
+    },
+    internal: {
+      title: "Memory extraction encountered an internal problem",
+      description: "The task was stopped to protect provenance and retained data.",
+    },
+    unknown: {
+      title: "Memory extraction needs attention",
+      description: "The task could not complete. Evidence was retained for diagnosis and retry.",
+    },
+  },
   health: "Health",
   search: "Search memory",
   empty: "No memories match this view.",
@@ -118,7 +157,9 @@ export const memory = {
   saving: "Saving…",
   loading: "Loading memory…",
   loadError: "Memory could not be loaded.",
+  loadEvidenceError: "Memory evidence could not be loaded.",
   actionError: "The memory change could not be saved.",
+  extractionActionError: "The extraction task could not be updated.",
   healthStates: {
     running: "Memory is running normally",
     stopped: "Memory is stopped",
@@ -159,9 +200,10 @@ export const memory = {
   extractionDegraded: "Memory extraction needs attention",
   extractionDegradedDescription:
     "{{count}} extraction job(s) could not produce memory. Captured evidence remains available for retry.",
+  viewExtractionTasks: "View extraction tasks",
+  closeAlert: "Dismiss alert",
   memoryDegraded: "Memory is degraded",
   memoryDegradedDescription:
     "The memory pipeline is not operating normally. Check Health for the affected module or delivery stage.",
-  lastExtractionError: "Latest extraction error: {{code}}",
   permissionNote: "Permissions can only be kept or tightened in this phase.",
 };

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/memory.ts
@@ -63,6 +63,10 @@ export const memory = {
     knowledge: "知识记忆",
     skill: "技能提炼",
   },
+  extractionCompletions: {
+    retained: "已生成",
+    rejected: "本次未生成",
+  },
   emptyExtractionLane: "当前状态暂无任务。",
   extractionPagination: "{{lane}}分页",
   previousPage: "上一页",
@@ -72,11 +76,46 @@ export const memory = {
   unknownAsset: "已删除的资产",
   extractNow: "立即提炼",
   retryExtraction: "重新提炼",
+  configureExtraction: "检查提炼设置",
+  reviewCandidates: "处理候选",
   interruptExtraction: "中断提炼",
-  deleteExtraction: "删除",
-  deleteExtractionTitle: "删除提炼任务？",
-  deleteExtractionDescription: "删除“{{title}}”及其待提炼数据？已经生成的记忆会继续保留。",
-  deletingExtraction: "正在删除…",
+  abandonExtraction: "放弃本次提炼",
+  abandonExtractionTitle: "放弃本次提炼？",
+  abandonExtractionDescription:
+    "放弃“{{title}}”并清除为本次提炼保留的证据？已经生成的记忆会继续保留。",
+  abandoningExtraction: "正在放弃…",
+  technicalDetails: "技术详情",
+  copyDiagnostics: "复制诊断信息",
+  extractionProblems: {
+    configuration: {
+      title: "提炼设置需要处理",
+      description: "当前提炼模型或服务商配置不可用或无效。",
+    },
+    capacity: {
+      title: "候选容量已满",
+      description: "请先处理已有候选，释放容量后再重新提炼。",
+    },
+    dependency: {
+      title: "正在等待执行上下文",
+      description: "缺失的上下文恢复后，系统会自动继续处理。",
+    },
+    invalid_output: {
+      title: "提炼结果无法验证",
+      description: "模型返回了无效结构或来源引用；相关证据已保留。",
+    },
+    runtime: {
+      title: "提炼服务未能完成",
+      description: "模型、服务商、网络或超时问题中断了本次提炼。",
+    },
+    internal: {
+      title: "记忆提炼遇到内部问题",
+      description: "为保护来源完整性和已保留数据，任务已停止。",
+    },
+    unknown: {
+      title: "记忆提炼需要处理",
+      description: "任务未能完成，证据已保留，可用于诊断和重试。",
+    },
+  },
   health: "健康状态",
   search: "搜索记忆",
   empty: "当前视图没有匹配的记忆。",
@@ -114,7 +153,9 @@ export const memory = {
   saving: "正在保存…",
   loading: "正在加载记忆…",
   loadError: "无法加载记忆。",
+  loadEvidenceError: "无法加载记忆证据。",
   actionError: "无法保存记忆变更。",
+  extractionActionError: "无法更新提炼任务。",
   healthStates: {
     running: "记忆系统运行正常",
     stopped: "记忆系统已停止",
@@ -154,9 +195,10 @@ export const memory = {
   },
   extractionDegraded: "记忆提取需要处理",
   extractionDegradedDescription:
-    "{{count}} 个提取任务未能生成记忆；已捕获的证据仍保留，可在修复配置后重试。",
+    "{{count}} 个提炼任务需要处理；已捕获的证据仍保留，可在问题解决后重试。",
+  viewExtractionTasks: "查看提炼任务",
+  closeAlert: "关闭提示",
   memoryDegraded: "记忆系统异常",
   memoryDegradedDescription: "记忆流水线未正常工作，请在健康状态中检查受影响的模块或投递阶段。",
-  lastExtractionError: "最近提取错误：{{code}}",
   permissionNote: "本阶段只能保持或收紧权限。",
 } satisfies DesktopTranslationResource["memory"];

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/memory.ts
@@ -63,6 +63,10 @@ export const memory = {
     knowledge: "知識記憶",
     skill: "技能提煉",
   },
+  extractionCompletions: {
+    retained: "已產生",
+    rejected: "本次未產生",
+  },
   emptyExtractionLane: "目前狀態暫無任務。",
   extractionPagination: "{{lane}}分頁",
   previousPage: "上一頁",
@@ -72,11 +76,46 @@ export const memory = {
   unknownAsset: "已刪除的資產",
   extractNow: "立即提煉",
   retryExtraction: "重新提煉",
+  configureExtraction: "檢查提煉設定",
+  reviewCandidates: "處理候選",
   interruptExtraction: "中斷提煉",
-  deleteExtraction: "刪除",
-  deleteExtractionTitle: "刪除提煉任務？",
-  deleteExtractionDescription: "刪除「{{title}}」及其待提煉資料？已經產生的記憶會繼續保留。",
-  deletingExtraction: "正在刪除…",
+  abandonExtraction: "放棄本次提煉",
+  abandonExtractionTitle: "放棄本次提煉？",
+  abandonExtractionDescription:
+    "放棄「{{title}}」並清除為本次提煉保留的證據？已經產生的記憶會繼續保留。",
+  abandoningExtraction: "正在放棄…",
+  technicalDetails: "技術詳情",
+  copyDiagnostics: "複製診斷資訊",
+  extractionProblems: {
+    configuration: {
+      title: "提煉設定需要處理",
+      description: "目前的提煉模型或服務商設定不可用或無效。",
+    },
+    capacity: {
+      title: "候選容量已滿",
+      description: "請先處理現有候選，釋放容量後再重新提煉。",
+    },
+    dependency: {
+      title: "正在等待執行上下文",
+      description: "缺少的上下文恢復後，系統會自動繼續處理。",
+    },
+    invalid_output: {
+      title: "提煉結果無法驗證",
+      description: "模型回傳了無效結構或來源引用；相關證據已保留。",
+    },
+    runtime: {
+      title: "提煉服務未能完成",
+      description: "模型、服務商、網路或逾時問題中斷了本次提煉。",
+    },
+    internal: {
+      title: "記憶提煉遇到內部問題",
+      description: "為保護來源完整性和已保留資料，任務已停止。",
+    },
+    unknown: {
+      title: "記憶提煉需要處理",
+      description: "任務未能完成，證據已保留，可用於診斷和重試。",
+    },
+  },
   health: "健康狀態",
   search: "搜尋記憶",
   empty: "目前檢視沒有符合的記憶。",
@@ -114,7 +153,9 @@ export const memory = {
   saving: "正在儲存…",
   loading: "正在載入記憶…",
   loadError: "無法載入記憶。",
+  loadEvidenceError: "無法載入記憶證據。",
   actionError: "無法儲存記憶變更。",
+  extractionActionError: "無法更新提煉任務。",
   healthStates: {
     running: "記憶系統運作正常",
     stopped: "記憶系統已停止",
@@ -154,9 +195,10 @@ export const memory = {
   },
   extractionDegraded: "記憶提取需要處理",
   extractionDegradedDescription:
-    "{{count}} 個提取任務未能產生記憶；已擷取的證據仍保留，可在修復設定後重試。",
+    "{{count}} 個提煉任務需要處理；已擷取的證據仍保留，可在問題解決後重試。",
+  viewExtractionTasks: "查看提煉任務",
+  closeAlert: "關閉提示",
   memoryDegraded: "記憶系統異常",
   memoryDegradedDescription: "記憶流水線未正常運作，請在健康狀態中檢查受影響的模組或投遞階段。",
-  lastExtractionError: "最近提取錯誤：{{code}}",
   permissionNote: "本階段只能維持或縮小權限。",
 } satisfies DesktopTranslationResource["memory"];

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.test.tsx
@@ -192,7 +192,10 @@ describe("MemoryPage", () => {
                   revision: 3,
                   lane: "attention",
                   title: "Pragma",
-                  lastErrorCode: "knowledge_candidate_capacity_exceeded",
+                  problem: {
+                    kind: "capacity",
+                    technicalCode: "knowledge_candidate_capacity_exceeded",
+                  },
                   updatedAt: "2026-08-05T01:00:00.000Z",
                 },
               ],
@@ -220,12 +223,59 @@ describe("MemoryPage", () => {
     expect(html).toContain("Prepare the release");
     expect(html).toContain("Episodic memory");
     expect(html).toContain("Knowledge memory");
+    expect(html).toContain("Candidate capacity is full");
+    expect(html).toContain("Technical details");
     expect(html).toContain("knowledge_candidate_capacity_exceeded");
+    expect(html.indexOf("<details")).toBeLessThan(
+      html.indexOf("knowledge_candidate_capacity_exceeded"),
+    );
     expect(html).toContain("Extract now");
     expect(html).toContain("Retry extraction");
-    expect(html).toContain("Delete");
+    expect(html).toContain("Review candidates");
+    expect(html).toContain("Abandon this extraction");
     expect(html).not.toContain("internal-job-a");
     expect(html).not.toContain("Evidence records");
+  });
+
+  it("presents rejected completed extraction as a neutral result without recovery actions", async () => {
+    await i18n.changeLanguage("zh-Hans");
+    const html = renderToStaticMarkup(
+      <MemoryExtractionJobs
+        board={{
+          lanes: {
+            waiting: { tasks: [], pageIndex: 0, pageCount: 1, totalTasks: 0 },
+            attention: { tasks: [], pageIndex: 0, pageCount: 1, totalTasks: 0 },
+            running: { tasks: [], pageIndex: 0, pageCount: 1, totalTasks: 0 },
+            completed: {
+              tasks: [
+                {
+                  module: "skill",
+                  id: "skill-job",
+                  revision: 5,
+                  lane: "completed",
+                  title: "研发专家团",
+                  completion: "rejected",
+                  updatedAt: "2026-08-05T00:00:03.000Z",
+                },
+              ],
+              pageIndex: 0,
+              pageCount: 1,
+              totalTasks: 1,
+            },
+          },
+        }}
+        loading={false}
+        onRefresh={() => undefined}
+        onAction={async () => undefined}
+        onPageChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("研发专家团");
+    expect(html).toContain("本次未生成");
+    expect(html).not.toContain("skill_source_threshold_not_met");
+    expect(html).not.toContain("重新提炼");
+    expect(html).not.toContain(">删除<");
   });
 
   it("shows extraction failures without requiring the Health tab", async () => {
@@ -286,7 +336,9 @@ describe("MemoryPage", () => {
 
     expect(html).toContain('role="alert"');
     expect(html).toContain("记忆提取需要处理");
-    expect(html).toContain("memory_curator_failed");
+    expect(html).toContain('aria-label="关闭提示"');
+    expect(html).toContain('class="memory-alert-close"');
+    expect(html).not.toContain("memory_curator_failed");
   });
 
   it("does not hide a concurrent delivery failure behind extraction wording", async () => {
@@ -347,7 +399,7 @@ describe("MemoryPage", () => {
 
     expect(html).toContain("记忆系统异常");
     expect(html).not.toContain("记忆提取需要处理");
-    expect(html).toContain("canonical_event_handoff_quarantined");
-    expect(html).toContain("memory_curator_failed");
+    expect(html).not.toContain("canonical_event_handoff_quarantined");
+    expect(html).not.toContain("memory_curator_failed");
   });
 });

--- a/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/memory/MemoryPage.tsx
@@ -12,6 +12,7 @@ import {
   StopCircle,
   Trash,
   WarningCircle,
+  X,
 } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 
@@ -25,8 +26,8 @@ import type {
   MemoryKnowledgeInitializationCandidate,
   MemorySkillCandidate,
 } from "../../../../shared/contracts/index.ts";
+import { classifyDesktopMemoryProblem } from "../../../../shared/memory-problem.ts";
 import { ConfirmationDialog, Dialog } from "../../components/Dialog.tsx";
-import { errorMessage } from "../../lib/errors.ts";
 
 type MemoryView =
   "all" | "episodic" | "semantic" | "candidates" | "skillCandidates" | "extractions" | "health";
@@ -42,7 +43,7 @@ const INITIAL_MEMORY_EXTRACTION_PAGES: ListDesktopMemoryExtractionJobs["pages"] 
   completed: { pageIndex: 0 },
 };
 
-export function MemoryPage() {
+export function MemoryPage(props: { readonly onConfigureExtraction?: () => void } = {}) {
   const { t } = useTranslation("memory");
   const [view, setView] = useState<MemoryView>("all");
   const [query, setQuery] = useState("");
@@ -139,15 +140,15 @@ export function MemoryPage() {
         );
         setError(undefined);
         return extractionJobs;
-      } catch (loadError) {
-        setError(errorMessage(loadError));
+      } catch {
+        setError(t("loadError"));
         return undefined;
       } finally {
         hasLoaded.current = true;
         setLoading(false);
       }
     },
-    [extractionPages, query, view],
+    [extractionPages, query, t, view],
   );
 
   useEffect(() => {
@@ -193,8 +194,8 @@ export function MemoryPage() {
       setEvidence(undefined);
       await reload();
       return true;
-    } catch (actionError) {
-      setError(errorMessage(actionError));
+    } catch {
+      setError(t("actionError"));
       return false;
     } finally {
       setActionBusy(false);
@@ -216,8 +217,8 @@ export function MemoryPage() {
         expectedRevision: task.revision,
       });
       await reload(true);
-    } catch (actionError) {
-      setError(errorMessage(actionError));
+    } catch {
+      setError(t("extractionActionError"));
     } finally {
       setBusyExtractionTask(undefined);
     }
@@ -289,7 +290,7 @@ export function MemoryPage() {
           <WarningCircle size={18} aria-hidden="true" /> {error}
         </div>
       ) : null}
-      <MemoryDegradedAlert health={health} />
+      <MemoryDegradedAlert health={health} onViewTasks={() => setView("extractions")} />
 
       {view === "health" ? (
         <MemoryHealth health={health} />
@@ -301,6 +302,10 @@ export function MemoryPage() {
           onRefresh={() => void reload(true)}
           onAction={manageExtraction}
           onPageChange={changeExtractionPage}
+          onConfigureExtraction={props.onConfigureExtraction}
+          onReviewCandidates={(module) =>
+            setView(module === "skill" ? "skillCandidates" : "candidates")
+          }
         />
       ) : view === "skillCandidates" ? (
         <MemorySkillCandidates
@@ -569,7 +574,9 @@ export function MemoryPage() {
                               evidenceId,
                             })
                             .then(setEvidence)
-                            .catch((value: unknown) => setError(errorMessage(value)))
+                            .catch(() => {
+                              setError(t("loadEvidenceError"));
+                            })
                         }
                       >
                         {evidenceId}
@@ -852,6 +859,9 @@ export function MemoryExtractionJobs(props: {
     action: "expedite" | "retry" | "interrupt" | "delete",
   ) => Promise<void>;
   readonly onPageChange: (lane: MemoryExtractionLane, pageIndex: number) => void;
+  readonly onConfigureExtraction?: (() => void) | undefined;
+  readonly onReviewCandidates?:
+    ((module: DesktopMemoryExtractionTask["module"]) => void) | undefined;
 }) {
   const { t } = useTranslation("memory");
   const [pendingDelete, setPendingDelete] = useState<DesktopMemoryExtractionTask>();
@@ -899,17 +909,33 @@ export function MemoryExtractionJobs(props: {
                   {page.tasks.map((task) => {
                     const taskKey = `${task.module}:${task.id}`;
                     const busy = props.busyTask === taskKey;
+                    const problem = task.problem;
                     return (
                       <article className="memory-extraction-task" key={taskKey}>
                         <strong>
                           {task.title ??
                             t(task.module === "knowledge" ? "unknownAsset" : "unknownMission")}
                         </strong>
-                        <span className={`memory-extraction-type is-${task.module}`}>
-                          {t(`extractionTaskTypes.${task.module}`)}
-                        </span>
-                        {lane === "attention" && task.lastErrorCode !== undefined ? (
-                          <code className="memory-extraction-error">{task.lastErrorCode}</code>
+                        <div className="memory-extraction-task-statuses">
+                          <span className={`memory-extraction-type is-${task.module}`}>
+                            {t(`extractionTaskTypes.${task.module}`)}
+                          </span>
+                          {lane === "completed" && task.completion !== undefined ? (
+                            <span className="memory-extraction-completion">
+                              {t(`extractionCompletions.${task.completion}`)}
+                            </span>
+                          ) : null}
+                        </div>
+                        {lane === "attention" && problem !== undefined ? (
+                          <section className={`memory-extraction-problem is-${problem.kind}`}>
+                            <strong>{t(`extractionProblems.${problem.kind}.title`)}</strong>
+                            <p>{t(`extractionProblems.${problem.kind}.description`)}</p>
+                            <MemoryTechnicalDetails
+                              code={problem.technicalCode}
+                              module={task.module}
+                              updatedAt={task.updatedAt}
+                            />
+                          </section>
                         ) : null}
                         {lane !== "completed" ? (
                           <footer>
@@ -925,22 +951,74 @@ export function MemoryExtractionJobs(props: {
                             ) : null}
                             {lane === "attention" ? (
                               <>
-                                <button
-                                  className="is-primary"
-                                  type="button"
-                                  disabled={busy}
-                                  onClick={() => void props.onAction(task, "retry")}
-                                >
-                                  <ArrowCounterClockwise size={16} aria-hidden="true" />
-                                  {t("retryExtraction")}
-                                </button>
+                                {problem?.kind === "configuration" ? (
+                                  <button
+                                    className="is-primary"
+                                    type="button"
+                                    disabled={busy || props.onConfigureExtraction === undefined}
+                                    onClick={props.onConfigureExtraction}
+                                  >
+                                    {t("configureExtraction")}
+                                  </button>
+                                ) : problem?.kind === "capacity" ? (
+                                  <button
+                                    className="is-primary"
+                                    type="button"
+                                    disabled={busy || props.onReviewCandidates === undefined}
+                                    onClick={() => props.onReviewCandidates?.(task.module)}
+                                  >
+                                    {t("reviewCandidates")}
+                                  </button>
+                                ) : problem?.kind === "dependency" ? (
+                                  <button
+                                    className="is-primary"
+                                    type="button"
+                                    disabled={busy}
+                                    onClick={props.onRefresh}
+                                  >
+                                    <ArrowClockwise size={16} aria-hidden="true" /> {t("refresh")}
+                                  </button>
+                                ) : (
+                                  <button
+                                    className="is-primary"
+                                    type="button"
+                                    disabled={busy}
+                                    onClick={() => void props.onAction(task, "retry")}
+                                  >
+                                    <ArrowCounterClockwise size={16} aria-hidden="true" />
+                                    {t("retryExtraction")}
+                                  </button>
+                                )}
+                                {problem?.kind === "configuration" ||
+                                problem?.kind === "capacity" ? (
+                                  <button
+                                    className="is-secondary"
+                                    type="button"
+                                    disabled={busy}
+                                    onClick={() => void props.onAction(task, "retry")}
+                                  >
+                                    <ArrowCounterClockwise size={16} aria-hidden="true" />
+                                    {t("retryExtraction")}
+                                  </button>
+                                ) : null}
+                                {problem?.kind === "invalid_output" &&
+                                props.onConfigureExtraction !== undefined ? (
+                                  <button
+                                    className="is-secondary"
+                                    type="button"
+                                    disabled={busy}
+                                    onClick={props.onConfigureExtraction}
+                                  >
+                                    {t("configureExtraction")}
+                                  </button>
+                                ) : null}
                                 <button
                                   className="is-danger"
                                   type="button"
                                   disabled={busy}
                                   onClick={() => setPendingDelete(task)}
                                 >
-                                  <Trash size={16} aria-hidden="true" /> {t("deleteExtraction")}
+                                  <Trash size={16} aria-hidden="true" /> {t("abandonExtraction")}
                                 </button>
                               </>
                             ) : null}
@@ -997,15 +1075,15 @@ export function MemoryExtractionJobs(props: {
       ) : null}
       {pendingDelete === undefined ? null : (
         <ConfirmationDialog
-          title={t("deleteExtractionTitle")}
-          description={t("deleteExtractionDescription", {
+          title={t("abandonExtractionTitle")}
+          description={t("abandonExtractionDescription", {
             title:
               pendingDelete.title ??
               t(pendingDelete.module === "knowledge" ? "unknownAsset" : "unknownMission"),
           })}
           cancelLabel={t("cancel")}
-          confirmLabel={t("deleteExtraction")}
-          busyLabel={t("deletingExtraction")}
+          confirmLabel={t("abandonExtraction")}
+          busyLabel={t("abandoningExtraction")}
           busy={props.busyTask === `${pendingDelete.module}:${pendingDelete.id}`}
           tone="danger"
           onCancel={() => setPendingDelete(undefined)}
@@ -1015,6 +1093,28 @@ export function MemoryExtractionJobs(props: {
         />
       )}
     </section>
+  );
+}
+
+function MemoryTechnicalDetails(props: {
+  readonly code: string;
+  readonly module: string;
+  readonly updatedAt?: string | undefined;
+}) {
+  const { t } = useTranslation("memory");
+  const diagnostic = [
+    `module=${props.module}`,
+    `code=${props.code}`,
+    ...(props.updatedAt === undefined ? [] : [`updatedAt=${props.updatedAt}`]),
+  ].join("\n");
+  return (
+    <details className="memory-technical-details">
+      <summary>{t("technicalDetails")}</summary>
+      <code>{props.code}</code>
+      <button type="button" onClick={() => void window.navigator.clipboard.writeText(diagnostic)}>
+        {t("copyDiagnostics")}
+      </button>
+    </details>
   );
 }
 
@@ -1032,6 +1132,10 @@ export function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus
       : props.health.state === "stopped"
         ? StopCircle
         : WarningCircle;
+  const globalProblem =
+    props.health.lastError === undefined
+      ? undefined
+      : classifyDesktopMemoryProblem(props.health.lastError.code);
   return (
     <section className={`memory-health is-${props.health.state}`} aria-label={t("health")}>
       <header className="memory-health-overview">
@@ -1046,6 +1150,16 @@ export function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus
                 modules: props.health.modules.length,
               })}
             </span>
+            {globalProblem === undefined ? null : (
+              <span className="memory-module-problem">
+                <small>{t(`extractionProblems.${globalProblem.kind}.title`)}</small>
+                <MemoryTechnicalDetails
+                  code={globalProblem.technicalCode}
+                  module="memory-plane"
+                  updatedAt={props.health.lastError?.occurredAt}
+                />
+              </span>
+            )}
           </div>
         </div>
         <dl className="memory-health-overview-metrics">
@@ -1112,6 +1226,10 @@ export function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus
               <tbody>
                 {props.health.modules.map((module) => {
                   const nameKey = memoryModuleNameKey(module.moduleId);
+                  const problem =
+                    module.lastErrorCode === undefined
+                      ? undefined
+                      : classifyDesktopMemoryProblem(module.lastErrorCode);
                   return (
                     <tr key={module.moduleId}>
                       <th scope="row">
@@ -1125,8 +1243,14 @@ export function MemoryHealth(props: { readonly health?: DesktopMemoryPlaneStatus
                           <small>
                             {module.moduleId}@{module.moduleVersion}
                           </small>
-                          {module.lastErrorCode === undefined ? null : (
-                            <code>{module.lastErrorCode}</code>
+                          {problem === undefined ? null : (
+                            <span className="memory-module-problem">
+                              <small>{t(`extractionProblems.${problem.kind}.title`)}</small>
+                              <MemoryTechnicalDetails
+                                code={problem.technicalCode}
+                                module={module.moduleId}
+                              />
+                            </span>
                           )}
                         </span>
                       </th>
@@ -1441,41 +1565,63 @@ function memoryModuleNameKey(
 
 export function MemoryDegradedAlert(props: {
   readonly health?: DesktopMemoryPlaneStatus | undefined;
+  readonly onViewTasks?: (() => void) | undefined;
 }) {
   const { t } = useTranslation("memory");
+  const signature = memoryDegradedAlertSignature(props.health);
+  const [dismissedSignature, setDismissedSignature] = useState<string>();
   if (props.health?.state !== "degraded") return null;
+  if (dismissedSignature === signature) return null;
   const attention = props.health.modules.reduce(
     (total, module) => total + (module.work?.needsAttention ?? 0),
     0,
-  );
-  const codes = [
-    props.health.lastError?.code,
-    ...props.health.modules.map((module) => module.lastErrorCode),
-  ].filter(
-    (code, index, values): code is string => code !== undefined && values.indexOf(code) === index,
   );
   const extractionOnly =
     attention > 0 &&
     !props.health.modules.some((module) => module.status === "unavailable") &&
     !isNonExtractionPipelineError(props.health.lastError?.code);
   return (
-    <div className="memory-error" role="alert">
+    <div className="memory-error is-dismissible" role="alert">
       <WarningCircle size={20} aria-hidden="true" />
-      <span>
+      <span className="memory-degraded-copy">
         <strong>{t(extractionOnly ? "extractionDegraded" : "memoryDegraded")}</strong>
         <br />
         {extractionOnly
           ? t("extractionDegradedDescription", { count: attention })
           : t("memoryDegradedDescription")}
-        {codes.length === 0 ? null : (
-          <>
-            <br />
-            <code>{t("lastExtractionError", { code: codes.join(", ") })}</code>
-          </>
-        )}
       </span>
+      {extractionOnly && props.onViewTasks !== undefined ? (
+        <button className="memory-alert-action" type="button" onClick={props.onViewTasks}>
+          {t("viewExtractionTasks")}
+        </button>
+      ) : null}
+      <button
+        className="memory-alert-close"
+        type="button"
+        aria-label={t("closeAlert")}
+        title={t("closeAlert")}
+        onClick={() => setDismissedSignature(signature)}
+      >
+        <X size={16} aria-hidden="true" />
+      </button>
     </div>
   );
+}
+
+function memoryDegradedAlertSignature(
+  health: DesktopMemoryPlaneStatus | undefined,
+): string | undefined {
+  if (health?.state !== "degraded") return undefined;
+  return JSON.stringify({
+    state: health.state,
+    lastError: health.lastError?.code,
+    modules: health.modules.map((module) => ({
+      id: module.moduleId,
+      status: module.status,
+      attention: module.work?.needsAttention ?? 0,
+      error: module.lastErrorCode,
+    })),
+  });
 }
 
 function isNonExtractionPipelineError(code: string | undefined): boolean {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -17418,6 +17418,43 @@ textarea:focus-visible,
   color: #8d382f;
 }
 
+.memory-error.is-dismissible {
+  position: relative;
+  padding-right: 44px;
+}
+
+.memory-error .memory-degraded-copy {
+  flex: 1;
+}
+
+.memory-error .memory-alert-action {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border: 1px solid currentcolor;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+}
+
+.memory-error .memory-alert-close {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+}
+
+.memory-error .memory-alert-close:hover {
+  background: rgb(141 56 47 / 10%);
+}
+
 .memory-browser {
   display: grid;
   min-height: 0;
@@ -18137,14 +18174,9 @@ textarea:focus-visible,
   white-space: nowrap;
 }
 
-.memory-health-module-table tbody th code {
-  max-width: 240px;
-  overflow: hidden;
-  color: var(--ui-danger);
-  font-size: 0.65rem;
-  font-weight: 500;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.memory-module-problem {
+  display: grid;
+  gap: 3px;
 }
 
 .memory-health-module-table td {
@@ -18391,15 +18423,67 @@ textarea:focus-visible,
   color: #76508a;
 }
 
-.memory-extraction-error {
+.memory-extraction-task-statuses {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.memory-extraction-completion {
+  color: var(--ui-text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.memory-extraction-problem {
   width: 100%;
-  padding: 7px 8px;
+  padding: 9px 10px;
   border-radius: 7px;
   background: #fff1ee;
   color: #9a3f35;
+}
+
+.memory-extraction-problem > strong {
+  display: block;
+  font-size: 0.78rem;
+}
+
+.memory-extraction-problem > p {
+  margin: 3px 0 0;
   font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.memory-technical-details {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 450;
+}
+
+.memory-technical-details summary {
+  width: fit-content;
+  cursor: pointer;
+}
+
+.memory-technical-details code {
+  display: block;
+  margin-top: 5px;
+  color: var(--ui-danger);
   overflow-wrap: anywhere;
   white-space: normal;
+}
+
+.memory-technical-details button {
+  margin-top: 5px;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 0.66rem;
 }
 
 .memory-extraction-task footer {

--- a/apps/desktop/src/shared/contracts/contracts.test.ts
+++ b/apps/desktop/src/shared/contracts/contracts.test.ts
@@ -34,6 +34,7 @@ import {
   DesktopGlobalMemoryPolicySnapshotSchema,
   DesktopAssetMemoryPolicySnapshotSchema,
   DesktopMemoryPlaneStatusSchema,
+  DesktopMemoryExtractionTaskSchema,
   DesktopMemoryItemSchema,
   UpdateDesktopAssetMemoryPolicySchema,
 } from "./index.ts";
@@ -141,6 +142,43 @@ describe("desktop memory contracts", () => {
       delivery: { pending: 1, quarantined: 0 },
       modules: [],
     });
+  });
+
+  it("keeps extraction completion and problem details in their matching lanes", () => {
+    const base = {
+      module: "episodic" as const,
+      id: "job-a",
+      revision: 1,
+      updatedAt: "2026-08-05T08:00:00.000Z",
+    };
+    expect(
+      DesktopMemoryExtractionTaskSchema.safeParse({
+        ...base,
+        lane: "completed",
+        completion: "rejected",
+      }).success,
+    ).toBe(true);
+    expect(
+      DesktopMemoryExtractionTaskSchema.safeParse({
+        ...base,
+        lane: "attention",
+        problem: { kind: "invalid_output", technicalCode: "extractor_output_invalid" },
+      }).success,
+    ).toBe(true);
+    expect(
+      DesktopMemoryExtractionTaskSchema.safeParse({
+        ...base,
+        lane: "waiting",
+        completion: "rejected",
+      }).success,
+    ).toBe(false);
+    expect(
+      DesktopMemoryExtractionTaskSchema.safeParse({
+        ...base,
+        lane: "running",
+        problem: { kind: "runtime", technicalCode: "memory_curator_timeout" },
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/apps/desktop/src/shared/contracts/memory.ts
+++ b/apps/desktop/src/shared/contracts/memory.ts
@@ -112,15 +112,48 @@ export const DesktopMemoryPlaneStatusSchema = z.object({
     }),
 });
 
-export const DesktopMemoryExtractionTaskSchema = z.object({
-  module: z.enum(["episodic", "semantic", "knowledge", "skill"]),
-  id: z.string().min(1),
-  revision: z.number().int().positive(),
-  lane: z.enum(["waiting", "attention", "running", "completed"]),
-  title: z.string().trim().min(1).max(200).optional(),
-  lastErrorCode: z.string().min(1).optional(),
-  updatedAt: z.string().datetime(),
-});
+export const DesktopMemoryProblemSchema = z
+  .object({
+    kind: z.enum([
+      "configuration",
+      "capacity",
+      "dependency",
+      "invalid_output",
+      "runtime",
+      "internal",
+      "unknown",
+    ]),
+    technicalCode: z.string().min(1),
+  })
+  .strict();
+
+export const DesktopMemoryExtractionTaskSchema = z
+  .object({
+    module: z.enum(["episodic", "semantic", "knowledge", "skill"]),
+    id: z.string().min(1),
+    revision: z.number().int().positive(),
+    lane: z.enum(["waiting", "attention", "running", "completed"]),
+    title: z.string().trim().min(1).max(200).optional(),
+    completion: z.enum(["retained", "rejected"]).optional(),
+    problem: DesktopMemoryProblemSchema.optional(),
+    updatedAt: z.string().datetime(),
+  })
+  .superRefine((task, context) => {
+    if (task.completion !== undefined && task.lane !== "completed") {
+      context.addIssue({
+        code: "custom",
+        path: ["completion"],
+        message: "Only completed extraction tasks may declare a completion result.",
+      });
+    }
+    if (task.problem !== undefined && task.lane !== "attention") {
+      context.addIssue({
+        code: "custom",
+        path: ["problem"],
+        message: "Only extraction tasks needing attention may declare a problem.",
+      });
+    }
+  });
 
 export const DESKTOP_MEMORY_EXTRACTION_PAGE_SIZE = 10;
 

--- a/apps/desktop/src/shared/contracts/types.ts
+++ b/apps/desktop/src/shared/contracts/types.ts
@@ -250,6 +250,7 @@ import {
   ReviewDesktopMemoryItemSchema,
   DesktopMissionMemoryActivitySchema,
   GetDesktopMissionMemoryActivitySchema,
+  DesktopMemoryProblemSchema,
   DesktopMemoryExtractionTaskSchema,
   DesktopMemoryExtractionBoardSchema,
   ListDesktopMemoryExtractionJobsSchema,
@@ -326,6 +327,7 @@ export type TightenDesktopMemoryAccess = z.infer<typeof TightenDesktopMemoryAcce
 export type ReviewDesktopMemoryItem = z.infer<typeof ReviewDesktopMemoryItemSchema>;
 export type DesktopMissionMemoryActivity = z.infer<typeof DesktopMissionMemoryActivitySchema>;
 export type GetDesktopMissionMemoryActivity = z.infer<typeof GetDesktopMissionMemoryActivitySchema>;
+export type DesktopMemoryProblem = z.infer<typeof DesktopMemoryProblemSchema>;
 export type DesktopMemoryExtractionTask = z.infer<typeof DesktopMemoryExtractionTaskSchema>;
 export type DesktopMemoryExtractionBoard = z.infer<typeof DesktopMemoryExtractionBoardSchema>;
 export type ListDesktopMemoryExtractionJobs = z.infer<typeof ListDesktopMemoryExtractionJobsSchema>;

--- a/apps/desktop/src/shared/memory-problem.test.ts
+++ b/apps/desktop/src/shared/memory-problem.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyDesktopMemoryProblem } from "./memory-problem.ts";
+
+describe("classifyDesktopMemoryProblem", () => {
+  it.each([
+    ["extractor_evidence_ref_invalid", undefined, "invalid_output"],
+    ["semantic_evidence_ref_invalid", undefined, "invalid_output"],
+    ["semantic_extraction_validation_failed", undefined, "invalid_output"],
+    ["semantic_fact_duplicate", "transient-exhausted", "invalid_output"],
+    ["semantic_subject_context_missing", "configuration", "dependency"],
+    ["memory_extractor_profile_invalid", "configuration", "configuration"],
+    ["knowledge_learning_sink_unavailable", undefined, "configuration"],
+    ["knowledge_candidate_capacity_exceeded", "capacity", "capacity"],
+    ["memory_curator_timeout", "transient-exhausted", "runtime"],
+    ["episodic_extraction_failed", "transient-exhausted", "runtime"],
+    ["episodic_root_attribution_invalid", "transient-exhausted", "internal"],
+    ["knowledge_source_digest_invalid", "transient-exhausted", "internal"],
+    ["new_provider_failure", "transient-exhausted", "runtime"],
+    ["future_unclassified_failure", "transient-exhausted", "unknown"],
+  ] as const)("classifies %s as %s", (technicalCode, failureClass, expected) => {
+    expect(classifyDesktopMemoryProblem(technicalCode, failureClass)).toEqual({
+      kind: expected,
+      technicalCode,
+    });
+  });
+});

--- a/apps/desktop/src/shared/memory-problem.ts
+++ b/apps/desktop/src/shared/memory-problem.ts
@@ -1,0 +1,73 @@
+import type { DesktopMemoryProblem } from "./contracts/index.ts";
+
+const INVALID_OUTPUT_CODES = new Set([
+  "extractor_evidence_ref_invalid",
+  "semantic_subject_ref_invalid",
+  "semantic_evidence_ref_invalid",
+  "semantic_review_time_invalid",
+  "semantic_expiry_time_invalid",
+  "semantic_fact_duplicate",
+  "semantic_replacement_target_invalid",
+  "memory_curator_output_missing",
+]);
+
+const INTERNAL_CODES = new Set([
+  "episodic_root_attribution_invalid",
+  "semantic_root_attribution_invalid",
+  "episodic_extraction_job_invalid",
+  "semantic_extraction_job_invalid",
+  "memory_pipeline_iteration_failed",
+  "canonical_event_handoff_quarantined",
+  "canonical_event_delivery_failed",
+  "knowledge_job_state_invalid",
+  "knowledge_source_digest_invalid",
+  "skill_job_state_invalid",
+  "skill_source_digest_invalid",
+  "memory_extraction_job_action_invalid",
+  "module_consume_failed",
+  "payload_schema_invalid",
+]);
+
+export function classifyDesktopMemoryProblem(
+  technicalCode: string,
+  failureClass?: string | undefined,
+): DesktopMemoryProblem {
+  const code = technicalCode.toLowerCase();
+  if (code === "semantic_subject_context_missing") {
+    return { kind: "dependency", technicalCode };
+  }
+  if (failureClass === "capacity" || code.includes("capacity")) {
+    return { kind: "capacity", technicalCode };
+  }
+  if (
+    INVALID_OUTPUT_CODES.has(code) ||
+    code.endsWith("_extraction_validation_failed") ||
+    code.includes("output_invalid")
+  ) {
+    return { kind: "invalid_output", technicalCode };
+  }
+  if (
+    failureClass === "configuration" ||
+    code.includes("configuration") ||
+    code.includes("profile") ||
+    code.includes("unavailable")
+  ) {
+    return { kind: "configuration", technicalCode };
+  }
+  if (
+    code.includes("curator") ||
+    code.includes("runtime") ||
+    code.includes("provider") ||
+    code.includes("timeout") ||
+    code.includes("rate_limit") ||
+    code.includes("network") ||
+    code.includes("temporarily") ||
+    /^(?:episodic|semantic|knowledge|skill)_extraction_failed$/u.test(code)
+  ) {
+    return { kind: "runtime", technicalCode };
+  }
+  if (INTERNAL_CODES.has(code) || code.includes("job_invalid")) {
+    return { kind: "internal", technicalCode };
+  }
+  return { kind: "unknown", technicalCode };
+}

--- a/packages/memory/src/knowledge/module.ts
+++ b/packages/memory/src/knowledge/module.ts
@@ -137,11 +137,15 @@ export async function createKnowledgeMemoryModule(options: {
           await store.completeRejected(job, now());
           return;
         }
-        assertEligibleCandidates(output.candidates, sources);
+        const candidates = eligibleCandidates(output.candidates, sources);
+        if (candidates.length === 0) {
+          await store.completeRejected(job, now());
+          return;
+        }
         await options.learningSink.submit({
           rootRef: job.rootRef,
           sourceDigest,
-          candidates: output.candidates,
+          candidates,
           sources,
         });
         await store.completeLearned(job, now());
@@ -188,30 +192,27 @@ function boundSources(
   return selected;
 }
 
-function assertEligibleCandidates(
+function eligibleCandidates(
   candidates: readonly KnowledgeExtractionCandidate[],
   sources: readonly KnowledgeSourceSnapshot[],
-): void {
+): readonly KnowledgeExtractionCandidate[] {
   const available = new Map(sources.map((source) => [sourceKey(source), source]));
   const normalizedKeys = new Set<string>();
+  const eligible: KnowledgeExtractionCandidate[] = [];
   for (const candidate of candidates) {
-    if (normalizedKeys.has(candidate.content.normalizedKey)) {
-      throw new Error("knowledge_normalized_key_duplicate");
-    }
-    normalizedKeys.add(candidate.content.normalizedKey);
-    const selected = [
-      ...new Map(
-        candidate.sourceRefs.map((ref) => {
-          const source = available.get(`${ref.kind}\0${ref.id}\0${ref.revision}`);
-          if (source === undefined) throw new Error("knowledge_source_ref_invalid");
-          return [sourceKey(source), source] as const;
-        }),
-      ).values(),
+    const selected = candidate.sourceRefs.map((ref) =>
+      available.get(`${ref.kind}\0${ref.id}\0${ref.revision}`),
+    );
+    if (selected.some((source) => source === undefined)) continue;
+    const uniqueSources = [
+      ...new Map(selected.map((source) => [sourceKey(source!), source!] as const)).values(),
     ];
-    if (!knowledgeSourceSelectionEligible(selected)) {
-      throw new Error("knowledge_source_threshold_not_met");
-    }
+    if (!knowledgeSourceSelectionEligible(uniqueSources)) continue;
+    if (normalizedKeys.has(candidate.content.normalizedKey)) continue;
+    normalizedKeys.add(candidate.content.normalizedKey);
+    eligible.push(candidate);
   }
+  return eligible;
 }
 
 export function knowledgeSourceSelectionEligible(

--- a/packages/memory/src/knowledge/store.ts
+++ b/packages/memory/src/knowledge/store.ts
@@ -348,7 +348,7 @@ export async function createKnowledgeLearningStore(
 function initialize(database: DatabaseSync): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS schema_meta(version INTEGER NOT NULL);
-    INSERT INTO schema_meta(version) SELECT 2 WHERE NOT EXISTS (SELECT 1 FROM schema_meta);
+    INSERT INTO schema_meta(version) SELECT 3 WHERE NOT EXISTS (SELECT 1 FROM schema_meta);
     CREATE TABLE IF NOT EXISTS jobs(
       id TEXT PRIMARY KEY, root_key TEXT NOT NULL, source_digest TEXT NOT NULL,
       status TEXT NOT NULL, retry_at TEXT, lease_until TEXT, job_json TEXT NOT NULL,
@@ -367,14 +367,13 @@ async function assertFreshOrCurrent(database: DatabaseSync, databasePath: string
   }
   const version = database.prepare("SELECT version FROM schema_meta LIMIT 1").get() as
     { version: number } | undefined;
-  if (version?.version === 1) {
-    await ensureSqliteMigrationBackup(database, databasePath, 1);
-    migrateV1ToV2(database);
-    return;
-  }
-  if (version?.version !== 2) {
+  if (version?.version !== 1 && version?.version !== 2 && version?.version !== 3) {
     throw new Error("Unsupported pragma.memory-knowledge-learning-store version.");
   }
+  if (version.version === 3) return;
+  await ensureSqliteMigrationBackup(database, databasePath, version.version);
+  if (version.version === 1) migrateV1ToV2(database);
+  migrateV2ToV3(database);
 }
 
 function migrateV1ToV2(database: DatabaseSync): void {
@@ -400,6 +399,52 @@ function migrateV1ToV2(database: DatabaseSync): void {
       update.run(migrated.retryAt ?? null, JSON.stringify(migrated), row.id);
     }
     database.prepare("UPDATE schema_meta SET version=2").run();
+    database.exec("COMMIT;");
+  } catch (error) {
+    database.exec("ROLLBACK;");
+    throw error;
+  }
+}
+
+const REQUEUEABLE_CANDIDATE_ERROR_CODES = new Set([
+  "knowledge_normalized_key_duplicate",
+  "knowledge_source_ref_invalid",
+  "knowledge_source_threshold_not_met",
+]);
+
+function migrateV2ToV3(database: DatabaseSync): void {
+  const rows = database.prepare("SELECT id, job_json FROM jobs").all() as unknown as readonly {
+    readonly id: string;
+    readonly job_json: string;
+  }[];
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    const update = database.prepare(
+      "UPDATE jobs SET status=?, retry_at=?, lease_until=NULL, job_json=? WHERE id=?",
+    );
+    for (const row of rows) {
+      const job = KnowledgeExtractionJobSchema.parse(JSON.parse(row.job_json));
+      if (
+        job.status !== "needs_attention" ||
+        job.lastErrorCode === undefined ||
+        !REQUEUEABLE_CANDIDATE_ERROR_CODES.has(job.lastErrorCode)
+      ) {
+        continue;
+      }
+      const migrated = KnowledgeExtractionJobSchema.parse({
+        ...job,
+        revision: job.revision + 1,
+        status: "pending",
+        attempts: 0,
+        retryAt: job.updatedAt,
+        leaseUntil: undefined,
+        lastErrorCode: undefined,
+        failureClass: undefined,
+        completion: undefined,
+      });
+      update.run(migrated.status, migrated.retryAt ?? null, JSON.stringify(migrated), migrated.id);
+    }
+    database.prepare("UPDATE schema_meta SET version=3").run();
     database.exec("COMMIT;");
   } catch (error) {
     database.exec("ROLLBACK;");

--- a/packages/memory/src/skill/module.ts
+++ b/packages/memory/src/skill/module.ts
@@ -103,6 +103,7 @@ export async function createSkillMemoryModule(options: {
       if (job === undefined) return;
       const controller = new AbortController();
       running.set(job.id, controller);
+      let retained = false;
       try {
         const available = await options.sourceReader.listEligibleSources({
           rootRef: job.rootRef,
@@ -139,15 +140,17 @@ export async function createSkillMemoryModule(options: {
           const result = await extractor.extract(input, { signal: controller.signal });
           const output = SkillExtractionOutputSchema.parse(result.output);
           if (!output.retain) continue;
-          assertEligibleCandidates(output.candidates, input.sources, existingTargets);
+          const candidates = eligibleCandidates(output.candidates, input.sources, existingTargets);
+          if (candidates.length === 0) continue;
           await options.learningSink.submit({
             rootRef: job.rootRef,
             sourceDigest,
-            candidates: output.candidates,
+            candidates,
             sources: input.sources,
           });
+          retained = true;
         }
-        await store.complete(job, "retained", now());
+        await store.complete(job, retained ? "retained" : "rejected", now());
       } catch (error) {
         await store.fail({
           job,
@@ -200,37 +203,33 @@ export function skillSourceThresholdMet(sources: readonly SkillSourceSnapshot[])
   return episodes.length >= 3 && conversations.size >= 2 && successful.length >= 2;
 }
 
-function assertEligibleCandidates(
+function eligibleCandidates(
   candidates: readonly SkillExtractionCandidate[],
   sources: readonly SkillSourceSnapshot[],
   targets: readonly ExistingMemorySkillTarget[],
-): void {
+): readonly SkillExtractionCandidate[] {
   const available = new Map(sources.map((source) => [sourceKey(source), source]));
   const targetIds = new Set(targets.map((target) => target.bindingId));
-  const keys = new Set<string>();
-  for (const candidate of candidates) {
-    if (keys.has(candidate.content.normalizedKey))
-      throw new Error("skill_normalized_key_duplicate");
-    keys.add(candidate.content.normalizedKey);
+  const normalizedKeys = new Set<string>();
+  return candidates.filter((candidate) => {
     const selected = candidate.sourceRefs.map((ref) =>
       available.get(`${ref.kind}\0${ref.id}\0${ref.revision}`),
     );
-    if (
-      selected.some((source) => source === undefined) ||
-      !skillSourceThresholdMet(
-        selected.filter((source): source is SkillSourceSnapshot => source !== undefined),
-      )
-    )
-      throw new Error("skill_source_threshold_not_met");
+    if (!selected.every((source): source is SkillSourceSnapshot => source !== undefined)) {
+      return false;
+    }
+    if (!skillSourceThresholdMet(selected)) return false;
     const bindingIds =
       candidate.route.type === "revise"
         ? [candidate.route.bindingId]
         : candidate.route.type === "ambiguous"
           ? candidate.route.bindingIds
           : [];
-    if (bindingIds.some((id) => !targetIds.has(id)))
-      throw new Error("skill_target_binding_invalid");
-  }
+    if (bindingIds.some((id) => !targetIds.has(id))) return false;
+    if (normalizedKeys.has(candidate.content.normalizedKey)) return false;
+    normalizedKeys.add(candidate.content.normalizedKey);
+    return true;
+  });
 }
 
 function groupTerminalSignals(

--- a/packages/memory/src/skill/store.ts
+++ b/packages/memory/src/skill/store.ts
@@ -4,34 +4,77 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 import { PragmaPaths, withFileLock } from "@pragma/core";
-import { SkillLearningJobSchema, type MemorySubjectRef, type SkillLearningJob } from "@pragma/shared";
+import {
+  SkillLearningJobSchema,
+  type MemorySubjectRef,
+  type SkillLearningJob,
+} from "@pragma/shared";
 
-import { queryMemoryJobPage, type MemoryJobPage, type MemoryJobPageInput } from "../pipeline/memory-job-page.ts";
+import {
+  queryMemoryJobPage,
+  type MemoryJobPage,
+  type MemoryJobPageInput,
+} from "../pipeline/memory-job-page.ts";
 import { DEFAULT_MEMORY_STORAGE_POLICY } from "../storage/memory-storage-policy.ts";
-import { assertFreshSqliteDatabase } from "../storage/sqlite-migration-backup.ts";
+import {
+  assertFreshSqliteDatabase,
+  ensureSqliteMigrationBackup,
+} from "../storage/sqlite-migration-backup.ts";
 
 const MODULE_ID = "pragma.memory.skill-learning";
 const LEASE_MS = 5 * 60_000;
 
 export interface SkillLearningStore {
-  schedule(input: { readonly rootRef: MemorySubjectRef; readonly sourceDigest: string; readonly now: Date }): Promise<SkillLearningJob | undefined>;
+  schedule(input: {
+    readonly rootRef: MemorySubjectRef;
+    readonly sourceDigest: string;
+    readonly now: Date;
+  }): Promise<SkillLearningJob | undefined>;
   claimDueJob(now: Date): Promise<SkillLearningJob | undefined>;
   isClaimCurrent(job: SkillLearningJob): Promise<boolean>;
   complete(job: SkillLearningJob, completion: "retained" | "rejected", now: Date): Promise<void>;
-  fail(input: { readonly job: SkillLearningJob; readonly errorCode: string; readonly retry: "configuration" | "transient" | "capacity"; readonly now: Date }): Promise<void>;
-  retryJob(input: { readonly id: string; readonly expectedRevision: number; readonly now: Date }): Promise<void>;
-  expediteJob(input: { readonly id: string; readonly expectedRevision: number; readonly now: Date }): Promise<void>;
-  interruptJob(input: { readonly id: string; readonly expectedRevision: number; readonly now: Date }): Promise<SkillLearningJob>;
+  fail(input: {
+    readonly job: SkillLearningJob;
+    readonly errorCode: string;
+    readonly retry: "configuration" | "transient" | "capacity";
+    readonly now: Date;
+  }): Promise<void>;
+  retryJob(input: {
+    readonly id: string;
+    readonly expectedRevision: number;
+    readonly now: Date;
+  }): Promise<void>;
+  expediteJob(input: {
+    readonly id: string;
+    readonly expectedRevision: number;
+    readonly now: Date;
+  }): Promise<void>;
+  interruptJob(input: {
+    readonly id: string;
+    readonly expectedRevision: number;
+    readonly now: Date;
+  }): Promise<SkillLearningJob>;
   deleteJob(input: { readonly id: string; readonly expectedRevision: number }): Promise<void>;
   wakeNeedsAttention(now: Date, reason?: "configuration" | "manual"): Promise<void>;
   listJobs(): Promise<readonly SkillLearningJob[]>;
-  listJobsPage(input: MemoryJobPageInput<SkillLearningJob["status"]>): Promise<MemoryJobPage<SkillLearningJob>>;
+  listJobsPage(
+    input: MemoryJobPageInput<SkillLearningJob["status"]>,
+  ): Promise<MemoryJobPage<SkillLearningJob>>;
   maintain(now: Date): Promise<{ readonly deletedJobs: number }>;
-  inspect(): Promise<{ readonly jobs: number; readonly pending: number; readonly running: number; readonly needsAttention: number; readonly completed: number; readonly lastErrorCode?: string | undefined }>;
+  inspect(): Promise<{
+    readonly jobs: number;
+    readonly pending: number;
+    readonly running: number;
+    readonly needsAttention: number;
+    readonly completed: number;
+    readonly lastErrorCode?: string | undefined;
+  }>;
   close(): void;
 }
 
-export async function createSkillLearningStore(options: { readonly pragmaHome?: string } = {}): Promise<SkillLearningStore> {
+export async function createSkillLearningStore(
+  options: { readonly pragmaHome?: string } = {},
+): Promise<SkillLearningStore> {
   const paths = new PragmaPaths(options);
   const dataRoot = paths.memoryModuleDataRoot(MODULE_ID);
   await mkdir(dataRoot, { recursive: true, mode: 0o700 });
@@ -39,21 +82,8 @@ export async function createSkillLearningStore(options: { readonly pragmaHome?: 
   const database = new DatabaseSync(databasePath);
   try {
     await withFileLock(`${databasePath}.migration.lock`, async () => {
-      const existing = database.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'").get();
-      if (existing === undefined) assertFreshSqliteDatabase(database, "pragma.memory-skill-learning-store");
-      else {
-        const version = database.prepare("SELECT version FROM schema_meta LIMIT 1").get() as { version: number } | undefined;
-        if (version?.version !== 1) throw new Error("Unsupported pragma.memory-skill-learning-store version.");
-      }
-      database.exec(`
-        CREATE TABLE IF NOT EXISTS schema_meta(version INTEGER NOT NULL);
-        INSERT INTO schema_meta(version) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM schema_meta);
-        CREATE TABLE IF NOT EXISTS jobs(
-          id TEXT PRIMARY KEY, root_key TEXT NOT NULL, source_digest TEXT NOT NULL,
-          status TEXT NOT NULL, retry_at TEXT, lease_until TEXT, job_json TEXT NOT NULL,
-          UNIQUE(root_key, source_digest)
-        );
-      `);
+      await assertFreshOrCurrent(database, databasePath);
+      initialize(database);
     });
   } catch (error) {
     database.close();
@@ -62,118 +92,354 @@ export async function createSkillLearningStore(options: { readonly pragmaHome?: 
 
   const parse = (json: string) => SkillLearningJobSchema.parse(JSON.parse(json));
   const read = (id: string): SkillLearningJob | undefined => {
-    const row = database.prepare("SELECT job_json FROM jobs WHERE id=?").get(id) as { job_json: string } | undefined;
+    const row = database.prepare("SELECT job_json FROM jobs WHERE id=?").get(id) as
+      { job_json: string } | undefined;
     return row === undefined ? undefined : parse(row.job_json);
   };
   const write = (job: SkillLearningJob) => {
-    database.prepare(`INSERT INTO jobs(id, root_key, source_digest, status, retry_at, lease_until, job_json)
+    database
+      .prepare(
+        `INSERT INTO jobs(id, root_key, source_digest, status, retry_at, lease_until, job_json)
       VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET status=excluded.status,
-      retry_at=excluded.retry_at, lease_until=excluded.lease_until, job_json=excluded.job_json`).run(
-      job.id,
-      refKey(job.rootRef),
-      job.sourceDigest,
-      job.status,
-      job.retryAt ?? null,
-      job.leaseUntil ?? null,
-      JSON.stringify(job),
-    );
+      retry_at=excluded.retry_at, lease_until=excluded.lease_until, job_json=excluded.job_json`,
+      )
+      .run(
+        job.id,
+        refKey(job.rootRef),
+        job.sourceDigest,
+        job.status,
+        job.retryAt ?? null,
+        job.leaseUntil ?? null,
+        JSON.stringify(job),
+      );
   };
-  const assertManaged = (job: SkillLearningJob | undefined, revision: number, states: readonly SkillLearningJob["status"][]): SkillLearningJob => {
+  const assertManaged = (
+    job: SkillLearningJob | undefined,
+    revision: number,
+    states: readonly SkillLearningJob["status"][],
+  ): SkillLearningJob => {
     if (job === undefined || job.revision !== revision) throw conflict();
     if (!states.includes(job.status)) throw new Error("skill_job_state_invalid");
     return job;
   };
-  const reset = (job: SkillLearningJob, now: Date) => SkillLearningJobSchema.parse({
-    ...job, revision: job.revision + 1, status: "pending", attempts: 0,
-    retryAt: undefined, leaseUntil: undefined, lastErrorCode: undefined,
-    failureClass: undefined, updatedAt: now.toISOString(),
-  });
+  const reset = (job: SkillLearningJob, now: Date) =>
+    SkillLearningJobSchema.parse({
+      ...job,
+      revision: job.revision + 1,
+      status: "pending",
+      attempts: 0,
+      retryAt: undefined,
+      leaseUntil: undefined,
+      lastErrorCode: undefined,
+      failureClass: undefined,
+      updatedAt: now.toISOString(),
+    });
 
   return {
     async schedule(input) {
-      if (!/^[a-f0-9]{64}$/u.test(input.sourceDigest)) throw new Error("skill_source_digest_invalid");
+      if (!/^[a-f0-9]{64}$/u.test(input.sourceDigest))
+        throw new Error("skill_source_digest_invalid");
       const rootKey = refKey(input.rootRef);
-      if (database.prepare("SELECT 1 FROM jobs WHERE root_key=? AND source_digest=?").get(rootKey, input.sourceDigest) !== undefined) return undefined;
+      if (
+        database
+          .prepare("SELECT 1 FROM jobs WHERE root_key=? AND source_digest=?")
+          .get(rootKey, input.sourceDigest) !== undefined
+      )
+        return undefined;
       const timestamp = input.now.toISOString();
       const job = SkillLearningJobSchema.parse({
         schemaVersion: "pragma.memory-skill-job/v1",
-        id: stableId("skill-job", rootKey, input.sourceDigest), revision: 1,
-        rootRef: input.rootRef, sourceDigest: input.sourceDigest, status: "pending",
-        attempts: 0, createdAt: timestamp, updatedAt: timestamp,
+        id: stableId("skill-job", rootKey, input.sourceDigest),
+        revision: 1,
+        rootRef: input.rootRef,
+        sourceDigest: input.sourceDigest,
+        status: "pending",
+        attempts: 0,
+        createdAt: timestamp,
+        updatedAt: timestamp,
       });
       write(job);
       return job;
     },
     async claimDueJob(now) {
       const timestamp = now.toISOString();
-      const row = database.prepare(`SELECT job_json FROM jobs WHERE
+      const row = database
+        .prepare(
+          `SELECT job_json FROM jobs WHERE
         (status='pending' AND (retry_at IS NULL OR retry_at<=?)) OR
-        (status='running' AND lease_until<=?) ORDER BY rowid LIMIT 1`).get(timestamp, timestamp) as { job_json: string } | undefined;
+        (status='running' AND lease_until<=?) ORDER BY rowid LIMIT 1`,
+        )
+        .get(timestamp, timestamp) as { job_json: string } | undefined;
       if (row === undefined) return undefined;
       const current = parse(row.job_json);
       const claimed = SkillLearningJobSchema.parse({
-        ...current, revision: current.revision + 1, status: "running",
-        attempts: current.attempts + 1, retryAt: undefined,
-        leaseUntil: new Date(now.getTime() + LEASE_MS).toISOString(), updatedAt: timestamp,
+        ...current,
+        revision: current.revision + 1,
+        status: "running",
+        attempts: current.attempts + 1,
+        retryAt: undefined,
+        leaseUntil: new Date(now.getTime() + LEASE_MS).toISOString(),
+        updatedAt: timestamp,
       });
       write(claimed);
       return claimed;
     },
-    async isClaimCurrent(job) { const current = read(job.id); return current?.revision === job.revision && current.status === "running"; },
+    async isClaimCurrent(job) {
+      const current = read(job.id);
+      return current?.revision === job.revision && current.status === "running";
+    },
     async complete(job, completion, now) {
       const current = read(job.id);
       if (current?.revision !== job.revision || current.status !== "running") throw conflict();
-      write(SkillLearningJobSchema.parse({ ...job, revision: job.revision + 1, status: "completed", completion, leaseUntil: undefined, updatedAt: now.toISOString() }));
+      write(
+        SkillLearningJobSchema.parse({
+          ...job,
+          revision: job.revision + 1,
+          status: "completed",
+          completion,
+          leaseUntil: undefined,
+          updatedAt: now.toISOString(),
+        }),
+      );
     },
     async fail(input) {
       const current = read(input.job.id);
       if (current?.revision !== input.job.revision || current.status !== "running") return;
       const attention = input.retry !== "transient" || input.job.attempts >= 3;
-      write(SkillLearningJobSchema.parse({
-        ...input.job, revision: input.job.revision + 1, status: attention ? "needs_attention" : "pending",
-        retryAt: attention ? undefined : new Date(input.now.getTime() + 2 ** input.job.attempts * 1_000).toISOString(),
-        leaseUntil: undefined, lastErrorCode: input.errorCode,
-        failureClass: attention ? input.retry === "capacity" ? "capacity" : input.retry === "configuration" ? "configuration" : "transient-exhausted" : undefined,
-        updatedAt: input.now.toISOString(),
-      }));
+      write(
+        SkillLearningJobSchema.parse({
+          ...input.job,
+          revision: input.job.revision + 1,
+          status: attention ? "needs_attention" : "pending",
+          retryAt: attention
+            ? undefined
+            : new Date(input.now.getTime() + 2 ** input.job.attempts * 1_000).toISOString(),
+          leaseUntil: undefined,
+          lastErrorCode: input.errorCode,
+          failureClass: attention
+            ? input.retry === "capacity"
+              ? "capacity"
+              : input.retry === "configuration"
+                ? "configuration"
+                : "transient-exhausted"
+            : undefined,
+          updatedAt: input.now.toISOString(),
+        }),
+      );
     },
-    async retryJob(input) { write(reset(assertManaged(read(input.id), input.expectedRevision, ["needs_attention"]), input.now)); },
+    async retryJob(input) {
+      write(
+        reset(
+          assertManaged(read(input.id), input.expectedRevision, ["needs_attention"]),
+          input.now,
+        ),
+      );
+    },
     async expediteJob(input) {
       const job = assertManaged(read(input.id), input.expectedRevision, ["pending"]);
-      write(SkillLearningJobSchema.parse({ ...job, revision: job.revision + 1, retryAt: input.now.toISOString(), updatedAt: input.now.toISOString() }));
+      write(
+        SkillLearningJobSchema.parse({
+          ...job,
+          revision: job.revision + 1,
+          retryAt: input.now.toISOString(),
+          updatedAt: input.now.toISOString(),
+        }),
+      );
     },
     async interruptJob(input) {
       const job = assertManaged(read(input.id), input.expectedRevision, ["running"]);
-      const next = SkillLearningJobSchema.parse({ ...reset(job, input.now), retryAt: new Date(input.now.getTime() + DEFAULT_MEMORY_STORAGE_POLICY.extractionIdleMs).toISOString() });
+      const next = SkillLearningJobSchema.parse({
+        ...reset(job, input.now),
+        retryAt: new Date(
+          input.now.getTime() + DEFAULT_MEMORY_STORAGE_POLICY.extractionIdleMs,
+        ).toISOString(),
+      });
       write(next);
       return next;
     },
-    async deleteJob(input) { const job = assertManaged(read(input.id), input.expectedRevision, ["needs_attention"]); database.prepare("DELETE FROM jobs WHERE id=?").run(job.id); },
-    async wakeNeedsAttention(now, reason = "configuration") {
-      const rows = database.prepare("SELECT job_json FROM jobs WHERE status='needs_attention'").all() as { job_json: string }[];
-      for (const row of rows) { const job = parse(row.job_json); if (reason === "manual" || job.failureClass === "configuration") write(reset(job, now)); }
+    async deleteJob(input) {
+      const job = assertManaged(read(input.id), input.expectedRevision, ["needs_attention"]);
+      database.prepare("DELETE FROM jobs WHERE id=?").run(job.id);
     },
-    async listJobs() { return (database.prepare("SELECT job_json FROM jobs ORDER BY rowid DESC").all() as { job_json: string }[]).map((row) => parse(row.job_json)); },
-    async listJobsPage(input) { return queryMemoryJobPage(database, input, parse); },
+    async wakeNeedsAttention(now, reason = "configuration") {
+      const rows = database
+        .prepare("SELECT job_json FROM jobs WHERE status='needs_attention'")
+        .all() as { job_json: string }[];
+      for (const row of rows) {
+        const job = parse(row.job_json);
+        if (reason === "manual" || job.failureClass === "configuration") write(reset(job, now));
+      }
+    },
+    async listJobs() {
+      return (
+        database.prepare("SELECT job_json FROM jobs ORDER BY rowid DESC").all() as {
+          job_json: string;
+        }[]
+      ).map((row) => parse(row.job_json));
+    },
+    async listJobsPage(input) {
+      return queryMemoryJobPage(database, input, parse);
+    },
     async maintain(now) {
       const cutoff = now.getTime() - DEFAULT_MEMORY_STORAGE_POLICY.jobRecordRetentionMs;
-      const rows = database.prepare("SELECT id, job_json FROM jobs WHERE status='completed'").all() as { id: string; job_json: string }[];
+      const rows = database
+        .prepare("SELECT id, job_json FROM jobs WHERE status='completed'")
+        .all() as { id: string; job_json: string }[];
       const expired = rows.filter((row) => Date.parse(parse(row.job_json).updatedAt) < cutoff);
       const remove = database.prepare("DELETE FROM jobs WHERE id=?");
       database.exec("BEGIN IMMEDIATE;");
-      try { for (const row of expired) remove.run(row.id); database.exec("COMMIT;"); } catch (error) { database.exec("ROLLBACK;"); throw error; }
+      try {
+        for (const row of expired) remove.run(row.id);
+        database.exec("COMMIT;");
+      } catch (error) {
+        database.exec("ROLLBACK;");
+        throw error;
+      }
       return { deletedJobs: expired.length };
     },
     async inspect() {
-      const rows = database.prepare("SELECT status, COUNT(*) AS count FROM jobs GROUP BY status").all() as { status: string; count: number }[];
+      const rows = database
+        .prepare("SELECT status, COUNT(*) AS count FROM jobs GROUP BY status")
+        .all() as { status: string; count: number }[];
       const counts = new Map(rows.map((row) => [row.status, Number(row.count)]));
-      const last = database.prepare("SELECT job_json FROM jobs WHERE status='needs_attention' ORDER BY rowid DESC LIMIT 1").get() as { job_json: string } | undefined;
-      return { jobs: [...counts.values()].reduce((sum, count) => sum + count, 0), pending: counts.get("pending") ?? 0, running: counts.get("running") ?? 0, needsAttention: counts.get("needs_attention") ?? 0, completed: counts.get("completed") ?? 0, ...(last === undefined ? {} : { lastErrorCode: parse(last.job_json).lastErrorCode }) };
+      const last = database
+        .prepare(
+          "SELECT job_json FROM jobs WHERE status='needs_attention' ORDER BY rowid DESC LIMIT 1",
+        )
+        .get() as { job_json: string } | undefined;
+      return {
+        jobs: [...counts.values()].reduce((sum, count) => sum + count, 0),
+        pending: counts.get("pending") ?? 0,
+        running: counts.get("running") ?? 0,
+        needsAttention: counts.get("needs_attention") ?? 0,
+        completed: counts.get("completed") ?? 0,
+        ...(last === undefined ? {} : { lastErrorCode: parse(last.job_json).lastErrorCode }),
+      };
     },
-    close() { database.close(); },
+    close() {
+      database.close();
+    },
   };
 }
 
-function refKey(ref: MemorySubjectRef): string { return `${ref.type}\0${ref.id}`; }
-function stableId(...parts: readonly string[]): string { return createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 32); }
-function conflict(): Error { return Object.assign(new Error("skill_job_conflict"), { code: "revision_conflict" }); }
+function initialize(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS schema_meta(version INTEGER NOT NULL);
+    INSERT INTO schema_meta(version) SELECT 3 WHERE NOT EXISTS (SELECT 1 FROM schema_meta);
+    CREATE TABLE IF NOT EXISTS jobs(
+      id TEXT PRIMARY KEY, root_key TEXT NOT NULL, source_digest TEXT NOT NULL,
+      status TEXT NOT NULL, retry_at TEXT, lease_until TEXT, job_json TEXT NOT NULL,
+      UNIQUE(root_key, source_digest)
+    );
+  `);
+}
+
+async function assertFreshOrCurrent(database: DatabaseSync, databasePath: string): Promise<void> {
+  const existing = database
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'")
+    .get();
+  if (existing === undefined) {
+    assertFreshSqliteDatabase(database, "pragma.memory-skill-learning-store");
+    return;
+  }
+  const version = database.prepare("SELECT version FROM schema_meta LIMIT 1").get() as
+    { readonly version: number } | undefined;
+  if (version?.version !== 1 && version?.version !== 2 && version?.version !== 3) {
+    throw new Error("Unsupported pragma.memory-skill-learning-store version.");
+  }
+  if (version.version === 3) return;
+  await ensureSqliteMigrationBackup(database, databasePath, version.version);
+  if (version.version === 1) migrateV1ToV2(database);
+  migrateV2ToV3(database);
+}
+
+function migrateV1ToV2(database: DatabaseSync): void {
+  const rows = database.prepare("SELECT id, job_json FROM jobs").all() as unknown as readonly {
+    readonly id: string;
+    readonly job_json: string;
+  }[];
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    const update = database.prepare(
+      "UPDATE jobs SET status=?, retry_at=NULL, lease_until=NULL, job_json=? WHERE id=?",
+    );
+    for (const row of rows) {
+      const job = SkillLearningJobSchema.parse(JSON.parse(row.job_json));
+      if (
+        job.status !== "needs_attention" ||
+        job.lastErrorCode !== "skill_source_threshold_not_met"
+      )
+        continue;
+      const migrated = SkillLearningJobSchema.parse({
+        ...job,
+        revision: job.revision + 1,
+        status: "completed",
+        completion: "rejected",
+        retryAt: undefined,
+        leaseUntil: undefined,
+        lastErrorCode: undefined,
+        failureClass: undefined,
+      });
+      update.run(migrated.status, JSON.stringify(migrated), migrated.id);
+    }
+    database.prepare("UPDATE schema_meta SET version=2").run();
+    database.exec("COMMIT;");
+  } catch (error) {
+    database.exec("ROLLBACK;");
+    throw error;
+  }
+}
+
+const REQUEUEABLE_CANDIDATE_ERROR_CODES = new Set([
+  "skill_normalized_key_duplicate",
+  "skill_target_binding_invalid",
+]);
+
+function migrateV2ToV3(database: DatabaseSync): void {
+  const rows = database.prepare("SELECT id, job_json FROM jobs").all() as unknown as readonly {
+    readonly id: string;
+    readonly job_json: string;
+  }[];
+  database.exec("BEGIN IMMEDIATE;");
+  try {
+    const update = database.prepare(
+      "UPDATE jobs SET status=?, retry_at=?, lease_until=NULL, job_json=? WHERE id=?",
+    );
+    for (const row of rows) {
+      const job = SkillLearningJobSchema.parse(JSON.parse(row.job_json));
+      if (
+        job.status !== "needs_attention" ||
+        job.lastErrorCode === undefined ||
+        !REQUEUEABLE_CANDIDATE_ERROR_CODES.has(job.lastErrorCode)
+      )
+        continue;
+      const migrated = SkillLearningJobSchema.parse({
+        ...job,
+        revision: job.revision + 1,
+        status: "pending",
+        attempts: 0,
+        retryAt: job.updatedAt,
+        leaseUntil: undefined,
+        lastErrorCode: undefined,
+        failureClass: undefined,
+        completion: undefined,
+      });
+      update.run(migrated.status, migrated.retryAt ?? null, JSON.stringify(migrated), migrated.id);
+    }
+    database.prepare("UPDATE schema_meta SET version=3").run();
+    database.exec("COMMIT;");
+  } catch (error) {
+    database.exec("ROLLBACK;");
+    throw error;
+  }
+}
+
+function refKey(ref: MemorySubjectRef): string {
+  return `${ref.type}\0${ref.id}`;
+}
+function stableId(...parts: readonly string[]): string {
+  return createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 32);
+}
+function conflict(): Error {
+  return Object.assign(new Error("skill_job_conflict"), { code: "revision_conflict" });
+}

--- a/packages/memory/test/episodic-memory.test.ts
+++ b/packages/memory/test/episodic-memory.test.ts
@@ -843,6 +843,7 @@ describe("Episodic Memory", () => {
       needsAttention: 1,
       lastErrorCode: "extractor_evidence_ref_invalid",
     });
+    expect(diagnostic.evidenceRecords).toBeGreaterThan(0);
     expect(await module.store.list()).toEqual([]);
 
     const database = new DatabaseSync(

--- a/packages/memory/test/fixtures/README.md
+++ b/packages/memory/test/fixtures/README.md
@@ -12,3 +12,12 @@ reintroducing the invalid value into current writes.
 records from the first-start failure shape. In particular, the historical Zod issue text is kept
 verbatim in `lastErrorCode` so the chained v1 → v2 → v3 repair is tested without manufacturing an
 old version by mutating a current job object.
+
+`skill-learning-store-v1.json` preserves the original Skill Learning v1 classification of a source
+threshold rejection beside a genuine extractor configuration failure. The v1 → v2 store migration
+archives only the threshold rejection as a completed job and leaves the actionable failure intact.
+
+`skill-learning-store-v2.json` and `knowledge-learning-store-v2.json` preserve candidate-level
+validation failures beside genuine configuration failures. Their v2 → v3 migrations requeue only
+the candidate failures so the new per-candidate filters can salvage valid siblings, while actionable
+configuration failures remain unchanged.

--- a/packages/memory/test/fixtures/knowledge-learning-store-v2.json
+++ b/packages/memory/test/fixtures/knowledge-learning-store-v2.json
@@ -1,0 +1,72 @@
+{
+  "jobs": [
+    {
+      "schemaVersion": "pragma.memory-knowledge-job/v2",
+      "id": "source-ref-job",
+      "revision": 2,
+      "rootRef": { "type": "pragma.expert", "id": "expert-a" },
+      "sourceDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "firstFactAt": "2026-08-05T08:00:00.000Z",
+      "lastFactAt": "2026-08-05T08:00:01.000Z",
+      "eligibleAt": "2026-08-05T08:00:00.000Z",
+      "deadlineAt": "2026-08-06T08:00:00.000Z",
+      "status": "needs_attention",
+      "attempts": 3,
+      "lastErrorCode": "knowledge_source_ref_invalid",
+      "failureClass": "transient-exhausted",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:03.000Z"
+    },
+    {
+      "schemaVersion": "pragma.memory-knowledge-job/v2",
+      "id": "threshold-job",
+      "revision": 4,
+      "rootRef": { "type": "pragma.expert", "id": "expert-b" },
+      "sourceDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "firstFactAt": "2026-08-05T08:00:00.000Z",
+      "lastFactAt": "2026-08-05T08:00:01.000Z",
+      "eligibleAt": "2026-08-05T08:00:00.000Z",
+      "deadlineAt": "2026-08-06T08:00:00.000Z",
+      "status": "needs_attention",
+      "attempts": 3,
+      "lastErrorCode": "knowledge_source_threshold_not_met",
+      "failureClass": "transient-exhausted",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:04.000Z"
+    },
+    {
+      "schemaVersion": "pragma.memory-knowledge-job/v2",
+      "id": "duplicate-job",
+      "revision": 1,
+      "rootRef": { "type": "pragma.expert", "id": "expert-c" },
+      "sourceDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "firstFactAt": "2026-08-05T08:00:00.000Z",
+      "lastFactAt": "2026-08-05T08:00:01.000Z",
+      "eligibleAt": "2026-08-05T08:00:00.000Z",
+      "deadlineAt": "2026-08-06T08:00:00.000Z",
+      "status": "needs_attention",
+      "attempts": 3,
+      "lastErrorCode": "knowledge_normalized_key_duplicate",
+      "failureClass": "transient-exhausted",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:05.000Z"
+    },
+    {
+      "schemaVersion": "pragma.memory-knowledge-job/v2",
+      "id": "configuration-job",
+      "revision": 2,
+      "rootRef": { "type": "pragma.expert", "id": "expert-d" },
+      "sourceDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "firstFactAt": "2026-08-05T08:00:00.000Z",
+      "lastFactAt": "2026-08-05T08:00:01.000Z",
+      "eligibleAt": "2026-08-05T08:00:00.000Z",
+      "deadlineAt": "2026-08-06T08:00:00.000Z",
+      "status": "needs_attention",
+      "attempts": 1,
+      "lastErrorCode": "memory_extractor_profile_invalid",
+      "failureClass": "configuration",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:02.000Z"
+    }
+  ]
+}

--- a/packages/memory/test/fixtures/skill-learning-store-v1.json
+++ b/packages/memory/test/fixtures/skill-learning-store-v1.json
@@ -1,0 +1,52 @@
+{
+  "jobs": [
+    {
+      "schemaVersion": "pragma.memory-skill-job/v1",
+      "id": "threshold-job",
+      "revision": 4,
+      "rootRef": {
+        "type": "pragma.expert",
+        "id": "expert-a"
+      },
+      "sourceDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "status": "needs_attention",
+      "attempts": 3,
+      "lastErrorCode": "skill_source_threshold_not_met",
+      "failureClass": "transient-exhausted",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:03.000Z"
+    },
+    {
+      "schemaVersion": "pragma.memory-skill-job/v1",
+      "id": "configuration-job",
+      "revision": 2,
+      "rootRef": {
+        "type": "pragma.expert",
+        "id": "expert-b"
+      },
+      "sourceDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "status": "needs_attention",
+      "attempts": 1,
+      "lastErrorCode": "memory_extractor_profile_invalid",
+      "failureClass": "configuration",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:01.000Z"
+    },
+    {
+      "schemaVersion": "pragma.memory-skill-job/v1",
+      "id": "target-binding-job",
+      "revision": 2,
+      "rootRef": {
+        "type": "pragma.expert",
+        "id": "expert-c"
+      },
+      "sourceDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "status": "needs_attention",
+      "attempts": 3,
+      "lastErrorCode": "skill_target_binding_invalid",
+      "failureClass": "transient-exhausted",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:02.000Z"
+    }
+  ]
+}

--- a/packages/memory/test/fixtures/skill-learning-store-v2.json
+++ b/packages/memory/test/fixtures/skill-learning-store-v2.json
@@ -1,0 +1,30 @@
+{
+  "jobs": [
+    {
+      "schemaVersion": "pragma.memory-skill-job/v1",
+      "id": "duplicate-job",
+      "revision": 3,
+      "rootRef": { "type": "pragma.expert", "id": "expert-a" },
+      "sourceDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "status": "needs_attention",
+      "attempts": 3,
+      "lastErrorCode": "skill_normalized_key_duplicate",
+      "failureClass": "transient-exhausted",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:03.000Z"
+    },
+    {
+      "schemaVersion": "pragma.memory-skill-job/v1",
+      "id": "configuration-job",
+      "revision": 2,
+      "rootRef": { "type": "pragma.expert", "id": "expert-b" },
+      "sourceDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "status": "needs_attention",
+      "attempts": 1,
+      "lastErrorCode": "memory_extractor_profile_invalid",
+      "failureClass": "configuration",
+      "createdAt": "2026-08-05T08:00:00.000Z",
+      "updatedAt": "2026-08-05T08:00:01.000Z"
+    }
+  ]
+}

--- a/packages/memory/test/knowledge-memory.test.ts
+++ b/packages/memory/test/knowledge-memory.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -75,6 +75,94 @@ describe("Knowledge learning jobs", () => {
     ]);
     await expect(stat(`${databasePath}.v1.backup`)).resolves.toBeDefined();
     store.close();
+    const migrated = new DatabaseSync(databasePath);
+    expect(
+      (migrated.prepare("SELECT version FROM schema_meta").get() as { version: number }).version,
+    ).toBe(3);
+    migrated.close();
+  });
+
+  it("requeues historical candidate validation failures in the v2 to v3 migration", async () => {
+    const root = await temporaryRoot();
+    const databasePath = await writeKnowledgeV2Store(root);
+
+    const store = await createKnowledgeLearningStore({ pragmaHome: root });
+    const jobs = await store.listJobs();
+    for (const id of ["source-ref-job", "threshold-job", "duplicate-job"]) {
+      expect(jobs.find((job) => job.id === id)).toMatchObject({
+        status: "pending",
+        attempts: 0,
+      });
+      expect(jobs.find((job) => job.id === id)).not.toHaveProperty("lastErrorCode");
+      expect(jobs.find((job) => job.id === id)).not.toHaveProperty("failureClass");
+    }
+    expect(jobs.find((job) => job.id === "configuration-job")).toMatchObject({
+      status: "needs_attention",
+      lastErrorCode: "memory_extractor_profile_invalid",
+      failureClass: "configuration",
+    });
+    store.close();
+
+    await expect(stat(`${databasePath}.v2.backup`)).resolves.toBeDefined();
+  });
+
+  it("opens current v3 storage without rewriting jobs", async () => {
+    const root = await temporaryRoot();
+    const store = await createKnowledgeLearningStore({ pragmaHome: root });
+    const scheduled = await store.schedule({
+      rootRef: ref("pragma.expert", "expert-a"),
+      sourceDigest,
+      now,
+    });
+    store.close();
+
+    const reopened = await createKnowledgeLearningStore({ pragmaHome: root });
+    expect(await reopened.listJobs()).toEqual([scheduled]);
+    reopened.close();
+  });
+
+  it("rolls back and replays the v2 to v3 migration", async () => {
+    const root = await temporaryRoot();
+    const databasePath = await writeKnowledgeV2Store(root);
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TRIGGER abort_candidate_migration
+      BEFORE UPDATE OF status ON jobs
+      WHEN NEW.id = 'source-ref-job'
+      BEGIN
+        SELECT RAISE(ABORT, 'simulated knowledge migration interruption');
+      END;
+    `);
+    database.close();
+
+    await expect(createKnowledgeLearningStore({ pragmaHome: root })).rejects.toThrow(
+      "simulated knowledge migration interruption",
+    );
+    const interrupted = new DatabaseSync(databasePath);
+    expect(
+      (interrupted.prepare("SELECT version FROM schema_meta").get() as { version: number }).version,
+    ).toBe(2);
+    interrupted.exec("DROP TRIGGER abort_candidate_migration;");
+    interrupted.close();
+
+    const recovered = await createKnowledgeLearningStore({ pragmaHome: root });
+    expect((await recovered.listJobs()).find((job) => job.id === "source-ref-job")).toMatchObject({
+      status: "pending",
+      attempts: 0,
+    });
+    recovered.close();
+  });
+
+  it("rejects a future knowledge learning storage version", async () => {
+    const root = await temporaryRoot();
+    const databasePath = await writeKnowledgeV2Store(root);
+    const database = new DatabaseSync(databasePath);
+    database.prepare("UPDATE schema_meta SET version=4").run();
+    database.close();
+
+    await expect(createKnowledgeLearningStore({ pragmaHome: root })).rejects.toThrow(
+      "Unsupported pragma.memory-knowledge-learning-store version.",
+    );
   });
 
   it("debounces Fact changes for six quiet hours and caps the batch at twenty-four hours", async () => {
@@ -289,6 +377,55 @@ describe("Knowledge learning jobs", () => {
     module.close();
   });
 
+  it("filters invalid, below-threshold, and duplicate candidates while retaining valid siblings", async () => {
+    const sourceRevisions = sources();
+    const valid = extractionCandidate();
+    const invalidRef = {
+      ...extractionCandidate(),
+      content: { ...valid.content, normalizedKey: "invalid.reference" },
+      sourceRefs: [{ kind: "semantic" as const, id: "missing", revision: 1 }],
+    };
+    const belowThreshold = {
+      ...extractionCandidate(),
+      content: { ...valid.content, normalizedKey: "insufficient.sources" },
+      sourceRefs: [sourceRevisions[0]!.ref],
+    };
+    const duplicate = {
+      ...extractionCandidate(),
+      content: { ...valid.content, title: "Duplicate should be ignored" },
+    };
+    const submit = vi.fn(async () => undefined);
+    const module = await createExtractionModule(
+      [invalidRef, belowThreshold, valid, duplicate],
+      submit,
+    );
+
+    await module.runBackgroundOnce?.();
+
+    expect(submit).toHaveBeenCalledWith(expect.objectContaining({ candidates: [valid] }));
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({ status: "completed", completion: "retained" }),
+    ]);
+    module.close();
+  });
+
+  it("completes as rejected when every extracted candidate is ineligible", async () => {
+    const invalid = {
+      ...extractionCandidate(),
+      sourceRefs: [{ kind: "semantic" as const, id: "missing", revision: 1 }],
+    };
+    const submit = vi.fn(async () => undefined);
+    const module = await createExtractionModule([invalid], submit);
+
+    await module.runBackgroundOnce?.();
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({ status: "completed", completion: "rejected" }),
+    ]);
+    module.close();
+  });
+
   it("requires a verified Semantic source or Semantic support from two executions", () => {
     const [episode, semantic] = sources();
     expect(knowledgeSourceSelectionEligible([episode!])).toBe(false);
@@ -393,4 +530,70 @@ async function temporaryRoot(): Promise<string> {
 
 async function temporaryStore(): Promise<KnowledgeLearningStore> {
   return await createKnowledgeLearningStore({ pragmaHome: await temporaryRoot() });
+}
+
+async function createExtractionModule(
+  candidates: readonly KnowledgeExtractionCandidate[],
+  submit: Parameters<typeof createKnowledgeMemoryModule>[0]["learningSink"]["submit"],
+) {
+  const sourceRevisions = sources();
+  const module = await createKnowledgeMemoryModule({
+    pragmaHome: await temporaryRoot(),
+    sourceReader: { listEligibleSources: async () => sourceRevisions },
+    extractor: {
+      extract: async () => ({
+        output: { retain: true as const, candidates: [...candidates] },
+        provenance: {
+          curatorRef: "pragma.memory.curator",
+          promptVersion: "knowledge-curator/v1",
+          profileRevision: 1,
+          runtimeId: "runtime-a",
+          providerId: "provider-a",
+          modelId: "model-a",
+          extractedAt: now.toISOString(),
+        },
+      }),
+    },
+    learningSink: { submit },
+    now: () => now,
+  });
+  await module.store.schedule({
+    rootRef: ref("pragma.expert", "expert-a"),
+    sourceDigest: digestSources(sourceRevisions),
+    now: new Date(now.getTime() - 6 * 60 * 60_000),
+  });
+  return module;
+}
+
+async function writeKnowledgeV2Store(root: string): Promise<string> {
+  const dataRoot = new PragmaPaths({ pragmaHome: root }).memoryModuleDataRoot(
+    "pragma.memory.knowledge-learning",
+  );
+  await mkdir(dataRoot, { recursive: true });
+  const databasePath = join(dataRoot, "knowledge.sqlite");
+  const fixture = JSON.parse(
+    await readFile(new URL("./fixtures/knowledge-learning-store-v2.json", import.meta.url), "utf8"),
+  ) as { readonly jobs: readonly KnowledgeExtractionJob[] };
+  const database = new DatabaseSync(databasePath);
+  database.exec(`
+    CREATE TABLE schema_meta(version INTEGER NOT NULL);
+    INSERT INTO schema_meta(version) VALUES (2);
+    CREATE TABLE jobs(
+      id TEXT PRIMARY KEY, root_key TEXT NOT NULL, source_digest TEXT NOT NULL,
+      status TEXT NOT NULL, retry_at TEXT, lease_until TEXT, job_json TEXT NOT NULL,
+      UNIQUE(root_key, source_digest)
+    );
+  `);
+  const insert = database.prepare("INSERT INTO jobs VALUES (?, ?, ?, ?, NULL, NULL, ?)");
+  for (const job of fixture.jobs) {
+    insert.run(
+      job.id,
+      `${job.rootRef.type}\0${job.rootRef.id}`,
+      job.sourceDigest,
+      job.status,
+      JSON.stringify(job),
+    );
+  }
+  database.close();
+  return databasePath;
 }

--- a/packages/memory/test/skill-memory.test.ts
+++ b/packages/memory/test/skill-memory.test.ts
@@ -1,0 +1,483 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { PragmaPaths } from "@pragma/core";
+import type {
+  MemorySubjectRef,
+  SkillExtractionCandidate,
+  SkillLearningJob,
+  SkillSourceSnapshot,
+} from "@pragma/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createSkillMemoryModule,
+  type SkillLearningSink,
+  type SkillMemoryExtractor,
+} from "../src/index.ts";
+import { createSkillLearningStore } from "../src/skill/store.ts";
+
+const roots: string[] = [];
+const now = new Date("2026-08-05T08:00:00.000Z");
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Skill learning extraction", () => {
+  it("completes insufficient overall evidence as a normal rejected result", async () => {
+    const sourceRevisions = sources().slice(0, 2);
+    const extract = vi.fn<SkillMemoryExtractor["extract"]>(async () =>
+      extractionResult([candidate("unused", validRefs())]),
+    );
+    const module = await createModule(sourceRevisions, { extract });
+
+    await schedule(module, sourceRevisions);
+    await module.runBackgroundOnce?.();
+
+    expect(extract).not.toHaveBeenCalled();
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({ status: "completed", completion: "rejected" }),
+    ]);
+    expect(await module.store.inspect()).toMatchObject({ needsAttention: 0, completed: 1 });
+    module.close();
+  });
+
+  it("filters a candidate below the source threshold and completes without user attention", async () => {
+    const sourceRevisions = sources();
+    const submit = vi.fn(async () => undefined);
+    const module = await createModule(sourceRevisions, {
+      extract: vi.fn(async () => extractionResult([candidate("invalid", invalidRefs())])),
+      submit,
+    });
+
+    await schedule(module, sourceRevisions);
+    await module.runBackgroundOnce?.();
+
+    expect(submit).not.toHaveBeenCalled();
+    const [job] = await module.store.listJobs();
+    expect(job).toMatchObject({ status: "completed", completion: "rejected" });
+    expect(job).not.toHaveProperty("lastErrorCode");
+    expect(job).not.toHaveProperty("failureClass");
+    expect(await module.store.inspect()).toMatchObject({ needsAttention: 0, completed: 1 });
+    module.close();
+  });
+
+  it("submits valid candidates while quietly discarding threshold failures", async () => {
+    const sourceRevisions = sources();
+    const valid = candidate("valid", validRefs());
+    const submit = vi.fn(async () => undefined);
+    const module = await createModule(sourceRevisions, {
+      extract: vi.fn(async () => extractionResult([candidate("invalid", invalidRefs()), valid])),
+      submit,
+    });
+
+    await schedule(module, sourceRevisions);
+    await module.runBackgroundOnce?.();
+
+    expect(submit).toHaveBeenCalledOnce();
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({ candidates: [valid], sources: sourceRevisions }),
+    );
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({ status: "completed", completion: "retained" }),
+    ]);
+    module.close();
+  });
+
+  it("filters stale targets and duplicate keys without discarding valid siblings", async () => {
+    const sourceRevisions = sources();
+    const valid = candidate("valid", validRefs());
+    const duplicate = {
+      ...candidate("valid", validRefs()),
+      content: { ...valid.content, package: { ...valid.content.package, name: "Duplicate" } },
+    };
+    const staleTarget = {
+      ...candidate("stale-target", validRefs()),
+      route: {
+        type: "revise" as const,
+        bindingId: "00000000-0000-4000-8000-000000000099",
+      },
+    };
+    const submit = vi.fn(async () => undefined);
+    const module = await createModule(sourceRevisions, {
+      extract: vi.fn(async () => extractionResult([staleTarget, valid, duplicate])),
+      submit,
+    });
+
+    await schedule(module, sourceRevisions);
+    await module.runBackgroundOnce?.();
+
+    expect(submit).toHaveBeenCalledWith(expect.objectContaining({ candidates: [valid] }));
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({ status: "completed", completion: "retained" }),
+    ]);
+    module.close();
+  });
+
+  it("records retain=false as rejected instead of retained", async () => {
+    const sourceRevisions = sources();
+    const module = await createModule(sourceRevisions, {
+      extract: vi.fn(async () => ({
+        output: { retain: false as const, reason: "no-reusable-skill" as const },
+        provenance: provenance(),
+      })),
+    });
+
+    await schedule(module, sourceRevisions);
+    await module.runBackgroundOnce?.();
+
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({ status: "completed", completion: "rejected" }),
+    ]);
+    module.close();
+  });
+
+  it("keeps genuine extractor configuration failures actionable", async () => {
+    const sourceRevisions = sources();
+    const module = await createModule(sourceRevisions, {
+      extract: vi.fn(async () => {
+        throw new Error("provider unavailable");
+      }),
+    });
+
+    await schedule(module, sourceRevisions);
+    await module.runBackgroundOnce?.();
+
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({
+        status: "needs_attention",
+        failureClass: "configuration",
+      }),
+    ]);
+    module.close();
+  });
+});
+
+describe("Skill learning store v3 migration", () => {
+  it("archives historical threshold attention as rejected and preserves other failures", async () => {
+    const root = await temporaryRoot();
+    const databasePath = await writeLegacyStore(root);
+
+    const store = await createSkillLearningStore({ pragmaHome: root });
+    const jobs = await store.listJobs();
+    const threshold = jobs.find((job) => job.id === "threshold-job");
+    expect(threshold).toMatchObject({
+      revision: 5,
+      status: "completed",
+      completion: "rejected",
+    });
+    expect(threshold).not.toHaveProperty("lastErrorCode");
+    expect(threshold).not.toHaveProperty("failureClass");
+    expect(jobs.find((job) => job.id === "configuration-job")).toMatchObject({
+      revision: 2,
+      status: "needs_attention",
+      lastErrorCode: "memory_extractor_profile_invalid",
+      failureClass: "configuration",
+    });
+    expect(jobs.find((job) => job.id === "target-binding-job")).toMatchObject({
+      revision: 3,
+      status: "pending",
+      attempts: 0,
+      retryAt: "2026-08-05T08:00:02.000Z",
+    });
+    expect(await store.inspect()).toMatchObject({ needsAttention: 1, pending: 1, completed: 1 });
+    store.close();
+
+    const migrated = new DatabaseSync(databasePath);
+    expect(
+      (migrated.prepare("SELECT version FROM schema_meta").get() as { version: number }).version,
+    ).toBe(3);
+    migrated.close();
+    await expect(stat(`${databasePath}.v1.backup`)).resolves.toBeDefined();
+  });
+
+  it("opens current v3 storage without rewriting jobs", async () => {
+    const root = await temporaryRoot();
+    const store = await createSkillLearningStore({ pragmaHome: root });
+    const scheduled = await store.schedule({
+      rootRef: ref("pragma.expert", "expert-a"),
+      sourceDigest: "c".repeat(64),
+      now,
+    });
+    store.close();
+
+    const reopened = await createSkillLearningStore({ pragmaHome: root });
+    expect(await reopened.listJobs()).toEqual([scheduled]);
+    reopened.close();
+  });
+
+  it("upgrades a v2 store directly and preserves its backup", async () => {
+    const root = await temporaryRoot();
+    const databasePath = await writeStoreFixture(root, 2, "skill-learning-store-v2.json");
+
+    const store = await createSkillLearningStore({ pragmaHome: root });
+    expect((await store.listJobs()).find((job) => job.id === "duplicate-job")).toMatchObject({
+      revision: 4,
+      status: "pending",
+      attempts: 0,
+      retryAt: "2026-08-05T08:00:03.000Z",
+    });
+    expect((await store.listJobs()).find((job) => job.id === "configuration-job")).toMatchObject({
+      status: "needs_attention",
+      failureClass: "configuration",
+    });
+    store.close();
+    await expect(stat(`${databasePath}.v2.backup`)).resolves.toBeDefined();
+  });
+
+  it("rolls back an interrupted migration and replays it after the fault is removed", async () => {
+    const root = await temporaryRoot();
+    const databasePath = await writeLegacyStore(root);
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TRIGGER abort_candidate_migration
+      BEFORE UPDATE OF status ON jobs
+      WHEN NEW.id = 'target-binding-job'
+      BEGIN
+        SELECT RAISE(ABORT, 'simulated migration interruption');
+      END;
+    `);
+    database.close();
+
+    await expect(createSkillLearningStore({ pragmaHome: root })).rejects.toThrow(
+      "simulated migration interruption",
+    );
+    const interrupted = new DatabaseSync(databasePath);
+    expect(
+      (interrupted.prepare("SELECT version FROM schema_meta").get() as { version: number }).version,
+    ).toBe(2);
+    expect(
+      interrupted.prepare("SELECT status FROM jobs WHERE id='target-binding-job'").get(),
+    ).toEqual({
+      status: "needs_attention",
+    });
+    interrupted.exec("DROP TRIGGER abort_candidate_migration;");
+    interrupted.close();
+
+    const recovered = await createSkillLearningStore({ pragmaHome: root });
+    expect(
+      (await recovered.listJobs()).find((job) => job.id === "target-binding-job"),
+    ).toMatchObject({
+      status: "pending",
+      attempts: 0,
+    });
+    recovered.close();
+  });
+
+  it("rejects a future storage version", async () => {
+    const root = await temporaryRoot();
+    const databasePath = await writeLegacyStore(root);
+    const database = new DatabaseSync(databasePath);
+    database.prepare("UPDATE schema_meta SET version=4").run();
+    database.close();
+
+    await expect(createSkillLearningStore({ pragmaHome: root })).rejects.toThrow(
+      "Unsupported pragma.memory-skill-learning-store version.",
+    );
+  });
+});
+
+async function createModule(
+  sourceRevisions: readonly SkillSourceSnapshot[],
+  overrides: {
+    readonly extract: SkillMemoryExtractor["extract"];
+    readonly submit?: SkillLearningSink["submit"];
+  },
+) {
+  return await createSkillMemoryModule({
+    pragmaHome: await temporaryRoot(),
+    sourceReader: { listEligibleSources: async () => sourceRevisions },
+    targetReader: { listTargets: async () => [] },
+    extractor: { extract: overrides.extract },
+    learningSink: { submit: overrides.submit ?? vi.fn(async () => undefined) },
+    now: () => now,
+  });
+}
+
+async function schedule(
+  module: Awaited<ReturnType<typeof createSkillMemoryModule>>,
+  sourceRevisions: readonly SkillSourceSnapshot[],
+): Promise<void> {
+  await module.store.schedule({
+    rootRef: ref("pragma.expert", "expert-a"),
+    sourceDigest: digestSources(sourceRevisions),
+    now,
+  });
+}
+
+function extractionResult(
+  candidates: readonly SkillExtractionCandidate[],
+): Awaited<ReturnType<SkillMemoryExtractor["extract"]>> {
+  return { output: { retain: true, candidates: [...candidates] }, provenance: provenance() };
+}
+
+function provenance() {
+  return {
+    curatorRef: "pragma.memory.curator",
+    promptVersion: "skill-curator/v1",
+    profileRevision: 1,
+    runtimeId: "runtime-a",
+    providerId: "provider-a",
+    modelId: "model-a",
+    extractedAt: now.toISOString(),
+  };
+}
+
+function candidate(
+  normalizedKey: string,
+  sourceRefs: SkillExtractionCandidate["sourceRefs"],
+): SkillExtractionCandidate {
+  const replay = (objective: string) => ({
+    objective,
+    requiredBehaviors: ["Apply the reusable workflow."],
+    forbiddenBehaviors: [],
+  });
+  return {
+    content: {
+      normalizedKey: `workflow.${normalizedKey}`,
+      applicability: ["A repeated workflow is required."],
+      failureModes: ["The workflow is applied without enough evidence."],
+      recoverySteps: ["Re-check the source evidence."],
+      package: {
+        name: `Workflow ${normalizedKey}`,
+        description: "A reusable workflow learned from successful executions.",
+        files: [
+          {
+            path: "SKILL.md",
+            content: `---\nname: workflow-${normalizedKey}\ndescription: Reusable workflow\n---\n`,
+          },
+        ],
+      },
+      replayCases: [replay("Replay one"), replay("Replay two"), replay("Replay three")],
+      boundaryCase: {
+        objective: "Recognize when the workflow does not apply.",
+        requiredBehaviors: ["Decline to force the workflow."],
+        forbiddenBehaviors: ["Apply the workflow anyway."],
+      },
+    },
+    sourceRefs,
+    route: { type: "create" },
+  };
+}
+
+function validRefs(): SkillExtractionCandidate["sourceRefs"] {
+  return sources()
+    .slice(0, 3)
+    .map((source) => source.ref);
+}
+
+function invalidRefs(): SkillExtractionCandidate["sourceRefs"] {
+  const sourceRevisions = sources();
+  return [sourceRevisions[0]!.ref, sourceRevisions[1]!.ref, sourceRevisions[3]!.ref];
+}
+
+function sources(): readonly SkillSourceSnapshot[] {
+  return [
+    episode("episode-a", "mission-a", "succeeded"),
+    episode("episode-b", "mission-a", "succeeded"),
+    episode("episode-c", "mission-b", "failed"),
+    {
+      ref: { kind: "semantic", id: "fact-a", revision: 1 },
+      rootRef: ref("pragma.expert", "expert-a"),
+      producerRefs: [ref("pragma.expert", "expert-a")],
+      sourceExecutionIds: ["execution-fact"],
+      title: "Supporting fact",
+      body: "A supporting fact that cannot satisfy the Skill threshold.",
+      outcome: "supporting",
+      hasSuccessfulRecovery: false,
+      observedAt: "2026-08-04T09:00:00.000Z",
+      verified: true,
+      visibility: { mode: "host-private" },
+      sensitivity: "internal",
+    },
+  ];
+}
+
+function episode(
+  id: string,
+  conversationId: string,
+  outcome: SkillSourceSnapshot["outcome"],
+): SkillSourceSnapshot {
+  return {
+    ref: { kind: "episodic", id, revision: 1 },
+    rootRef: ref("pragma.expert", "expert-a"),
+    conversationRef: ref("pragma.mission", conversationId),
+    sourceExecutionIds: [`execution-${id}`],
+    producerRefs: [ref("pragma.expert", "expert-a")],
+    title: `Episode ${id}`,
+    body: "A reusable multi-step workflow was completed.",
+    outcome,
+    hasSuccessfulRecovery: false,
+    observedAt: "2026-08-04T08:00:00.000Z",
+    verified: true,
+    valueScore: 0.9,
+    visibility: { mode: "host-private" },
+    sensitivity: "internal",
+  };
+}
+
+function digestSources(sourceRevisions: readonly SkillSourceSnapshot[]): string {
+  const keys = sourceRevisions
+    .map((source) => `${source.ref.kind}\0${source.ref.id}\0${source.ref.revision}`)
+    .toSorted();
+  return createHash("sha256")
+    .update(["skill-sources", ...keys].join("\0"))
+    .digest("hex");
+}
+
+async function writeLegacyStore(root: string): Promise<string> {
+  return await writeStoreFixture(root, 1, "skill-learning-store-v1.json");
+}
+
+async function writeStoreFixture(
+  root: string,
+  version: number,
+  fixtureName: string,
+): Promise<string> {
+  const dataRoot = new PragmaPaths({ pragmaHome: root }).memoryModuleDataRoot(
+    "pragma.memory.skill-learning",
+  );
+  await mkdir(dataRoot, { recursive: true });
+  const databasePath = join(dataRoot, "skill-learning.sqlite");
+  const fixture = JSON.parse(
+    await readFile(new URL(`./fixtures/${fixtureName}`, import.meta.url), "utf8"),
+  ) as { readonly jobs: readonly SkillLearningJob[] };
+  const database = new DatabaseSync(databasePath);
+  database.exec(`
+    CREATE TABLE schema_meta(version INTEGER NOT NULL);
+    INSERT INTO schema_meta(version) VALUES (${version});
+    CREATE TABLE jobs(
+      id TEXT PRIMARY KEY, root_key TEXT NOT NULL, source_digest TEXT NOT NULL,
+      status TEXT NOT NULL, retry_at TEXT, lease_until TEXT, job_json TEXT NOT NULL,
+      UNIQUE(root_key, source_digest)
+    );
+  `);
+  const insert = database.prepare("INSERT INTO jobs VALUES (?, ?, ?, ?, NULL, NULL, ?)");
+  for (const job of fixture.jobs) {
+    insert.run(
+      job.id,
+      `${job.rootRef.type}\0${job.rootRef.id}`,
+      job.sourceDigest,
+      job.status,
+      JSON.stringify(job),
+    );
+  }
+  database.close();
+  return databasePath;
+}
+
+function ref(type: string, id: string): MemorySubjectRef {
+  return { type, id };
+}
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pragma-skill-learning-"));
+  roots.push(root);
+  return root;
+}


### PR DESCRIPTION
## Summary

- Treat evidence and candidate eligibility misses as neutral completed/rejected outcomes while preserving real extraction failures for retry and diagnosis.
- Add a browser-safe problem taxonomy and localized, actionable Desktop UI; stable error codes are shown only in collapsed technical details.
- Add a dismissible memory health alert and Knowledge/Skill SQLite v3 migrations with backups, fixtures, and replay coverage.

## Root cause

Candidate eligibility outcomes and extractor/system faults shared the same needs-attention and raw-error-code presentation, so normal rejection looked like a degraded subsystem and users received internal diagnostics instead of actionable guidance.

## Validation

- `pnpm check`
- `pnpm build`
- Memory focused tests: 67 passed
- Desktop focused tests: 75 passed
- Claude Code review completed; the verified protocol invariant finding was fixed