### PR TITLE
Avoid Mission stream readback

### DIFF
--- a/apps/desktop/src/main/features/missions/mission-ipc.ts
+++ b/apps/desktop/src/main/features/missions/mission-ipc.ts
@@ -35,6 +35,10 @@ import { availableRecentWorkspaces } from "../workspaces/workspace-history-store
 import { validateWorkspace } from "../workspaces/workspace-scope.ts";
 import type { HomeExecutorCatalog } from "./home-executor-catalog.ts";
 import { installMissionAttachmentProtocol } from "./mission-attachment-protocol.ts";
+import {
+  forwardMissionChatNotification,
+  forwardMissionWorkNotification,
+} from "./mission-renderer-update-forwarder.ts";
 
 export function installMissionHandlers(options: {
   readonly missions: MissionStore;
@@ -342,18 +346,29 @@ export function installMissionHandlers(options: {
       publishRemoval(missionId);
     }),
   );
-  options.runner.subscribeChat((update) => {
-    void getUserMission(update.missionId)
-      .then((mission) => {
-        options.getWindow()?.webContents.send("missions:chat:updated", update);
-        if (update.kind === "invalidate") publishMission(mission);
-      })
-      .catch(() => undefined);
+  options.runner.subscribeChat((notification) => {
+    forwardMissionChatNotification({
+      notification,
+      getSender: () => options.getWindow()?.webContents ?? null,
+      refreshMissionSummary: async (missionId) => publishMission(await getUserMission(missionId)),
+      reportSummaryRefreshFailure: (error, missionId) => {
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            component: "desktop.missions",
+            event: "mission_renderer_summary_refresh_failed",
+            message: error instanceof Error ? error.message : String(error),
+            missionId,
+          }),
+        );
+      },
+    });
   });
-  options.runner.subscribeWork((update) => {
-    void getUserMission(update.missionId)
-      .then(() => options.getWindow()?.webContents.send("missions:work:updated", update))
-      .catch(() => undefined);
+  options.runner.subscribeWork((notification) => {
+    forwardMissionWorkNotification({
+      notification,
+      getSender: () => options.getWindow()?.webContents ?? null,
+    });
   });
 }
 

--- a/apps/desktop/src/main/features/missions/mission-renderer-update-forwarder.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-renderer-update-forwarder.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { MissionChatUpdate } from "../../../shared/contracts/index.ts";
+import {
+  forwardMissionChatNotification,
+  forwardMissionWorkNotification,
+} from "./mission-renderer-update-forwarder.ts";
+
+const missionId = "00000000-0000-4000-8000-000000000000";
+
+describe("Mission renderer update forwarding", () => {
+  it("forwards user chat patches in revision order without refreshing the Mission", () => {
+    const send = vi.fn();
+    const refreshMissionSummary = vi.fn(async () => undefined);
+    const reportSummaryRefreshFailure = vi.fn();
+    const updates: MissionChatUpdate[] = [1, 2, 3].map((revision) => ({
+      kind: "patch",
+      missionId,
+      revision,
+      patches: [
+        {
+          type: "entry.append",
+          entryId: "answer",
+          field: "content",
+          delta: String(revision),
+        },
+      ],
+    }));
+
+    for (const update of updates) {
+      forwardMissionChatNotification({
+        notification: { audience: "user", update },
+        getSender: () => ({ send }),
+        refreshMissionSummary,
+        reportSummaryRefreshFailure,
+      });
+    }
+
+    expect(send.mock.calls).toEqual(updates.map((update) => ["missions:chat:updated", update]));
+    expect(refreshMissionSummary).not.toHaveBeenCalled();
+    expect(reportSummaryRefreshFailure).not.toHaveBeenCalled();
+  });
+
+  it("drops internal chat and work updates", () => {
+    const send = vi.fn();
+    const refreshMissionSummary = vi.fn(async () => undefined);
+
+    forwardMissionChatNotification({
+      notification: {
+        audience: "internal",
+        update: { kind: "invalidate", missionId, revision: 1 },
+      },
+      getSender: () => ({ send }),
+      refreshMissionSummary,
+      reportSummaryRefreshFailure: vi.fn(),
+    });
+    forwardMissionWorkNotification({
+      notification: {
+        audience: "internal",
+        update: { missionId, revision: 1 },
+      },
+      getSender: () => ({ send }),
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(refreshMissionSummary).not.toHaveBeenCalled();
+  });
+
+  it("forwards invalidation before asynchronously refreshing the Mission summary", async () => {
+    const send = vi.fn();
+    let finishRefresh: (() => void) | undefined;
+    const refreshMissionSummary = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishRefresh = resolve;
+        }),
+    );
+    const reportSummaryRefreshFailure = vi.fn();
+    const update = { kind: "invalidate", missionId, revision: 1 } as const;
+
+    forwardMissionChatNotification({
+      notification: { audience: "user", update },
+      getSender: () => ({ send }),
+      refreshMissionSummary,
+      reportSummaryRefreshFailure,
+    });
+
+    expect(send).toHaveBeenCalledWith("missions:chat:updated", update);
+    expect(refreshMissionSummary).toHaveBeenCalledWith(missionId);
+    expect(reportSummaryRefreshFailure).not.toHaveBeenCalled();
+    finishRefresh?.();
+    await vi.waitFor(() => expect(reportSummaryRefreshFailure).not.toHaveBeenCalled());
+  });
+
+  it("reports a failed summary refresh without blocking invalidation delivery", async () => {
+    const send = vi.fn();
+    const failure = new Error("unavailable");
+    const reportSummaryRefreshFailure = vi.fn();
+    const update = { kind: "invalidate", missionId, revision: 1 } as const;
+
+    forwardMissionChatNotification({
+      notification: { audience: "user", update },
+      getSender: () => ({ send }),
+      refreshMissionSummary: async () => await Promise.reject(failure),
+      reportSummaryRefreshFailure,
+    });
+
+    expect(send).toHaveBeenCalledWith("missions:chat:updated", update);
+    await vi.waitFor(() =>
+      expect(reportSummaryRefreshFailure).toHaveBeenCalledWith(failure, missionId),
+    );
+  });
+
+  it("forwards user work updates without Mission access", () => {
+    const send = vi.fn();
+    const update = { missionId, revision: 1 };
+
+    forwardMissionWorkNotification({
+      notification: { audience: "user", update },
+      getSender: () => ({ send }),
+    });
+
+    expect(send).toHaveBeenCalledWith("missions:work:updated", update);
+  });
+});

