### PR TITLE
refactor(desktop): simplify evaluation navigation

### DIFF
--- a/apps/desktop/design-qa.md
+++ b/apps/desktop/design-qa.md
@@ -1,3 +1,62 @@
+# Evaluation Secondary Navigation Design QA
+
+- Source visual truth:
+  `/Users/linminqiu/.codex/generated_images/019ff6a6-5aea-7931-b2f5-793bcb62a956/exec-62921af1-f544-4b26-9be0-2d9b96ca53f5.png`
+- Implementation screenshot: unavailable; the in-app browser rejected the local preview URL under
+  its URL security policy.
+- Combined comparison: unavailable because no compliant implementation screenshot could be
+  captured.
+- Intended comparison viewport: 1440 × 1024 CSS pixels at DPR 1, light theme.
+- Density normalization:
+  - Source: 1487 × 1058 pixels, intended to be normalized to the 1440 × 1024 CSS viewport.
+  - Implementation: unavailable.
+- State: Simplified Chinese Evaluations page with the Project Manager Expert selected, no Agent
+  Judge datasets, and no queued runs.
+
+**Findings**
+
+- [Blocked] The required browser-rendered implementation evidence is unavailable. The local Vite
+  preview started successfully, but the selected in-app browser refused navigation to the local
+  preview under its URL security policy. Browser guidance prohibits switching surfaces or using an
+  alternate route to bypass that decision.
+- Fonts and typography, spacing and layout rhythm, colors and tokens, image/icon fidelity, copy,
+  responsive wrapping, and the visible no-shadow empty state could not be compared against the
+  source image without the implementation capture.
+- Static implementation review confirms that the screen continues to use the existing
+  Inter/SF/PingFang stack, Pragma tokens, and Phosphor icons; this is not a substitute for visual
+  evidence and does not change the blocked result.
+
+**Interaction and code evidence**
+
+- Focused renderer tests verify that Experts and Expert Teams expose Start evaluation, Datasets,
+  and Queue actions while Flows keep only the existing Run Dry action.
+- Focused renderer tests verify explicit Back to target semantics for both secondary pages.
+- Desktop node/web typechecks and Desktop lint pass. Focused Evaluation tests pass 8/8.
+- The full Desktop suite passes 790/792 assertions. Two unrelated Runtime availability tests fail
+  because local Claude Code and Qoder CLI executables are unavailable and a built-in Runtime probe
+  resolves differently in this machine environment.
+
+**Comparison history**
+
+1. Started a local Vite harness using the real Evaluations components, styles, localization, and a
+   deterministic project fixture matching the source state.
+2. Attempted to open the preview in the selected Codex in-app browser at the required local preview
+   address.
+3. Navigation was rejected by browser URL policy before any DOM, screenshot, or console evidence
+   could be collected. No alternate browser or URL workaround was attempted.
+
+**Implementation checklist**
+
+- Capture the implemented Expert empty state at 1440 × 1024 when local preview navigation is
+  permitted.
+- Compare the source and implementation in one combined image, then fix any P0/P1/P2 differences.
+- Verify Datasets, Queue, Back to target, target switching, keyboard focus, and browser console
+  errors before changing the result to passed.
+
+final result: blocked
+
+---
+
 # Memory Health Design QA
 
 - Source visual truth: `design-qa/source-option-2.png`
@@ -628,3 +687,13 @@ final result: passed
 - None required for this change.
 
 final result: passed
+
+---
+
+# Current Design QA Gate
+
+- Current report: Evaluation Secondary Navigation Design QA at the top of this file.
+- The implementation screenshot and combined comparison remain unavailable because local preview
+  navigation was rejected by the selected in-app browser's URL security policy.
+
+final result: blocked