--- a/apps/desktop/src/main/features/missions/mission-renderer-update-forwarder.ts
+++ b/apps/desktop/src/main/features/missions/mission-renderer-update-forwarder.ts
@@ -1,0 +1,33 @@
+import type { MissionChatUpdate, MissionWorkUpdate } from "../../../shared/contracts/index.ts";
+import type { MissionChatNotification, MissionWorkNotification } from "./mission-runner.ts";
+
+export interface MissionRendererUpdateSender {
+  send(
+    channel: "missions:chat:updated" | "missions:work:updated",
+    update: MissionChatUpdate | MissionWorkUpdate,
+  ): void;
+}
+
+export function forwardMissionChatNotification(options: {
+  readonly notification: MissionChatNotification;
+  readonly getSender: () => MissionRendererUpdateSender | null;
+  readonly refreshMissionSummary: (missionId: string) => Promise<void>;
+  readonly reportSummaryRefreshFailure: (error: unknown, missionId: string) => void;
+}): void {
+  const { audience, update } = options.notification;
+  if (audience !== "user") return;
+  options.getSender()?.send("missions:chat:updated", update);
+  if (update.kind !== "invalidate") return;
+  void options
+    .refreshMissionSummary(update.missionId)
+    .catch((error: unknown) => options.reportSummaryRefreshFailure(error, update.missionId));
+}
+
+export function forwardMissionWorkNotification(options: {
+  readonly notification: MissionWorkNotification;
+  readonly getSender: () => MissionRendererUpdateSender | null;
+}): void {
+  const { audience, update } = options.notification;
+  if (audience !== "user") return;
+  options.getSender()?.send("missions:work:updated", update);
+}

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -195,6 +195,78 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     ]);
   });
 
+  it("marks system Mission chat and work notifications as internal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-system-mission-notifications-"));
+    temporaryPaths.push(root);
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Run an internal Mission",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(
+        snapshot.resources.find((resource) => resource.kind === "Expert")!,
+      ),
+      origin: { type: "system-memory", jobId: "memory-job" },
+    });
+    const runtime = defineRuntimeDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      startTurn(_session, turn) {
+        turn.stream.write({
+          runId: turn.runId,
+          source: turn.source,
+          type: "message.delta",
+          payload: {
+            role: "assistant",
+            contentType: "text",
+            delta: "internal output",
+          },
+        });
+        return { outputText: "internal output", runtimeSessionId: "runtime" };
+      },
+      mapEvent: () => ({ events: [] }),
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome: join(root, "state"),
+      runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
+    });
+    const chatNotifications = vi.fn();
+    const workNotifications = vi.fn();
+    const unsubscribeChat = runner.subscribeChat(chatNotifications);
+    const unsubscribeWork = runner.subscribeWork(workNotifications);
+
+    await runner.run(mission.id);
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+
+    expect(chatNotifications).toHaveBeenCalled();
+    expect(
+      chatNotifications.mock.calls.some(([notification]) => notification.update.kind === "patch"),
+    ).toBe(true);
+    expect(
+      chatNotifications.mock.calls.every(([notification]) => notification.audience === "internal"),
+    ).toBe(true);
+    expect(workNotifications).toHaveBeenCalled();
+    expect(
+      workNotifications.mock.calls.every(([notification]) => notification.audience === "internal"),
+    ).toBe(true);
+    unsubscribeChat();
+    unsubscribeWork();
+  });
+
   it("skips compilation for a follow-up on the live Mission Session", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-mission-followup-fast-path-"));
     temporaryPaths.push(root);
@@ -568,7 +640,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       });
     const runner = createRunner();
     const chatUpdates: MissionChatUpdate[] = [];
-    const unsubscribe = runner.subscribeChat((update) => chatUpdates.push(update));
+    const unsubscribe = runner.subscribeChat(({ update }) => chatUpdates.push(update));
 
     await runner.run(mission.id);
     await vi.waitFor(() => {
@@ -796,7 +868,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     );
     expect(updates).toHaveBeenCalled();
     const patchUpdates = updates.mock.calls
-      .map(([update]) => update)
+      .map(([notification]) => notification.update)
       .filter((update) => update.kind === "patch");
     expect(patchUpdates.length).toBeGreaterThanOrEqual("Checking constraints.".length + 1);
     expect(patchUpdates.flatMap((update) => update.patches)).toEqual(
@@ -900,7 +972,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
     });
     const updates: unknown[] = [];
-    const unsubscribe = runner.subscribeChat((update) => updates.push(update));
+    const unsubscribe = runner.subscribeChat(({ update }) => updates.push(update));
 
     await runner.run(mission.id);
     await outputWasWritten;
@@ -1135,7 +1207,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
     });
     const updates: MissionChatUpdate[] = [];