--- a/apps/desktop/src/renderer/src/i18n/resources/en/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/studio.ts
@@ -8,6 +8,7 @@ export const studio = {
     sections: "Evaluation sections",
     tabs: { targets: "Targets", datasets: "Datasets", queue: "Queue" },
     back: "Back",
+    backToTarget: "Back to target",
     newRun: "New evaluation",
     runDescription: "Choose a reusable dataset and randomly sample cases for this target.",
     noDatasetsForRun: "Create an Agent Judge dataset before starting an evaluation.",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/studio.ts
@@ -8,6 +8,7 @@ export const studio = {
     sections: "测评分类",
     tabs: { targets: "测评对象", datasets: "测评集", queue: "队列" },
     back: "返回",
+    backToTarget: "返回当前对象",
     newRun: "新建测评",
     runDescription: "选择可复用测评集，并为当前对象随机抽取测试用例。",
     noDatasetsForRun: "请先创建 Agent Judge 测评集。",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/studio.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/studio.ts
@@ -8,6 +8,7 @@ export const studio = {
     sections: "評測分類",
     tabs: { targets: "評測物件", datasets: "評測集", queue: "佇列" },
     back: "返回",
+    backToTarget: "返回目前物件",
     newRun: "新增評測",
     runDescription: "選擇可重用評測集，並為目前物件隨機抽取測試案例。",
     noDatasetsForRun: "請先建立 Agent Judge 評測集。",

--- a/apps/desktop/src/renderer/src/pages/evaluations/AgentEvaluationWorkspace.test.ts
+++ b/apps/desktop/src/renderer/src/pages/evaluations/AgentEvaluationWorkspace.test.ts
@@ -1,13 +1,48 @@
 import { PragmaAgentJudgeEvaluationResourceSchema } from "@pragma/evaluation/ast";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import type { PragmaProjectSnapshot } from "../../../../shared/contracts/index.ts";
 
 import {
+  AgentEvaluationDatasets,
+  AgentEvaluationQueue,
   createDatasetCaseDraft,
   createDatasetCriterionDraft,
   createDatasetForm,
   datasetFormIsValid,
   datasetFromForm,
 } from "./AgentEvaluationWorkspace.tsx";
+
+const emptyProject = {
+  schemaVersion: "pragma.project-snapshot/v3",
+  projectId: "studio",
+  revision: 1,
+  diagnostics: [],
+  resources: [],
+} satisfies PragmaProjectSnapshot;
+
+describe("agent evaluation secondary pages", () => {
+  it("provides an explicit route back to the selected target", () => {
+    const datasetsHtml = renderToStaticMarkup(
+      createElement(AgentEvaluationDatasets, {
+        project: emptyProject,
+        onBack: () => undefined,
+        onProjectChange: () => undefined,
+      }),
+    );
+    const queueHtml = renderToStaticMarkup(
+      createElement(AgentEvaluationQueue, { onBack: () => undefined }),
+    );
+
+    expect(datasetsHtml).toContain("Back to target");
+    expect(datasetsHtml).toContain("autofocus");
+    expect(datasetsHtml).toContain('aria-labelledby="agent-evaluation-datasets-heading"');
+    expect(queueHtml).toContain("Back to target");
+    expect(queueHtml).toContain("autofocus");
+    expect(queueHtml).toContain('aria-labelledby="agent-evaluation-queue-heading"');
+  });
+});
 
 function completeForm() {
   const form = createDatasetForm();

--- a/apps/desktop/src/renderer/src/pages/evaluations/AgentEvaluationWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/AgentEvaluationWorkspace.tsx
@@ -1,4 +1,4 @@
-import { FileArrowUp, Flask, Plus, Trash, X } from "@phosphor-icons/react";
+import { ArrowLeft, FileArrowUp, Flask, Plus, Trash, X } from "@phosphor-icons/react";
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { PragmaAgentJudgeEvaluationResource } from "@pragma/evaluation/ast";
@@ -126,6 +126,7 @@ export function AgentEvaluationRunSetup(props: {
 
 export function AgentEvaluationDatasets(props: {
   readonly project: PragmaProjectSnapshot;
+  readonly onBack: () => void;
   readonly onProjectChange: (project: PragmaProjectSnapshot) => void;
 }) {
   const { t } = useTranslation("studio");
@@ -194,10 +195,22 @@ export function AgentEvaluationDatasets(props: {
   };
 
   return (
-    <section className="agent-evaluation-page-section">
+    <section
+      className="agent-evaluation-page-section"
+      aria-labelledby="agent-evaluation-datasets-heading"
+    >
+      <button
+        className="agent-evaluation-secondary-back"
+        type="button"
+        autoFocus
+        onClick={props.onBack}
+      >
+        <ArrowLeft size={16} aria-hidden="true" />
+        {t("agentEvaluation.backToTarget")}
+      </button>
       <header className="agent-evaluation-section-heading">
         <div>
-          <h1>{t("agentEvaluation.datasets")}</h1>
+          <h1 id="agent-evaluation-datasets-heading">{t("agentEvaluation.datasets")}</h1>
           <p>{t("agentEvaluation.datasetsDescription")}</p>
         </div>
         <button
@@ -333,7 +346,7 @@ export function AgentEvaluationDatasets(props: {
   );
 }
 
-export function AgentEvaluationQueue() {
+export function AgentEvaluationQueue(props: { readonly onBack: () => void }) {
   const { t } = useTranslation("studio");
   const [runs, setRuns] = useState<AgentEvaluationRun[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -387,10 +400,22 @@ export function AgentEvaluationQueue() {
   };
 
   return (
-    <section className="agent-evaluation-page-section">
+    <section
+      className="agent-evaluation-page-section"
+      aria-labelledby="agent-evaluation-queue-heading"
+    >
+      <button
+        className="agent-evaluation-secondary-back"
+        type="button"
+        autoFocus
+        onClick={props.onBack}
+      >
+        <ArrowLeft size={16} aria-hidden="true" />
+        {t("agentEvaluation.backToTarget")}
+      </button>
       <header className="agent-evaluation-section-heading">
         <div>
-          <h1>{t("agentEvaluation.queue")}</h1>
+          <h1 id="agent-evaluation-queue-heading">{t("agentEvaluation.queue")}</h1>
           <p>{t("agentEvaluation.queueDescription")}</p>
         </div>
       </header>

--- a/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.test.tsx
@@ -1,5 +1,9 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import {
+  PragmaExpertResourceSchema,
+  PragmaExpertTeamResourceSchema,
+} from "@pragma/interpreter/ast";
 import type { PragmaProjectSnapshot } from "../../../../shared/contracts/index.ts";
 
 import {
@@ -139,5 +143,94 @@ describe("EvaluationDirectoryFragment", () => {
     expect(detailHtml).toContain("Evaluation targets");
     expect(detailHtml).toContain("Evaluation detail");
     expect(detailHtml).not.toContain('id="evaluations-heading"');
+  });
+
+  it("shows dataset and queue entrances only for agent targets", () => {
+    const expert = PragmaExpertResourceSchema.parse({
+      apiVersion: "pragma/v4",
+      kind: "Expert",
+      metadata: {
+        id: "1h2j3k4m5n6p7q8r",
+        name: "Project manager",
+        description: "Coordinates delivery.",
+        tags: [],
+      },
+      spec: { scope: "general", instructions: "Coordinate the project." },
+    });
+    const team = PragmaExpertTeamResourceSchema.parse({
+      apiVersion: "pragma/v4",
+      kind: "ExpertTeam",
+      metadata: {
+        id: "2h3j4k5m6n7p8q9r",
+        name: "Delivery team",
+        description: "Coordinates specialists.",
+        tags: [],
+      },
+      spec: {
+        coordinator: { ref: `expert:${expert.metadata.id}` },
+        members: [{ ref: `expert:${expert.metadata.id}` }],
+        delegation: {},
+      },
+    });
+    const callbacks = {
+      onCreate: () => undefined,
+      onDelete: async () => undefined,
+      onOpen: () => undefined,
+      onOpenDatasets: () => undefined,
+      onOpenQueue: () => undefined,
+    };
+
+    const expertHtml = renderToStaticMarkup(
+      <EvaluationDirectoryFragment
+        {...callbacks}
+        project={{
+          schemaVersion: "pragma.project-snapshot/v3",
+          projectId: "studio",
+          revision: 1,
+          diagnostics: [],
+          resources: [expert, team],
+        }}
+      />,
+    );
+
+    expect(expertHtml).toContain("Start evaluation");
+    expect(expertHtml).toContain(">Datasets</button>");
+    expect(expertHtml).toContain(">Queue</button>");
+    expect(expertHtml).toContain('class="evaluation-target-actions"');
+
+    const teamHtml = renderToStaticMarkup(
+      <EvaluationDirectoryFragment
+        {...callbacks}
+        project={{
+          schemaVersion: "pragma.project-snapshot/v3",
+          projectId: "studio",
+          revision: 1,
+          diagnostics: [],
+          resources: [team],
+        }}
+      />,
+    );
+
+    expect(teamHtml).toContain("Start evaluation");
+    expect(teamHtml).toContain(">Datasets</button>");
+    expect(teamHtml).toContain(">Queue</button>");
+
+    const flow = createEmptyFlow("8h9j0k1m2n3p4q5r");
+    const flowHtml = renderToStaticMarkup(
+      <EvaluationDirectoryFragment
+        {...callbacks}
+        project={{
+          schemaVersion: "pragma.project-snapshot/v3",
+          projectId: "studio",
+          revision: 1,
+          diagnostics: [],
+          resources: [flow],
+        }}
+      />,
+    );
+
+    expect(flowHtml).toContain("New");
+    expect(flowHtml).not.toContain(">Datasets</button>");
+    expect(flowHtml).not.toContain(">Queue</button>");
   });
 });

--- a/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/EvaluationDirectoryFragment.tsx
@@ -59,6 +59,10 @@ export function EvaluationDirectoryFragment(props: {
   readonly onCreate: (resourceId: string, flow: PragmaFlowResource) => void;
   readonly onCreateAgentEvaluation?:
     ((target: PragmaExpertResource | PragmaExpertTeamResource) => void) | undefined;
+  readonly onOpenDatasets?: (() => void) | undefined;
+  readonly onOpenQueue?: (() => void) | undefined;
+  readonly focusAction?: "datasets" | "queue" | null | undefined;
+  readonly onFocusActionHandled?: (() => void) | undefined;
   readonly onDelete: (evaluation: PragmaFlowRunDryEvaluationResource) => Promise<void>;
   readonly onSelectTarget?: ((target: EvaluationTarget) => void) | undefined;
   readonly detail?: ReactNode | undefined;
@@ -77,8 +81,18 @@ export function EvaluationDirectoryFragment(props: {
   );
   const [search, setSearch] = useState("");
   const [expandedKinds, setExpandedKinds] = useState<ReadonlySet<EvaluationTargetKind>>(new Set());
+  const datasetsButtonRef = useRef<HTMLButtonElement>(null);
+  const queueButtonRef = useRef<HTMLButtonElement>(null);
   const mountedRef = useRef(false);
   useEffect(() => activateEvaluationDirectory(mountedRef), []);
+  useEffect(() => {
+    if (props.detail !== undefined || props.focusAction == null) return;
+    const target =
+      props.focusAction === "datasets" ? datasetsButtonRef.current : queueButtonRef.current;
+    if (target === null) return;
+    target.focus();
+    props.onFocusActionHandled?.();
+  }, [props.detail, props.focusAction, props.onFocusActionHandled]);
 
   const { evaluations, agentDatasetCount, experts, teams, flows, targets, defaultTargetId } =
     useMemo(() => {
@@ -306,19 +320,41 @@ export function EvaluationDirectoryFragment(props: {
                         : t("llmJudgeDescription")}
                     </p>
                   </div>
-                  <button
-                    className="primary-button"
-                    type="button"
-                    disabled={allocating}
-                    onClick={createEvaluation}
-                  >
-                    <Plus size={17} aria-hidden="true" />
-                    {allocating
-                      ? t("creatingEvaluation")
-                      : selectedTarget.kind === "Flow"
-                        ? t("newEvaluation")
-                        : t("agentEvaluation.startNewRun")}
-                  </button>
+                  <div className="evaluation-target-actions">
+                    <button
+                      className="primary-button"
+                      type="button"
+                      disabled={allocating}
+                      onClick={createEvaluation}
+                    >
+                      <Plus size={17} aria-hidden="true" />
+                      {allocating
+                        ? t("creatingEvaluation")
+                        : selectedTarget.kind === "Flow"
+                          ? t("newEvaluation")
+                          : t("agentEvaluation.startNewRun")}
+                    </button>
+                    {selectedTarget.kind !== "Flow" && props.onOpenDatasets !== undefined ? (
+                      <button
+                        ref={datasetsButtonRef}
+                        className="secondary-button"
+                        type="button"
+                        onClick={props.onOpenDatasets}
+                      >
+                        {t("agentEvaluation.tabs.datasets")}
+                      </button>
+                    ) : null}
+                    {selectedTarget.kind !== "Flow" && props.onOpenQueue !== undefined ? (
+                      <button
+                        ref={queueButtonRef}
+                        className="secondary-button"
+                        type="button"
+                        onClick={props.onOpenQueue}
+                      >
+                        {t("agentEvaluation.tabs.queue")}
+                      </button>
+                    ) : null}
+                  </div>
                 </header>
 
                 {selectedTarget.kind === "Flow" ? (

--- a/apps/desktop/src/renderer/src/pages/evaluations/EvaluationsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/EvaluationsPage.test.tsx
@@ -1,9 +1,17 @@
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { createEmptyFlow } from "../studio/flow-editor/flow-model.ts";
-import { createFlowRunDryEvaluation } from "./EvaluationsPage.tsx";
+import { createFlowRunDryEvaluation, EvaluationsPage } from "./EvaluationsPage.tsx";
 
 describe("EvaluationsPage", () => {
+  it("keeps the loading state inset after removing the page tabs", () => {
+    const html = renderToStaticMarkup(<EvaluationsPage />);
+
+    expect(html).toContain('class="studio-empty-copy evaluations-page-loading"');
+    expect(html).not.toContain('class="agent-evaluation-tabs"');
+  });
+
   it("creates a standalone Run Dry draft for the selected Flow", () => {
     const flow = {
       ...createEmptyFlow("8h9j0k1m2n3p4q5r"),

--- a/apps/desktop/src/renderer/src/pages/evaluations/EvaluationsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/evaluations/EvaluationsPage.tsx
@@ -14,7 +14,7 @@ import {
   AgentEvaluationRunSetup,
 } from "./AgentEvaluationWorkspace.tsx";
 
-type EvaluationPageTab = "targets" | "datasets" | "queue";
+type EvaluationSecondaryView = "datasets" | "queue";
 
 export function createFlowRunDryEvaluation(
   resourceId: string,
@@ -54,7 +54,10 @@ export function EvaluationsPage() {
   const [runTarget, setRunTarget] = useState<
     PragmaExpertResource | PragmaExpertTeamResource | null
   >(null);
-  const [tab, setTab] = useState<EvaluationPageTab>("targets");
+  const [secondaryView, setSecondaryView] = useState<EvaluationSecondaryView | null>(null);
+  const [secondaryReturnFocus, setSecondaryReturnFocus] = useState<EvaluationSecondaryView | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -98,41 +101,44 @@ export function EvaluationsPage() {
 
   return (
     <section className="evaluations-page" aria-busy={project === null && error === null}>
-      <nav
-        className="agent-evaluation-tabs"
-        aria-label={t("agentEvaluation.sections", { ns: "studio" })}
-      >
-        {(["targets", "datasets", "queue"] as const).map((item) => (
-          <button
-            key={item}
-            type="button"
-            className={tab === item ? "is-active" : ""}
-            onClick={() => {
-              setTab(item);
-              setDraft(null);
-              setRunTarget(null);
-            }}
-          >
-            {t(`agentEvaluation.tabs.${item}`, { ns: "studio" })}
-          </button>
-        ))}
-      </nav>
       {project === null && error === null ? (
-        <p className="studio-empty-copy">{t("actions.loading")}</p>
+        <p className="studio-empty-copy evaluations-page-loading">{t("actions.loading")}</p>
       ) : null}
-      {project !== null && tab === "targets" ? (
+      {project !== null ? (
         <EvaluationDirectoryFragment
           project={project}
-          onCreate={(resourceId, flow) => setDraft(createFlowRunDryEvaluation(resourceId, flow))}
-          onOpen={setDraft}
+          onCreate={(resourceId, flow) => {
+            setSecondaryView(null);
+            setDraft(createFlowRunDryEvaluation(resourceId, flow));
+          }}
+          onOpen={(evaluation) => {
+            setSecondaryView(null);
+            setDraft(evaluation);
+          }}
           onCreateAgentEvaluation={(target) => {
+            setSecondaryView(null);
             setDraft(null);
             setRunTarget(target);
           }}
           onSelectTarget={() => {
+            setSecondaryView(null);
             setDraft(null);
             setRunTarget(null);
           }}
+          onOpenDatasets={() => {
+            setDraft(null);
+            setRunTarget(null);
+            setSecondaryReturnFocus(null);
+            setSecondaryView("datasets");
+          }}
+          onOpenQueue={() => {
+            setDraft(null);
+            setRunTarget(null);
+            setSecondaryReturnFocus(null);
+            setSecondaryView("queue");
+          }}
+          focusAction={secondaryReturnFocus}
+          onFocusActionHandled={() => setSecondaryReturnFocus(null)}
           onDelete={async (evaluation) => {
             const api = typeof window === "undefined" ? undefined : window.pragmaDesktop;
             if (api === undefined) throw new Error("Desktop bridge is unavailable.");
@@ -143,14 +149,30 @@ export function EvaluationsPage() {
             setProject(snapshot);
           }}
           detail={
-            runTarget !== null ? (
+            secondaryView === "datasets" ? (
+              <AgentEvaluationDatasets
+                project={project}
+                onBack={() => {
+                  setSecondaryView(null);
+                  setSecondaryReturnFocus("datasets");
+                }}
+                onProjectChange={setProject}
+              />
+            ) : secondaryView === "queue" ? (
+              <AgentEvaluationQueue
+                onBack={() => {
+                  setSecondaryView(null);
+                  setSecondaryReturnFocus("queue");
+                }}
+              />
+            ) : runTarget !== null ? (
               <AgentEvaluationRunSetup
                 project={project}
                 target={runTarget}
                 onBack={() => setRunTarget(null)}
                 onCreated={() => {
                   setRunTarget(null);
-                  setTab("queue");
+                  setSecondaryView("queue");
                 }}
               />
             ) : draft === null ? undefined : (
@@ -171,18 +193,18 @@ export function EvaluationsPage() {
             )
           }
           detailLabelledBy={
-            runTarget !== null
-              ? "agent-evaluation-run-heading"
-              : draft === null
-                ? undefined
-                : "flow-run-dry-heading"
+            secondaryView === "datasets"
+              ? "agent-evaluation-datasets-heading"
+              : secondaryView === "queue"
+                ? "agent-evaluation-queue-heading"
+                : runTarget !== null
+                  ? "agent-evaluation-run-heading"
+                  : draft === null
+                    ? undefined
+                    : "flow-run-dry-heading"
           }
         />
       ) : null}
-      {project !== null && tab === "datasets" ? (
-        <AgentEvaluationDatasets project={project} onProjectChange={setProject} />
-      ) : null}
-      {tab === "queue" ? <AgentEvaluationQueue /> : null}
       {error !== null ? (
         <p className="form-error evaluations-page-error" role="alert">
           {error}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -9371,35 +9371,16 @@ html.is-resizing-sidebar * {
 .evaluations-page {
   position: relative;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  padding: 50px clamp(38px, 6vw, 88px) 62px;
-  background: var(--ui-canvas);
+  padding: 0;
+  background: var(--background);
 }
 
-.agent-evaluation-tabs {
-  display: flex;
-  gap: 4px;
-  padding: 10px 18px 0;
-  border-bottom: 1px solid var(--border);
-  background: var(--surface);
-}
-
-.agent-evaluation-tabs button {
-  border: 0;
-  border-bottom: 2px solid transparent;
-  padding: 9px 14px;
-  color: var(--muted);
-  background: transparent;
-  cursor: pointer;
-}
-
-.agent-evaluation-tabs button.is-active {
-  border-bottom-color: var(--green);
-  color: var(--text);
-  font-weight: 650;
+.evaluations-page-loading {
+  padding: 48px;
 }
 
 .agent-evaluation-page-section,
@@ -9641,26 +9622,6 @@ html.is-resizing-sidebar * {
 .agent-evaluation-status.is-running-subject,
 .agent-evaluation-status.is-running-judge {
   background: var(--green);
-}
-
-/* Evaluation workspace: keep the three tasks visually consistent and action-led. */
-.evaluations-page:not(:has(.evaluation-directory)) {
-  grid-template-rows: 56px minmax(0, 1fr);
-  padding: 0 58px 0 0;
-  background: var(--background);
-}
-
-.evaluations-page:not(:has(.evaluation-directory)) .agent-evaluation-tabs {
-  gap: 18px;
-  padding: 0 0 0 48px;
-  background: transparent;
-}
-
-.evaluations-page:not(:has(.evaluation-directory)) .agent-evaluation-tabs button {
-  min-height: 56px;
-  padding: 0 2px;
-  font-size: 13px;
-  font-weight: 500;
 }
 
 .agent-evaluation-page-section {
@@ -10398,6 +10359,18 @@ html.is-resizing-sidebar * {
   min-height: 40px;
 }
 
+.evaluation-target-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.evaluation-target-actions .secondary-button {
+  min-height: 40px;
+  padding: 0 14px;
+}
+
 .evaluation-target-title {
   display: flex;
   min-width: 0;
@@ -10605,6 +10578,40 @@ html.is-resizing-sidebar * {
   margin-top: 20px;
   border: 0;
   background: transparent;
+  box-shadow: none;
+}
+
+.evaluation-directory-main > .agent-evaluation-page-section {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0 0 40px;
+}
+
+.agent-evaluation-secondary-back {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 20px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ui-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 550;
+}
+
+.agent-evaluation-secondary-back:hover {
+  color: var(--ui-accent-strong);
+}
+
+.agent-evaluation-secondary-back:focus-visible {
+  border-radius: var(--ui-radius-md);
+  outline: 0;
+  box-shadow: 0 0 0 3px var(--ui-focus);
 }
 
 .evaluation-target-empty h2,
@@ -10647,6 +10654,10 @@ html.is-resizing-sidebar * {
 
   .evaluation-target-heading {
     grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .evaluation-target-actions {
+    flex-wrap: wrap;
   }
 
   .evaluation-directory-error {


### PR DESCRIPTION
## Summary

- remove the prominent top-level evaluation tabs and keep the target directory as the primary surface
- expose datasets and queue as secondary pages beside “Start evaluation” only for Expert and Expert Team targets
- preserve the existing Flow Run Dry path, remove empty-state card elevation, and tighten page spacing
- restore predictable keyboard focus when entering and leaving secondary pages
- update English, Simplified Chinese, and Traditional Chinese copy plus focused regression coverage

## Why

The previous top tab bar competed with the page hierarchy, the directory spacing was oversized, and the empty state used an unnecessary elevated card. Datasets and queue are contextual tools for expert-based evaluation rather than peer-level navigation, while Flow continues to use the existing Run Dry workflow.

## Validation

- `pnpm check`
- `pnpm --filter @pragma/desktop build`
- focused evaluation renderer tests: 9/9 passed
- two Claude Code review passes completed; all verified actionable findings were fixed

## QA note

In-app visual QA against the local preview remains blocked because the browser security policy rejected the local URL. The limitation and manual verification checklist are recorded in `apps/desktop/design-qa.md`. The full Desktop suite previously reached 790/792, with two environment-dependent local Runtime availability failures unrelated to this UI change.