-    const unsubscribe = runner.subscribeChat((update) => updates.push(update));
+    const unsubscribe = runner.subscribeChat(({ update }) => updates.push(update));
 
     for (const mission of [expertMission, teamMission, flowMission]) {
       await runner.run(mission.id);

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -104,6 +104,18 @@ import type { PragmaProjectStore } from "../projects/pragma-project-store.ts";
 import type { PluginStore } from "../plugins/plugin-store.ts";
 import type { DesktopUsageStore } from "../usage/usage-store.ts";
 
+export type MissionSurfaceAudience = "user" | "internal";
+
+export interface MissionChatNotification {
+  readonly audience: MissionSurfaceAudience;
+  readonly update: MissionChatUpdate;
+}
+
+export interface MissionWorkNotification {
+  readonly audience: MissionSurfaceAudience;
+  readonly update: MissionWorkUpdate;
+}
+
 export interface MissionRunner {
   reconcileUsage(): Promise<void>;
   invalidateEstimatedContextWindows(): Promise<void>;
@@ -118,8 +130,8 @@ export interface MissionRunner {
   getChat(input: MissionChatQuery): Promise<MissionChatSnapshot>;
   compactContext(id: string): Promise<MissionContextCompactionResult>;
   getRuntimeBinding(id: string): Promise<RuntimeEnvironmentBinding | undefined>;
-  subscribeChat(listener: (update: MissionChatUpdate) => void): () => void;
-  subscribeWork(listener: (update: MissionWorkUpdate) => void): () => void;
+  subscribeChat(listener: (notification: MissionChatNotification) => void): () => void;
+  subscribeWork(listener: (notification: MissionWorkNotification) => void): () => void;
   interrupt(id: string): Promise<Mission>;
   getWork(id: string): Promise<MissionWorkSnapshot>;
   getWorkConversation(input: GetMissionWorkConversation): Promise<MissionWorkConversationSnapshot>;
@@ -171,6 +183,11 @@ type PendingMissionOperation =
 interface ActiveMissionExecution {
   readonly handle: MutableExecution & { readonly result: Promise<unknown> };
   readonly settlement: Promise<void>;
+  readonly audience: MissionSurfaceAudience;
+}
+
+function missionSurfaceAudience(mission: Pick<Mission, "origin">): MissionSurfaceAudience {
+  return mission.origin.type === "user" ? "user" : "internal";
 }
 
 export async function compactExpertSessionContext(
@@ -450,11 +467,11 @@ export function createMissionRunner(options: {
   const sessionCompilationIdentities = new Map<string, string>();
   const sessionDefinitionFingerprints = new Map<string, string>();
   const pendingOperations = new Map<string, PendingMissionOperation>();
-  const chatListeners = new Set<(update: MissionChatUpdate) => void>();
+  const chatListeners = new Set<(notification: MissionChatNotification) => void>();
   const chatRevisions = new Map<string, number>();
   const liveChats = new Map<string, LiveMissionChat>();
   const liveContextWindows = new Map<string, RuntimeContextWindowUsage>();
-  const workListeners = new Set<(update: MissionWorkUpdate) => void>();
+  const workListeners = new Set<(notification: MissionWorkNotification) => void>();
   const workRevisions = new Map<string, number>();
   const liveWorkOutputs = new Map<string, Map<string, LiveMissionChat>>();
   const executorNameCache = new Map<string, ReadonlyMap<string, string>>();
@@ -502,6 +519,7 @@ export function createMissionRunner(options: {
 
   const emitChatUpdate = (
     id: string,
+    audience: MissionSurfaceAudience,
     update:
       | { readonly kind: "patch"; readonly patches: readonly MissionChatPatch[] }
       | { readonly kind: "invalidate" },
@@ -514,7 +532,7 @@ export function createMissionRunner(options: {
         : { missionId: id, revision, kind: "invalidate" };
     for (const listener of chatListeners) {
       try {
-        listener(notification);
+        listener({ audience, update: notification });
       } catch (error) {
         logger.error(
           "mission.chat_listener_failed",
@@ -526,19 +544,24 @@ export function createMissionRunner(options: {
     }
   };
 
-  const emitChatPatches = (id: string, patches: readonly MissionChatPatch[]): void => {
-    if (patches.length > 0) emitChatUpdate(id, { kind: "patch", patches });
+  const emitChatPatches = (
+    id: string,
+    audience: MissionSurfaceAudience,
+    patches: readonly MissionChatPatch[],
+  ): void => {
+    if (patches.length > 0) emitChatUpdate(id, audience, { kind: "patch", patches });
   };
 
-  const invalidateChat = (id: string): void => emitChatUpdate(id, { kind: "invalidate" });
+  const invalidateChat = (id: string, audience: MissionSurfaceAudience): void =>
+    emitChatUpdate(id, audience, { kind: "invalidate" });
 
-  const invalidateWork = (id: string): void => {
+  const invalidateWork = (id: string, audience: MissionSurfaceAudience): void => {
     const revision = (workRevisions.get(id) ?? 0) + 1;
     workRevisions.set(id, revision);
     const update: MissionWorkUpdate = { missionId: id, revision };
     for (const listener of workListeners) {
       try {
-        listener(update);
+        listener({ audience, update });
       } catch (error) {
         logger.error(
           "mission.work_listener_failed",
@@ -550,7 +573,11 @@ export function createMissionRunner(options: {
     }
   };
 
-  const forgetActive = async (id: string, executionId: string): Promise<void> => {
+  const forgetActive = async (
+    id: string,
+    executionId: string,
+    audience: MissionSurfaceAudience,
+  ): Promise<void> => {
     if (active.get(id)?.handle.executionId === executionId) active.delete(id);
     const live = liveChats.get(id);
     if (live?.executionId === executionId) {
@@ -559,8 +586,8 @@ export function createMissionRunner(options: {
     }
     liveWorkOutputs.delete(id);
     liveContextWindows.delete(id);
-    invalidateChat(id);
-    invalidateWork(id);
+    invalidateChat(id, audience);
+    invalidateWork(id, audience);
   };
 
   const compileMissionExecutor = async (
@@ -784,6 +811,7 @@ export function createMissionRunner(options: {
     readonly onFinished?: (() => void | Promise<void>) | undefined;
   }): void => {
     const missionId = input.mission.id;
+    const audience = missionSurfaceAudience(input.mission);
     const resolveExecutorName = createMissionExecutorNameResolver(
       input.mission,
       input.executorNames,
@@ -792,7 +820,7 @@ export function createMissionRunner(options: {
     const live = observeMissionChat(
       input.handle,
       (patches) => {
-        emitChatPatches(missionId, patches);
+        emitChatPatches(missionId, audience, patches);
         if (
           !firstProjectionLogged &&
           input.acceptedAt !== undefined &&
@@ -810,7 +838,7 @@ export function createMissionRunner(options: {
           );
         }
       },
-      () => invalidateChat(missionId),
+      () => invalidateChat(missionId, audience),
       (item) => {
         if (item.channel === "telemetry" && item.parentInvocationId === undefined) {
           const payload = asRecord(item.value);
@@ -818,7 +846,9 @@ export function createMissionRunner(options: {
             const usage = RuntimeContextWindowUsageSchema.safeParse(payload["usage"]);
             if (usage.success) {
               liveContextWindows.set(missionId, usage.data);
-              emitChatPatches(missionId, [{ type: "context-window.update", usage: usage.data }]);
+              emitChatPatches(missionId, audience, [
+                { type: "context-window.update", usage: usage.data },
+              ]);
             }
           }
         }
@@ -844,10 +874,10 @@ export function createMissionRunner(options: {
             });
           }
           if (isNewRecord || item.channel === "agent") {
-            invalidateWork(missionId);
+            invalidateWork(missionId, audience);
           }
         } else if (item.channel === "agent") {
-          invalidateWork(missionId);
+          invalidateWork(missionId, audience);
         }
       },
       resolveExecutorName,
@@ -884,10 +914,10 @@ export function createMissionRunner(options: {
           });
         }
       })
-      .finally(async () => await forgetActive(missionId, input.handle.executionId));
-    active.set(missionId, { handle: input.handle, settlement });
-    invalidateChat(missionId);
-    invalidateWork(missionId);
+      .finally(async () => await forgetActive(missionId, input.handle.executionId, audience));
+    active.set(missionId, { handle: input.handle, settlement, audience });
+    invalidateChat(missionId, audience);
+    invalidateWork(missionId, audience);
     void settlement.catch((error: unknown) => {
       logger.error(
         "mission.execution_observer_failed",
@@ -1505,7 +1535,7 @@ export function createMissionRunner(options: {
     const compaction = await compactExpertSessionContext(session);
     if (compaction.outcome === "not_needed") return await notNeededResult();
     const { usage } = compaction;
-    invalidateChat(id);
+    invalidateChat(id, missionSurfaceAudience(mission));
     const state = await getContextWindowState(mission, usage);
     if (state === undefined || !state.supportsCompaction) {
       throw new Error(
@@ -1819,7 +1849,7 @@ export function createMissionRunner(options: {
   return {
     reconcileUsage,
     async invalidateEstimatedContextWindows() {
-      for (const mission of await options.missions.list()) invalidateChat(mission.id);
+      for (const mission of await options.missions.list()) invalidateChat(mission.id, "user");
     },
     async run(id) {
       const pending = pendingOperations.get(id);
@@ -1915,7 +1945,7 @@ export function createMissionRunner(options: {
           requestId: input.requestId,
         },
       );
-      invalidateChat(input.missionId);
+      invalidateChat(input.missionId, execution.audience);
     },
   };
 


### PR DESCRIPTION
## What changed

- carry user/internal audience metadata on Mission chat and work notifications
- forward user-visible stream patches directly to the renderer without re-reading the Mission
- keep low-frequency invalidation summary refresh asynchronous
- prevent internal Mission updates from reaching renderer IPC
- add regression coverage for forwarding order, internal filtering, refresh failure handling, and system Mission audiences

## Why

Every streaming delta previously called `MissionStore.get()` before IPC delivery. That path acquires the Mission file lock and reads/parses `mission.yaml`, amplifying coarse Runtime output into visible stalls.

The runner already holds the Mission origin when tracking an execution, so the notification can carry its audience without adding a cache or disk lookup.

## Impact

User Mission text and work updates reach the renderer immediately. Public renderer contracts and persisted Mission schemas are unchanged.

## Validation

- `pnpm check`
- `pnpm --filter @pragma/desktop exec vitest run src/main/features/missions/mission-renderer-update-forwarder.test.ts src/main/features/missions/mission-runner.test.ts src/main/features/missions/mission-store.test.ts` (48 tests)
- Claude Code review followed by independent finding verification
