### PR TITLE
feat(runtime): add feature framework and conformance harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify Runtime feature checklist
+        run: pnpm runtime:features:check
+
       - name: Lint
         run: pnpm lint
 
@@ -61,4 +64,3 @@ jobs:
 
       - name: Build
         run: pnpm build
-

--- a/apps/desktop/src/main/features/experts/system-expert-runtime.test.ts
+++ b/apps/desktop/src/main/features/experts/system-expert-runtime.test.ts
@@ -1,4 +1,5 @@
-import { createStaticRuntimeResolver, defineRuntimeDriver } from "@pragma/core";
+import { createStaticRuntimeResolver } from "@pragma/core";
+import { defineRuntimeTestDriver } from "@pragma/core/testing";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -50,7 +51,7 @@ describe("system Expert Runtime defaults", () => {
 });
 
 function runtime(id: string, kind: string) {
-  return defineRuntimeDriver({
+  return defineRuntimeTestDriver({
     descriptor: { id, kind, displayName: id },
     canUse: () => ({ usable: true }),
     listModels: async () => [

--- a/apps/desktop/src/main/features/missions/mission-executor-catalog.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-executor-catalog.test.ts
@@ -1,4 +1,5 @@
 import type { RuntimeModel, RuntimeResolver } from "@pragma/core";
+import { createRuntimeTestFeatures } from "@pragma/core/testing";
 import type { PragmaResource } from "@pragma/interpreter/ast";
 import { describe, expect, it } from "vitest";
 
@@ -111,6 +112,7 @@ describe("Mission executor model options", () => {
       },
     ];
     const runtime = (id: string, models: readonly RuntimeModel[]) => ({
+      features: createRuntimeTestFeatures({ enabled: ["availability", "modelDiscovery"] }),
       descriptor: { id, kind: "test", displayName: id },
       canUse: async () => ({ usable: true }),
       listModels: async () => models,
@@ -155,6 +157,7 @@ describe("Mission executor model options", () => {
   it("resolves model defaults from the Mission's pinned project resources", async () => {
     const boundRuntimeIds: string[] = [];
     const runtime = {
+      features: createRuntimeTestFeatures({ enabled: ["availability", "modelDiscovery"] }),
       descriptor: { id: "pinned-runtime", kind: "test", displayName: "Pinned Runtime" },
       canUse: async () => ({ usable: true }),
       listModels: async () => [],
@@ -223,6 +226,7 @@ function createCatalog(
     bind: async () => ({
       binding: { runtimeId: "pi", revision: 1, fingerprint: "a".repeat(64) },
       adapter: {
+        features: createRuntimeTestFeatures({ enabled: ["availability", "modelDiscovery"] }),
         descriptor: { id: "pi", kind: "cloud-pi-agent", displayName: "PI" },
         canUse: async () => ({ usable: true }),
         listModels,

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -8,7 +8,6 @@ import {
   createStaticRuntimeResolver,
   createNoopLoggerProvider,
   defineExpert,
-  defineRuntimeDriver,
   fingerprintExpertExecutionDefinition,
   InMemoryContextStore,
   PragmaPaths,
@@ -21,6 +20,7 @@ import {
   type RuntimeModelSelection,
   type RuntimeResolver,
 } from "@pragma/core";
+import { defineRuntimeTestDriver } from "@pragma/core/testing";
 import type {
   PragmaExpertResource,
   PragmaExpertTeamResource,
@@ -160,7 +160,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         },
       ],
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
@@ -213,7 +213,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       ),
       origin: { type: "system-memory", jobId: "memory-job" },
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
@@ -285,7 +285,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         snapshot.resources.find((resource) => resource.kind === "Expert")!,
       ),
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
@@ -359,7 +359,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       ),
     });
     const historicalBoardOutput: { id: string | undefined } = { id: undefined };
-    const runtime = defineRuntimeDriver<
+    const runtime = defineRuntimeTestDriver<
       never,
       { id: string; context: RuntimeDriverSessionContext }
     >({
@@ -533,7 +533,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       .spyOn(project, "openRevision")
       .mockRejectedValueOnce(new Error("usage attribution unavailable"));
     const onStorageTrashed = vi.fn();
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
@@ -600,7 +600,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     const turnCanFinish = new Promise<void>((resolve) => {
       finishTurn = resolve;
     });
-    const runtime = defineRuntimeDriver<RuntimeContextWindowUsage, { id: string }>({
+    const runtime = defineRuntimeTestDriver<RuntimeContextWindowUsage, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
@@ -753,7 +753,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       toolPermissionMode: "full-access",
     });
     const cancelTurn = vi.fn();
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
@@ -919,7 +919,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       finishTurn = resolve;
     });
     const oversizedError = "validation failed: ".padEnd(12_000, "x");
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
@@ -1034,7 +1034,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     const turnCanFinish = new Promise<void>((resolve) => {
       finishTurn = resolve;
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
@@ -1150,7 +1150,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     const expertMission = await missionFor(writer, "Delegate review");
     const teamMission = await missionFor(team, "Coordinate review");
     const flowMission = await missionFor(flow, "Run review flow");
-    const runtime = defineRuntimeDriver<
+    const runtime = defineRuntimeTestDriver<
       never,
       { context: RuntimeDriverSessionContext; id: string }
     >({
@@ -1356,7 +1356,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     const turnCanFinish = new Promise<void>((resolve) => {
       finishTurn = resolve;
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "codex-local", displayName: "Codex" },
       createSession: () => ({ id: "codex-thread" }),
       readSession: (session) => ({ runtimeSessionId: session.id }),
@@ -1486,7 +1486,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       };
     });
     const runtimeForMode = (toolPermissionMode: DesktopToolPermissionMode) =>
-      defineRuntimeDriver<
+      defineRuntimeTestDriver<
         never,
         {
           context: RuntimeDriverSessionContext;
@@ -1956,7 +1956,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       return { outputText: "pi", runtimeSessionId: "pi-session" };
     });
     const codexTurns = vi.fn(() => ({ outputText: "codex", runtimeSessionId: "codex-session" }));
-    const pi = defineRuntimeDriver<never, { id: string }>({
+    const pi = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "pi", kind: "cloud-pi-agent", displayName: "PI" },
       listModels: async () => [
         {
@@ -1971,7 +1971,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       mapEvent: () => ({ events: [] }),
       closeSession: () => undefined,
     });
-    const codex = defineRuntimeDriver<never, { id: string }>({
+    const codex = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "codex", kind: "codex-local", displayName: "Codex" },
       listModels: async () => [
         {
@@ -2128,7 +2128,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       ],
     };
     let runtimeStarts = 0;
-    const runtime = defineRuntimeDriver<never, { context: RuntimeDriverSessionContext }>({
+    const runtime = defineRuntimeTestDriver<never, { context: RuntimeDriverSessionContext }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: (context) => ({ context }),
       readSession: () => ({ runtimeSessionId: "recovered-runtime-session" }),
@@ -2332,7 +2332,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       project: { id: snapshot.projectId, revision: snapshot.revision },
       executor: missionExecutorSnapshot(flow),
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
@@ -2447,7 +2447,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       project: { id: snapshot.projectId, revision: snapshot.revision },
       executor: missionExecutorSnapshot(expertResource),
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
@@ -2548,7 +2548,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       project: { id: snapshot.projectId, revision: snapshot.revision },
       executor: missionExecutorSnapshot(expertResource),
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
@@ -2694,7 +2694,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       project: { id: snapshot.projectId, revision: snapshot.revision },
       executor: missionExecutorSnapshot(expertResource),
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),
@@ -2820,7 +2820,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         snapshot.resources.find((resource) => resource.kind === "Expert")!,
       ),
     });
-    const runtime = defineRuntimeDriver<never, { id: string }>({
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
       descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
       createSession: () => ({ id: "runtime" }),
       restoreSession: () => ({ id: "runtime" }),

--- a/apps/desktop/src/main/features/runtimes/runtime-availability.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-availability.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { defineRuntimeDriver } from "@pragma/core";
+import { defineRuntimeTestDriver } from "@pragma/core/testing";
 import { describe, expect, it } from "vitest";
 
 import { getRuntimeAvailability } from "./runtime-availability.ts";
@@ -24,7 +24,7 @@ describe("getRuntimeAvailability", () => {
           id: "test.runtime",
           version: "v1",
           create: (environment) =>
-            defineRuntimeDriver({
+            defineRuntimeTestDriver({
               descriptor: {
                 id: environment.id,
                 kind: "test",
@@ -81,7 +81,7 @@ describe("getRuntimeAvailability", () => {
           id: "test.runtime",
           version: "v1",
           create: (environment) =>
-            defineRuntimeDriver({
+            defineRuntimeTestDriver({
               descriptor: {
                 id: environment.id,
                 kind: "cloud-pi-agent",
@@ -99,7 +99,7 @@ describe("getRuntimeAvailability", () => {
       ],
     });
 
-    await expect(getRuntimeAvailability(runtimes)).resolves.toEqual([
+    await expect(getRuntimeAvailability(runtimes, { forceRefresh: true })).resolves.toEqual([
       expect.objectContaining({
         id: "pi",
         displayName: "Built-in Runtime",
@@ -129,7 +129,7 @@ describe("getRuntimeAvailability", () => {
           id: "test.runtime",
           version: "v1",
           create: (env) =>
-            defineRuntimeDriver({
+            defineRuntimeTestDriver({
               descriptor: { id: env.id, kind: "test", displayName: env.displayName },
               canUse: async (opts?: Record<string, unknown>) => {
                 if (opts) receivedOptions.push(opts);

--- a/apps/desktop/src/main/features/runtimes/runtime-environment-service.test.ts
+++ b/apps/desktop/src/main/features/runtimes/runtime-environment-service.test.ts
@@ -1,9 +1,8 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import * as coreModule from "@pragma/core";
-import { defineRuntimeDriver } from "@pragma/core";
+import { defineRuntimeTestDriver } from "@pragma/core/testing";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DesktopToolPermissionMode } from "../../../shared/contracts/index.ts";
@@ -97,7 +96,7 @@ describe("RuntimeEnvironmentService", () => {
               };
             }[]
           | undefined;
-        return defineRuntimeDriver({
+        return defineRuntimeTestDriver({
           descriptor: {
             id: environment.id,
             kind: "test",
@@ -177,7 +176,7 @@ describe("RuntimeEnvironmentService", () => {
       create: async (environment) => {
         createCount += 1;
         if (createCount === 1) throw new Error("transient adapter failure");
-        return defineRuntimeDriver({
+        return defineRuntimeTestDriver({
           descriptor: {
             id: environment.id,
             kind: "test",
@@ -237,57 +236,63 @@ describe("Antigravity CLI tool permission mapping", () => {
 });
 
 describe("built-in Runtime process environments", () => {
-  it("injects one recovered environment into CLI availability probes and skips it for PI", async () => {
-    const probeSpy = vi.spyOn(coreModule, "runRuntimeCommand").mockResolvedValue({
-      exitCode: 0,
-      signal: null,
-      stdout: "1.1.11\n",
-      stderr: "",
-    });
+  it.runIf(process.platform !== "win32")(
+    "injects one recovered environment into CLI availability probes and skips it for PI",
+    async () => {
+      const executableDirectory = await mkdtemp(join(tmpdir(), "pragma-runtime-probes-"));
+      await Promise.all(
+        ["codex", "claude", "qodercli", "agy"].map(async (name) => {
+          await writeFile(
+            join(executableDirectory, name),
+            [
+              "#!/bin/sh",
+              '[ "$MOCK_ENV_TEST" = "true" ] || exit 42',
+              'printf "1.1.11\\n"',
+              "",
+            ].join("\n"),
+            { mode: 0o755 },
+          );
+        }),
+      );
 
-    const environment = Object.freeze({
-      ...process.env,
-      PATH: "/mock/bin",
-      MOCK_ENV_TEST: "true",
-    });
-    const getRuntimeProcessEnvironment = vi.fn(async () => environment);
-    const factories = createBuiltInRuntimeFactories({
-      modelProviders: {} as ModelProviderStore,
-      getRuntimeProcessEnvironment,
-    });
+      const environment = Object.freeze({
+        ...process.env,
+        PATH: executableDirectory,
+        MOCK_ENV_TEST: "true",
+      });
+      const getRuntimeProcessEnvironment = vi.fn(async () => environment);
+      const factories = createBuiltInRuntimeFactories({
+        modelProviders: {} as ModelProviderStore,
+        getRuntimeProcessEnvironment,
+      });
 
-    const cliAdapters = await Promise.all(
-      [
-        ["codex", "pragma.runtime.codex"],
-        ["claude-code", "pragma.runtime.claude-code"],
-        ["qodercli", "pragma.runtime.qodercli"],
-        ["antigravity", "pragma.runtime.antigravity"],
-      ].map(async ([id, adapterId]) => {
-        const factory = factories.find((candidate) => candidate.id === adapterId)!;
-        return await factory.create(definition(id!, id!, adapterId));
-      }),
-    );
+      const cliAdapters = await Promise.all(
+        [
+          ["codex", "pragma.runtime.codex"],
+          ["claude-code", "pragma.runtime.claude-code"],
+          ["qodercli", "pragma.runtime.qodercli"],
+          ["antigravity", "pragma.runtime.antigravity"],
+        ].map(async ([id, adapterId]) => {
+          const factory = factories.find((candidate) => candidate.id === adapterId)!;
+          return await factory.create(definition(id!, id!, adapterId));
+        }),
+      );
 
-    await expect(
-      Promise.all(cliAdapters.map(async (adapter) => await adapter.canUse())),
-    ).resolves.toEqual([
-      expect.objectContaining({ usable: true }),
-      expect.objectContaining({ usable: true }),
-      expect.objectContaining({ usable: true }),
-      expect.objectContaining({ usable: true }),
-    ]);
-    expect(getRuntimeProcessEnvironment).toHaveBeenCalledTimes(4);
-    expect(probeSpy).toHaveBeenCalled();
-    for (const call of probeSpy.mock.calls) {
-      expect(call[0].env).toMatchObject({ MOCK_ENV_TEST: "true" });
-    }
+      await expect(
+        Promise.all(cliAdapters.map(async (adapter) => await adapter.canUse())),
+      ).resolves.toEqual([
+        expect.objectContaining({ usable: true }),
+        expect.objectContaining({ usable: true }),
+        expect.objectContaining({ usable: true }),
+        expect.objectContaining({ usable: true }),
+      ]);
+      expect(getRuntimeProcessEnvironment).toHaveBeenCalledTimes(4);
 
-    const piFactory = factories.find((candidate) => candidate.id === "pragma.runtime.pi")!;
-    await piFactory.create(definition("pi", "PI", "pragma.runtime.pi"));
-    expect(getRuntimeProcessEnvironment).toHaveBeenCalledTimes(4);
-
-    probeSpy.mockRestore();
-  });
+      const piFactory = factories.find((candidate) => candidate.id === "pragma.runtime.pi")!;
+      await piFactory.create(definition("pi", "PI", "pragma.runtime.pi"));
+      expect(getRuntimeProcessEnvironment).toHaveBeenCalledTimes(4);
+    },
+  );
 });
 
 function factory(): RuntimeEnvironmentAdapterFactory {
@@ -295,7 +300,7 @@ function factory(): RuntimeEnvironmentAdapterFactory {
     id: "test.runtime",
     version: "v1",
     create: (environment) =>
-      defineRuntimeDriver({
+      defineRuntimeTestDriver({
         descriptor: { id: environment.id, kind: "test", displayName: environment.displayName },
         canUse: () => ({ usable: true }),
         listModels: async () => [

--- a/docs/adr/041-runtime-feature-framework.md
+++ b/docs/adr/041-runtime-feature-framework.md
@@ -1,0 +1,73 @@
+# ADR 041: Runtime Feature Framework and Conformance Evidence
+
+## Status
+
+Accepted
+
+## Context
+
+`defineRuntimeDriver()` standardized Session and turn execution, but cross-Harness capabilities such
+as MCP, Skills, permissions, attachments, streaming and cleanup remained implicit inside each
+adapter. A Runtime could therefore compile and complete a basic chat turn while silently omitting an
+integration area. Descriptor booleans duplicated implementation claims and were not proof that the
+native Harness discovered or executed a capability.
+
+The Runtime packages also repeated ownership, partial-initialization cleanup, bounded process
+diagnostics and TERM-to-KILL escalation. Those mechanics are shared, while JSON-RPC, NDJSON,
+stream-json and SDK event semantics remain provider-specific.
+
+## Decision
+
+Core owns one closed `RUNTIME_FEATURE_CATALOG`. Every concrete Runtime passes a complete
+`RuntimeFeatureSet` to `defineRuntimeDriver()` and declares each slot as `supported`, `degraded`,
+`unsupported` or `notApplicable`. Non-supported declarations carry a reason. Runtime capability
+booleans are projections of this declaration; driver descriptors only choose placement targets and
+execution locations.
+
+Driver-, Session- and turn-scoped features have explicit phases. Core executes enabled Session hooks
+in catalog order before native Session creation, executes enabled turn hooks before `startTurn()`, and
+passes immutable per-feature preparation results to the provider implementation. Antigravity is the
+reference implementation for MCP, permission relay and Skill preparation. Other Runtime packages
+adopt the same declaration and Core-owned resource scope without sharing provider protocol code.
+
+`RuntimeResourceScope` owns leases, registrations, relays and other acquired resources. It transfers
+ownership only after successful preparation, releases in reverse order, closes idempotently, keeps
+cleaning after individual disposer failures and reports an `AggregateError`. Native processes stop
+before Session feature resources are released.
+
+`RuntimeProcessSupervisor` and `BoundedRuntimeOutputBuffer` provide process ownership, structured
+exit observation, bounded diagnostics and graceful-to-forced termination. They do not parse or
+serialize any Harness protocol. At least Claude Code and Antigravity use these primitives.
+
+The conformance API derives its checks from feature declarations. It verifies mandatory slots,
+capability projection, executed evidence for `supported` claims, stream ordering, terminal event
+ownership, text and tool lifecycle, expected tool execution, output markers and Core persistence
+invariants. The versioned probe evidence schema records sanitized environment, command, assertions
+and observations. MCP and Skills distinguish Materialized, Discovered and Executed evidence.
+
+Real probes run through the public Pragma API:
+
+```bash
+pnpm runtime:probe <pi|codex|claude-code|qodercli|antigravity> \
+  <availability|models|stream|native-tool|mcp|skills|attachments|resume|compaction|cancellation|full>
+```
+
+Probe output is opt-in, redacted and archived under the Runtime probe diagnostics root. Normal CI
+replays fixtures and conformance observations; it does not require developer authentication. The
+Runtime integration checklist contains an auto-generated catalog section, and CI rejects catalog and
+documentation drift.
+
+## Consequences
+
+A Runtime addition is intentionally incomplete until every feature slot is handled. Feature catalog
+changes are centralized and force all adapters and the generated checklist to move together. Existing
+descriptor feature booleans and the unstructured driver `prepare()` hook are removed rather than kept
+as compatibility paths.
+
+`supported` is an evidence-backed state, not an implementation aspiration. Until executed, sanitized
+real-Runtime evidence is recorded, an implemented adapter capability remains `degraded` with an
+explicit reason. Mock success or materialized files alone cannot promote MCP or Skills.
+
+This decision does not introduce ACP, a remote driver, a generic Runtime transport, a base adapter
+class or a process pool. Provider command lines, config layouts, event parsing, permission semantics
+and native Session identity remain in their concrete Runtime packages.

--- a/docs/architecture/runtime-feature-framework.md
+++ b/docs/architecture/runtime-feature-framework.md
@@ -1,0 +1,85 @@
+# Runtime Feature Framework
+
+The Runtime Feature Framework makes integration completeness executable. The authoritative feature
+catalog is `packages/core/src/runtime/features.ts`; adapter descriptors no longer maintain a second
+set of capability booleans.
+
+## Lifecycle and ownership
+
+```text
+defineRuntimeDriver(features, provider methods)
+  -> validate every mandatory slot and direct method contract
+  -> derive public descriptor capabilities
+  -> create Core Runtime Session resource scope
+  -> run enabled Session feature hooks in catalog order
+  -> create or restore the provider-native Session
+  -> transfer resource ownership to the live Session
+  -> for each turn:
+       create turn resource scope
+       run enabled turn feature hooks in catalog order
+       call provider startTurn and map provider-native events
+       release turn resources in reverse order
+  -> stop the provider-native Session/process
+  -> release Session feature resources in reverse order
+```
+
+Feature hooks receive provider-neutral lifecycle context and may return provider-specific prepared
+data. Results are stored by feature name and exposed as immutable snapshots. A concrete adapter reads
+only the entries it owns with `readRuntimePreparedFeature()`. Core does not interpret provider argv,
+environment fragments, plugin layouts or event protocols.
+
+`RuntimeResourceScope.acquire()` registers disposal at the acquisition boundary. This covers partial
+initialization, normal close and disposer failure through one path. `transfer()` closes registration
+after preparation so late resources cannot escape ownership. Receipts expose labels, order and final
+state for diagnostics without exposing the resource value.
+
+## Declaration and public capabilities
+
+Every catalog slot has exactly one status:
+
+- `supported`: implemented and backed by executed evidence;
+- `degraded(reason)`: usable with a stated limitation or awaiting real-Runtime verification;
+- `unsupported(reason)`: not implemented or unavailable from the provider;
+- `notApplicable(reason)`: irrelevant to this Runtime product shape.
+
+Core treats `supported` and `degraded` as enabled behavior. Placement (`targets` and
+`executionLocations`) remains explicit in the driver descriptor. Streaming, MCP, resume, cancellation,
+close, context inspection and compaction capabilities are derived from the feature set. Direct method
+contracts such as model discovery, cancellation, steering, context inspection and close are checked
+at registration and, where TypeScript can express the relationship, at compile time.
+
+## Conformance and evidence
+
+`assertRuntimeConformance()` and `describeRuntimeConformance()` verify declaration and observation
+invariants. Enabled text streaming requires a delta before the completed message and exactly one final
+run event. Tool calls require one start and one terminal event. Capability projections cannot diverge
+from the feature declaration.
+
+The evidence protocol is `pragma.runtime-probe-evidence/v1`. It stores Runtime and probe identity,
+version/platform/authentication context, a safe command summary, staged assertions and normalized
+observations. Sensitive keys, known credential shapes, registered secrets and workspace/home paths
+are replaced before schema validation and atomic archival.
+
+MCP and Skills use three independent stages:
+
+1. Materialized: registration, config or files were created.
+2. Discovered: the native Harness exposed or acknowledged the capability.
+3. Executed: a harmless real invocation completed and its marker was observed.
+
+Materialized or Discovered evidence alone does not justify `supported`.
+
+## Adding a Runtime
+
+1. Declare every slot with `defineRuntimeFeatures()`; do not copy capability booleans into the
+   descriptor.
+2. Put reusable leases, registrations, relays and listeners in `ctx.resources`; keep native protocol
+   setup in the Runtime package.
+3. Add Session or turn hooks for lifecycle-bound features and consume their prepared results from the
+   native method.
+4. Register declaration and fixture observations with `describeRuntimeConformance()`.
+5. Run one feature probe at a time, inspect the redacted evidence, then run `full` as the combined
+   smoke. Never commit credentials or unreviewed raw logs.
+6. Run `pnpm runtime:features:check`; catalog changes require regenerating the integration checklist.
+
+See [ADR 041](../adr/041-runtime-feature-framework.md) and the
+[Runtime Adapter integration checklist](../conventions/runtime-adapter-integration-checklist.md).

--- a/docs/conventions/runtime-adapter-integration-checklist.md
+++ b/docs/conventions/runtime-adapter-integration-checklist.md
@@ -9,7 +9,8 @@ Runtime 中工作。
 每一项必须标记以下一种状态，不允许留空或仅写“待验证”：
 
 - **Supported**：已接通，具有代码位置、自动测试和真实 Runtime 验证证据。
-- **Degraded**：有明确降级行为，用户可观察，能力声明不夸大；同样需要自动测试和真实验证。
+- **Degraded**：有明确降级行为、证据尚未齐备或真实 Runtime 尚未复验；必须写明原因并有自动测试，
+  不能把已有实现当成 Supported。若声明某个降级行为已经可用，仍需附对应的真实验证。
 - **Unsupported**：供应商公开接口不支持或本 Adapter 尚未实现；必须 fail closed 或给出可操作诊断。
 - **N/A**：该 Runtime 的产品形态不适用，并说明原因。
 
@@ -17,6 +18,46 @@ Runtime 中工作。
 记录。配置文件存在、mock 进程成功和 capability 布尔值都不能单独作为 Supported 证据。MCP 必须完成一次
 真实工具发现与调用；streaming 必须在 terminal result 前观察到增量事件；Skill 必须实际影响一次模型行为或
 出现明确的发现日志。
+
+<!-- RUNTIME_FEATURE_CATALOG_GENERATED_START -->
+
+## 可执行特性目录（自动生成）
+
+下表直接由 `packages/core/src/runtime/features.ts` 的权威目录生成。新增、删除或重排特性后，
+`pnpm runtime:features:check` 会在文档未同步时失败。每个 Runtime 必须为每一行声明
+`supported`、`degraded(reason)`、`unsupported(reason)` 或 `notApplicable(reason)`。
+
+<!-- prettier-ignore -->
+| Feature slot | Core 生命周期阶段 | 验收结果 |
+| --- | --- | --- |
+| `availability` | Driver 注册/探测 | Runtime availability probing |
+| `authentication` | Driver 注册/探测 | Runtime authentication setup and validation |
+| `modelDiscovery` | Driver 注册/探测 | Model catalog discovery |
+| `modelSelection` | Turn 准备/清理 | Per-Session or per-turn model selection |
+| `thinking` | Turn 准备/清理 | Thinking or reasoning level selection |
+| `freshSession` | Session 准备/清理 | Fresh native Session creation |
+| `resume` | Session 准备/清理 | Native Session restoration |
+| `systemPrompt` | Session 准备/清理 | System prompt delivery |
+| `startupMessages` | Session 准备/清理 | Startup message delivery and reinjection |
+| `textStreaming` | Turn 准备/清理 | Ordered text streaming |
+| `reasoningStreaming` | Turn 准备/清理 | Ordered reasoning streaming |
+| `nativeToolLifecycle` | Turn 准备/清理 | Native tool start, update, and completion events |
+| `mcp` | Session 准备/清理 | MCP tool registration and execution |
+| `permissions` | Session 准备/清理 | Tool permission policy and approval |
+| `userInteraction` | Turn 准备/清理 | Durable human interaction |
+| `skills` | Session 准备/清理 | Skill materialization and invocation |
+| `attachmentImage` | Turn 准备/清理 | Image attachments |
+| `attachmentFile` | Turn 准备/清理 | File attachments |
+| `attachmentDirectory` | Turn 准备/清理 | Directory attachments |
+| `usage` | Turn 准备/清理 | Token usage observation |
+| `contextWindow` | Driver 注册/探测 | Context window inspection |
+| `compaction` | Session 准备/清理 | Context compaction and compaction events |
+| `cancellation` | Turn 准备/清理 | Active turn cancellation |
+| `steering` | Turn 准备/清理 | Active turn steering |
+| `close` | Session 准备/清理 | Native Session shutdown |
+| `cleanup` | Session 准备/清理 | Feature resource cleanup |
+
+<!-- RUNTIME_FEATURE_CATALOG_GENERATED_END -->
 
 ## 证据优先的 Harness 适配方法
 
@@ -203,21 +244,20 @@ Supported。提升 capability 时应把对应 smoke 作为同一改动的验收�
 
 ## Actions：缩短下一次 Runtime 适配周期
 
-以下 Action 是后续工程方向，不代表当前仓库已经具备。完成时必须提交实现、测试和使用文档，并在本表更新
-状态；不得仅因建了目录或脚本占位就关闭 Action。
+Action 状态以实现、测试和使用文档为准；目录或脚本占位不算完成。
 
-| Action               | 优先级 | 后续工作                                                                                                                                        | 完成标准                                                                                                          |
-| -------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `RUNTIME-ACTION-001` | P0     | 建设版本化 Runtime Probe Harness，将 version/help/models、stream、tool、MCP、Skill、attachment、resume、compaction、cancel 拆成可单独运行的探针 | 一条本地命令可选择 Runtime 和探针，生成脱敏证据包；失败能指出协议、发现、权限或生命周期阶段                       |
-| `RUNTIME-ACTION-002` | P0     | 定义真实证据包格式和脱敏规则，按 Runtime/version/platform/auth mode 保存 argv 摘要、stdout NDJSON、stderr、诊断日志和预期断言                   | fixture 可由 parser 测试直接消费；路径、token、cookie、用户名和会话私密内容不可逆脱敏；保留协议字段形状           |
-| `RUNTIME-ACTION-003` | P0     | 为注入能力建立 Materialized/Discovered/Executed 三段断言和 silent-fallback 检测                                                                 | system prompt、Agent、MCP、Skill 与模型选择均能报告实际激活身份；配置存在但未加载时 smoke 必须失败                |
-| `RUNTIME-ACTION-004` | P1     | 抽取 Runtime 进程诊断基元：有界 stdout/stderr scanner、受管日志证据、terminal semantic-success classifier、取消与强杀升级                       | 至少两个 Runtime 复用；退出码 0 的空输出、内部 timeout、provider error 和缺失 terminal event 有稳定错误码         |
-| `RUNTIME-ACTION-005` | P1     | 为 customization/materialization 增加 ownership receipt 或 manifest，记录 Adapter 创建的文件、目录、registration、relay 和 lease                | prepare/close 可重复；只清理当前 Session 拥有的资源；预存文件、并发新增文件和部分失败均不被覆盖或误删             |
-| `RUNTIME-ACTION-006` | P1     | 把真实 smoke 拆成快速、单能力用例，并保留一个组合验收用例                                                                                       | 日常定位无需反复运行完整模型流程；组合用例仍覆盖 fresh/resume、长回答、native tool、managed MCP、Skill 和附件降级 |
-| `RUNTIME-ACTION-007` | P1     | 建立 Runtime 版本升级审计流程，对公开协议、help、模型目录、事件 fixture 和 customization 加载日志做差异比较                                     | 升级最低支持版本或检测到新版本时自动生成差异报告；未知事件和已移除 flag 不会静默进入正式能力声明                  |
-| `RUNTIME-ACTION-008` | P2     | 在适配调研模板中记录官方资料、真实 CLI 证据和外部实现的适用版本                                                                                 | 每个外部结论标注来源版本和“可借鉴/不可照搬”边界，不把旧版纯文本实现当作新版结构化协议基线                         |
-| `RUNTIME-ACTION-009` | P0     | 为 Runtime event 与 turn result 定义 observation ownership 测试，重点覆盖 usage、session id、output snapshot 和 compaction                      | 每个事实只有一个累计通道；完整 Driver 测试能发现双计、重复正文和 Session identity 覆盖                            |
-| `RUNTIME-ACTION-010` | P0     | 保存各版本真实 Hook/tool 参数 schema fixture，并生成文件工具路径字段、MCP dispatcher 与终态状态的 fail-closed contract tests                    | 供应商字段改名、缺失、非法 URI、namespace 前缀碰撞和审批后参数修改都不能绕过权限边界                              |
+| Action               | 状态     | 当前结果 / 后续工作                                                                                                    |
+| -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `RUNTIME-ACTION-001` | 已完成   | `pnpm runtime:probe <runtime> <probe>` 提供独立探针和组合 `full` 探针。                                                |
+| `RUNTIME-ACTION-002` | 已完成   | `pragma.runtime-probe-evidence/v1` 提供 Schema、脱敏、泄漏扫描和原子归档。                                             |
+| `RUNTIME-ACTION-003` | 部分完成 | MCP、Skills 已有 Materialized/Discovered/Executed 断言；其他注入能力仍应增加供应商原生 identity/silent-fallback 证据。 |
+| `RUNTIME-ACTION-004` | 已完成   | Core 提供有界输出、结构化退出和 TERM→KILL；Claude Code、Antigravity 复用，语义终态由各自 parser 与 conformance 校验。  |
+| `RUNTIME-ACTION-005` | 部分完成 | `RuntimeResourceScope` 已记录 lease/registration/relay receipt；文件 materialization manifest 仍按具体 Runtime 推进。  |
+| `RUNTIME-ACTION-006` | 已完成   | stream/tool/MCP/Skill/attachment/resume/compaction/cancel 可单跑，`full` 保留组合验收。                                |
+| `RUNTIME-ACTION-007` | 未完成   | 仍需建立跨 Runtime 版本的 help、模型目录、事件和 customization 差异审计。                                              |
+| `RUNTIME-ACTION-008` | 未完成   | 仍需统一适配调研模板和外部实现的版本/适用边界记录。                                                                    |
+| `RUNTIME-ACTION-009` | 已完成   | Conformance 检查 event identity/order、正文与工具终态、输出 marker、structured output 和 owner persistence。           |
+| `RUNTIME-ACTION-010` | 未完成   | 继续按 Runtime 保存 Hook/tool 参数 Schema fixture，并扩展文件路径与审批后参数的 fail-closed contract tests。           |
 
 下一 Runtime 的推荐顺序是：先完成 `001` 的最小探针和 `002` 的证据包，再写 Adapter；随后逐能力完成
 `003` 的行为断言，最后才进入 Desktop 组合验收。这样可以在第一轮就区分“协议不认识”“配置没发现”“权限

--- a/examples/package.json
+++ b/examples/package.json
@@ -16,6 +16,7 @@
     "example:runtime-codex": "tsx src/runtimes/codex/console-chat.ts",
     "example:runtime-claude-code": "tsx src/runtimes/claude-code/console-chat.ts",
     "example:runtime-antigravity": "tsx src/runtimes/antigravity/console-chat.ts",
+    "runtime:probe": "tsx src/runtimes/probe.ts",
     "example:skills": "tsx src/capabilities/skills.ts",
     "example:tool-approval": "tsx src/capabilities/tool-approval.ts",
     "build": "tsc -p tsconfig.build.json",
@@ -33,6 +34,7 @@
     "@pragma/runtime-claude-code": "workspace:*",
     "@pragma/runtime-codex": "workspace:*",
     "@pragma/runtime-pi": "workspace:*",
+    "@pragma/runtime-qodercli": "workspace:*",
     "cac": "^7.0.0",
     "dotenv": "latest",
     "zod": "latest"

--- a/examples/src/bundles/export-load.ts
+++ b/examples/src/bundles/export-load.ts
@@ -1,7 +1,12 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import { createStaticRuntimeResolver, type Expert } from "@pragma/core";
+import {
+  createStaticRuntimeResolver,
+  defineRuntimeFeatures,
+  runtimeFeature,
+  type Expert,
+} from "@pragma/core";
 import {
   loadPragmaProject,
   type PragmaBindingRecord,
@@ -119,10 +124,39 @@ try {
 }
 
 function createExampleRuntimeResolver() {
+  const omitted = () => runtimeFeature.notApplicable("The bundle example does not execute turns.");
   return createStaticRuntimeResolver({
     defaultRuntimeId: "example-runtime",
     runtimes: [
       {
+        features: defineRuntimeFeatures({
+          availability: runtimeFeature.degraded("The example uses a local availability stub."),
+          authentication: omitted(),
+          modelDiscovery: omitted(),
+          modelSelection: omitted(),
+          thinking: omitted(),
+          freshSession: omitted(),
+          resume: omitted(),
+          systemPrompt: omitted(),
+          startupMessages: omitted(),
+          textStreaming: omitted(),
+          reasoningStreaming: omitted(),
+          nativeToolLifecycle: omitted(),
+          mcp: omitted(),
+          permissions: omitted(),
+          userInteraction: omitted(),
+          skills: omitted(),
+          attachmentImage: omitted(),
+          attachmentFile: omitted(),
+          attachmentDirectory: omitted(),
+          usage: omitted(),
+          contextWindow: omitted(),
+          compaction: omitted(),
+          cancellation: omitted(),
+          steering: omitted(),
+          close: omitted(),
+          cleanup: omitted(),
+        }),
         descriptor: {
           id: "example-runtime",
           kind: "example",

--- a/examples/src/runtimes/probe.ts
+++ b/examples/src/runtimes/probe.ts
@@ -1,0 +1,625 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createPragma,
+  createRuntimeProbeEvidence,
+  createStaticRuntimeResolver,
+  defineExpert,
+  inspectRuntimeObservationConformance,
+  writeRuntimeProbeEvidence,
+  ExpertAgentStreamEventSchema,
+  type ExecutionEvent,
+  type IExpertAgentModelsConfig,
+  type RuntimeAdapter,
+  type RuntimeFeatureName,
+  type RuntimeProbeAssertion,
+  type RuntimeStreamEvent,
+} from "@pragma/core";
+import { createAntigravityRuntime } from "@pragma/runtime-antigravity";
+import { createClaudeCodeRuntime } from "@pragma/runtime-claude-code";
+import { createCodexRuntime } from "@pragma/runtime-codex";
+import { createPiRuntime } from "@pragma/runtime-pi";
+import { createQoderCliRuntime } from "@pragma/runtime-qodercli";
+
+import { createExampleModelsConfig, createExamplePiRuntime } from "../support/example-kit.ts";
+
+const runtimeName = process.argv[2];
+const probeName = process.argv[3];
+const runtimeNames = ["pi", "codex", "claude-code", "qodercli", "antigravity"] as const;
+const probeNames = [
+  "availability",
+  "models",
+  "stream",
+  "native-tool",
+  "mcp",
+  "skills",
+  "attachments",
+  "resume",
+  "compaction",
+  "cancellation",
+  "full",
+] as const;
+
+if (!runtimeNames.includes(runtimeName as (typeof runtimeNames)[number])) {
+  throw new Error(`Runtime must be one of: ${runtimeNames.join(", ")}.`);
+}
+if (!probeNames.includes(probeName as (typeof probeNames)[number])) {
+  throw new Error(`Probe must be one of: ${probeNames.join(", ")}.`);
+}
+
+const root = await mkdtemp(join(tmpdir(), `pragma-${runtimeName}-${probeName}-`));
+const workspace = join(root, "workspace");
+const pragmaHome = join(root, "pragma-home");
+const skillDir = join(root, "skill");
+await Promise.all([
+  mkdir(workspace, { recursive: true }),
+  mkdir(pragmaHome, { recursive: true }),
+  mkdir(skillDir, { recursive: true }),
+]);
+const filePath = join(workspace, "RUNTIME_PROBE_FILE.txt");
+const imagePath = join(workspace, "runtime-probe.png");
+await Promise.all([
+  writeFile(filePath, "Pragma Runtime probe file marker: FILE_PROBE_OK_9241\n"),
+  writeFile(
+    imagePath,
+    Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=",
+      "base64",
+    ),
+  ),
+  writeFile(
+    join(skillDir, "SKILL.md"),
+    [
+      "---",
+      "name: pragma-runtime-probe",
+      "description: Runtime conformance Skill probe.",
+      "---",
+      "",
+      "When explicitly invoked, include the exact marker SKILL_PROBE_OK_7419 in the answer.",
+      "",
+    ].join("\n"),
+  ),
+]);
+
+const runtimeSetup = createProbeRuntime(
+  runtimeName as (typeof runtimeNames)[number],
+  probeName as (typeof probeNames)[number],
+);
+const runtime = runtimeSetup.runtime;
+const assertions: RuntimeProbeAssertion[] = [];
+const observations: string[] = [];
+let runtimeVersion: string | undefined;
+let failed: unknown;
+
+try {
+  if (runtimeSetup.configurationError !== undefined) {
+    throw runtimeSetup.configurationError;
+  }
+  const availability = await runtime.canUse();
+  runtimeVersion =
+    readString(availability.details?.["version"]) ??
+    readString(availability.details?.["parsedVersion"]);
+  recordObservation(observations, { phase: "availability", result: availability });
+  if (probeName === "availability") {
+    assertions.push(
+      assertion(
+        "availability.executed",
+        "availability",
+        "executed",
+        availability.usable ? "passed" : "failed",
+        availability.usable
+          ? "Runtime availability probe succeeded."
+          : (availability.reason ?? "Runtime availability probe failed."),
+      ),
+    );
+  }
+  if (!availability.usable) throw new Error(availability.reason ?? "Runtime is unavailable.");
+  if (probeName === "models") {
+    const models = await runtime.listModels?.();
+    const passed = models !== undefined && models.length > 0;
+    assertions.push(
+      assertion(
+        "models.discovered",
+        "modelDiscovery",
+        "discovered",
+        passed ? "passed" : "failed",
+        passed ? `Discovered ${models.length} models.` : "Runtime returned no model catalog.",
+      ),
+    );
+    recordObservation(observations, models ?? []);
+    if (!passed) throw new Error("Runtime returned no model catalog.");
+  } else if (probeName !== "availability") {
+    await runSessionProbe(runtime, probeName as (typeof probeNames)[number], {
+      workspace,
+      pragmaHome,
+      skillDir,
+      filePath,
+      imagePath,
+      assertions,
+      observations,
+      models: runtimeSetup.models,
+    });
+  }
+} catch (error) {
+  failed = error;
+  if (!assertions.some(({ status }) => status === "failed")) {
+    assertions.push(
+      assertion(
+        `${probeName}.failed`,
+        probeFeature(probeName as (typeof probeNames)[number]),
+        "executed",
+        "failed",
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+  }
+}
+
+const capturedAt = new Date().toISOString();
+const { evidence, evidencePath } = await (async () => {
+  try {
+    const evidence = createRuntimeProbeEvidence(
+      {
+        runtime: {
+          id: runtime.descriptor.id,
+          kind: runtime.descriptor.kind,
+          ...(runtimeVersion === undefined ? {} : { version: runtimeVersion }),
+        },
+        probe: { id: probeName!, version: "v1" },
+        environment: {
+          capturedAt,
+          platform: process.platform,
+          architecture: process.arch,
+          authenticationMode: runtimeSetup.authenticationMode,
+        },
+        command: {
+          executable: "pnpm runtime:probe",
+          arguments: [runtimeName!, probeName!],
+        },
+        assertions,
+        observations,
+      },
+      {
+        home: process.env["HOME"],
+        workspace,
+        paths: [root, pragmaHome, skillDir],
+        secrets: readProbeSecrets(process.env),
+      },
+    );
+    return { evidence, evidencePath: await writeRuntimeProbeEvidence(evidence) };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+})();
+console.log(
+  JSON.stringify(
+    {
+      runtime: runtime.descriptor.id,
+      probe: probeName,
+      status: failed === undefined ? "passed" : "failed",
+      evidencePath,
+      assertions: evidence.assertions,
+    },
+    null,
+    2,
+  ),
+);
+if (failed !== undefined) {
+  process.exitCode = 1;
+  console.error(failed instanceof Error ? failed.message : String(failed));
+}
+
+interface ProbeRuntimeSetup {
+  readonly runtime: RuntimeAdapter;
+  readonly authenticationMode: string;
+  readonly models?: IExpertAgentModelsConfig | undefined;
+  readonly configurationError?: Error | undefined;
+}
+
+function createProbeRuntime(
+  name: (typeof runtimeNames)[number],
+  probe: (typeof probeNames)[number],
+): ProbeRuntimeSetup {
+  const modelName = process.env["PRAGMA_RUNTIME_PROBE_MODEL"];
+  const thinkingLevel = process.env["PRAGMA_RUNTIME_PROBE_THINKING"];
+  const defaults = {
+    ...(modelName === undefined ? {} : { defaultModelName: modelName }),
+    ...(thinkingLevel === undefined ? {} : { defaultThinkingLevel: thinkingLevel }),
+  };
+  switch (name) {
+    case "pi":
+      if (probe === "availability") {
+        return { runtime: createPiRuntime(), authenticationMode: "host-registered-provider" };
+      }
+      try {
+        return {
+          runtime: createExamplePiRuntime(process.env),
+          models: createExampleModelsConfig(process.env),
+          authenticationMode: "host-registered-provider",
+        };
+      } catch (error) {
+        return {
+          runtime: createPiRuntime(),
+          authenticationMode: "host-registered-provider",
+          configurationError: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    case "codex":
+      return { runtime: createCodexRuntime(defaults), authenticationMode: "native-cli-profile" };
+    case "claude-code":
+      return {
+        runtime: createClaudeCodeRuntime(defaults),
+        authenticationMode: "native-cli-profile",
+      };
+    case "qodercli":
+      return {
+        runtime: createQoderCliRuntime(defaults),
+        authenticationMode: "native-cli-profile",
+      };
+    case "antigravity": {
+      const authenticationMode =
+        process.env["PRAGMA_ANTIGRAVITY_PROBE_AUTH_MODE"] === "isolated-environment"
+          ? "isolated-environment"
+          : "host-keyring";
+      return {
+        runtime: createAntigravityRuntime({
+          ...defaults,
+          authenticationMode,
+        }),
+        authenticationMode,
+      };
+    }
+  }
+}
+
+async function runSessionProbe(
+  runtime: RuntimeAdapter,
+  probe: (typeof probeNames)[number],
+  paths: {
+    readonly workspace: string;
+    readonly pragmaHome: string;
+    readonly skillDir: string;
+    readonly filePath: string;
+    readonly imagePath: string;
+    readonly assertions: RuntimeProbeAssertion[];
+    readonly observations: string[];
+    readonly models?: IExpertAgentModelsConfig | undefined;
+  },
+): Promise<void> {
+  const expert = await defineExpert({
+    id: "pr0bexpt00000001",
+    name: "Runtime Probe",
+    description: "Exercises Runtime conformance features.",
+    instructions:
+      "Follow the probe request exactly. Use tools when requested and preserve every exact marker.",
+    tags: ["runtime", "probe"],
+    scope: "test",
+    workspace: paths.workspace,
+    pragmaHome: paths.pragmaHome,
+    skills: {
+      skills: [
+        {
+          type: "local",
+          name: "pragma-runtime-probe",
+          description: "Runtime conformance Skill probe.",
+          path: join(paths.skillDir, "SKILL.md"),
+          baseDir: paths.skillDir,
+        },
+      ],
+    },
+    ...(paths.models === undefined ? {} : { models: paths.models }),
+  });
+  const app = createPragma({
+    pragmaHome: paths.pragmaHome,
+    runtimes: createStaticRuntimeResolver({
+      runtimes: [runtime],
+      defaultRuntimeId: runtime.descriptor.id,
+    }),
+  });
+  const session = await app.experts.createSession(expert, { runtime: runtime.descriptor.id });
+  const operations =
+    probe === "full"
+      ? (["stream", "native-tool", "mcp", "skills", "attachments", "resume"] as const)
+      : [probe];
+  try {
+    for (const operation of operations) {
+      if (operation === "compaction") {
+        const canCompact = await session.canCompactRootContext();
+        if (canCompact !== true) {
+          paths.assertions.push(
+            assertion(
+              "compaction.executed",
+              "compaction",
+              "executed",
+              "skipped",
+              "Runtime reported that the current context did not require compaction.",
+            ),
+          );
+          continue;
+        }
+        await session.compactRootContext();
+        paths.assertions.push(
+          assertion(
+            "compaction.executed",
+            "compaction",
+            "executed",
+            "passed",
+            "Manual context compaction completed.",
+          ),
+        );
+        continue;
+      }
+      if (operation === "cancellation") {
+        const turn = await session.prompt(
+          "Do a long-running analysis for at least two minutes before answering.",
+          { requestId: `probe-cancel-${Date.now()}` },
+        );
+        setTimeout(() => void session.abort("Runtime cancellation probe"), 500).unref();
+        await turn.result.then(
+          () => {
+            throw new Error("Cancellation probe completed instead of being cancelled.");
+          },
+          () => undefined,
+        );
+        const events = readRuntimeEvents((await turn.listEvents()).items);
+        const passed = events.some((event) => event.type === "run.cancelled");
+        paths.assertions.push(
+          assertion(
+            "cancellation.executed",
+            "cancellation",
+            "executed",
+            passed ? "passed" : "failed",
+            passed ? "Observed run.cancelled." : "Cancellation produced no run.cancelled event.",
+          ),
+        );
+        if (!passed) throw new Error("Cancellation produced no run.cancelled event.");
+        continue;
+      }
+
+      const request = createProbePrompt(operation, paths);
+      const turn = await session.prompt(request.prompt, {
+        requestId: `probe-${operation}-${Date.now()}`,
+        ...(request.attachments === undefined ? {} : { attachments: request.attachments }),
+      });
+      const output = String(await turn.result);
+      const events = readRuntimeEvents((await turn.listEvents()).items);
+      const sessionState = await session.getState();
+      const rootContext = sessionState.contexts[sessionState.rootContextId];
+      const ownerPersistenceValidated =
+        rootContext?.owner.type === "expert-session" &&
+        rootContext.owner.ownerId === session.sessionId &&
+        rootContext.origin.type === "expert-session" &&
+        rootContext.origin.sessionId === session.sessionId &&
+        rootContext.snapshot?.systemSessionId !== undefined;
+      recordObservation(paths.observations, {
+        operation,
+        output,
+        events: events.map(({ type, sequence, payload }) => ({ type, sequence, payload })),
+      });
+      const expectedToolNames =
+        operation === "native-tool"
+          ? ["list_dir"]
+          : operation === "mcp"
+            ? ["list_expert_context"]
+            : [];
+      const expectedMarkers = request.marker === undefined ? [] : [request.marker];
+      const failures = inspectRuntimeObservationConformance(runtime, {
+        events,
+        outputText: output,
+        expectedToolNames,
+        expectedOutputMarkers: expectedMarkers,
+        requiredFeatures: operationFeatures(operation),
+        structuredOutputValidated: true,
+        ownerPersistenceValidated,
+      });
+      if (operation === "mcp" || operation === "skills") {
+        const feature = operation === "mcp" ? "mcp" : "skills";
+        paths.assertions.push(
+          assertion(
+            `${feature}.materialized`,
+            feature,
+            "materialized",
+            "passed",
+            `${feature} Session resources were prepared.`,
+          ),
+          assertion(
+            `${feature}.discovered`,
+            feature,
+            "discovered",
+            failures.length === 0 ? "passed" : "failed",
+            failures.length === 0
+              ? `${feature} was discovered by the native Runtime.`
+              : failures.map(({ message }) => message).join(" "),
+          ),
+        );
+      }
+      paths.assertions.push(
+        assertion(
+          `${operation}.executed`,
+          probeFeature(operation),
+          "executed",
+          failures.length === 0 ? "passed" : "failed",
+          failures.length === 0
+            ? `${operation} probe completed.`
+            : failures.map(({ message }) => message).join(" "),
+        ),
+      );
+      if (failures.length > 0) throw new Error(failures.map(({ message }) => message).join(" "));
+
+      if (operation === "resume") {
+        await session.refreshRuntimeSessions();
+        const resumed = await session.prompt(
+          "Reply with RESUME_PROBE_OK_3187 and the exact prior marker RESUME_MEMORY_6249.",
+          { requestId: `probe-resume-second-${Date.now()}` },
+        );
+        const resumedOutput = String(await resumed.result);
+        const passed =
+          resumedOutput.includes("RESUME_PROBE_OK_3187") &&
+          resumedOutput.includes("RESUME_MEMORY_6249");
+        paths.assertions.push(
+          assertion(
+            "resume.executed_after_refresh",
+            "resume",
+            "executed",
+            passed ? "passed" : "failed",
+            passed
+              ? "Native Session identity resumed after refresh."
+              : "The resumed turn did not recall the marker.",
+          ),
+        );
+        if (!passed) throw new Error("The resumed turn did not recall the marker.");
+      }
+    }
+  } finally {
+    await session.close("Runtime probe completed.");
+  }
+}
+
+function createProbePrompt(
+  operation: string,
+  paths: { readonly workspace: string; readonly filePath: string; readonly imagePath: string },
+): {
+  readonly prompt: string;
+  readonly marker?: string | undefined;
+  readonly attachments?: readonly {
+    readonly id: string;
+    readonly kind: "image" | "file" | "directory";
+    readonly name: string;
+    readonly path: string;
+    readonly mimeType?: string | undefined;
+  }[];
+} {
+  switch (operation) {
+    case "stream":
+      return {
+        prompt: "Write at least 160 words and finish with STREAM_PROBE_OK_1193.",
+        marker: "STREAM_PROBE_OK_1193",
+      };
+    case "native-tool":
+      return {
+        prompt:
+          "Use the native list_dir tool on the current workspace, then reply NATIVE_TOOL_PROBE_OK_8821.",
+        marker: "NATIVE_TOOL_PROBE_OK_8821",
+      };
+    case "mcp":
+      return {
+        prompt: "Call the managed list_expert_context MCP tool, then reply MCP_PROBE_OK_4412.",
+        marker: "MCP_PROBE_OK_4412",
+      };
+    case "skills":
+      return {
+        prompt: "/pragma-runtime-probe Invoke this Skill and obey its exact marker instruction.",
+        marker: "SKILL_PROBE_OK_7419",
+      };
+    case "attachments":
+      return {
+        prompt: "Confirm all three attachment paths and reply ATTACHMENT_PROBE_OK_5528.",
+        marker: "ATTACHMENT_PROBE_OK_5528",
+        attachments: [
+          {
+            id: "00000000-0000-4000-8000-000000000001",
+            kind: "image",
+            name: "runtime-probe.png",
+            path: paths.imagePath,
+            mimeType: "image/png",
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000002",
+            kind: "file",
+            name: "RUNTIME_PROBE_FILE.txt",
+            path: paths.filePath,
+            mimeType: "text/plain",
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000003",
+            kind: "directory",
+            name: "workspace",
+            path: paths.workspace,
+          },
+        ],
+      };
+    case "resume":
+      return {
+        prompt: "Remember the exact marker RESUME_MEMORY_6249 and reply with it now.",
+        marker: "RESUME_MEMORY_6249",
+      };
+    default:
+      throw new Error(`Unsupported Session probe operation: ${operation}`);
+  }
+}
+
+function readRuntimeEvents(events: readonly ExecutionEvent[]): readonly RuntimeStreamEvent[] {
+  return events.flatMap((event) => {
+    if (event.type !== "runtime.event") return [];
+    const parsed = ExpertAgentStreamEventSchema.safeParse(event.data);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+function assertion(
+  id: string,
+  feature: RuntimeFeatureName,
+  stage: RuntimeProbeAssertion["stage"],
+  status: RuntimeProbeAssertion["status"],
+  message: string,
+): RuntimeProbeAssertion {
+  return { id, feature, stage, status, message };
+}
+
+function probeFeature(probe: (typeof probeNames)[number] | string): RuntimeFeatureName {
+  switch (probe) {
+    case "availability":
+      return "availability";
+    case "models":
+      return "modelDiscovery";
+    case "stream":
+      return "textStreaming";
+    case "native-tool":
+      return "nativeToolLifecycle";
+    case "mcp":
+      return "mcp";
+    case "skills":
+      return "skills";
+    case "attachments":
+      return "attachmentImage";
+    case "resume":
+      return "resume";
+    case "compaction":
+      return "compaction";
+    case "cancellation":
+      return "cancellation";
+    default:
+      return "cleanup";
+  }
+}
+
+function operationFeatures(operation: string): readonly RuntimeFeatureName[] {
+  return operation === "attachments"
+    ? ["attachmentImage", "attachmentFile", "attachmentDirectory"]
+    : [probeFeature(operation)];
+}
+
+function readProbeSecrets(environment: NodeJS.ProcessEnv): readonly string[] {
+  return Object.entries(environment).flatMap(([name, value]) =>
+    value !== undefined &&
+    /(?:token|secret|password|api[-_]?key|authorization|credential)/i.test(name)
+      ? [value]
+      : [],
+  );
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function recordObservation(observations: string[], value: unknown): void {
+  const serialized = JSON.stringify(value) ?? String(value);
+  const limit = 16_000;
+  observations.push(
+    serialized.length <= limit
+      ? serialized
+      : `${serialized.slice(0, limit)}...[truncated ${serialized.length - limit} characters]`,
+  );
+}

--- a/examples/src/support/example-kit.ts
+++ b/examples/src/support/example-kit.ts
@@ -44,9 +44,20 @@ export function createExampleModelsConfig(env: NodeJS.ProcessEnv): IExpertAgentM
 }
 
 export function createExampleApp(pragmaHome?: string) {
-  const providerId = requiredEnv(process.env, "PRAGMA_MODEL_PROVIDER");
-  const modelId = requiredEnv(process.env, "PRAGMA_MODEL_NAME");
-  const api = parseModelApi(process.env["PRAGMA_MODEL_API"]) ?? "openai-completions";
+  const runtime = createExamplePiRuntime(process.env);
+  return createPragma({
+    ...(pragmaHome === undefined ? {} : { pragmaHome }),
+    runtimes: createStaticRuntimeResolver({
+      runtimes: [runtime],
+      defaultRuntimeId: runtime.descriptor.id,
+    }),
+  });
+}
+
+export function createExamplePiRuntime(env: NodeJS.ProcessEnv = process.env) {
+  const providerId = requiredEnv(env, "PRAGMA_MODEL_PROVIDER");
+  const modelId = requiredEnv(env, "PRAGMA_MODEL_NAME");
+  const api = parseModelApi(env["PRAGMA_MODEL_API"]) ?? "openai-completions";
   const provider: ModelProviderDefinition = {
     id: providerId,
     catalogId: providerId,
@@ -63,28 +74,21 @@ export function createExampleApp(pragmaHome?: string) {
         maxTokens: 16_384,
       },
     ],
-    baseUrl: requiredEnv(process.env, "PRAGMA_MODEL_BASE_API"),
+    baseUrl: requiredEnv(env, "PRAGMA_MODEL_BASE_API"),
     api,
   };
-  const runtime = createPiRuntime({
+  return createPiRuntime({
     modelProviders: {
       listProviders: async () => [provider],
       resolveProvider: async (id) => {
         if (id !== providerId) throw new Error(`Unknown example model provider: ${id}`);
         return {
           ...provider,
-          apiKey: requiredEnv(process.env, "PRAGMA_MODEL_API_KEY"),
+          apiKey: requiredEnv(env, "PRAGMA_MODEL_API_KEY"),
           credentialFingerprint: `example:${providerId}`,
         };
       },
     },
-  });
-  return createPragma({
-    ...(pragmaHome === undefined ? {} : { pragmaHome }),
-    runtimes: createStaticRuntimeResolver({
-      runtimes: [runtime],
-      defaultRuntimeId: runtime.descriptor.id,
-    }),
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "test": "turbo run test:core",
     "test:core": "turbo run test:core",
     "test:all": "turbo run test",
-    "check": "pnpm lint && pnpm typecheck && pnpm test:core",
+    "runtime:probe": "pnpm --filter @pragma/examples runtime:probe --",
+    "runtime:features:generate": "node ./packages/core/scripts/generate-runtime-feature-checklist.mjs",
+    "runtime:features:check": "node ./packages/core/scripts/generate-runtime-feature-checklist.mjs --check",
+    "check": "pnpm runtime:features:check && pnpm lint && pnpm typecheck && pnpm test:core",
     "clean": "turbo run clean && rm -rf node_modules"
   },
   "devDependencies": {

--- a/packages/built-in-agents/test/builtin.test.ts
+++ b/packages/built-in-agents/test/builtin.test.ts
@@ -11,6 +11,7 @@ import {
   registerExpertToolsMcpSession,
   type Expert,
 } from "@pragma/core";
+import { createRuntimeTestFeatures } from "@pragma/core/testing";
 import { loadPragmaProject, parsePragmaYaml } from "@pragma/interpreter";
 import { PragmaCapabilityResourceSchema, PragmaResourceSchema } from "@pragma/interpreter/ast";
 import { MEMORY_CURATOR_REF as MEMORY_PLANE_CURATOR_REF } from "@pragma/memory";
@@ -386,6 +387,7 @@ describe("built-in Pragma Agent DSL", () => {
       defaultRuntimeId: "test-runtime",
       runtimes: [
         {
+          features: createRuntimeTestFeatures(),
           descriptor: { id: "test-runtime", kind: "test", displayName: "Test Runtime" },
           canUse: () => ({ usable: true }),
         },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,14 +15,24 @@
     "./runtime/runtime-adapter": {
       "types": "./src/runtime/runtime-adapter.ts",
       "default": "./src/runtime/runtime-adapter.ts"
+    },
+    "./testing": {
+      "types": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
+    },
+    "./testing/vitest": {
+      "types": "./src/testing/vitest.ts",
+      "default": "./src/testing/vitest.ts"
     }
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "lint": "eslint src test",
+    "lint": "eslint src test scripts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "test:core": "vitest run --passWithNoTests test/resource-id.test.ts test/pragma-paths.test.ts test/token-counter.test.ts test/plugin-manifest.test.ts test/context-binding-metadata.test.ts",
+    "test:core": "vitest run --passWithNoTests test/resource-id.test.ts test/pragma-paths.test.ts test/token-counter.test.ts test/plugin-manifest.test.ts test/context-binding-metadata.test.ts test/process-probe.test.ts test/process-supervisor.test.ts test/runtime-conformance.test.ts test/runtime-probe-evidence.test.ts test/runtime-resource-scope.test.ts",
+    "runtime:features:generate": "node ./scripts/generate-runtime-feature-checklist.mjs",
+    "runtime:features:check": "node ./scripts/generate-runtime-feature-checklist.mjs --check",
     "clean": "rm -rf dist"
   },
   "devDependencies": {

--- a/packages/core/scripts/generate-runtime-feature-checklist.mjs
+++ b/packages/core/scripts/generate-runtime-feature-checklist.mjs
@@ -1,0 +1,99 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptDirectory, "../../..");
+const catalogPath = resolve(repositoryRoot, "packages/core/src/runtime/features.ts");
+const checklistPath = resolve(
+  repositoryRoot,
+  "docs/conventions/runtime-adapter-integration-checklist.md",
+);
+const startMarker = "<!-- RUNTIME_FEATURE_CATALOG_GENERATED_START -->";
+const endMarker = "<!-- RUNTIME_FEATURE_CATALOG_GENERATED_END -->";
+
+const [catalogSource, checklistSource] = await Promise.all([
+  readFile(catalogPath, "utf8"),
+  readFile(checklistPath, "utf8"),
+]);
+const catalog = readCatalog(catalogSource);
+const generated = renderCatalog(catalog);
+const nextChecklist = replaceGeneratedSection(checklistSource, generated);
+
+if (process.argv.includes("--check")) {
+  if (nextChecklist !== checklistSource) {
+    process.stderr.write(
+      "Runtime feature checklist is stale. Run `pnpm runtime:features:generate` and commit the result.\n",
+    );
+    process.exitCode = 1;
+  }
+} else {
+  await writeFile(checklistPath, nextChecklist, "utf8");
+  process.stdout.write(`Updated ${checklistPath}\n`);
+}
+
+function readCatalog(source) {
+  const block = source.match(
+    /\/\/ RUNTIME_FEATURE_CATALOG_START([\s\S]*?)\/\/ RUNTIME_FEATURE_CATALOG_END/,
+  )?.[1];
+  if (block === undefined) {
+    throw new Error(`Runtime feature catalog markers were not found in ${catalogPath}.`);
+  }
+  const entries = [
+    ...block.matchAll(
+      /\{\s*"?name"?\s*:\s*"([^"]+)"\s*,\s*"?lifecycle"?\s*:\s*"([^"]+)"\s*,\s*"?description"?\s*:\s*"([^"]+)"\s*,?\s*\}/g,
+    ),
+  ].map((match) => ({
+    name: match[1],
+    lifecycle: match[2],
+    description: match[3],
+  }));
+  if (entries.length === 0) {
+    throw new Error(`No Runtime features could be parsed from ${catalogPath}.`);
+  }
+  const names = new Set(entries.map(({ name }) => name));
+  if (names.size !== entries.length) {
+    throw new Error("Runtime feature catalog contains duplicate names.");
+  }
+  return entries;
+}
+
+function renderCatalog(catalog) {
+  const lifecycleLabels = {
+    driver: "Driver 注册/探测",
+    session: "Session 准备/清理",
+    turn: "Turn 准备/清理",
+  };
+  const rows = catalog.map(
+    ({ name, lifecycle, description }) =>
+      `| \`${name}\` | ${lifecycleLabels[lifecycle] ?? lifecycle} | ${description} |`,
+  );
+  return [
+    startMarker,
+    "",
+    "## 可执行特性目录（自动生成）",
+    "",
+    "下表直接由 `packages/core/src/runtime/features.ts` 的权威目录生成。新增、删除或重排特性后，",
+    "`pnpm runtime:features:check` 会在文档未同步时失败。每个 Runtime 必须为每一行声明",
+    "`supported`、`degraded(reason)`、`unsupported(reason)` 或 `notApplicable(reason)`。",
+    "",
+    "<!-- prettier-ignore -->",
+    "| Feature slot | Core 生命周期阶段 | 验收结果 |",
+    "| --- | --- | --- |",
+    ...rows,
+    "",
+    endMarker,
+  ].join("\n");
+}
+
+function replaceGeneratedSection(source, generated) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+  if (start < 0 || end < start) {
+    throw new Error(
+      `Generated Runtime feature section markers were not found in ${checklistPath}.`,
+    );
+  }
+  return `${source.slice(0, start)}${generated}${source.slice(end + endMarker.length)}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export { AgentMessageSchema, type AgentMessage, type AgentMessageUsage } from "@pragma/shared";
 export type { ExecutionEvent, ExecutionOutputItem } from "@pragma/shared";
+export { ExpertAgentStreamEventSchema } from "@pragma/shared";
 export {
   HumanInteractionRecordSchema,
   type HumanInteractionRecord,
@@ -60,8 +61,13 @@ export * from "./plugins/plugin-loader.ts";
 export * from "./runtime/agent-lifecycle.ts";
 export * from "./runtime/async-push-queue.ts";
 export * from "./runtime/driver.ts";
+export * from "./runtime/features.ts";
 export * from "./runtime/output.ts";
 export * from "./runtime/process-probe.ts";
+export * from "./runtime/process-supervisor.ts";
+export * from "./runtime/probe-evidence.ts";
+export * from "./runtime/resource-scope.ts";
+export * from "./runtime/conformance.ts";
 export * from "./runtime/run-context.ts";
 export * from "./runtime/runtime-adapter.ts";
 export * from "./runtime/runtime-event-emitter.ts";

--- a/packages/core/src/runtime/conformance.ts
+++ b/packages/core/src/runtime/conformance.ts
@@ -1,0 +1,396 @@
+import type { RuntimeAdapter } from "./runtime-adapter.ts";
+import {
+  RUNTIME_FEATURE_CATALOG,
+  deriveRuntimeAdapterCapabilities,
+  isRuntimeFeatureEnabled,
+  type RuntimeFeatureName,
+  type RuntimeFeatureSet,
+} from "./features.ts";
+import type { RuntimeProbeEvidence } from "./probe-evidence.ts";
+import { RuntimeProbeEvidenceSchema } from "./probe-evidence.ts";
+import type { RuntimeStreamEvent } from "./stream-events.ts";
+
+export interface RuntimeConformanceFailure {
+  readonly code: string;
+  readonly message: string;
+  readonly feature?: RuntimeFeatureName | undefined;
+}
+
+export interface RuntimeConformanceObservation {
+  readonly events: readonly RuntimeStreamEvent[];
+  readonly outputText?: string | undefined;
+  readonly requiredFeatures?: readonly RuntimeFeatureName[] | undefined;
+  readonly expectedToolNames?: readonly string[] | undefined;
+  readonly expectedOutputMarkers?: readonly string[] | undefined;
+  readonly structuredOutputValidated?: boolean | undefined;
+  readonly ownerPersistenceValidated?: boolean | undefined;
+  readonly evidence?: RuntimeProbeEvidence | undefined;
+}
+
+export function inspectRuntimeDeclarationConformance(
+  runtime: RuntimeAdapter,
+): readonly RuntimeConformanceFailure[] {
+  const failures: RuntimeConformanceFailure[] = [];
+  for (const { name } of RUNTIME_FEATURE_CATALOG) {
+    const feature = runtime.features[name];
+    if (feature === undefined) {
+      failures.push({
+        code: "feature.missing",
+        feature: name,
+        message: `Missing feature ${name}.`,
+      });
+      continue;
+    }
+    if (feature.status === "supported") {
+      const evidenceLevels = new Set(feature.evidence?.map(({ level }) => level) ?? []);
+      if (!evidenceLevels.has("executed")) {
+        failures.push({
+          code: "feature.supported_without_execution_evidence",
+          feature: name,
+          message: `Feature ${name} is supported but has no executed evidence reference.`,
+        });
+      }
+      if (
+        !feature.evidence?.some(
+          ({ level, source }) => level === "executed" && source === "real-probe",
+        )
+      ) {
+        failures.push({
+          code: "feature.supported_without_real_probe",
+          feature: name,
+          message: `Feature ${name} is supported but has no executed real-Runtime probe reference.`,
+        });
+      }
+      if (name === "mcp" || name === "skills") {
+        for (const level of ["materialized", "discovered", "executed"] as const) {
+          if (!evidenceLevels.has(level)) {
+            failures.push({
+              code: "feature.supported_without_staged_evidence",
+              feature: name,
+              message: `Feature ${name} is supported but has no ${level} evidence reference.`,
+            });
+          }
+        }
+      }
+    }
+  }
+  const expected = deriveRuntimeAdapterCapabilities(
+    runtime.features as RuntimeFeatureSet,
+    runtime.descriptor.capabilities,
+  );
+  for (const key of [
+    "supportsStreaming",
+    "supportsAbort",
+    "supportsMcp",
+    "supportsResume",
+    "supportsSteer",
+    "supportsCancel",
+    "supportsClose",
+    "supportsContextWindowInspection",
+    "supportsManualCompaction",
+    "supportsContextCompactionEvents",
+  ] as const) {
+    if (runtime.descriptor.capabilities?.[key] !== expected[key]) {
+      failures.push({
+        code: "capability.projection_mismatch",
+        message: `Capability ${key} is not the projection of Runtime features.`,
+      });
+    }
+  }
+  return failures;
+}
+
+export function inspectRuntimeObservationConformance(
+  runtime: RuntimeAdapter,
+  observation: RuntimeConformanceObservation,
+): readonly RuntimeConformanceFailure[] {
+  const failures: RuntimeConformanceFailure[] = [...inspectRuntimeDeclarationConformance(runtime)];
+  const events = observation.events;
+  const eventIds = new Set<string>();
+  let previousSequence = -1;
+  for (const event of events) {
+    if (eventIds.has(event.eventId)) {
+      failures.push({
+        code: "stream.duplicate_event",
+        message: `Duplicate eventId ${event.eventId}.`,
+      });
+    }
+    eventIds.add(event.eventId);
+    if (event.sequence <= previousSequence) {
+      failures.push({
+        code: "stream.sequence_order",
+        message: `Event sequence ${event.sequence} is not strictly increasing.`,
+      });
+    }
+    previousSequence = event.sequence;
+  }
+  const terminalIndexes = events.flatMap((event, index) =>
+    event.type === "run.completed" || event.type === "run.failed" || event.type === "run.cancelled"
+      ? [index]
+      : [],
+  );
+  if (events.length > 0 && events[0]?.type !== "run.started") {
+    failures.push({ code: "stream.run_start_order", message: "run.started must be first." });
+  }
+  if (terminalIndexes.length !== 1 || terminalIndexes[0] !== events.length - 1) {
+    failures.push({
+      code: "stream.terminal_order",
+      message: "Exactly one terminal run event must be last.",
+    });
+  }
+  if (isRuntimeFeatureEnabled(runtime.features.textStreaming)) {
+    const deltaIndex = events.findIndex(
+      (event) =>
+        event.type === "message.delta" &&
+        event.payload.role === "assistant" &&
+        event.payload.contentType === "text",
+    );
+    const completedIndex = events.findIndex(
+      (event) =>
+        event.type === "message.completed" &&
+        event.payload.role === "assistant" &&
+        event.payload.contentType === "text",
+    );
+    if (deltaIndex < 0 || completedIndex <= deltaIndex) {
+      failures.push({
+        code: "stream.text_lifecycle",
+        feature: "textStreaming",
+        message: "Text streaming must emit delta before completed.",
+      });
+    }
+    inspectTextSnapshotConsistency(events, observation.outputText, failures);
+  }
+  inspectToolLifecycle(events, failures);
+  for (const toolName of observation.expectedToolNames ?? []) {
+    if (
+      !events.some(
+        (event) =>
+          event.type === "tool.completed" &&
+          runtimeToolNameMatches(event.payload.toolName, toolName),
+      )
+    ) {
+      failures.push({
+        code: "tool.expected_not_executed",
+        feature: isExpectedMcpTool(toolName) ? "mcp" : "nativeToolLifecycle",
+        message: `Expected tool ${toolName} did not complete.`,
+      });
+    }
+  }
+  for (const marker of observation.expectedOutputMarkers ?? []) {
+    if (!observation.outputText?.includes(marker)) {
+      failures.push({
+        code: "output.marker_missing",
+        message: `Expected output marker ${marker} is missing.`,
+      });
+    }
+  }
+  if (observation.structuredOutputValidated === false) {
+    failures.push({
+      code: "invariant.structured_output",
+      message: "Structured output validation is an unconditional Runtime invariant.",
+    });
+  }
+  if (observation.ownerPersistenceValidated === false) {
+    failures.push({
+      code: "invariant.owner_persistence",
+      message: "Runtime Session owner persistence is an unconditional invariant.",
+    });
+  }
+  for (const feature of observation.requiredFeatures ?? []) {
+    if (!isRuntimeFeatureEnabled(runtime.features[feature])) {
+      failures.push({
+        code: "probe.required_feature_disabled",
+        feature,
+        message: `Probe requires disabled feature ${feature}.`,
+      });
+    }
+  }
+  if (observation.evidence !== undefined) {
+    failures.push(...inspectRuntimeProbeEvidenceConformance(runtime, observation.evidence));
+  }
+  return failures;
+}
+
+function inspectTextSnapshotConsistency(
+  events: readonly RuntimeStreamEvent[],
+  outputText: string | undefined,
+  failures: RuntimeConformanceFailure[],
+): void {
+  let streamed = "";
+  let lastCompletedText: string | undefined;
+  for (const event of events) {
+    if (
+      event.type === "message.delta" &&
+      event.payload.role === "assistant" &&
+      event.payload.contentType === "text"
+    ) {
+      streamed += event.payload.delta;
+      continue;
+    }
+    if (
+      event.type !== "message.completed" ||
+      event.payload.role !== "assistant" ||
+      event.payload.contentType !== "text"
+    ) {
+      continue;
+    }
+    const completedText = event.payload.text;
+    if (streamed !== "" && completedText !== undefined && completedText !== streamed) {
+      failures.push({
+        code: "stream.snapshot_mismatch",
+        feature: "textStreaming",
+        message:
+          "The completed text snapshot differs from the preceding deltas and may duplicate output.",
+      });
+    }
+    lastCompletedText = completedText;
+    streamed = "";
+  }
+  if (
+    outputText !== undefined &&
+    lastCompletedText !== undefined &&
+    outputText !== lastCompletedText
+  ) {
+    failures.push({
+      code: "stream.output_mismatch",
+      feature: "textStreaming",
+      message: "The Runtime result differs from the final completed text snapshot.",
+    });
+  }
+}
+
+export function inspectRuntimeProbeEvidenceConformance(
+  runtime: RuntimeAdapter,
+  evidence: RuntimeProbeEvidence,
+): readonly RuntimeConformanceFailure[] {
+  const parsed = RuntimeProbeEvidenceSchema.parse(evidence);
+  const failures: RuntimeConformanceFailure[] = [];
+  if (
+    parsed.runtime.id !== runtime.descriptor.id ||
+    parsed.runtime.kind !== runtime.descriptor.kind
+  ) {
+    failures.push({
+      code: "evidence.runtime_mismatch",
+      message: `Evidence belongs to ${parsed.runtime.id}/${parsed.runtime.kind}, not ${runtime.descriptor.id}/${runtime.descriptor.kind}.`,
+    });
+  }
+  for (const assertion of parsed.assertions) {
+    if (!isRuntimeFeatureEnabled(runtime.features[assertion.feature])) {
+      failures.push({
+        code: "evidence.feature_disabled",
+        feature: assertion.feature,
+        message: `Evidence targets disabled feature ${assertion.feature}.`,
+      });
+    }
+    if (assertion.status === "failed") {
+      failures.push({
+        code: "evidence.assertion_failed",
+        feature: assertion.feature,
+        message: `Evidence assertion ${assertion.id} failed: ${assertion.message}`,
+      });
+    }
+  }
+  const stagedFeatures = (["mcp", "skills"] as const).filter(
+    (feature) =>
+      parsed.probe.id === feature ||
+      parsed.assertions.some((assertion) => assertion.feature === feature),
+  );
+  for (const stagedFeature of stagedFeatures) {
+    for (const stage of ["materialized", "discovered", "executed"] as const) {
+      if (
+        !parsed.assertions.some(
+          (assertion) =>
+            assertion.feature === stagedFeature &&
+            assertion.stage === stage &&
+            assertion.status === "passed",
+        )
+      ) {
+        failures.push({
+          code: "evidence.stage_missing",
+          feature: stagedFeature,
+          message: `${stagedFeature} evidence has no passing ${stage} assertion.`,
+        });
+      }
+    }
+  }
+  return failures;
+}
+
+export function assertRuntimeConformance(
+  runtime: RuntimeAdapter,
+  observation?: RuntimeConformanceObservation,
+): void {
+  const failures =
+    observation === undefined
+      ? inspectRuntimeDeclarationConformance(runtime)
+      : inspectRuntimeObservationConformance(runtime, observation);
+  if (failures.length > 0) {
+    throw new Error(
+      `Runtime ${runtime.descriptor.id} failed conformance:\n${failures
+        .map((failure) => `- [${failure.code}] ${failure.message}`)
+        .join("\n")}`,
+    );
+  }
+}
+
+function inspectToolLifecycle(
+  events: readonly RuntimeStreamEvent[],
+  failures: RuntimeConformanceFailure[],
+): void {
+  const states = new Map<string, "started" | "terminal">();
+  for (const event of events) {
+    if (!event.type.startsWith("tool.")) continue;
+    if (!("toolCallId" in event.payload)) continue;
+    const toolCallId = event.payload.toolCallId;
+    const state = states.get(toolCallId);
+    if (event.type === "tool.started") {
+      if (state !== undefined) {
+        failures.push({
+          code: "tool.duplicate_start",
+          feature: "nativeToolLifecycle",
+          message: `Tool ${toolCallId} started more than once.`,
+        });
+      }
+      states.set(toolCallId, "started");
+    } else if (event.type === "tool.delta") {
+      if (state !== "started") {
+        failures.push({
+          code: "tool.delta_without_start",
+          feature: "nativeToolLifecycle",
+          message: `Tool ${toolCallId} emitted delta before start.`,
+        });
+      }
+    } else if (event.type === "tool.completed" || event.type === "tool.failed") {
+      if (state !== "started") {
+        failures.push({
+          code: "tool.terminal_without_start",
+          feature: "nativeToolLifecycle",
+          message: `Tool ${toolCallId} terminated without one active start.`,
+        });
+      }
+      states.set(toolCallId, "terminal");
+    }
+  }
+  for (const [toolCallId, state] of states) {
+    if (state !== "terminal") {
+      failures.push({
+        code: "tool.missing_terminal",
+        feature: "nativeToolLifecycle",
+        message: `Tool ${toolCallId} has no terminal event.`,
+      });
+    }
+  }
+}
+
+function runtimeToolNameMatches(actual: string, expected: string): boolean {
+  return (
+    actual === expected ||
+    actual.endsWith(`__${expected}`) ||
+    actual.endsWith(`/${expected}`) ||
+    actual.endsWith(`_${expected}`)
+  );
+}
+
+function isExpectedMcpTool(toolName: string): boolean {
+  return toolName.startsWith("mcp_") || toolName.includes("expert_context");
+}

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -77,9 +77,20 @@ import type {
   RuntimeSubmitHandle,
   RuntimeSubmitRequest,
   RuntimeTaskSubmission,
+  RuntimeDriverDescriptor,
 } from "./runtime-adapter.ts";
 import type { RuntimeStreamEvent } from "./stream-events.ts";
 import { registerRuntimeSessionFactory } from "./session-factory.ts";
+import {
+  RUNTIME_FEATURE_CATALOG,
+  deriveRuntimeAdapterCapabilities,
+  isRuntimeFeatureEnabled,
+  snapshotRuntimeFeatures,
+  validateRuntimeFeatures,
+  type RuntimeFeatureName,
+  type RuntimeFeatureSet,
+} from "./features.ts";
+import { RuntimeResourceScope, type RuntimeResourceRegistrar } from "./resource-scope.ts";
 import type {
   ExpertAgentHumanInteractionHandler,
   ExpertToolExecutionContext,
@@ -113,13 +124,7 @@ export interface RuntimePrepareContext {
   readonly processEnvironment: Readonly<NodeJS.ProcessEnv>;
 }
 
-export interface RuntimePreparedContext {
-  readonly metadata?: Record<string, unknown> | undefined;
-}
-
-export interface RuntimeDriverSessionContext<
-  TPrepared = RuntimePreparedContext,
-> extends RuntimePrepareContext {
+export interface RuntimeFeatureSessionPrepareContext extends RuntimePrepareContext {
   readonly agentContext: ExpertAgentContext;
   readonly lifecycle: AgentLifecycle<ExpertAgentRunContext | undefined>;
   readonly persistence: {
@@ -127,8 +132,21 @@ export interface RuntimeDriverSessionContext<
     readonly restoredRuntimeSessionId?: string | undefined;
     readonly checkpoint: (trigger: RuntimeCheckpointTrigger) => Promise<void>;
   };
-  readonly prepared: TPrepared;
+  readonly resources: RuntimeResourceRegistrar;
+  readonly preparedFeatures: Readonly<Partial<Record<RuntimeFeatureName, unknown>>>;
   readonly sessionInfo: RuntimeSessionInfo;
+}
+
+export type RuntimeDriverSessionContext = RuntimeFeatureSessionPrepareContext;
+
+export function readRuntimePreparedFeature<T>(
+  context: Pick<RuntimeFeatureSessionPrepareContext, "preparedFeatures">,
+  feature: RuntimeFeatureName,
+): T {
+  if (!(feature in context.preparedFeatures)) {
+    throw new Error(`Runtime feature ${feature} did not produce Session preparation data.`);
+  }
+  return context.preparedFeatures[feature] as T;
 }
 
 export interface RuntimeSessionReadContext {
@@ -154,6 +172,24 @@ export interface RuntimeTurnContext<TNativeEvent> {
   readonly signal: AbortSignal;
   readonly source: RuntimeStreamEvent["source"];
   readonly stream: RuntimeStreamWriter<TNativeEvent>;
+  readonly preparedFeatures: Readonly<Partial<Record<RuntimeFeatureName, unknown>>>;
+}
+
+export interface RuntimeFeatureTurnPrepareContext {
+  readonly feature: RuntimeFeatureName;
+  readonly agent: Expert;
+  readonly runContext: ExpertAgentRunContext;
+  readonly sessionInfo: RuntimeSessionInfo;
+  readonly runId: string;
+  readonly query: string;
+  readonly attachments: readonly ExpertPromptAttachment[];
+  readonly modelSelection?: RuntimeModelSelection | undefined;
+  readonly output?: RuntimeOutputSchema | undefined;
+  readonly signal: AbortSignal;
+  readonly logger: PragmaLogger;
+  readonly resources: RuntimeResourceRegistrar;
+  readonly sessionFeatures: Readonly<Partial<Record<RuntimeFeatureName, unknown>>>;
+  readonly preparedFeatures: Readonly<Partial<Record<RuntimeFeatureName, unknown>>>;
 }
 
 export interface RuntimeTurnResult {
@@ -179,8 +215,9 @@ export interface RuntimeCloseContext {
   readonly logger: PragmaLogger;
 }
 
-export interface RuntimeDriver<TNativeEvent, TNativeSession, TPrepared = RuntimePreparedContext> {
-  readonly descriptor: RuntimeAdapterDescriptor;
+export interface RuntimeDriver<TNativeEvent, TNativeSession> {
+  readonly descriptor: RuntimeDriverDescriptor;
+  readonly features: RuntimeFeatureSet;
   readonly canUse?:
     | ((options?: Record<string, unknown>) => Promise<RuntimeCanUseResult> | RuntimeCanUseResult)
     | undefined;
@@ -189,15 +226,11 @@ export interface RuntimeDriver<TNativeEvent, TNativeSession, TPrepared = Runtime
   readonly outputRetryLimit?: number | undefined;
   readonly resolvePersistence?:
     ((context: RuntimePrepareContext) => RuntimeSessionPersistenceSpec | undefined) | undefined;
-  readonly prepare?:
-    ((context: RuntimePrepareContext) => Promise<TPrepared> | TPrepared) | undefined;
   readonly createSession: (
-    context: RuntimeDriverSessionContext<TPrepared>,
+    context: RuntimeDriverSessionContext,
   ) => Promise<TNativeSession> | TNativeSession;
   readonly restoreSession?:
-    | ((
-        context: RuntimeDriverSessionContext<TPrepared>,
-      ) => Promise<TNativeSession> | TNativeSession)
+    | ((context: RuntimeDriverSessionContext) => Promise<TNativeSession> | TNativeSession)
     | undefined;
   readonly listMessages?:
     | ((session: TNativeSession, context: RuntimeSessionReadContext) => readonly AgentMessage[])
@@ -253,14 +286,81 @@ export interface RuntimeDriver<TNativeEvent, TNativeSession, TPrepared = Runtime
     ((session: TNativeSession, context: RuntimeCloseContext) => Promise<void> | void) | undefined;
 }
 
+type RuntimeDriverFeatureMethodContract<
+  TNativeEvent,
+  TNativeSession,
+  TFeatures extends RuntimeFeatureSet,
+> = RuntimeFeatureSet extends TFeatures
+  ? object
+  : RequireRuntimeFeatureMethod<TNativeEvent, TNativeSession, TFeatures, "availability", "canUse"> &
+      RequireRuntimeFeatureMethod<
+        TNativeEvent,
+        TNativeSession,
+        TFeatures,
+        "modelDiscovery",
+        "listModels"
+      > &
+      RequireRuntimeFeatureMethod<
+        TNativeEvent,
+        TNativeSession,
+        TFeatures,
+        "contextWindow",
+        "readContextWindow"
+      > &
+      RequireRuntimeManualCompactionMethod<TNativeEvent, TNativeSession, TFeatures> &
+      RequireRuntimeFeatureMethod<
+        TNativeEvent,
+        TNativeSession,
+        TFeatures,
+        "cancellation",
+        "cancelTurn"
+      > &
+      RequireRuntimeFeatureMethod<
+        TNativeEvent,
+        TNativeSession,
+        TFeatures,
+        "steering",
+        "steerTurn"
+      > &
+      RequireRuntimeFeatureMethod<TNativeEvent, TNativeSession, TFeatures, "close", "closeSession">;
+
+type RequireRuntimeFeatureMethod<
+  TNativeEvent,
+  TNativeSession,
+  TFeatures extends RuntimeFeatureSet,
+  TFeature extends RuntimeFeatureName,
+  TMethod extends keyof RuntimeDriver<TNativeEvent, TNativeSession>,
+> = TFeatures[TFeature]["status"] extends "supported" | "degraded"
+  ? Required<Pick<RuntimeDriver<TNativeEvent, TNativeSession>, TMethod>>
+  : object;
+
+type RequireRuntimeManualCompactionMethod<
+  TNativeEvent,
+  TNativeSession,
+  TFeatures extends RuntimeFeatureSet,
+> = TFeatures["compaction"]["status"] extends "supported" | "degraded"
+  ? TFeatures["compaction"] extends {
+      readonly compactionModes?: infer TModes;
+    }
+    ? "manual" extends ArrayElement<TModes>
+      ? Required<Pick<RuntimeDriver<TNativeEvent, TNativeSession>, "compactContext">>
+      : object
+    : object
+  : object;
+
+type ArrayElement<TValue> = TValue extends readonly (infer TElement)[] ? TElement : never;
+
 export function defineRuntimeDriver<
   TNativeEvent,
   TNativeSession,
-  TPrepared = RuntimePreparedContext,
+  const TFeatures extends RuntimeFeatureSet = RuntimeFeatureSet,
 >(
-  driver: RuntimeDriver<TNativeEvent, TNativeSession, TPrepared>,
+  driver: RuntimeDriver<TNativeEvent, TNativeSession> & {
+    readonly features: TFeatures;
+  } & RuntimeDriverFeatureMethodContract<TNativeEvent, TNativeSession, TFeatures>,
   options: DefineRuntimeDriverOptions = {},
 ): RuntimeAdapter {
+  validateRuntimeFeatures(driver.features);
   const createPersistenceProvider = (): RuntimeSessionPersistenceProvider =>
     options.persistenceProvider ??
     (options.sessionRestoreHandler === undefined && options.sessionSyncCallback === undefined
@@ -270,20 +370,14 @@ export function defineRuntimeDriver<
           syncCallback: options.sessionSyncCallback,
         }));
 
-  const descriptor: RuntimeAdapterDescriptor = {
+  const descriptor: RuntimeAdapterDescriptor = Object.freeze({
     ...driver.descriptor,
-    capabilities: {
-      ...driver.descriptor.capabilities,
-      supportsResume: true,
-      supportsSteer: driver.steerTurn !== undefined,
-      supportsCancel: driver.cancelTurn !== undefined,
-      supportsClose: true,
-      supportsContextWindowInspection: driver.readContextWindow !== undefined,
-      supportsManualCompaction: driver.compactContext !== undefined,
-    },
-  };
+    capabilities: deriveRuntimeAdapterCapabilities(driver.features, driver.descriptor.capabilities),
+  });
+  assertRuntimeFeatureMethodContracts(driver, descriptor);
   const runtime: RuntimeAdapter = {
     descriptor,
+    features: snapshotRuntimeFeatures(driver.features),
     canUse: async (options?: Record<string, unknown>) =>
       (await (
         driver.canUse as
@@ -297,6 +391,7 @@ export function defineRuntimeDriver<
     async (request) =>
       await createManagedRuntimeSession(
         driver,
+        descriptor,
         request,
         createPersistenceProvider(),
         options.createProcessEnvironment,
@@ -305,19 +400,19 @@ export function defineRuntimeDriver<
   return runtime;
 }
 
-async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared>(
-  driver: RuntimeDriver<TNativeEvent, TNativeSession, TPrepared>,
+async function createManagedRuntimeSession<TNativeEvent, TNativeSession>(
+  driver: RuntimeDriver<TNativeEvent, TNativeSession>,
+  descriptor: RuntimeAdapterDescriptor,
   request: RuntimeDriverSessionRequest,
   persistenceProvider: RuntimeSessionPersistenceProvider,
   createProcessEnvironment: (() => NodeJS.ProcessEnv) | undefined,
-): Promise<ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared>> {
+): Promise<ManagedRuntimeSession<TNativeEvent, TNativeSession>> {
   const executionBindings = new RuntimeExecutionBindings({
     humanInteractionHandler: request.humanInteractionHandler,
     executionContext: request.executionContext,
   });
   request = executionBindings.bindRequest(request);
   const agent = request.agent;
-  const descriptor = driver.descriptor;
   const systemSessionId = request.systemSessionId ?? randomUUID();
   const runContext = createExpertAgentRunContext(request.context);
   const logger = createPragmaLogger(request.loggerProvider ?? agent.loggerProvider, {
@@ -340,6 +435,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
   }
   const pragmaPaths = new PragmaPaths({ pragmaHome: request.pragmaHome ?? agent.pragmaHome });
   const paths = createRuntimePaths(pragmaPaths, request.owner.ownerId, systemSessionId, descriptor);
+  const resources = new RuntimeResourceScope(`runtime-session:${systemSessionId}`);
   const baseProcessEnvironment = freezeProcessEnvironment(
     createProcessEnvironment?.() ?? process.env,
   );
@@ -390,7 +486,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
   let restoredRuntimeSessionId: string | undefined;
   let lifecycle: AgentLifecycle<ExpertAgentRunContext | undefined> | undefined;
   let nativeSession: TNativeSession | undefined;
-  let managedSession: ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> | undefined;
+  let managedSession: ManagedRuntimeSession<TNativeEvent, TNativeSession> | undefined;
 
   try {
     if (persistenceSpec?.sessionDir !== undefined) {
@@ -431,11 +527,8 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
     logRuntimePhase(logger, "runtime.persistence_restore", phaseStartedAt, sessionStartedAt);
 
     phaseStartedAt = performance.now();
-    const [prepared, agentContext] = await Promise.all([
-      Promise.resolve(driver.prepare?.(prepareContext)).then((value) => value ?? ({} as TPrepared)),
-      agent.buildContext(runContext, request.contextAssembly),
-    ]);
-    logRuntimePhase(logger, "runtime.prepare_and_context", phaseStartedAt, sessionStartedAt, {
+    const agentContext = await agent.buildContext(runContext, request.contextAssembly);
+    logRuntimePhase(logger, "runtime.context_prepared", phaseStartedAt, sessionStartedAt, {
       systemPromptCharacters: agentContext.systemPrompt.length,
       startupMessageCount: agentContext.startupMessages.length,
       toolCount: agent.tools?.length ?? 0,
@@ -497,6 +590,9 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
             cleanupErrors.push(error);
           });
         }
+        await resources.dispose().catch((error: unknown) => {
+          cleanupErrors.push(error);
+        });
         await checkpoint("session.destroyed").catch((error: unknown) => {
           cleanupErrors.push(error);
         });
@@ -532,7 +628,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       },
     });
 
-    const sessionContext: RuntimeDriverSessionContext<TPrepared> = {
+    const featureContext: Omit<RuntimeFeatureSessionPrepareContext, "preparedFeatures"> = {
       ...prepareContext,
       agentContext,
       lifecycle,
@@ -541,14 +637,20 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
         restoredRuntimeSessionId,
         checkpoint,
       },
-      prepared,
+      resources,
       sessionInfo: readSessionInfo(),
+    };
+    const preparedFeatures = await prepareRuntimeSessionFeatures(driver, featureContext);
+    const sessionContext: RuntimeDriverSessionContext = {
+      ...featureContext,
+      preparedFeatures,
     };
     phaseStartedAt = performance.now();
     nativeSession =
       request.runtimeSession === undefined
         ? await driver.createSession(sessionContext)
         : await (driver.restoreSession ?? driver.createSession)(sessionContext);
+    resources.transfer();
     logRuntimePhase(logger, "runtime.native_session_create", phaseStartedAt, sessionStartedAt);
     const snapshot = driver.readSession?.(nativeSession, { agent, runContext });
     currentRuntimeSessionId = snapshot?.runtimeSessionId ?? currentRuntimeSessionId;
@@ -568,6 +670,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       lifecycle,
       logger,
       runContext,
+      preparedFeatures,
       startupMessages: agentContext.startupMessages,
       systemSessionId,
       outputRetryLimit: driver.outputRetryLimit,
@@ -636,6 +739,7 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
     if (lifecycle !== undefined) {
       await lifecycle.close().catch(() => undefined);
     } else {
+      await resources.dispose().catch(() => undefined);
       await dispatchExpertAgentHook(agent.hooks, "afterSessionDestroy", {
         agent,
         session: {
@@ -653,6 +757,109 @@ async function createManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepar
       }).catch(() => undefined);
     }
     throw error;
+  }
+}
+
+async function prepareRuntimeSessionFeatures<TNativeEvent, TNativeSession>(
+  driver: RuntimeDriver<TNativeEvent, TNativeSession>,
+  context: Omit<RuntimeFeatureSessionPrepareContext, "preparedFeatures">,
+): Promise<Readonly<Partial<Record<RuntimeFeatureName, unknown>>>> {
+  const prepared: Partial<Record<RuntimeFeatureName, unknown>> = {};
+  for (const catalogEntry of RUNTIME_FEATURE_CATALOG) {
+    if (catalogEntry.lifecycle !== "session") continue;
+    const declaration = driver.features[catalogEntry.name];
+    const startedAt = performance.now();
+    if (isRuntimeFeatureEnabled(declaration) && declaration.prepareSession !== undefined) {
+      const value = await declaration.prepareSession({
+        ...context,
+        preparedFeatures: Object.freeze({ ...prepared }),
+      });
+      if (value !== undefined) prepared[catalogEntry.name] = value;
+    }
+    context.logger.debug(
+      "runtime.feature_session_phase",
+      `Runtime Session feature phase completed: ${catalogEntry.name}`,
+      {
+        feature: catalogEntry.name,
+        status: declaration.status,
+        hookExecuted:
+          isRuntimeFeatureEnabled(declaration) && declaration.prepareSession !== undefined,
+        durationMs: elapsedRuntimeMs(startedAt),
+      },
+    );
+  }
+  return Object.freeze({ ...prepared });
+}
+
+async function prepareRuntimeTurnFeatures<TNativeEvent, TNativeSession>(
+  context: Omit<RuntimeFeatureTurnPrepareContext, "feature" | "preparedFeatures"> & {
+    readonly driver: RuntimeDriver<TNativeEvent, TNativeSession>;
+  },
+): Promise<Readonly<Partial<Record<RuntimeFeatureName, unknown>>>> {
+  const prepared: Partial<Record<RuntimeFeatureName, unknown>> = {};
+  const { driver, ...baseContext } = context;
+  for (const catalogEntry of RUNTIME_FEATURE_CATALOG) {
+    if (catalogEntry.lifecycle !== "turn") continue;
+    const declaration = driver.features[catalogEntry.name];
+    const startedAt = performance.now();
+    if (isRuntimeFeatureEnabled(declaration) && declaration.prepareTurn !== undefined) {
+      const value = await declaration.prepareTurn({
+        ...baseContext,
+        feature: catalogEntry.name,
+        preparedFeatures: Object.freeze({ ...prepared }),
+      });
+      if (value !== undefined) prepared[catalogEntry.name] = value;
+    }
+    context.logger.debug(
+      "runtime.feature_turn_phase",
+      `Runtime turn feature phase completed: ${catalogEntry.name}`,
+      {
+        feature: catalogEntry.name,
+        status: declaration.status,
+        hookExecuted: isRuntimeFeatureEnabled(declaration) && declaration.prepareTurn !== undefined,
+        durationMs: elapsedRuntimeMs(startedAt),
+      },
+    );
+  }
+  return Object.freeze({ ...prepared });
+}
+
+function assertRuntimeFeatureMethodContracts<TNativeEvent, TNativeSession>(
+  driver: RuntimeDriver<TNativeEvent, TNativeSession>,
+  descriptor: RuntimeAdapterDescriptor,
+): void {
+  const contracts: readonly [
+    RuntimeFeatureName,
+    string,
+    unknown,
+    ((feature: RuntimeFeatureSet[RuntimeFeatureName]) => boolean)?,
+  ][] = [
+    ["availability", "canUse", driver.canUse],
+    ["modelDiscovery", "listModels", driver.listModels],
+    ["contextWindow", "readContextWindow", driver.readContextWindow],
+    [
+      "compaction",
+      "compactContext",
+      driver.compactContext,
+      (feature) => feature.compactionModes?.includes("manual") === true,
+    ],
+    ["cancellation", "cancelTurn", driver.cancelTurn],
+    ["steering", "steerTurn", driver.steerTurn],
+    ["close", "closeSession", driver.closeSession],
+  ];
+  for (const [featureName, methodName, method, applies = isRuntimeFeatureEnabled] of contracts) {
+    const feature = driver.features[featureName];
+    const enabled = isRuntimeFeatureEnabled(feature) && applies(feature);
+    if (enabled && method === undefined) {
+      throw new Error(
+        `Runtime ${descriptor.id} declares ${featureName} as ${feature.status} but does not implement ${methodName}().`,
+      );
+    }
+    if (!enabled && method !== undefined) {
+      throw new Error(
+        `Runtime ${descriptor.id} implements ${methodName}() while feature ${featureName} is not enabled.`,
+      );
+    }
   }
 }
 
@@ -699,8 +906,8 @@ function assertRequestedRuntimeSessionMatches(
   );
 }
 
-async function assertRuntimeCanUse<TNativeEvent, TNativeSession, TPrepared>(
-  driver: RuntimeDriver<TNativeEvent, TNativeSession, TPrepared>,
+async function assertRuntimeCanUse<TNativeEvent, TNativeSession>(
+  driver: RuntimeDriver<TNativeEvent, TNativeSession>,
   descriptor: RuntimeAdapterDescriptor,
 ): Promise<void> {
   const availability = (await driver.canUse?.()) ?? { usable: true };
@@ -723,7 +930,7 @@ function createRuntimeUnavailableMessage(
     : `Runtime is not available: ${descriptor.displayName} (${descriptor.id}). ${reason}`;
 }
 
-class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
+class ManagedRuntimeSession<TNativeEvent, TNativeSession> {
   private watcher: RuntimeSessionWatcher | undefined;
   private activeRunId: string | undefined;
   private contextWindowCalibrated = false;
@@ -734,12 +941,13 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
   constructor(
     private readonly options: {
       readonly agent: Expert;
-      readonly driver: RuntimeDriver<TNativeEvent, TNativeSession, TPrepared>;
+      readonly driver: RuntimeDriver<TNativeEvent, TNativeSession>;
       readonly nativeSession: TNativeSession;
       readonly descriptor: RuntimeAdapterDescriptor;
       readonly lifecycle: AgentLifecycle<ExpertAgentRunContext | undefined>;
       readonly logger: PragmaLogger;
       readonly runContext: ExpertAgentRunContext;
+      readonly preparedFeatures: Readonly<Partial<Record<RuntimeFeatureName, unknown>>>;
       readonly startupMessages: readonly ExpertAgentStartupMessage[];
       readonly systemSessionId: string;
       readonly outputRetryLimit?: number | undefined;
@@ -1042,6 +1250,43 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
     controller: ReturnType<typeof createRuntimeStreamController<TNativeEvent>>,
     observeUsage: (usage: AgentMessageUsage | undefined) => void,
   ): Promise<RuntimeRunResult<TOutput>> {
+    const resources = new RuntimeResourceScope(`runtime-turn:${runId}`);
+    const outcome = await this.executeSubmissionInScope(
+      runId,
+      submission,
+      signal,
+      controller,
+      observeUsage,
+      resources,
+    ).then(
+      (result) => ({ ok: true as const, result }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const cleanupError = await resources.dispose().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    if (!outcome.ok) {
+      if (cleanupError !== undefined) {
+        throw new AggregateError(
+          [outcome.error, cleanupError],
+          `Runtime turn ${runId} and resource cleanup failed.`,
+        );
+      }
+      throw outcome.error;
+    }
+    if (cleanupError !== undefined) throw cleanupError;
+    return outcome.result;
+  }
+
+  private async executeSubmissionInScope<TOutput>(
+    runId: string,
+    submission: RuntimeSubmitRequest<TOutput>,
+    signal: AgentRunExecutionContext["signal"],
+    controller: ReturnType<typeof createRuntimeStreamController<TNativeEvent>>,
+    observeUsage: (usage: AgentMessageUsage | undefined) => void,
+    resources: RuntimeResourceScope,
+  ): Promise<RuntimeRunResult<TOutput>> {
     const startupMessages = this.takeStartupMessages();
     const attachmentPlan = await resolveRuntimeAttachmentPlan({
       attachments: submission.attachments ?? [],
@@ -1051,6 +1296,22 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
       query: submission.query,
       runtimeId: this.options.descriptor.id,
     });
+    const preparedFeatures = await prepareRuntimeTurnFeatures({
+      driver: this.options.driver,
+      agent: this.options.agent,
+      runContext: this.options.runContext,
+      sessionInfo: this.info(),
+      runId,
+      query: attachmentPlan.query,
+      attachments: attachmentPlan.nativeAttachments,
+      modelSelection: submission.modelSelection,
+      output: submission.output,
+      signal,
+      logger: this.options.logger,
+      resources,
+      sessionFeatures: this.options.preparedFeatures,
+    });
+    resources.transfer();
     const maxAttempts =
       submission.output === undefined
         ? 1
@@ -1100,6 +1361,7 @@ class ManagedRuntimeSession<TNativeEvent, TNativeSession, TPrepared> {
             signal,
             source: controller.source,
             stream: controller.writer,
+            preparedFeatures,
           });
           this.options.logger.info(
             "runtime.model_request_finished",

--- a/packages/core/src/runtime/features.ts
+++ b/packages/core/src/runtime/features.ts
@@ -1,0 +1,274 @@
+import type {
+  RuntimeAdapterCapabilities,
+  RuntimeAdapterPlacementCapabilities,
+} from "./runtime-adapter.ts";
+import type {
+  RuntimeFeatureSessionPrepareContext,
+  RuntimeFeatureTurnPrepareContext,
+} from "./driver.ts";
+
+// RUNTIME_FEATURE_CATALOG_START
+export const RUNTIME_FEATURE_CATALOG = [
+  { name: "availability", lifecycle: "driver", description: "Runtime availability probing" },
+  {
+    name: "authentication",
+    lifecycle: "driver",
+    description: "Runtime authentication setup and validation",
+  },
+  { name: "modelDiscovery", lifecycle: "driver", description: "Model catalog discovery" },
+  {
+    name: "modelSelection",
+    lifecycle: "turn",
+    description: "Per-Session or per-turn model selection",
+  },
+  { name: "thinking", lifecycle: "turn", description: "Thinking or reasoning level selection" },
+  { name: "freshSession", lifecycle: "session", description: "Fresh native Session creation" },
+  { name: "resume", lifecycle: "session", description: "Native Session restoration" },
+  { name: "systemPrompt", lifecycle: "session", description: "System prompt delivery" },
+  {
+    name: "startupMessages",
+    lifecycle: "session",
+    description: "Startup message delivery and reinjection",
+  },
+  { name: "textStreaming", lifecycle: "turn", description: "Ordered text streaming" },
+  { name: "reasoningStreaming", lifecycle: "turn", description: "Ordered reasoning streaming" },
+  {
+    name: "nativeToolLifecycle",
+    lifecycle: "turn",
+    description: "Native tool start, update, and completion events",
+  },
+  { name: "mcp", lifecycle: "session", description: "MCP tool registration and execution" },
+  { name: "permissions", lifecycle: "session", description: "Tool permission policy and approval" },
+  { name: "userInteraction", lifecycle: "turn", description: "Durable human interaction" },
+  { name: "skills", lifecycle: "session", description: "Skill materialization and invocation" },
+  { name: "attachmentImage", lifecycle: "turn", description: "Image attachments" },
+  { name: "attachmentFile", lifecycle: "turn", description: "File attachments" },
+  { name: "attachmentDirectory", lifecycle: "turn", description: "Directory attachments" },
+  { name: "usage", lifecycle: "turn", description: "Token usage observation" },
+  { name: "contextWindow", lifecycle: "driver", description: "Context window inspection" },
+  {
+    name: "compaction",
+    lifecycle: "session",
+    description: "Context compaction and compaction events",
+  },
+  { name: "cancellation", lifecycle: "turn", description: "Active turn cancellation" },
+  { name: "steering", lifecycle: "turn", description: "Active turn steering" },
+  { name: "close", lifecycle: "session", description: "Native Session shutdown" },
+  { name: "cleanup", lifecycle: "session", description: "Feature resource cleanup" },
+] as const;
+// RUNTIME_FEATURE_CATALOG_END
+
+export type RuntimeFeatureName = (typeof RUNTIME_FEATURE_CATALOG)[number]["name"];
+export type RuntimeFeatureLifecycle = (typeof RUNTIME_FEATURE_CATALOG)[number]["lifecycle"];
+export type RuntimeFeatureEvidenceLevel = "materialized" | "discovered" | "executed";
+export type RuntimeCompactionMode = "manual" | "events";
+
+export interface RuntimeFeatureEvidenceRef {
+  readonly probe: string;
+  readonly level: RuntimeFeatureEvidenceLevel;
+  readonly source: "conformance" | "fixture" | "real-probe" | "test";
+  readonly runtimeVersion?: string | undefined;
+  readonly platform?: string | undefined;
+  readonly verifiedAt?: string | undefined;
+}
+
+interface RuntimeFeatureBase {
+  readonly evidence?: readonly RuntimeFeatureEvidenceRef[] | undefined;
+  readonly compactionModes?: readonly RuntimeCompactionMode[] | undefined;
+}
+
+export interface RuntimeFeatureSupported extends RuntimeFeatureBase {
+  readonly status: "supported";
+}
+
+export interface RuntimeFeatureDegraded extends RuntimeFeatureBase {
+  readonly status: "degraded";
+  readonly reason: string;
+}
+
+export interface RuntimeFeatureUnsupported extends RuntimeFeatureBase {
+  readonly status: "unsupported";
+  readonly reason: string;
+}
+
+export interface RuntimeFeatureNotApplicable extends RuntimeFeatureBase {
+  readonly status: "notApplicable";
+  readonly reason: string;
+}
+
+export type RuntimeFeatureStatus =
+  | RuntimeFeatureSupported
+  | RuntimeFeatureDegraded
+  | RuntimeFeatureUnsupported
+  | RuntimeFeatureNotApplicable;
+
+export interface RuntimeFeatureDeclarationHooks {
+  readonly prepareSession?:
+    ((context: RuntimeFeatureSessionPrepareContext) => Promise<unknown> | unknown) | undefined;
+  readonly prepareTurn?:
+    ((context: RuntimeFeatureTurnPrepareContext) => Promise<unknown> | unknown) | undefined;
+}
+
+export type RuntimeFeatureDeclaration = RuntimeFeatureStatus & RuntimeFeatureDeclarationHooks;
+
+export type RuntimeFeatureSet = {
+  readonly [TName in RuntimeFeatureName]: RuntimeFeatureDeclaration;
+};
+
+export type RuntimeFeatureSnapshotSet = {
+  readonly [TName in RuntimeFeatureName]: RuntimeFeatureStatus;
+};
+
+type RuntimeFeatureOptions = RuntimeFeatureBase & RuntimeFeatureDeclarationHooks;
+type EmptyRuntimeFeatureOptions = Record<never, never>;
+
+export const runtimeFeature = {
+  supported<const TOptions extends RuntimeFeatureOptions = EmptyRuntimeFeatureOptions>(
+    options?: TOptions,
+  ): RuntimeFeatureSupported & TOptions {
+    return { status: "supported", ...(options ?? {}) } as RuntimeFeatureSupported & TOptions;
+  },
+  degraded<const TOptions extends RuntimeFeatureOptions = EmptyRuntimeFeatureOptions>(
+    reason: string,
+    options?: TOptions,
+  ): RuntimeFeatureDegraded & TOptions {
+    return {
+      status: "degraded",
+      reason: requireReason(reason),
+      ...(options ?? {}),
+    } as RuntimeFeatureDegraded & TOptions;
+  },
+  unsupported(reason: string): RuntimeFeatureUnsupported {
+    return { status: "unsupported", reason: requireReason(reason) };
+  },
+  notApplicable(reason: string): RuntimeFeatureNotApplicable {
+    return { status: "notApplicable", reason: requireReason(reason) };
+  },
+};
+
+export function defineRuntimeFeatures<const TFeatures extends RuntimeFeatureSet>(
+  features: TFeatures,
+): TFeatures {
+  validateRuntimeFeatures(features);
+  return features;
+}
+
+export function validateRuntimeFeatures(features: RuntimeFeatureSet): void {
+  const expected = new Set<RuntimeFeatureName>(
+    RUNTIME_FEATURE_CATALOG.map((feature) => feature.name),
+  );
+  for (const name of Object.keys(features)) {
+    if (!expected.has(name as RuntimeFeatureName)) {
+      throw new Error(`Unknown Runtime feature slot: ${name}`);
+    }
+  }
+  for (const name of expected) {
+    const feature = features[name];
+    const lifecycle = runtimeFeatureLifecycle(name);
+    if (feature === undefined) {
+      throw new Error(`Runtime feature declaration is missing mandatory slot: ${name}`);
+    }
+    if (
+      (feature.status === "degraded" ||
+        feature.status === "unsupported" ||
+        feature.status === "notApplicable") &&
+      feature.reason.trim() === ""
+    ) {
+      throw new Error(`Runtime feature ${name} requires a non-empty reason.`);
+    }
+    if (
+      !isRuntimeFeatureEnabled(feature) &&
+      (feature.prepareSession !== undefined || feature.prepareTurn !== undefined)
+    ) {
+      throw new Error(`Disabled Runtime feature ${name} must not declare lifecycle hooks.`);
+    }
+    if (feature.prepareSession !== undefined && lifecycle !== "session") {
+      throw new Error(
+        `Runtime feature ${name} has ${lifecycle} lifecycle and cannot declare prepareSession().`,
+      );
+    }
+    if (feature.prepareTurn !== undefined && lifecycle !== "turn") {
+      throw new Error(
+        `Runtime feature ${name} has ${lifecycle} lifecycle and cannot declare prepareTurn().`,
+      );
+    }
+    if (
+      feature.status === "supported" &&
+      (name === "mcp" || name === "permissions" || name === "skills") &&
+      feature.prepareSession === undefined
+    ) {
+      throw new Error(
+        `Supported Runtime feature ${name} must participate in Core-owned Session preparation.`,
+      );
+    }
+  }
+}
+
+export function snapshotRuntimeFeatures(features: RuntimeFeatureSet): RuntimeFeatureSnapshotSet {
+  return Object.freeze(
+    Object.fromEntries(
+      RUNTIME_FEATURE_CATALOG.map(({ name }) => {
+        const status = Object.fromEntries(
+          Object.entries(features[name])
+            .filter(([key]) => key !== "prepareSession" && key !== "prepareTurn")
+            .map(([key, value]) => [
+              key,
+              key === "evidence"
+                ? Object.freeze(
+                    (value as readonly RuntimeFeatureEvidenceRef[]).map((entry) =>
+                      Object.freeze({ ...entry }),
+                    ),
+                  )
+                : key === "compactionModes"
+                  ? Object.freeze([...(value as readonly RuntimeCompactionMode[])])
+                  : value,
+            ]),
+        ) as unknown as RuntimeFeatureStatus;
+        return [name, Object.freeze(status)];
+      }),
+    ) as RuntimeFeatureSnapshotSet,
+  );
+}
+
+export function isRuntimeFeatureEnabled(feature: RuntimeFeatureStatus): boolean {
+  return feature.status === "supported" || feature.status === "degraded";
+}
+
+export function deriveRuntimeAdapterCapabilities(
+  features: RuntimeFeatureSet,
+  placement: RuntimeAdapterPlacementCapabilities | undefined,
+): RuntimeAdapterCapabilities {
+  const compaction = features.compaction;
+  const compactionModes = new Set(compaction.compactionModes ?? []);
+  const targets =
+    placement?.targets === undefined ? undefined : Object.freeze([...placement.targets]);
+  const executionLocations =
+    placement?.executionLocations === undefined
+      ? undefined
+      : Object.freeze([...placement.executionLocations]);
+  return Object.freeze({
+    ...(targets === undefined ? {} : { targets }),
+    ...(executionLocations === undefined ? {} : { executionLocations }),
+    supportsStreaming: isRuntimeFeatureEnabled(features.textStreaming),
+    supportsAbort: isRuntimeFeatureEnabled(features.cancellation),
+    supportsMcp: isRuntimeFeatureEnabled(features.mcp),
+    supportsResume: isRuntimeFeatureEnabled(features.resume),
+    supportsSteer: isRuntimeFeatureEnabled(features.steering),
+    supportsCancel: isRuntimeFeatureEnabled(features.cancellation),
+    supportsClose: isRuntimeFeatureEnabled(features.close),
+    supportsContextWindowInspection: isRuntimeFeatureEnabled(features.contextWindow),
+    supportsManualCompaction: isRuntimeFeatureEnabled(compaction) && compactionModes.has("manual"),
+    supportsContextCompactionEvents:
+      isRuntimeFeatureEnabled(compaction) && compactionModes.has("events"),
+  });
+}
+
+export function runtimeFeatureLifecycle(name: RuntimeFeatureName): RuntimeFeatureLifecycle {
+  return RUNTIME_FEATURE_CATALOG.find((feature) => feature.name === name)!.lifecycle;
+}
+
+function requireReason(reason: string): string {
+  const normalized = reason.trim();
+  if (normalized === "") throw new Error("Runtime feature reason must not be empty.");
+  return normalized;
+}

--- a/packages/core/src/runtime/probe-evidence.ts
+++ b/packages/core/src/runtime/probe-evidence.ts
@@ -1,0 +1,213 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { encodePragmaPathSegment, PragmaPaths } from "../storage/pragma-paths.ts";
+import { RUNTIME_FEATURE_CATALOG } from "./features.ts";
+
+export const RUNTIME_PROBE_EVIDENCE_SCHEMA_VERSION = "pragma.runtime-probe-evidence/v1";
+
+const RuntimeProbeAssertionSchema = z
+  .object({
+    id: z.string().min(1).max(200),
+    feature: z.enum(RUNTIME_FEATURE_CATALOG.map(({ name }) => name)),
+    stage: z.enum(["materialized", "discovered", "executed", "invariant"]),
+    status: z.enum(["passed", "failed", "skipped"]),
+    message: z.string().min(1).max(4_000),
+  })
+  .strict();
+
+export const RuntimeProbeEvidenceSchema = z
+  .object({
+    schemaVersion: z.literal(RUNTIME_PROBE_EVIDENCE_SCHEMA_VERSION),
+    runtime: z
+      .object({
+        id: z.string().min(1).max(200),
+        kind: z.string().min(1).max(200),
+        version: z.string().min(1).max(200).optional(),
+      })
+      .strict(),
+    probe: z
+      .object({
+        id: z.string().min(1).max(200),
+        version: z.string().min(1).max(50),
+      })
+      .strict(),
+    environment: z
+      .object({
+        capturedAt: z.string().datetime(),
+        platform: z.string().min(1).max(100),
+        architecture: z.string().min(1).max(100),
+        authenticationMode: z.string().min(1).max(200).optional(),
+      })
+      .strict(),
+    command: z
+      .object({
+        executable: z.string().min(1).max(500),
+        arguments: z.array(z.string().max(1_000)).max(100),
+      })
+      .strict(),
+    assertions: z.array(RuntimeProbeAssertionSchema).min(1).max(500),
+    observations: z.array(z.string().max(16_384)).max(1_000).default([]),
+    redaction: z
+      .object({
+        version: z.literal("sha256-placeholders/v1"),
+        leakScanPassed: z.literal(true),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type RuntimeProbeEvidence = z.infer<typeof RuntimeProbeEvidenceSchema>;
+export type RuntimeProbeAssertion = z.infer<typeof RuntimeProbeAssertionSchema>;
+
+export interface RuntimeProbeRedactionOptions {
+  readonly home?: string | undefined;
+  readonly workspace?: string | undefined;
+  readonly paths?: readonly string[] | undefined;
+  readonly secrets?: readonly string[] | undefined;
+}
+
+const SENSITIVE_KEY =
+  /(?:authorization|cookie|credential|password|secret|token|api[-_]?key|private[-_]?key)/i;
+const SENSITIVE_VALUE_PATTERNS = [
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\bsk-[A-Za-z0-9_-]{8,}/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{8,}/gi,
+  /\bxox[a-z]-[A-Za-z0-9-]{8,}/gi,
+  /\bAIza[A-Za-z0-9_-]{12,}/g,
+] as const;
+
+export function redactRuntimeProbeValue(
+  value: unknown,
+  options: RuntimeProbeRedactionOptions = {},
+): unknown {
+  return redactValue(value, options, new WeakSet<object>());
+}
+
+export function assertRuntimeProbeValueIsRedacted(
+  value: unknown,
+  options: RuntimeProbeRedactionOptions = {},
+): void {
+  const serialized = JSON.stringify(value);
+  for (const secret of options.secrets ?? []) {
+    if (secret.length >= 4 && serialized.includes(secret)) {
+      throw new Error("Runtime probe evidence contains an explicitly registered secret.");
+    }
+  }
+  for (const [label, path] of [
+    ["home", options.home],
+    ["workspace", options.workspace],
+    ...(options.paths ?? []).map((path, index) => [`registered path ${index + 1}`, path] as const),
+  ] as const) {
+    if (path !== undefined && path !== "" && serialized.includes(path)) {
+      throw new Error(`Runtime probe evidence contains the unredacted ${label} path.`);
+    }
+  }
+  for (const pattern of SENSITIVE_VALUE_PATTERNS) {
+    pattern.lastIndex = 0;
+    if (pattern.test(serialized)) {
+      throw new Error(`Runtime probe evidence failed secret-pattern scan: ${pattern.source}`);
+    }
+  }
+}
+
+export function createRuntimeProbeEvidence(
+  input: Omit<RuntimeProbeEvidence, "schemaVersion" | "redaction">,
+  redaction: RuntimeProbeRedactionOptions = {},
+): RuntimeProbeEvidence {
+  const sanitized = redactRuntimeProbeValue(input, redaction);
+  assertRuntimeProbeValueIsRedacted(sanitized, redaction);
+  return RuntimeProbeEvidenceSchema.parse({
+    ...(sanitized as object),
+    schemaVersion: RUNTIME_PROBE_EVIDENCE_SCHEMA_VERSION,
+    redaction: {
+      version: "sha256-placeholders/v1",
+      leakScanPassed: true,
+    },
+  });
+}
+
+export async function writeRuntimeProbeEvidence(
+  evidence: RuntimeProbeEvidence,
+  options: {
+    readonly paths?: PragmaPaths | undefined;
+    readonly fileName?: string | undefined;
+  } = {},
+): Promise<string> {
+  const parsed = RuntimeProbeEvidenceSchema.parse(evidence);
+  const paths = options.paths ?? new PragmaPaths();
+  const capturedDate = parsed.environment.capturedAt.slice(0, 10);
+  const directory = join(
+    paths.runtimeProbeArchivesRoot(),
+    encodePragmaPathSegment(parsed.runtime.id),
+    capturedDate,
+  );
+  await mkdir(directory, { recursive: true });
+  const fileName =
+    options.fileName ?? `${encodePragmaPathSegment(parsed.probe.id)}-${randomUUID()}.json`;
+  if (!/^[A-Za-z0-9._-]+\.json$/.test(fileName)) {
+    throw new Error(`Invalid Runtime probe evidence file name: ${fileName}`);
+  }
+  const target = join(directory, fileName);
+  const temporary = `${target}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(parsed, null, 2)}\n`, { mode: 0o600 });
+    await rename(temporary, target);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+  return target;
+}
+
+function redactValue(
+  value: unknown,
+  options: RuntimeProbeRedactionOptions,
+  visited: WeakSet<object>,
+  key?: string,
+): unknown {
+  if (SENSITIVE_KEY.test(key ?? "") && value !== undefined && value !== null) {
+    return redactionPlaceholder(String(value));
+  }
+  if (typeof value === "string") return redactString(value, options);
+  if (value === null || typeof value !== "object") return value;
+  if (visited.has(value)) return "[redacted:circular]";
+  visited.add(value);
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry, options, visited));
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([entryKey, entry]) => [
+      entryKey,
+      redactValue(entry, options, visited, entryKey),
+    ]),
+  );
+}
+
+function redactString(value: string, options: RuntimeProbeRedactionOptions): string {
+  let redacted = value;
+  const replacements: readonly (readonly [string | undefined, string])[] = [
+    [options.workspace, "[workspace]"],
+    [options.home, "[home]"],
+    ...(options.paths ?? []).map((path) => [path, "[path]"] as const),
+  ];
+  for (const [candidate, replacement] of replacements) {
+    if (candidate !== undefined && candidate !== "")
+      redacted = redacted.split(candidate).join(replacement);
+  }
+  for (const secret of options.secrets ?? []) {
+    if (secret.length >= 4) redacted = redacted.split(secret).join(redactionPlaceholder(secret));
+  }
+  for (const pattern of SENSITIVE_VALUE_PATTERNS) {
+    redacted = redacted.replace(pattern, (match) => redactionPlaceholder(match));
+  }
+  return redacted;
+}
+
+function redactionPlaceholder(value: string): string {
+  const digest = createHash("sha256").update(value).digest("hex").slice(0, 12);
+  return `[redacted:sha256:${digest}]`;
+}

--- a/packages/core/src/runtime/process-probe.ts
+++ b/packages/core/src/runtime/process-probe.ts
@@ -1,6 +1,7 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 
 import type { RuntimeCanUseResult } from "./runtime-adapter.ts";
+import { BoundedRuntimeOutputBuffer, RuntimeProcessSupervisor } from "./process-supervisor.ts";
 
 export type RuntimeCommandSpawn = (
   command: string,
@@ -100,59 +101,50 @@ export function runRuntimeCommand(options: RuntimeCommandOptions): Promise<Runti
   const spawn = options.spawn ?? defaultSpawn;
 
   return new Promise<RuntimeCommandResult>((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
+    const stdout = new BoundedRuntimeOutputBuffer(options.outputLimit ?? OUTPUT_LIMIT, "head");
+    const stderr = new BoundedRuntimeOutputBuffer(options.outputLimit ?? OUTPUT_LIMIT, "head");
     let settled = false;
+    let timedOut = false;
     const child = spawn(options.executablePath, options.args, {
       cwd: options.cwd,
       env: options.env,
     });
+    const supervisor = new RuntimeProcessSupervisor(child);
     // Runtime probes are non-interactive. Closing stdin is materially
     // different from leaving Node's default pipe open: some CLIs wait for EOF
     // before running a subcommand when they are launched without a TTY.
     child.stdin.on("error", () => undefined);
     child.stdin.end();
-    let forceKillTimer: NodeJS.Timeout | undefined;
     const timeout = setTimeout(() => {
-      finish(() => {
-        try {
-          child.kill("SIGTERM");
-        } catch {
-          // Ignore process signaling errors
-        }
-        forceKillTimer = setTimeout(() => {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            // Ignore process signaling errors
-          }
-        }, 1_000);
-        forceKillTimer.unref();
-        reject(new Error(`Probe timed out after ${options.timeoutMs}ms.`));
+      timedOut = true;
+      void supervisor.terminate().finally(() => {
+        finish(() => reject(new Error(`Probe timed out after ${options.timeoutMs}ms.`)));
       });
     }, options.timeoutMs);
+    timeout.unref();
 
     child.stdout.on("data", (chunk: Buffer | string) => {
-      stdout = appendLimited(stdout, chunk, options.outputLimit ?? OUTPUT_LIMIT);
+      stdout.append(chunk);
     });
     child.stderr.on("data", (chunk: Buffer | string) => {
-      stderr = appendLimited(stderr, chunk, options.outputLimit ?? OUTPUT_LIMIT);
+      stderr.append(chunk);
     });
-    child.on("error", (error) => {
-      finish(() => {
-        reject(error);
-      });
-    });
-    child.on("exit", (exitCode, signal) => {
-      finish(() => {
-        resolve({
-          exitCode,
-          signal,
-          stdout,
-          stderr,
+    void supervisor.exit.then(
+      ({ code, signal }) => {
+        if (timedOut) return;
+        finish(() => {
+          resolve({
+            exitCode: code,
+            signal,
+            stdout: stdout.text(),
+            stderr: stderr.text(),
+          });
         });
-      });
-    });
+      },
+      (error: unknown) => {
+        finish(() => reject(error));
+      },
+    );
 
     function finish(callback: () => void): void {
       if (settled) {
@@ -161,9 +153,6 @@ export function runRuntimeCommand(options: RuntimeCommandOptions): Promise<Runti
 
       settled = true;
       clearTimeout(timeout);
-      if (forceKillTimer !== undefined) {
-        clearTimeout(forceKillTimer);
-      }
       callback();
     }
   });
@@ -178,14 +167,6 @@ function defaultSpawn(
     cwd: options.cwd,
     env: options.env,
   });
-}
-
-function appendLimited(current: string, chunk: Buffer | string, outputLimit: number): string {
-  if (current.length >= outputLimit) {
-    return current;
-  }
-
-  return (current + String(chunk)).slice(0, outputLimit);
 }
 
 function readFirstOutputLine(output: string): string | undefined {

--- a/packages/core/src/runtime/process-supervisor.ts
+++ b/packages/core/src/runtime/process-supervisor.ts
@@ -1,0 +1,130 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+export interface RuntimeProcessExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export interface RuntimeProcessTerminationOptions {
+  readonly process: ChildProcessWithoutNullStreams;
+  readonly exit: Promise<RuntimeProcessExit>;
+  readonly hasExited: () => boolean;
+  readonly graceMs?: number | undefined;
+  readonly closeStdin?: boolean | undefined;
+  readonly onForceKill?: (() => void) | undefined;
+  readonly onStuck?: (() => void) | undefined;
+}
+
+const DEFAULT_TERMINATION_GRACE_MS = 1_000;
+
+/** Supervises one provider process without imposing a transport abstraction. */
+export class RuntimeProcessSupervisor {
+  readonly exit: Promise<RuntimeProcessExit>;
+  private exited = false;
+  private termination: Promise<void> | undefined;
+
+  constructor(readonly process: ChildProcessWithoutNullStreams) {
+    this.exit = new Promise<RuntimeProcessExit>((resolve, reject) => {
+      process.once("error", reject);
+      process.once("exit", (code, signal) => {
+        this.exited = true;
+        resolve({ code, signal });
+      });
+    });
+  }
+
+  hasExited = (): boolean => this.exited;
+
+  terminate(
+    options: Omit<RuntimeProcessTerminationOptions, "process" | "exit" | "hasExited"> = {},
+  ): Promise<void> {
+    this.termination ??= terminateRuntimeProcess({
+      ...options,
+      process: this.process,
+      exit: this.exit,
+      hasExited: this.hasExited,
+    });
+    return this.termination;
+  }
+}
+
+export async function terminateRuntimeProcess(
+  options: RuntimeProcessTerminationOptions,
+): Promise<void> {
+  if (options.hasExited()) return;
+  if (options.closeStdin ?? true) closeRuntimeProcessInput(options.process);
+  signalRuntimeProcess(options.process, "SIGTERM");
+  if (await waitForRuntimeProcessExit(options.exit, options.graceMs)) return;
+  if (options.hasExited()) return;
+  options.onForceKill?.();
+  signalRuntimeProcess(options.process, "SIGKILL");
+  if (!(await waitForRuntimeProcessExit(options.exit, options.graceMs)) && !options.hasExited()) {
+    options.onStuck?.();
+  }
+}
+
+export async function waitForRuntimeProcessExit(
+  exit: Promise<RuntimeProcessExit>,
+  timeoutMs = DEFAULT_TERMINATION_GRACE_MS,
+): Promise<boolean> {
+  let timer: NodeJS.Timeout | undefined;
+  return await Promise.race([
+    exit.then(
+      () => true,
+      () => true,
+    ),
+    new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+      timer.unref();
+    }),
+  ]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+export class BoundedRuntimeOutputBuffer {
+  private bytes = Buffer.alloc(0);
+
+  constructor(
+    readonly limit: number,
+    readonly mode: "head" | "tail" = "tail",
+  ) {
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error("Runtime output buffer limit must be a positive safe integer.");
+    }
+  }
+
+  append(chunk: Buffer | string): void {
+    if (this.mode === "head" && this.bytes.length >= this.limit) return;
+    const next = Buffer.concat([this.bytes, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
+    this.bytes = this.mode === "head" ? next.subarray(0, this.limit) : next.subarray(-this.limit);
+  }
+
+  text(): string {
+    return this.bytes.toString("utf8");
+  }
+
+  get byteLength(): number {
+    return this.bytes.length;
+  }
+}
+
+function closeRuntimeProcessInput(process: ChildProcessWithoutNullStreams): void {
+  if (process.stdin.destroyed || process.stdin.writableEnded) return;
+  try {
+    process.stdin.end();
+  } catch {
+    process.stdin.destroy();
+  }
+}
+
+function signalRuntimeProcess(
+  process: ChildProcessWithoutNullStreams,
+  signal: "SIGTERM" | "SIGKILL",
+): void {
+  try {
+    process.kill(signal);
+  } catch {
+    // Exit observation remains authoritative; signaling races are expected.
+  }
+}

--- a/packages/core/src/runtime/resource-scope.ts
+++ b/packages/core/src/runtime/resource-scope.ts
@@ -1,0 +1,124 @@
+export type RuntimeResourceDisposer<T> = (resource: T) => Promise<void> | void;
+
+export type RuntimeResourceReceiptState = "active" | "disposed" | "failed";
+
+export interface RuntimeResourceReceipt {
+  readonly label: string;
+  readonly order: number;
+  readonly state: RuntimeResourceReceiptState;
+}
+
+interface RuntimeResourceEntry {
+  readonly label: string;
+  readonly order: number;
+  readonly dispose: () => Promise<void> | void;
+  state: RuntimeResourceReceiptState;
+}
+
+/** Acquisition-only view passed to Runtime feature and driver code. */
+export interface RuntimeResourceRegistrar {
+  readonly acquire: <T>(
+    label: string,
+    acquire: () => Promise<T> | T,
+    dispose: RuntimeResourceDisposer<T>,
+  ) => Promise<T>;
+  readonly adopt: <T>(label: string, resource: T, dispose: RuntimeResourceDisposer<T>) => T;
+  readonly receipts: () => readonly RuntimeResourceReceipt[];
+}
+
+/**
+ * Owns resources acquired while a Runtime Session or turn is being prepared.
+ *
+ * Resources are released exactly once in reverse acquisition order. Core keeps
+ * ownership of the scope, so partial initialization failures use the same
+ * cleanup path as normal Session shutdown.
+ */
+export class RuntimeResourceScope implements RuntimeResourceRegistrar {
+  private readonly entries: RuntimeResourceEntry[] = [];
+  private transferred = false;
+  private disposal: Promise<void> | undefined;
+
+  constructor(readonly label: string) {
+    if (label.trim() === "") {
+      throw new Error("Runtime resource scope label must not be empty.");
+    }
+  }
+
+  async acquire<T>(
+    label: string,
+    acquire: () => Promise<T> | T,
+    dispose: RuntimeResourceDisposer<T>,
+  ): Promise<T> {
+    this.assertCanRegister();
+    const resource = await acquire();
+    try {
+      return this.adopt(label, resource, dispose);
+    } catch (error) {
+      try {
+        await dispose(resource);
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          `Runtime resource ${label} was acquired after its scope closed and cleanup failed.`,
+          { cause: cleanupError },
+        );
+      }
+      throw error;
+    }
+  }
+
+  adopt<T>(label: string, resource: T, dispose: RuntimeResourceDisposer<T>): T {
+    this.assertCanRegister();
+    if (label.trim() === "") {
+      throw new Error("Runtime resource label must not be empty.");
+    }
+    this.entries.push({
+      label,
+      order: this.entries.length,
+      dispose: () => dispose(resource),
+      state: "active",
+    });
+    return resource;
+  }
+
+  /** Marks successful ownership transfer from preparation to the managed Session. */
+  transfer(): void {
+    this.assertCanRegister();
+    this.transferred = true;
+  }
+
+  receipts(): readonly RuntimeResourceReceipt[] {
+    return this.entries.map(({ label, order, state }) => ({ label, order, state }));
+  }
+
+  dispose(): Promise<void> {
+    this.disposal ??= this.disposeEntries();
+    return this.disposal;
+  }
+
+  private async disposeEntries(): Promise<void> {
+    const errors: unknown[] = [];
+    for (const entry of [...this.entries].reverse()) {
+      if (entry.state !== "active") continue;
+      try {
+        await entry.dispose();
+        entry.state = "disposed";
+      } catch (error) {
+        entry.state = "failed";
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, `Runtime resource scope ${this.label} cleanup failed.`);
+    }
+  }
+
+  private assertCanRegister(): void {
+    if (this.disposal !== undefined) {
+      throw new Error(`Runtime resource scope ${this.label} is closing.`);
+    }
+    if (this.transferred) {
+      throw new Error(`Runtime resource scope ${this.label} has transferred ownership.`);
+    }
+  }
+}

--- a/packages/core/src/runtime/runtime-adapter.ts
+++ b/packages/core/src/runtime/runtime-adapter.ts
@@ -18,6 +18,7 @@ import type {
   ExpertAgentHumanInteractionHandler,
   ExpertToolExecutionContext,
 } from "../tools/managed-tool.ts";
+import type { RuntimeFeatureSnapshotSet } from "./features.ts";
 
 export type RuntimeAdapterKind = "cloud-pi-agent" | (string & {});
 
@@ -38,6 +39,11 @@ export interface RuntimeAdapterCapabilities {
   readonly supportsContextCompactionEvents?: boolean | undefined;
 }
 
+export type RuntimeAdapterPlacementCapabilities = Pick<
+  RuntimeAdapterCapabilities,
+  "targets" | "executionLocations"
+>;
+
 export type RuntimeTarget = "expert" | "code" | "flow" | "operator" | (string & {});
 
 export interface RuntimeAdapterDescriptor {
@@ -46,6 +52,17 @@ export interface RuntimeAdapterDescriptor {
   readonly displayName: string;
   readonly capabilities?: RuntimeAdapterCapabilities | undefined;
 }
+
+/** Descriptor accepted from a concrete driver. Feature booleans are Core-derived. */
+export interface RuntimeDriverDescriptor extends Omit<RuntimeAdapterDescriptor, "capabilities"> {
+  readonly capabilities?: RuntimeAdapterPlacementCapabilities | undefined;
+}
+
+export type RuntimeDriverDescriptorOverride = Partial<
+  Omit<RuntimeDriverDescriptor, "capabilities">
+> & {
+  readonly capabilities?: RuntimeAdapterPlacementCapabilities | undefined;
+};
 
 export interface RuntimeCanUseResult {
   readonly usable: boolean;
@@ -215,6 +232,9 @@ export interface RuntimeAgentSession {
 
 export interface RuntimeAdapter {
   readonly descriptor: RuntimeAdapterDescriptor;
-  readonly canUse: (options?: Record<string, unknown>) => Promise<RuntimeCanUseResult> | RuntimeCanUseResult;
+  readonly features: RuntimeFeatureSnapshotSet;
+  readonly canUse: (
+    options?: Record<string, unknown>,
+  ) => Promise<RuntimeCanUseResult> | RuntimeCanUseResult;
   readonly listModels?: (() => Promise<readonly RuntimeModel[]>) | undefined;
 }

--- a/packages/core/src/storage/pragma-paths.ts
+++ b/packages/core/src/storage/pragma-paths.ts
@@ -52,6 +52,10 @@ export class PragmaPaths {
     return join(this.archivesRoot(), "diagnostics");
   }
 
+  runtimeProbeArchivesRoot(): string {
+    return join(this.archivesRoot(), "runtime-probes");
+  }
+
   diagnosticApplicationRoot(application: string): string {
     if (!/^[a-z0-9]+(?:[.-][a-z0-9]+)*$/.test(application)) {
       throw new Error(`Invalid diagnostic application name: ${application}`);

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,0 +1,112 @@
+import {
+  RUNTIME_FEATURE_CATALOG,
+  defineRuntimeFeatures,
+  runtimeFeature,
+  type RuntimeCompactionMode,
+  type RuntimeFeatureDeclaration,
+  type RuntimeFeatureName,
+  type RuntimeFeatureSet,
+} from "../runtime/features.ts";
+import {
+  assertRuntimeConformance,
+  type RuntimeConformanceObservation,
+} from "../runtime/conformance.ts";
+import type { RuntimeAdapter } from "../runtime/runtime-adapter.ts";
+import {
+  defineRuntimeDriver,
+  type DefineRuntimeDriverOptions,
+  type RuntimeDriver,
+} from "../runtime/driver.ts";
+
+export interface RuntimeConformanceCase {
+  readonly name: string;
+  readonly run: () => Promise<void>;
+}
+
+export interface RuntimeConformanceCaseOptions {
+  readonly createRuntime: () => RuntimeAdapter | Promise<RuntimeAdapter>;
+  readonly createObservation?:
+    | ((
+        runtime: RuntimeAdapter,
+      ) => RuntimeConformanceObservation | Promise<RuntimeConformanceObservation>)
+    | undefined;
+}
+
+export function createRuntimeConformanceCases(
+  options: RuntimeConformanceCaseOptions,
+): readonly RuntimeConformanceCase[] {
+  const declaration: RuntimeConformanceCase = {
+    name: "declares every mandatory feature and derives capabilities",
+    run: async () => assertRuntimeConformance(await options.createRuntime()),
+  };
+  if (options.createObservation === undefined) return [declaration];
+  return [
+    declaration,
+    {
+      name: "preserves streaming, tool, output, and persistence invariants",
+      run: async () => {
+        const runtime = await options.createRuntime();
+        assertRuntimeConformance(runtime, await options.createObservation!(runtime));
+      },
+    },
+  ];
+}
+
+export function createRuntimeTestFeatures(
+  options: {
+    readonly enabled?: readonly RuntimeFeatureName[] | undefined;
+    readonly overrides?: Partial<Record<RuntimeFeatureName, RuntimeFeatureDeclaration>> | undefined;
+    readonly compactionModes?: readonly RuntimeCompactionMode[] | undefined;
+  } = {},
+): RuntimeFeatureSet {
+  const enabled = new Set<RuntimeFeatureName>([
+    "freshSession",
+    "systemPrompt",
+    "startupMessages",
+    "textStreaming",
+    "cleanup",
+    ...(options.enabled ?? []),
+  ]);
+  const features = Object.fromEntries(
+    RUNTIME_FEATURE_CATALOG.map(({ name }) => [
+      name,
+      enabled.has(name)
+        ? runtimeFeature.degraded("Enabled by an in-memory Runtime test fixture.", {
+            ...(name === "compaction"
+              ? { compactionModes: options.compactionModes ?? ["manual"] }
+              : {}),
+          })
+        : runtimeFeature.notApplicable("Not exercised by this Runtime test fixture."),
+    ]),
+  ) as RuntimeFeatureSet;
+  return defineRuntimeFeatures({ ...features, ...options.overrides });
+}
+
+export function defineRuntimeTestDriver<TNativeEvent, TNativeSession>(
+  driver: Omit<RuntimeDriver<TNativeEvent, TNativeSession>, "features"> & {
+    readonly features?: RuntimeFeatureSet | undefined;
+  },
+  options: DefineRuntimeDriverOptions = {},
+): RuntimeAdapter {
+  const enabled: RuntimeFeatureName[] = [];
+  if (driver.canUse !== undefined) enabled.push("availability");
+  if (driver.listModels !== undefined) enabled.push("modelDiscovery");
+  if (driver.restoreSession !== undefined) enabled.push("resume");
+  if (driver.readContextWindow !== undefined) enabled.push("contextWindow");
+  if (driver.compactContext !== undefined) enabled.push("compaction");
+  if (driver.cancelTurn !== undefined) enabled.push("cancellation");
+  if (driver.steerTurn !== undefined) enabled.push("steering");
+  if (driver.closeSession !== undefined) enabled.push("close");
+  return defineRuntimeDriver(
+    {
+      ...driver,
+      features:
+        driver.features ??
+        createRuntimeTestFeatures({
+          enabled,
+          compactionModes: driver.compactContext === undefined ? [] : ["manual"],
+        }),
+    },
+    options,
+  );
+}

--- a/packages/core/src/testing/vitest.ts
+++ b/packages/core/src/testing/vitest.ts
@@ -1,0 +1,14 @@
+import { describe, it } from "vitest";
+
+import { createRuntimeConformanceCases, type RuntimeConformanceCaseOptions } from "./index.ts";
+
+export function describeRuntimeConformance(
+  runtimeName: string,
+  options: RuntimeConformanceCaseOptions,
+): void {
+  describe(`${runtimeName} Runtime conformance`, () => {
+    for (const testCase of createRuntimeConformanceCases(options)) {
+      it(testCase.name, testCase.run);
+    }
+  });
+}

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -42,6 +42,7 @@ import {
   type RuntimeUsageObservation,
   type UsageSink,
 } from "../src/index.ts";
+import { createRuntimeTestFeatures } from "../src/testing/index.ts";
 
 interface FakeSession {
   readonly context: RuntimeDriverSessionContext;
@@ -91,6 +92,13 @@ interface FakeRuntimeOptions {
 function createFakeRuntime(options: FakeRuntimeOptions = {}) {
   const stats = options.stats;
   return defineRuntimeDriver<AgentMessageUsage, FakeSession>({
+    features: createRuntimeTestFeatures({
+      enabled: [
+        "cancellation",
+        "close",
+        ...(options.onSteer === undefined ? [] : (["steering"] as const)),
+      ],
+    }),
     descriptor: {
       id: options.runtimeId ?? "fake",
       kind: "fake",
@@ -221,6 +229,7 @@ function createOrchestrationRuntime(
     signalChildSessionOpening = resolve;
   });
   return defineRuntimeDriver<never, FakeSession>({
+    features: createRuntimeTestFeatures({ enabled: ["close"] }),
     descriptor: { id: `orchestration-${scenario}`, kind: "fake", displayName: "Orchestration" },
     createSession: async (context) => {
       if (scenario === "parent-failure" && context.agent.id !== "lead") {
@@ -699,6 +708,7 @@ describe("ExpertSession", () => {
     const board = new InMemoryContextStore();
     let createSessionCalls = 0;
     const runtime = defineRuntimeDriver<never, FakeSession>({
+      features: createRuntimeTestFeatures(),
       descriptor: { id: "handoff-reader", kind: "fake", displayName: "Handoff Reader" },
       createSession: (context) => {
         createSessionCalls += 1;

--- a/packages/core/test/human-interaction-recovery.test.ts
+++ b/packages/core/test/human-interaction-recovery.test.ts
@@ -17,6 +17,7 @@ import {
   type ExpertAgentHumanResponse,
   type RuntimeDriverSessionContext,
 } from "../src/index.ts";
+import { createRuntimeTestFeatures } from "../src/testing/index.ts";
 
 const tempDirs: string[] = [];
 
@@ -282,6 +283,7 @@ function createRecoveryRuntime(request: ExpertAgentHumanRequest, onStart: () => 
   }
 
   return defineRuntimeDriver<never, RecoverySession>({
+    features: createRuntimeTestFeatures({ enabled: ["cancellation", "close"] }),
     descriptor: {
       id: "human-recovery",
       kind: "fake",

--- a/packages/core/test/pragma-paths.test.ts
+++ b/packages/core/test/pragma-paths.test.ts
@@ -33,6 +33,9 @@ describe("PragmaPaths", () => {
     expect(paths.diagnosticFailureLog("desktop", "2026-07-26", bootId, 12)).toBe(
       join(bootRoot, "errors-0012.jsonl"),
     );
+    expect(paths.runtimeProbeArchivesRoot()).toBe(
+      join(paths.archivesRoot(), "runtime-probes"),
+    );
     expect(() => paths.diagnosticBootRoot("desktop", "../escape", bootId)).toThrow(
       "Invalid diagnostic archive date",
     );

--- a/packages/core/test/process-probe.test.ts
+++ b/packages/core/test/process-probe.test.ts
@@ -22,4 +22,16 @@ describe("Runtime process probe", () => {
       stderr: "",
     });
   });
+
+  it("reports a timeout after supervising process termination", async () => {
+    await expect(
+      runRuntimeCommand({
+        executablePath: process.execPath,
+        args: ["-e", "setInterval(() => undefined, 1_000)"],
+        cwd: process.cwd(),
+        env: { ...process.env },
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow("Probe timed out after 20ms.");
+  });
 });

--- a/packages/core/test/process-supervisor.test.ts
+++ b/packages/core/test/process-supervisor.test.ts
@@ -1,0 +1,40 @@
+import { spawn } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BoundedRuntimeOutputBuffer,
+  RuntimeProcessSupervisor,
+} from "../src/runtime/process-supervisor.ts";
+
+describe("RuntimeProcessSupervisor", () => {
+  it("terminates a provider process and makes repeated termination idempotent", async () => {
+    const child = spawn(process.execPath, ["-e", "setInterval(() => undefined, 1_000)"], {
+      stdio: "pipe",
+    });
+    const supervisor = new RuntimeProcessSupervisor(child);
+
+    const first = supervisor.terminate({ graceMs: 500 });
+    const second = supervisor.terminate({ graceMs: 500 });
+
+    expect(first).toBe(second);
+    await first;
+    await expect(supervisor.exit).resolves.toMatchObject({ signal: "SIGTERM" });
+    expect(supervisor.hasExited()).toBe(true);
+  });
+});
+
+describe("BoundedRuntimeOutputBuffer", () => {
+  it("retains only the configured head or tail bytes", () => {
+    const head = new BoundedRuntimeOutputBuffer(4, "head");
+    const tail = new BoundedRuntimeOutputBuffer(4, "tail");
+
+    head.append("abcdef");
+    tail.append("abcdef");
+
+    expect(head.text()).toBe("abcd");
+    expect(tail.text()).toBe("cdef");
+    expect(head.byteLength).toBe(4);
+    expect(tail.byteLength).toBe(4);
+  });
+});

--- a/packages/core/test/runtime-conformance.test.ts
+++ b/packages/core/test/runtime-conformance.test.ts
@@ -1,0 +1,322 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ExpertAgentStreamEventSchema } from "@pragma/shared";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertRuntimeConformance,
+  inspectRuntimeObservationConformance,
+  inspectRuntimeProbeEvidenceConformance,
+} from "../src/runtime/conformance.ts";
+import { defineExpert } from "../src/agent/expert-agent.ts";
+import { defineRuntimeFeatures, runtimeFeature } from "../src/runtime/features.ts";
+import { createRuntimeProbeEvidence } from "../src/runtime/probe-evidence.ts";
+import { createRuntimeTestFeatures, defineRuntimeTestDriver } from "../src/testing/index.ts";
+import type { RuntimeStreamEvent } from "../src/runtime/stream-events.ts";
+import { openRuntimeSession } from "../src/runtime/session-factory.ts";
+
+describe("Runtime conformance runner", () => {
+  it("accepts ordered streaming and one complete MCP tool lifecycle", () => {
+    const runtime = defineRuntimeTestDriver({
+      features: createRuntimeTestFeatures({
+        enabled: ["mcp", "skills", "nativeToolLifecycle"],
+      }),
+      descriptor: { id: "conformance", kind: "test", displayName: "Conformance" },
+      createSession: () => ({}),
+      startTurn: () => ({ outputText: "SKILL_OK" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const events = [
+      event(0, "run.started", { task: "probe" }),
+      event(1, "tool.started", {
+        toolCallId: "tool-1",
+        toolName: "mcp_list_expert_context",
+        kind: "tool",
+      }),
+      event(2, "tool.completed", {
+        toolCallId: "tool-1",
+        toolName: "mcp_list_expert_context",
+        kind: "tool",
+      }),
+      event(3, "message.delta", {
+        role: "assistant",
+        contentType: "text",
+        delta: "SKILL_OK",
+      }),
+      event(4, "message.completed", {
+        role: "assistant",
+        contentType: "text",
+        text: "SKILL_OK",
+      }),
+      event(5, "run.completed", {}),
+    ];
+
+    expect(
+      inspectRuntimeObservationConformance(runtime, {
+        events,
+        outputText: "SKILL_OK",
+        expectedToolNames: ["mcp_list_expert_context"],
+        expectedOutputMarkers: ["SKILL_OK"],
+        requiredFeatures: ["mcp", "skills"],
+        structuredOutputValidated: true,
+        ownerPersistenceValidated: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it("detects duplicate and out-of-order tool events", () => {
+    const runtime = defineRuntimeTestDriver({
+      descriptor: { id: "broken", kind: "test", displayName: "Broken" },
+      createSession: () => ({}),
+      startTurn: () => ({ outputText: "x" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const failures = inspectRuntimeObservationConformance(runtime, {
+      events: [
+        event(0, "run.started", { task: "probe" }),
+        event(1, "tool.completed", { toolCallId: "tool-1", toolName: "bad", kind: "tool" }),
+        event(2, "run.completed", {}),
+      ],
+      structuredOutputValidated: false,
+      ownerPersistenceValidated: false,
+    });
+    expect(failures.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "tool.terminal_without_start",
+        "invariant.structured_output",
+        "invariant.owner_persistence",
+      ]),
+    );
+  });
+
+  it("detects a terminal text snapshot that duplicates streamed output", () => {
+    const runtime = defineRuntimeTestDriver({
+      descriptor: { id: "duplicate-text", kind: "test", displayName: "Duplicate Text" },
+      createSession: () => ({}),
+      startTurn: () => ({ outputText: "hellohello" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const failures = inspectRuntimeObservationConformance(runtime, {
+      events: [
+        event(0, "run.started", { task: "probe" }),
+        event(1, "message.delta", {
+          role: "assistant",
+          contentType: "text",
+          delta: "hello",
+        }),
+        event(2, "message.completed", {
+          role: "assistant",
+          contentType: "text",
+          text: "hellohello",
+        }),
+        event(3, "run.completed", {}),
+      ],
+      outputText: "hellohello",
+    });
+
+    expect(failures.map(({ code }) => code)).toContain("stream.snapshot_mismatch");
+  });
+
+  it("requires Materialized, Discovered, and Executed evidence for Skills probes", () => {
+    const runtime = defineRuntimeTestDriver({
+      features: createRuntimeTestFeatures({ enabled: ["skills"] }),
+      descriptor: { id: "skills-evidence", kind: "test", displayName: "Skills Evidence" },
+      createSession: () => ({}),
+      startTurn: () => ({ outputText: "x" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const evidence = createRuntimeProbeEvidence({
+      runtime: { id: "skills-evidence", kind: "test" },
+      probe: { id: "skills", version: "v1" },
+      environment: {
+        capturedAt: "2026-08-13T00:00:00.000Z",
+        platform: "test",
+        architecture: "test",
+      },
+      command: { executable: "runtime", arguments: ["skills"] },
+      assertions: [
+        {
+          id: "skills.executed",
+          feature: "skills",
+          stage: "executed",
+          status: "passed",
+          message: "Skill marker was observed.",
+        },
+      ],
+      observations: [],
+    });
+
+    expect(
+      inspectRuntimeProbeEvidenceConformance(runtime, evidence).map(({ code }) => code),
+    ).toEqual(["evidence.stage_missing", "evidence.stage_missing"]);
+  });
+
+  it("keeps staged MCP and Skills requirements in combined evidence", () => {
+    const runtime = defineRuntimeTestDriver({
+      features: createRuntimeTestFeatures({ enabled: ["mcp", "skills"] }),
+      descriptor: { id: "full-evidence", kind: "test", displayName: "Full Evidence" },
+      createSession: () => ({}),
+      startTurn: () => ({ outputText: "x" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const evidence = createRuntimeProbeEvidence({
+      runtime: { id: "full-evidence", kind: "test" },
+      probe: { id: "full", version: "v1" },
+      environment: {
+        capturedAt: "2026-08-13T00:00:00.000Z",
+        platform: "test",
+        architecture: "test",
+      },
+      command: { executable: "runtime", arguments: ["full"] },
+      assertions: [
+        {
+          id: "mcp.executed",
+          feature: "mcp",
+          stage: "executed",
+          status: "passed",
+          message: "MCP marker was observed.",
+        },
+        {
+          id: "skills.executed",
+          feature: "skills",
+          stage: "executed",
+          status: "passed",
+          message: "Skill marker was observed.",
+        },
+      ],
+      observations: [],
+    });
+
+    expect(
+      inspectRuntimeProbeEvidenceConformance(runtime, evidence).map(
+        ({ feature, code }) => `${feature}:${code}`,
+      ),
+    ).toEqual([
+      "mcp:evidence.stage_missing",
+      "mcp:evidence.stage_missing",
+      "skills:evidence.stage_missing",
+      "skills:evidence.stage_missing",
+    ]);
+  });
+
+  it("rejects Supported lifecycle features without a Core preparation hook", () => {
+    const base = createRuntimeTestFeatures();
+    expect(() =>
+      defineRuntimeFeatures({
+        ...base,
+        mcp: runtimeFeature.supported({
+          evidence: [
+            { probe: "mcp", level: "materialized", source: "real-probe" },
+            { probe: "mcp", level: "discovered", source: "real-probe" },
+            { probe: "mcp", level: "executed", source: "real-probe" },
+          ],
+        }),
+      }),
+    ).toThrow(/Core-owned Session preparation/);
+  });
+
+  it("rejects feature hooks outside their catalog lifecycle", () => {
+    const base = createRuntimeTestFeatures();
+    expect(() =>
+      defineRuntimeFeatures({
+        ...base,
+        availability: runtimeFeature.degraded("Probe fixture.", {
+          prepareSession: () => undefined,
+        }),
+      }),
+    ).toThrow(/driver lifecycle.*prepareSession/);
+    expect(() =>
+      defineRuntimeFeatures({
+        ...base,
+        mcp: runtimeFeature.degraded("MCP fixture.", {
+          prepareTurn: () => undefined,
+        }),
+      }),
+    ).toThrow(/session lifecycle.*prepareTurn/);
+  });
+
+  it("does not promote Supported from test-only execution evidence", () => {
+    const runtime = defineRuntimeTestDriver({
+      features: createRuntimeTestFeatures({
+        overrides: {
+          textStreaming: runtimeFeature.supported({
+            evidence: [{ probe: "stream", level: "executed", source: "test" }],
+          }),
+        },
+      }),
+      descriptor: { id: "test-evidence", kind: "test", displayName: "Test Evidence" },
+      createSession: () => ({}),
+      startTurn: () => ({ outputText: "x" }),
+      mapEvent: () => ({ events: [] }),
+    });
+
+    expect(() => assertRuntimeConformance(runtime)).toThrow(
+      /no executed real-Runtime probe reference/,
+    );
+  });
+
+  it("uses the same derived descriptor in public and managed Session views", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-runtime-conformance-"));
+    const runtime = defineRuntimeTestDriver({
+      descriptor: {
+        id: "descriptor-view",
+        kind: "test",
+        displayName: "Descriptor View",
+        capabilities: { targets: ["agent"], executionLocations: ["local"] },
+      },
+      createSession: () => ({}),
+      startTurn: () => ({ outputText: "done" }),
+      mapEvent: () => ({ events: [] }),
+    });
+    const expert = await defineExpert({
+      id: "0000000000000001",
+      name: "Descriptor Test",
+      description: "Checks the managed Runtime descriptor.",
+      instructions: "Reply concisely.",
+      tags: ["test"],
+      scope: "test",
+      workspace: root,
+      pragmaHome: root,
+    });
+    const session = await openRuntimeSession(runtime, {
+      agent: expert,
+      owner: { type: "expert-session", ownerId: "owner", contextId: "context" },
+      pragmaHome: root,
+      systemSessionId: "system-session",
+    });
+
+    try {
+      expect(session.info().runtime).toBe(runtime.descriptor);
+      expect(session.info().runtime.capabilities).toMatchObject({
+        targets: ["agent"],
+        executionLocations: ["local"],
+        supportsStreaming: true,
+        supportsMcp: false,
+      });
+      expect(Object.isFrozen(runtime.descriptor)).toBe(true);
+      expect(Object.isFrozen(runtime.features)).toBe(true);
+    } finally {
+      await session.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function event(
+  sequence: number,
+  type: RuntimeStreamEvent["type"],
+  payload: unknown,
+): RuntimeStreamEvent {
+  return ExpertAgentStreamEventSchema.parse({
+    schemaVersion: "pragma.stream/v1",
+    eventId: `event-${sequence}`,
+    sequence,
+    runId: "run-1",
+    emittedAt: new Date(sequence * 1_000).toISOString(),
+    source: { kind: "runtime", runId: "run-1", path: [] },
+    type,
+    payload,
+  });
+}

--- a/packages/core/test/runtime-probe-evidence.test.ts
+++ b/packages/core/test/runtime-probe-evidence.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createRuntimeProbeEvidence,
+  RuntimeProbeEvidenceSchema,
+  writeRuntimeProbeEvidence,
+} from "../src/runtime/probe-evidence.ts";
+import { PragmaPaths } from "../src/storage/pragma-paths.ts";
+
+describe("Runtime probe evidence", () => {
+  it("irreversibly redacts credentials and managed paths before validation", () => {
+    const evidence = createEvidence({
+      observations: [
+        "Bearer secret-token-value",
+        "workspace=/private/work/project home=/private/home cache=/private/cache/runtime",
+      ],
+      command: {
+        executable: "/private/home/bin/runtime",
+        arguments: ["--api-key", "secret-token-value"],
+      },
+    });
+    const serialized = JSON.stringify(evidence);
+    expect(serialized).not.toContain("secret-token-value");
+    expect(serialized).not.toContain("/private/work/project");
+    expect(serialized).not.toContain("/private/home");
+    expect(serialized).not.toContain("/private/cache/runtime");
+    expect(serialized).toContain("[redacted:sha256:");
+    expect(RuntimeProbeEvidenceSchema.parse(evidence)).toEqual(evidence);
+  });
+
+  it("writes validated evidence atomically below archives/runtime-probes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-probe-evidence-"));
+    const path = await writeRuntimeProbeEvidence(createEvidence(), {
+      paths: new PragmaPaths({ pragmaHome: root }),
+      fileName: "probe.json",
+    });
+    expect(path).toContain(join("archives", "runtime-probes"));
+    expect(RuntimeProbeEvidenceSchema.parse(JSON.parse(await readFile(path, "utf8")))).toBeTruthy();
+  });
+});
+
+function createEvidence(overrides: Partial<Parameters<typeof createRuntimeProbeEvidence>[0]> = {}) {
+  return createRuntimeProbeEvidence(
+    {
+      runtime: { id: "test-runtime", kind: "test", version: "1.0.0" },
+      probe: { id: "stream", version: "v1" },
+      environment: {
+        capturedAt: "2026-08-13T00:00:00.000Z",
+        platform: "test",
+        architecture: "test",
+      },
+      command: { executable: "runtime", arguments: ["probe"] },
+      assertions: [
+        {
+          id: "stream.executed",
+          feature: "textStreaming",
+          stage: "executed",
+          status: "passed",
+          message: "Observed ordered deltas.",
+        },
+      ],
+      observations: [],
+      ...overrides,
+    },
+    {
+      home: "/private/home",
+      workspace: "/private/work/project",
+      paths: ["/private/cache/runtime"],
+      secrets: ["secret-token-value"],
+    },
+  );
+}

--- a/packages/core/test/runtime-resource-scope.test.ts
+++ b/packages/core/test/runtime-resource-scope.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { RuntimeResourceScope } from "../src/runtime/resource-scope.ts";
+
+describe("RuntimeResourceScope", () => {
+  it("releases resources once in reverse acquisition order", async () => {
+    const order: string[] = [];
+    const scope = new RuntimeResourceScope("test");
+    await scope.acquire(
+      "first",
+      () => 1,
+      () => {
+        order.push("first");
+      },
+    );
+    scope.adopt("second", 2, () => {
+      order.push("second");
+    });
+    scope.transfer();
+
+    const firstDisposal = scope.dispose();
+    const secondDisposal = scope.dispose();
+    expect(firstDisposal).toBe(secondDisposal);
+    await firstDisposal;
+
+    expect(order).toEqual(["second", "first"]);
+    expect(scope.receipts()).toEqual([
+      { label: "first", order: 0, state: "disposed" },
+      { label: "second", order: 1, state: "disposed" },
+    ]);
+  });
+
+  it("continues cleanup and aggregates disposer failures", async () => {
+    const dispose = vi.fn();
+    const scope = new RuntimeResourceScope("failures");
+    scope.adopt("first", 1, () => {
+      dispose("first");
+      throw new Error("first failed");
+    });
+    scope.adopt("second", 2, () => {
+      dispose("second");
+      throw new Error("second failed");
+    });
+
+    await expect(scope.dispose()).rejects.toBeInstanceOf(AggregateError);
+    expect(dispose.mock.calls).toEqual([["second"], ["first"]]);
+  });
+
+  it("cleans an acquisition that resolves while the scope is closing", async () => {
+    const scope = new RuntimeResourceScope("acquisition-race");
+    const dispose = vi.fn();
+    let resolve!: (value: object) => void;
+    const pending = scope.acquire(
+      "late",
+      async () =>
+        await new Promise<object>((next) => {
+          resolve = next;
+        }),
+      dispose,
+    );
+
+    await scope.dispose();
+    resolve({});
+
+    await expect(pending).rejects.toThrow("is closing");
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/test/runtime-session-environment.test.ts
+++ b/packages/core/test/runtime-session-environment.test.ts
@@ -14,6 +14,7 @@ import {
   type ExpertAgentPluginManifest,
   type RuntimeDriverSessionContext,
 } from "../src/index.ts";
+import { createRuntimeTestFeatures } from "../src/testing/index.ts";
 import { openRuntimeSession } from "../src/runtime/session-factory.ts";
 
 const roots: string[] = [];
@@ -96,6 +97,7 @@ describe("Runtime Session process environment", () => {
     const agent = await expert(root, "failed-turn-session-id", "token");
     const nativeSessionId = "11111111-2222-4333-8444-555555555555";
     const runtime = defineRuntimeDriver<{ readonly sessionId: string }, Record<string, never>>({
+      features: createRuntimeTestFeatures(),
       descriptor: {
         id: "failed-turn-session-id-runtime",
         kind: "failed-turn-session-id-runtime",
@@ -153,6 +155,7 @@ describe("Runtime Session context window", () => {
       }),
     );
     const runtime = defineRuntimeDriver<never, Record<string, never>>({
+      features: createRuntimeTestFeatures({ enabled: ["contextWindow"] }),
       descriptor: { id: "context-test", kind: "context-test", displayName: "Context Test" },
       createSession: () => ({}),
       startTurn: async (_session, turn) => {
@@ -207,6 +210,10 @@ describe("Runtime Session context window", () => {
     );
     const canCompact = vi.fn(() => true);
     const runtime = defineRuntimeDriver<never, Record<string, never>>({
+      features: createRuntimeTestFeatures({
+        enabled: ["contextWindow", "compaction"],
+        compactionModes: ["manual"],
+      }),
       descriptor: { id: "context-test", kind: "context-test", displayName: "Context Test" },
       createSession: () => ({}),
       startTurn: async () => ({ outputText: "done" }),
@@ -264,6 +271,7 @@ async function expert(root: string, id: string, token: string) {
 function fakeRuntime(captured: Readonly<NodeJS.ProcessEnv>[]) {
   return defineRuntimeDriver<never, { readonly context: RuntimeDriverSessionContext }>(
     {
+      features: createRuntimeTestFeatures(),
       descriptor: { id: "environment-test", kind: "environment-test", displayName: "Test" },
       createSession(context) {
         captured.push(context.processEnvironment);

--- a/packages/core/test/runtime-startup-messages.test.ts
+++ b/packages/core/test/runtime-startup-messages.test.ts
@@ -20,6 +20,7 @@ import {
   type RuntimeDriverSessionContext,
   type RuntimeTurnContext,
 } from "../src/index.ts";
+import { createRuntimeTestFeatures } from "../src/testing/index.ts";
 import { openRuntimeSession } from "../src/runtime/session-factory.ts";
 
 const roots: string[] = [];
@@ -276,6 +277,16 @@ async function createFixture(inputModalities?: readonly string[], modelCatalogUn
     contextSystem,
   });
   const runtime = defineRuntimeDriver<TestNativeEvent, TestNativeSession>({
+    features: createRuntimeTestFeatures({
+      enabled: [
+        "contextWindow",
+        "compaction",
+        ...(modelCatalogUnavailable || inputModalities !== undefined
+          ? ["modelDiscovery" as const]
+          : []),
+      ],
+      compactionModes: ["manual", "events"],
+    }),
     descriptor: { id: "startup-runtime", kind: "startup-runtime", displayName: "Startup" },
     ...(modelCatalogUnavailable
       ? {

--- a/packages/interpreter/test/pragma-bundle.test.ts
+++ b/packages/interpreter/test/pragma-bundle.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { createStaticRuntimeResolver, type Expert } from "@pragma/core";
+import { createRuntimeTestFeatures } from "@pragma/core/testing";
 import { strToU8, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 
@@ -454,6 +455,7 @@ function runtimeResolver() {
     defaultRuntimeId: "codex",
     runtimes: [
       {
+        features: createRuntimeTestFeatures(),
         descriptor: { id: "codex", kind: "test", displayName: "Codex" },
         canUse: () => ({ usable: true }),
       },

--- a/packages/interpreter/test/pragma-dsl.test.ts
+++ b/packages/interpreter/test/pragma-dsl.test.ts
@@ -10,6 +10,7 @@ import {
   type ExpertTeam,
   type Flow,
 } from "@pragma/core";
+import { createRuntimeTestFeatures } from "@pragma/core/testing";
 import { PRAGMA_TEXT_LIMITS } from "@pragma/shared";
 
 import {
@@ -1873,6 +1874,7 @@ describe("Pragma YAML DSL", () => {
       defaultRuntimeId: "codex",
       runtimes: [
         {
+          features: createRuntimeTestFeatures(),
           descriptor: { id: "codex", kind: "test", displayName: "Codex" },
           canUse: () => ({ usable: false, reason: "codex executable is missing" }),
         },
@@ -1920,6 +1922,7 @@ describe("Pragma YAML DSL", () => {
         defaultRuntimeId: "pi",
         runtimes: [
           {
+            features: createRuntimeTestFeatures(),
             descriptor: { id: "pi", kind: "test", displayName: "Pi" },
             canUse: () => ({ usable: true }),
           },
@@ -1953,6 +1956,7 @@ describe("Pragma YAML DSL", () => {
           defaultRuntimeId: "codex",
           runtimes: [
             {
+              features: createRuntimeTestFeatures({ enabled: ["modelDiscovery"] }),
               descriptor: { id: "codex", kind: "test", displayName: "Codex" },
               canUse: () => ({ usable: true, details: { version } }),
               listModels: async () => [
@@ -2084,6 +2088,7 @@ describe("Pragma YAML DSL", () => {
           defaultRuntimeId: "other",
           runtimes: [
             {
+              features: createRuntimeTestFeatures(),
               descriptor: { id: "other", kind: "test", displayName: "Other" },
               canUse: () => ({ usable: true }),
             },

--- a/packages/runtime/antigravity/package.json
+++ b/packages/runtime/antigravity/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint src test",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
+    "test:core": "vitest run --passWithNoTests test/adapter-contract.test.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/runtime/antigravity/src/adapter.ts
+++ b/packages/runtime/antigravity/src/adapter.ts
@@ -2,12 +2,16 @@ import { join } from "node:path";
 
 import {
   createMcpToolRegistryPool,
+  defineRuntimeFeatures,
   defineRuntimeDriver,
   registerExpertToolsMcpSession,
+  readRuntimePreparedFeature,
+  runtimeFeature,
   type ExpertToolsMcpSessionRegistration,
   type ExpertToolRuntimeState,
   type McpToolRegistryLease,
   type RuntimeAdapter,
+  type RuntimeFeatureSessionPrepareContext,
   type RuntimeSessionPersistenceSpec,
 } from "@pragma/core";
 
@@ -42,18 +46,34 @@ const ANTIGRAVITY_DESCRIPTOR = {
   capabilities: {
     targets: ["agent"],
     executionLocations: ["local"],
-    supportsAbort: true,
-    supportsMcp: true,
-    supportsStreaming: true,
-    supportsContextCompactionEvents: true,
   },
 };
 
-interface AntigravityDriverSession extends AntigravityNativeSession {
+const ANTIGRAVITY_EVIDENCE_PENDING =
+  "Implemented in the adapter; an executed Runtime probe evidence bundle is not recorded yet.";
+
+interface AntigravityMcpPreparation {
   readonly mcpToolRegistryLease: McpToolRegistryLease;
   readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
+  readonly toolRuntimeState: ExpertToolRuntimeState;
+  readonly permissionMode: NonNullable<AntigravityRuntimeAdapterOptions["permissionMode"]>;
+  readonly sessionId: string;
+  readonly sessionDir: string;
+  readonly managedIdentity: ReturnType<typeof createManagedAntigravityIdentity>;
+  readonly authenticationMode: ReturnType<typeof resolveAntigravityAuthenticationMode>;
+  readonly customizationWorkspace?: string | undefined;
+  readonly managedConfigDir: string;
+}
+
+interface AntigravityPermissionPreparation {
   readonly hookRelay: AntigravityHookRelay;
 }
+
+interface AntigravitySkillsPreparation {
+  readonly managedHome: Awaited<ReturnType<typeof prepareManagedAntigravityHome>>;
+}
+
+type AntigravityDriverSession = AntigravityNativeSession;
 
 export function createAntigravityRuntime(
   options: AntigravityRuntimeAdapterOptions = {},
@@ -69,10 +89,168 @@ export function createAntigravityRuntime(
     },
   };
   const listModels = options.listModels ?? createAntigravityModelDiscovery(options);
+  const prepareMcp = async (
+    ctx: RuntimeFeatureSessionPrepareContext,
+  ): Promise<AntigravityMcpPreparation> => {
+    await assertAntigravityWorkspaceCustomizationsAreIsolated(ctx.workspace);
+    const permissionMode = options.permissionMode ?? "request-approval";
+    const sessionDir =
+      ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("antigravity");
+    const managedIdentity = createManagedAntigravityIdentity(ctx.agent.id, sessionDir);
+    const authenticationMode = resolveAntigravityAuthenticationMode(
+      options.authenticationMode ?? "isolated-environment",
+      ctx.processEnvironment,
+    );
+    const customizationWorkspace =
+      authenticationMode === "host-keyring"
+        ? join(sessionDir, "managed-customizations")
+        : undefined;
+    const managedConfigDir =
+      customizationWorkspace === undefined
+        ? join(sessionDir, "home", ".gemini", "config")
+        : join(customizationWorkspace, ".agents");
+    const restoredSessionId =
+      ctx.persistence.restoredRuntimeSessionId ?? ctx.request.runtimeSession?.id ?? "";
+    const sessionId =
+      restoredSessionId === "" ? "" : assertAntigravityConversationId(restoredSessionId);
+    const toolRuntimeState: ExpertToolRuntimeState = {};
+    const mcpToolRegistryLease = await ctx.resources.acquire(
+      "antigravity.mcp-registry",
+      async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
+      async (lease) => await lease.release(),
+    );
+    const expertToolsMcpRegistration = await ctx.resources.acquire(
+      "antigravity.mcp-registration",
+      async () =>
+        await registerExpertToolsMcpSession({
+          agent: ctx.agent,
+          getContext: () => ctx.lifecycle.currentContext,
+          humanInteractionHandler: ctx.request.humanInteractionHandler,
+          logger: ctx.logger,
+          mcpTools: mcpToolRegistryLease.registry.tools,
+          state: toolRuntimeState,
+          executionContext: ctx.request.executionContext,
+        }),
+      async (registration) => await registration.dispose(),
+    );
+    return {
+      mcpToolRegistryLease,
+      expertToolsMcpRegistration,
+      toolRuntimeState,
+      permissionMode,
+      sessionId,
+      sessionDir,
+      managedIdentity,
+      authenticationMode,
+      ...(customizationWorkspace === undefined ? {} : { customizationWorkspace }),
+      managedConfigDir,
+    };
+  };
+  const preparePermissions = async (
+    ctx: RuntimeFeatureSessionPrepareContext,
+  ): Promise<AntigravityPermissionPreparation> => {
+    const mcp = readRuntimePreparedFeature<AntigravityMcpPreparation>(ctx, "mcp");
+    const hookRelay = await ctx.resources.acquire(
+      "antigravity.permission-relay",
+      async () =>
+        await createAntigravityHookRelay({
+          workspace: ctx.workspace,
+          allowedWorkspacePaths: [
+            ctx.workspace,
+            ...(mcp.customizationWorkspace === undefined ? [] : [mcp.customizationWorkspace]),
+          ],
+          managedSkillReadRoots: [
+            join(
+              mcp.managedConfigDir,
+              "plugins",
+              `pragma-${mcp.managedIdentity.namespace}`,
+              "skills",
+            ),
+          ],
+          mcpServerName: mcp.managedIdentity.mcpServerName,
+          permissionMode: mcp.permissionMode,
+          getHumanInteractionHandler: () => ctx.request.humanInteractionHandler,
+          toolRuntimeState: mcp.toolRuntimeState,
+          onDecision(event) {
+            ctx.logger.debug(
+              "runtime.antigravity_hook_decision",
+              "Antigravity PreToolUse hook decision completed",
+              event,
+            );
+          },
+        }),
+      async (relay) => await relay.close(),
+    );
+    return { hookRelay };
+  };
+  const prepareSkills = async (
+    ctx: RuntimeFeatureSessionPrepareContext,
+  ): Promise<AntigravitySkillsPreparation> => {
+    const mcp = readRuntimePreparedFeature<AntigravityMcpPreparation>(ctx, "mcp");
+    const permissions = readRuntimePreparedFeature<AntigravityPermissionPreparation>(
+      ctx,
+      "permissions",
+    );
+    return {
+      managedHome: await prepareManagedAntigravityHome({
+        agent: ctx.agent,
+        sessionDir: mcp.sessionDir,
+        systemPrompt: ctx.agentContext.systemPrompt,
+        mcpServerUrl: mcp.expertToolsMcpRegistration.url,
+        hookRelay: permissions.hookRelay,
+        permissionMode: mcp.permissionMode,
+        authenticationMode: mcp.authenticationMode,
+        processEnvironment: ctx.processEnvironment,
+        nodeExecutablePath: options.hookNodeExecutablePath,
+      }),
+    };
+  };
+  const implemented = () => runtimeFeature.degraded(ANTIGRAVITY_EVIDENCE_PENDING);
+  const features = defineRuntimeFeatures({
+    availability: implemented(),
+    authentication: implemented(),
+    modelDiscovery: implemented(),
+    modelSelection: implemented(),
+    thinking: implemented(),
+    freshSession: implemented(),
+    resume: implemented(),
+    systemPrompt: implemented(),
+    startupMessages: implemented(),
+    textStreaming: implemented(),
+    reasoningStreaming: implemented(),
+    nativeToolLifecycle: implemented(),
+    mcp: runtimeFeature.degraded(ANTIGRAVITY_EVIDENCE_PENDING, {
+      prepareSession: prepareMcp,
+    }),
+    permissions: runtimeFeature.degraded(ANTIGRAVITY_EVIDENCE_PENDING, {
+      prepareSession: preparePermissions,
+    }),
+    userInteraction: implemented(),
+    skills: runtimeFeature.degraded(ANTIGRAVITY_EVIDENCE_PENDING, {
+      prepareSession: prepareSkills,
+    }),
+    attachmentImage: runtimeFeature.degraded(
+      "The CLI receives image paths through prompt context because agy has no stable native image flag.",
+    ),
+    attachmentFile: implemented(),
+    attachmentDirectory: implemented(),
+    usage: implemented(),
+    contextWindow: runtimeFeature.unsupported(
+      "agy does not expose a stable context-window inspection endpoint.",
+    ),
+    compaction: runtimeFeature.degraded(ANTIGRAVITY_EVIDENCE_PENDING, {
+      compactionModes: ["events"],
+    }),
+    cancellation: implemented(),
+    steering: runtimeFeature.unsupported("agy exposes no safe active-turn steering API."),
+    close: implemented(),
+    cleanup: implemented(),
+  });
 
   return defineRuntimeDriver(
     {
       descriptor,
+      features,
       canUse: options.canUse ?? (() => canUseAntigravityRuntime(options)),
       listModels,
       outputRetryLimit: options.outputRetryLimit,
@@ -93,7 +271,6 @@ export function createAntigravityRuntime(
         };
       },
       async createSession(ctx): Promise<AntigravityDriverSession> {
-        await assertAntigravityWorkspaceCustomizationsAreIsolated(ctx.workspace);
         assertProvider(ctx.request.modelSelection?.model.providerId);
         const defaultModelName =
           ctx.request.modelSelection?.model.modelId ?? options.defaultModelName;
@@ -106,125 +283,39 @@ export function createAntigravityRuntime(
             defaultThinkingLevel,
           );
         }
-        const permissionMode = options.permissionMode ?? "request-approval";
-        const sessionDir =
-          ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("antigravity");
-        const managedIdentity = createManagedAntigravityIdentity(ctx.agent.id, sessionDir);
-        const authenticationMode = resolveAntigravityAuthenticationMode(
-          options.authenticationMode ?? "isolated-environment",
-          ctx.processEnvironment,
+        const mcp = readRuntimePreparedFeature<AntigravityMcpPreparation>(ctx, "mcp");
+        const skills = readRuntimePreparedFeature<AntigravitySkillsPreparation>(ctx, "skills");
+        const { managedHome } = skills;
+        ctx.logger.info(
+          "runtime.antigravity_session_ready",
+          "Antigravity CLI Session preparation completed",
+          {
+            restoring: mcp.sessionId !== "",
+            systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+            skillCount: managedHome.skills.length,
+            toolCount: mcp.mcpToolRegistryLease.registry.tools.length,
+            authenticationMode: managedHome.authenticationMode,
+            mcpOpenedConnections: mcp.mcpToolRegistryLease.stats.openedConnections,
+            mcpReusedConnections: mcp.mcpToolRegistryLease.stats.reusedConnections,
+            mcpCoalescedConnections: mcp.mcpToolRegistryLease.stats.coalescedConnections,
+          },
         );
-        const customizationWorkspace =
-          authenticationMode === "host-keyring"
-            ? join(sessionDir, "managed-customizations")
-            : undefined;
-        const managedConfigDir =
-          customizationWorkspace === undefined
-            ? join(sessionDir, "home", ".gemini", "config")
-            : join(customizationWorkspace, ".agents");
-        const restoredSessionId =
-          ctx.persistence.restoredRuntimeSessionId ?? ctx.request.runtimeSession?.id ?? "";
-        const sessionId =
-          restoredSessionId === "" ? "" : assertAntigravityConversationId(restoredSessionId);
-        const toolRuntimeState: ExpertToolRuntimeState = {};
-        let mcpToolRegistryLease: McpToolRegistryLease | undefined;
-        let expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined;
-        let hookRelay: AntigravityHookRelay | undefined;
-
-        try {
-          mcpToolRegistryLease = await mcpToolRegistries.acquire(ctx.agent.mcp);
-          expertToolsMcpRegistration = await registerExpertToolsMcpSession({
-            agent: ctx.agent,
-            getContext: () => ctx.lifecycle.currentContext,
-            humanInteractionHandler: ctx.request.humanInteractionHandler,
-            logger: ctx.logger,
-            mcpTools: mcpToolRegistryLease.registry.tools,
-            state: toolRuntimeState,
-            executionContext: ctx.request.executionContext,
-          });
-          hookRelay = await createAntigravityHookRelay({
-            workspace: ctx.workspace,
-            allowedWorkspacePaths: [
-              ctx.workspace,
-              ...(customizationWorkspace === undefined ? [] : [customizationWorkspace]),
-            ],
-            managedSkillReadRoots: [
-              join(managedConfigDir, "plugins", `pragma-${managedIdentity.namespace}`, "skills"),
-            ],
-            mcpServerName: managedIdentity.mcpServerName,
-            permissionMode,
-            getHumanInteractionHandler: () => ctx.request.humanInteractionHandler,
-            toolRuntimeState,
-            onDecision(event) {
-              ctx.logger.debug(
-                "runtime.antigravity_hook_decision",
-                "Antigravity PreToolUse hook decision completed",
-                event,
-              );
-            },
-          });
-          const managedHome = await prepareManagedAntigravityHome({
-            agent: ctx.agent,
-            sessionDir,
-            systemPrompt: ctx.agentContext.systemPrompt,
-            mcpServerUrl: expertToolsMcpRegistration.url,
-            hookRelay,
-            permissionMode,
-            authenticationMode,
-            processEnvironment: ctx.processEnvironment,
-            nodeExecutablePath: options.hookNodeExecutablePath,
-          });
-          ctx.logger.info(
-            "runtime.antigravity_session_ready",
-            "Antigravity CLI Session preparation completed",
-            {
-              restoring: sessionId !== "",
-              systemPromptCharacters: ctx.agentContext.systemPrompt.length,
-              skillCount: managedHome.skills.length,
-              toolCount: mcpToolRegistryLease.registry.tools.length,
-              authenticationMode: managedHome.authenticationMode,
-              mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
-              mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
-              mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
-            },
-          );
-          return {
-            ...createAntigravityNativeSession({
-              agent: ctx.agent,
-              executablePath: resolveAntigravityExecutablePath(options),
-              env: managedHome.env,
-              logger: ctx.logger,
-              managedHome,
-              permissionMode,
-              defaultModelName,
-              defaultThinkingLevel,
-              spawn: options.spawn,
-              systemPrompt: ctx.agentContext.systemPrompt,
-              toolRuntimeState,
-              tokenCounter: options.tokenCounter,
-              startupMessages: sessionId === "" ? ctx.agentContext.startupMessages : [],
-              sessionId,
-            }),
-            mcpToolRegistryLease,
-            expertToolsMcpRegistration,
-            hookRelay,
-          };
-        } catch (error) {
-          try {
-            await disposeAntigravityResources(
-              expertToolsMcpRegistration,
-              mcpToolRegistryLease,
-              hookRelay,
-            );
-          } catch (cleanupError) {
-            throw new AggregateError(
-              [error, cleanupError],
-              "Antigravity CLI Runtime initialization and cleanup failed.",
-              { cause: cleanupError },
-            );
-          }
-          throw error;
-        }
+        return createAntigravityNativeSession({
+          agent: ctx.agent,
+          executablePath: resolveAntigravityExecutablePath(options),
+          env: managedHome.env,
+          logger: ctx.logger,
+          managedHome,
+          permissionMode: mcp.permissionMode,
+          defaultModelName,
+          defaultThinkingLevel,
+          spawn: options.spawn,
+          systemPrompt: ctx.agentContext.systemPrompt,
+          toolRuntimeState: mcp.toolRuntimeState,
+          tokenCounter: options.tokenCounter,
+          startupMessages: mcp.sessionId === "" ? ctx.agentContext.startupMessages : [],
+          sessionId: mcp.sessionId,
+        });
       },
       readSession(session) {
         return {
@@ -249,24 +340,7 @@ export function createAntigravityRuntime(
       },
       cancelTurn: cancelAntigravityTurn,
       async closeSession(session) {
-        const errors: unknown[] = [];
-        try {
-          await closeAntigravitySession(session);
-        } catch (error) {
-          errors.push(error);
-        }
-        try {
-          await disposeAntigravityResources(
-            session.expertToolsMcpRegistration,
-            session.mcpToolRegistryLease,
-            session.hookRelay,
-          );
-        } catch (error) {
-          errors.push(error);
-        }
-        if (errors.length > 0) {
-          throw new AggregateError(errors, "Antigravity CLI Runtime cleanup failed.");
-        }
+        await closeAntigravitySession(session);
       },
     },
     {
@@ -285,30 +359,5 @@ function assertProvider(providerId: string | undefined): void {
     throw new Error(
       `Antigravity CLI Runtime requires provider antigravity; received ${providerId}.`,
     );
-  }
-}
-
-async function disposeAntigravityResources(
-  registration: ExpertToolsMcpSessionRegistration | undefined,
-  lease: McpToolRegistryLease | undefined,
-  hookRelay: AntigravityHookRelay | undefined,
-): Promise<void> {
-  const errors: unknown[] = [];
-  try {
-    await registration?.dispose();
-  } catch (error) {
-    errors.push(error);
-  }
-  const results = await Promise.allSettled([
-    Promise.resolve().then(async () => await lease?.release()),
-    Promise.resolve().then(async () => await hookRelay?.close()),
-  ]);
-  errors.push(
-    ...results.flatMap((result) =>
-      result.status === "rejected" ? [result.reason as unknown] : [],
-    ),
-  );
-  if (errors.length > 0) {
-    throw new AggregateError(errors, "Antigravity CLI Runtime resources could not be released.");
   }
 }

--- a/packages/runtime/antigravity/src/session.ts
+++ b/packages/runtime/antigravity/src/session.ts
@@ -6,11 +6,14 @@ import { StringDecoder } from "node:string_decoder";
 
 import type { AgentAssistantMessage, AgentMessage, AgentMessageUsage } from "@pragma/shared";
 import {
+  BoundedRuntimeOutputBuffer,
   createUsageFromTokenCounts,
   defaultRuntimeTokenCounter,
   hasNonZeroUsage,
   readFirstTokenCount,
   RUNTIME_CONTEXT_COMPACTION_STAGES,
+  RuntimeProcessSupervisor,
+  terminateRuntimeProcess,
   type Expert,
   type ExpertAgentStartupMessage,
   type ExpertToolRuntimeState,
@@ -498,20 +501,14 @@ async function runAntigravityProcess(options: {
     cwd: options.cwd,
     env: options.env,
   });
-  let exited = false;
-  const exitPromise = new Promise<ProcessExit>((resolveExit, reject) => {
-    child.once("error", reject);
-    child.once("exit", (code, signal) => {
-      exited = true;
-      resolveExit({ code, signal });
-    });
-  });
-  options.onProcessStarted(child, exitPromise, () => exited);
+  const supervisor = new RuntimeProcessSupervisor(child);
+  const exitPromise = supervisor.exit;
+  options.onProcessStarted(child, exitPromise, supervisor.hasExited);
   child.stdin.end();
-  let stderrTail = "";
+  const stderrTail = new BoundedRuntimeOutputBuffer(STDERR_TAIL_LIMIT);
   child.stderr.setEncoding("utf8");
   child.stderr.on("data", (chunk: string) => {
-    stderrTail = `${stderrTail}${chunk}`.slice(-STDERR_TAIL_LIMIT);
+    stderrTail.append(chunk);
     options.logger.debug("runtime.antigravity_stderr", "Antigravity CLI emitted stderr", {
       characters: chunk.length,
     });
@@ -531,7 +528,7 @@ async function runAntigravityProcess(options: {
     void terminateAntigravityProcess({
       process: child,
       exitPromise,
-      hasExited: () => exited,
+      hasExited: supervisor.hasExited,
       logger: options.logger,
     });
   };
@@ -562,21 +559,21 @@ async function runAntigravityProcess(options: {
     if (options.signal.aborted) throw createAbortError();
     if (streamError !== undefined) throw streamError;
     if (state.resultError !== undefined) {
-      throw classifyAntigravityError(state.resultError, stderrTail, logTail);
+      throw classifyAntigravityError(state.resultError, stderrTail.text(), logTail);
     }
     if (exit.code !== 0) {
       throw classifyAntigravityError(
         `Antigravity CLI exited with code ${exit.code ?? "null"}${
           exit.signal === null ? "" : ` and signal ${exit.signal}`
         }.`,
-        stderrTail,
+        stderrTail.text(),
         logTail,
       );
     }
     if (!state.terminalSeen) {
       const degradedError = readDegradedAntigravityError(state.outputText, logTail);
       if (degradedError !== undefined) {
-        throw classifyAntigravityError(degradedError, stderrTail, logTail);
+        throw classifyAntigravityError(degradedError, stderrTail.text(), logTail);
       }
     }
 
@@ -1525,42 +1522,24 @@ async function terminateAntigravityProcess(options: {
   readonly hasExited: () => boolean;
   readonly logger: PragmaLogger;
 }): Promise<void> {
-  if (options.hasExited()) return;
-  options.process.stdin.end();
-  options.process.kill("SIGTERM");
-  const exited = await waitForAntigravityExit(options.exitPromise, PROCESS_TERMINATION_GRACE_MS);
-  if (!exited && !options.hasExited()) {
-    options.logger.warn(
-      "runtime.antigravity_force_kill",
-      "Antigravity CLI did not stop after SIGTERM; sending SIGKILL",
-    );
-    options.process.kill("SIGKILL");
-    const killed = await waitForAntigravityExit(options.exitPromise, PROCESS_TERMINATION_GRACE_MS);
-    if (!killed && !options.hasExited()) {
+  await terminateRuntimeProcess({
+    process: options.process,
+    exit: options.exitPromise,
+    hasExited: options.hasExited,
+    graceMs: PROCESS_TERMINATION_GRACE_MS,
+    onForceKill: () => {
+      options.logger.warn(
+        "runtime.antigravity_force_kill",
+        "Antigravity CLI did not stop after SIGTERM; sending SIGKILL",
+      );
+    },
+    onStuck: () => {
       options.logger.error(
         "runtime.antigravity_process_did_not_exit",
         "Antigravity CLI did not report exit after SIGKILL; continuing bounded Session cleanup",
         new Error("Antigravity CLI remained alive after SIGKILL."),
       );
-    }
-  }
-}
-
-async function waitForAntigravityExit(
-  exitPromise: Promise<ProcessExit>,
-  timeoutMs: number,
-): Promise<boolean> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  return await Promise.race([
-    exitPromise.then(
-      () => true,
-      () => true,
-    ),
-    new Promise<false>((resolveTimeout) => {
-      timeout = setTimeout(() => resolveTimeout(false), timeoutMs);
-    }),
-  ]).finally(() => {
-    if (timeout !== undefined) clearTimeout(timeout);
+    },
   });
 }
 

--- a/packages/runtime/antigravity/src/types.ts
+++ b/packages/runtime/antigravity/src/types.ts
@@ -1,6 +1,6 @@
 import type {
   McpToolRegistryPool,
-  RuntimeAdapterDescriptor,
+  RuntimeDriverDescriptorOverride,
   RuntimeCanUseResult,
   RuntimeCommandSpawn,
   RuntimeModel,
@@ -16,7 +16,7 @@ export type AntigravityAuthenticationMode = "auto" | "isolated-environment" | "h
 export type AntigravityRuntimeSpawn = RuntimeCommandSpawn;
 
 export interface AntigravityRuntimeAdapterOptions {
-  readonly descriptor?: Partial<RuntimeAdapterDescriptor> | undefined;
+  readonly descriptor?: RuntimeDriverDescriptorOverride | undefined;
   readonly executablePath?: string | undefined;
   readonly env?: NodeJS.ProcessEnv | undefined;
   readonly defaultModelName?: string | undefined;

--- a/packages/runtime/antigravity/test/adapter-contract.test.ts
+++ b/packages/runtime/antigravity/test/adapter-contract.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { describeRuntimeConformance } from "@pragma/core/testing/vitest";
 
 import { createAntigravityRuntime } from "../src/index.ts";
+
+describeRuntimeConformance("Antigravity", { createRuntime: createAntigravityRuntime });
 
 describe("Antigravity Runtime contract", () => {
   it("declares local agent, streaming, MCP, model, effort, resume, and lifecycle capabilities", () => {
@@ -8,7 +11,6 @@ describe("Antigravity Runtime contract", () => {
       listModels: async () => [],
       canUse: () => ({ usable: true }),
     });
-
     expect(runtime.descriptor).toMatchObject({
       id: "antigravity",
       kind: "antigravity-local",

--- a/packages/runtime/antigravity/test/adapter-lifecycle.test.ts
+++ b/packages/runtime/antigravity/test/adapter-lifecycle.test.ts
@@ -12,6 +12,7 @@ import type {
   RuntimeDriverSessionContext,
   RuntimeSessionReadContext,
 } from "@pragma/core";
+import { RuntimeResourceScope } from "@pragma/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createAntigravityRuntime } from "../src/adapter.ts";
@@ -92,7 +93,8 @@ describe("Antigravity Runtime adapter lifecycle", () => {
       runContext: {},
     } satisfies RuntimeSessionReadContext;
 
-    const fresh = await driver.createSession(createSessionContext(sessionDir));
+    const freshPrepared = await createPreparedSession(driver, createSessionContext(sessionDir));
+    const fresh = freshPrepared.session;
     expect(fresh.sessionId).toBe("");
     expect(fresh.pendingStartupMessages).toEqual([{ role: "user", content: "always-on context" }]);
     expect(driver.consumeStartupMessages?.(fresh, readContext)).toEqual([
@@ -106,15 +108,17 @@ describe("Antigravity Runtime adapter lifecycle", () => {
     await expect(
       readFile(join(fresh.managedHome.pluginDir, "mcp_config.json"), "utf8"),
     ).resolves.toContain("http://127.0.0.1:43127/private/mcp");
-    await driver.closeSession?.(fresh, closeContext());
+    await closePreparedSession(driver, freshPrepared);
 
-    const restored = await driver.createSession(
+    const restoredPrepared = await createPreparedSession(
+      driver,
       createSessionContext(sessionDir, restoredConversationId),
     );
+    const restored = restoredPrepared.session;
     expect(restored.sessionId).toBe(restoredConversationId);
     expect(restored.pendingStartupMessages).toEqual([]);
     expect(driver.consumeStartupMessages?.(restored, readContext)).toEqual([]);
-    await driver.closeSession?.(restored, closeContext());
+    await closePreparedSession(driver, restoredPrepared);
 
     expect(mcpToolRegistryPool.acquire).toHaveBeenCalledTimes(2);
     expect(runtimeMocks.registerExpertToolsMcpSession).toHaveBeenCalledTimes(2);
@@ -154,17 +158,15 @@ describe("Antigravity Runtime adapter lifecycle", () => {
       mcpToolRegistryPool,
     });
     const driver = runtimeMocks.driver as RuntimeDriver<unknown, AntigravityNativeSession>;
-    const session = await driver.createSession(createSessionContext(sessionDir));
-    const mutableSession = session as unknown as {
+    const prepared = await createPreparedSession(driver, createSessionContext(sessionDir));
+    const permissionPreparation = prepared.preparedFeatures["permissions"] as {
       hookRelay: { close: () => Promise<void> };
     };
-    const originalCloseRelay = mutableSession.hookRelay.close;
+    const originalCloseRelay = permissionPreparation.hookRelay.close;
     const closeRelay = vi.fn(async () => await originalCloseRelay());
-    mutableSession.hookRelay.close = closeRelay;
+    permissionPreparation.hookRelay.close = closeRelay;
 
-    await expect(driver.closeSession?.(session, closeContext())).rejects.toBeInstanceOf(
-      AggregateError,
-    );
+    await expect(closePreparedSession(driver, prepared)).rejects.toBeInstanceOf(AggregateError);
     expect(dispose).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledTimes(1);
     expect(closeRelay).toHaveBeenCalledTimes(1);
@@ -188,7 +190,8 @@ describe("Antigravity Runtime adapter lifecycle", () => {
       },
     });
     const driver = runtimeMocks.driver as RuntimeDriver<unknown, AntigravityNativeSession>;
-    const session = await driver.createSession(createSessionContext(sessionDir));
+    const prepared = await createPreparedSession(driver, createSessionContext(sessionDir));
+    const session = prepared.session;
     const dispose = runtimeMocks.registrationDisposals.at(-1)!;
     let resolveRegistrationDispose!: () => void;
     dispose.mockImplementationOnce(
@@ -197,12 +200,12 @@ describe("Antigravity Runtime adapter lifecycle", () => {
           resolveRegistrationDispose = resolve;
         }),
     );
-    const sessionResources = session as typeof session & {
+    const permissionPreparation = prepared.preparedFeatures["permissions"] as {
       hookRelay: { close: () => Promise<void> };
     };
-    const originalCloseRelay = sessionResources.hookRelay.close;
+    const originalCloseRelay = permissionPreparation.hookRelay.close;
     const closeRelay = vi.fn(async () => await originalCloseRelay());
-    sessionResources.hookRelay.close = closeRelay;
+    permissionPreparation.hookRelay.close = closeRelay;
 
     let exited = false;
     let resolveExit!: (value: { code: number; signal: null }) => void;
@@ -218,7 +221,7 @@ describe("Antigravity Runtime adapter lifecycle", () => {
     });
     session.activeHasExited = () => exited;
 
-    const closing = driver.closeSession!(session, closeContext());
+    const closing = closePreparedSession(driver, prepared);
     await new Promise((resolve) => setImmediate(resolve));
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     expect(dispose).not.toHaveBeenCalled();
@@ -230,7 +233,7 @@ describe("Antigravity Runtime adapter lifecycle", () => {
     await new Promise((resolve) => setImmediate(resolve));
     expect(dispose).toHaveBeenCalledOnce();
     expect(release).not.toHaveBeenCalled();
-    expect(closeRelay).not.toHaveBeenCalled();
+    expect(closeRelay).toHaveBeenCalledOnce();
 
     resolveRegistrationDispose();
     await closing;
@@ -251,9 +254,11 @@ describe("Antigravity Runtime adapter lifecycle", () => {
       authenticationMode: "host-keyring",
     });
     const driver = runtimeMocks.driver as RuntimeDriver<unknown, AntigravityNativeSession>;
-    const session = await driver.createSession(
+    const prepared = await createPreparedSession(
+      driver,
       createSessionContext(sessionDir, undefined, "/workspace/project", { HOME: hostHome }),
     );
+    const session = prepared.session;
 
     expect(session.env["HOME"]).toBe(hostHome);
     expect(session.managedHome.authenticationMode).toBe("host-keyring");
@@ -266,7 +271,7 @@ describe("Antigravity Runtime adapter lifecycle", () => {
         "utf8",
       ),
     ).resolves.toContain("system prompt");
-    await driver.closeSession?.(session, closeContext());
+    await closePreparedSession(driver, prepared);
   });
 
   it("rejects workspace customizations before allocating MCP or spawning agy", async () => {
@@ -287,7 +292,7 @@ describe("Antigravity Runtime adapter lifecycle", () => {
     const driver = runtimeMocks.driver as RuntimeDriver<unknown, AntigravityNativeSession>;
 
     await expect(
-      driver.createSession(createSessionContext(sessionDir, undefined, workspace)),
+      createPreparedSession(driver, createSessionContext(sessionDir, undefined, workspace)),
     ).rejects.toThrow(/workspace customization root/i);
     expect(mcpToolRegistryPool.acquire).not.toHaveBeenCalled();
   });
@@ -345,9 +350,77 @@ function createSessionContext(
       restoredRuntimeSessionId,
       checkpoint: vi.fn(async () => undefined),
     },
-    prepared: {},
+    resources: new RuntimeResourceScope("antigravity-adapter-test-placeholder"),
+    preparedFeatures: {},
     sessionInfo: {},
   } as unknown as RuntimeDriverSessionContext;
+}
+
+interface PreparedSession<TSession> {
+  readonly session: TSession;
+  readonly resources: RuntimeResourceScope;
+  readonly preparedFeatures: Readonly<Record<string, unknown>>;
+}
+
+async function createPreparedSession<TSession>(
+  driver: RuntimeDriver<unknown, TSession>,
+  baseContext: RuntimeDriverSessionContext,
+): Promise<PreparedSession<TSession>> {
+  const resources = new RuntimeResourceScope("antigravity-adapter-test");
+  const preparedFeatures: Record<string, unknown> = {};
+  try {
+    for (const featureName of ["mcp", "permissions", "skills"] as const) {
+      const prepare = driver.features[featureName].prepareSession;
+      if (prepare === undefined) continue;
+      const value = await prepare({
+        ...baseContext,
+        resources,
+        preparedFeatures: Object.freeze({ ...preparedFeatures }),
+      });
+      if (value !== undefined) preparedFeatures[featureName] = value;
+    }
+    const session = await driver.createSession({
+      ...baseContext,
+      resources,
+      preparedFeatures: Object.freeze({ ...preparedFeatures }),
+    });
+    resources.transfer();
+    return {
+      session,
+      resources,
+      preparedFeatures: Object.freeze({ ...preparedFeatures }),
+    };
+  } catch (error) {
+    try {
+      await resources.dispose();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "Antigravity test Session preparation and cleanup failed.",
+        { cause: cleanupError },
+      );
+    }
+    throw error;
+  }
+}
+
+async function closePreparedSession<TSession>(
+  driver: RuntimeDriver<unknown, TSession>,
+  prepared: PreparedSession<TSession>,
+): Promise<void> {
+  const errors: unknown[] = [];
+  await Promise.resolve(driver.closeSession?.(prepared.session, closeContext())).catch(
+    (error: unknown) => {
+      errors.push(error);
+    },
+  );
+  await prepared.resources.dispose().catch((error: unknown) => {
+    errors.push(error);
+  });
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Antigravity test Session cleanup failed.");
+  }
 }
 
 function closeContext() {

--- a/packages/runtime/antigravity/test/session.test.ts
+++ b/packages/runtime/antigravity/test/session.test.ts
@@ -1239,6 +1239,7 @@ function createTurn(
     prompt: "rendered user request",
     attachments: [],
     startupMessages: options.startupMessages ?? [],
+    preparedFeatures: {},
     signal: options.signal ?? new AbortController().signal,
     source: { kind: "runtime", runId: "run-1", path: [] },
     stream: {

--- a/packages/runtime/claude-code/package.json
+++ b/packages/runtime/claude-code/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint src test",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
+    "test:core": "vitest run --passWithNoTests test/adapter-contract.test.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/runtime/claude-code/src/adapter.ts
+++ b/packages/runtime/claude-code/src/adapter.ts
@@ -10,9 +10,10 @@ import type {
 } from "@pragma/core";
 import {
   createMcpToolRegistryPool,
+  defineRuntimeFeatures,
   defineRuntimeDriver,
+  runtimeFeature,
   registerExpertToolsMcpSession,
-  type PragmaLogger,
   type RuntimeSessionPersistenceSpec,
   type ExpertToolRuntimeState,
 } from "@pragma/core";
@@ -44,18 +45,14 @@ const CLAUDE_CODE_LOCAL_RUNTIME_DESCRIPTOR = {
   capabilities: {
     targets: ["agent"],
     executionLocations: ["local"],
-    supportsAbort: true,
-    supportsMcp: true,
-    supportsStreaming: true,
-    supportsContextCompactionEvents: true,
   },
 };
+
+const CLAUDE_CODE_EVIDENCE_PENDING =
+  "Implemented in the adapter; an executed Runtime probe evidence bundle is not recorded yet.";
 const DEFAULT_CLAUDE_CODE_PERMISSION_MODE = "bypassPermissions" as const;
 
-interface ClaudeCodeDriverSession extends ClaudeCodeNativeSession {
-  readonly mcpToolRegistryLease: McpToolRegistryLease;
-  readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
-}
+type ClaudeCodeDriverSession = ClaudeCodeNativeSession;
 
 export function createClaudeCodeRuntime(
   options: ClaudeCodeRuntimeAdapterOptions = {},
@@ -78,10 +75,44 @@ export function createClaudeCodeRuntime(
     },
   };
   const listModels = options.listModels ?? createClaudeCodeModelDiscovery(options);
+  const implemented = () => runtimeFeature.degraded(CLAUDE_CODE_EVIDENCE_PENDING);
+  const features = defineRuntimeFeatures({
+    availability: implemented(),
+    authentication: implemented(),
+    modelDiscovery: implemented(),
+    modelSelection: implemented(),
+    thinking: implemented(),
+    freshSession: implemented(),
+    resume: implemented(),
+    systemPrompt: implemented(),
+    startupMessages: implemented(),
+    textStreaming: implemented(),
+    reasoningStreaming: implemented(),
+    nativeToolLifecycle: implemented(),
+    mcp: implemented(),
+    permissions: implemented(),
+    userInteraction: implemented(),
+    skills: implemented(),
+    attachmentImage: implemented(),
+    attachmentFile: implemented(),
+    attachmentDirectory: implemented(),
+    usage: implemented(),
+    contextWindow: implemented(),
+    compaction: runtimeFeature.degraded(CLAUDE_CODE_EVIDENCE_PENDING, {
+      compactionModes: ["manual", "events"],
+    }),
+    cancellation: implemented(),
+    steering: runtimeFeature.unsupported(
+      "Claude Code stream-json mode exposes no safe active-turn steering API.",
+    ),
+    close: implemented(),
+    cleanup: implemented(),
+  });
 
   return defineRuntimeDriver(
     {
       descriptor,
+      features,
       canUse: createClaudeCodeRuntimeCanUse(options),
       listModels,
       outputRetryLimit: options.outputRetryLimit,
@@ -127,106 +158,89 @@ export function createClaudeCodeRuntime(
             ctx.persistence.restoredRuntimeSessionId ?? ctx.request.runtimeSession?.id ?? "",
         };
         const toolRuntimeState: ExpertToolRuntimeState = {};
-        const compactionHookRelay = await createClaudeCompactionHookRelay();
-        let mcpToolRegistry: McpToolRegistry | undefined;
-        let mcpToolRegistryLease: McpToolRegistryLease | undefined;
-        let expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined;
+        const compactionHookRelay = await ctx.resources.acquire(
+          "claude-code.compaction-relay",
+          createClaudeCompactionHookRelay,
+          async (relay) => await relay.close(),
+        );
 
-        try {
-          const pluginDir = await materializeClaudeCodePlugin({
-            agent: ctx.agent,
-            sessionDir,
-            compactionHook: {
-              url: compactionHookRelay.url,
-              authorization: compactionHookRelay.authorization,
-            },
-          });
-          mcpToolRegistryLease = await mcpToolRegistries.acquire(ctx.agent.mcp);
-          mcpToolRegistry = mcpToolRegistryLease.registry;
-          expertToolsMcpRegistration = await registerExpertToolsMcpSession({
-            agent: ctx.agent,
-            getContext: () => ctx.lifecycle.currentContext,
-            humanInteractionHandler: ctx.request.humanInteractionHandler,
-            logger: ctx.logger,
-            mcpTools: mcpToolRegistry.tools,
-            state: toolRuntimeState,
-            executionContext: ctx.request.executionContext,
-          });
-          const managedConfig = await prepareManagedClaudeCodeConfig({
-            sessionDir,
-            env: ctx.processEnvironment,
-            logger: ctx.logger,
-          });
-          if (state.sessionId !== "") {
-            const exists = await nativeSessionFileExists(
-              join(managedConfig.configDir, "projects"),
-              state.sessionId,
-            );
-            if (!exists) {
-              throw new Error(
-                `Claude Code runtime session file was not found: ${state.sessionId}.`,
-              );
-            }
-          }
-          ctx.logger.info(
-            "runtime.claude_code_session_ready",
-            "Claude Code Session preparation completed",
-            {
-              systemPromptCharacters: ctx.agentContext.systemPrompt.length,
-              toolCount: mcpToolRegistry.tools.length,
-              mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
-              mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
-              mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
-            },
+        const pluginDir = await materializeClaudeCodePlugin({
+          agent: ctx.agent,
+          sessionDir,
+          compactionHook: {
+            url: compactionHookRelay.url,
+            authorization: compactionHookRelay.authorization,
+          },
+        });
+        const mcpToolRegistryLease: McpToolRegistryLease = await ctx.resources.acquire(
+          "claude-code.mcp-registry",
+          async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
+          async (lease) => await lease.release(),
+        );
+        const mcpToolRegistry: McpToolRegistry = mcpToolRegistryLease.registry;
+        const expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration =
+          await ctx.resources.acquire(
+            "claude-code.mcp-registration",
+            async () =>
+              await registerExpertToolsMcpSession({
+                agent: ctx.agent,
+                getContext: () => ctx.lifecycle.currentContext,
+                humanInteractionHandler: ctx.request.humanInteractionHandler,
+                logger: ctx.logger,
+                mcpTools: mcpToolRegistry.tools,
+                state: toolRuntimeState,
+                executionContext: ctx.request.executionContext,
+              }),
+            async (registration) => await registration.dispose(),
           );
-
-          return {
-            ...createClaudeCodeNativeSession({
-              agent: ctx.agent,
-              executablePath: command.executablePath,
-              launcherArgs: command.launcherArgs,
-              additionalArgs: options.additionalArgs ?? [],
-              defaultModelName,
-              defaultThinkingLevel,
-              env: ctx.processEnvironment,
-              humanInteractionHandler: ctx.request.humanInteractionHandler,
-              logger: ctx.logger,
-              managedConfig,
-              mcpServerUrl: expertToolsMcpRegistration.url,
-              permissionMode: options.permissionMode ?? DEFAULT_CLAUDE_CODE_PERMISSION_MODE,
-              pluginDir,
-              compactionHookRelay,
-              sessionDir,
-              spawn: options.spawn,
-              startupMessages: state.sessionId === "" ? ctx.agentContext.startupMessages : [],
-              state,
-              systemPrompt: ctx.agentContext.systemPrompt,
-              tokenCounter: options.tokenCounter,
-            }),
-            mcpToolRegistryLease,
-            expertToolsMcpRegistration,
-          };
-        } catch (error) {
-          const cleanup = await Promise.allSettled([
-            disposeClaudeRuntimeResources(
-              expertToolsMcpRegistration,
-              mcpToolRegistryLease,
-              ctx.logger,
-            ),
-            compactionHookRelay.close(),
-          ]);
-          const cleanupErrors = cleanup.flatMap((result) =>
-            result.status === "rejected" ? [result.reason as unknown] : [],
+        const managedConfig = await prepareManagedClaudeCodeConfig({
+          sessionDir,
+          env: ctx.processEnvironment,
+          logger: ctx.logger,
+        });
+        if (state.sessionId !== "") {
+          const exists = await nativeSessionFileExists(
+            join(managedConfig.configDir, "projects"),
+            state.sessionId,
           );
-          if (cleanupErrors.length > 0) {
-            throw new AggregateError(
-              [error, ...cleanupErrors],
-              "Claude Code runtime initialization and cleanup failed.",
-              { cause: error },
-            );
+          if (!exists) {
+            throw new Error(`Claude Code runtime session file was not found: ${state.sessionId}.`);
           }
-          throw error;
         }
+        ctx.logger.info(
+          "runtime.claude_code_session_ready",
+          "Claude Code Session preparation completed",
+          {
+            systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+            toolCount: mcpToolRegistry.tools.length,
+            mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
+            mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
+            mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
+          },
+        );
+
+        return createClaudeCodeNativeSession({
+          agent: ctx.agent,
+          executablePath: command.executablePath,
+          launcherArgs: command.launcherArgs,
+          additionalArgs: options.additionalArgs ?? [],
+          defaultModelName,
+          defaultThinkingLevel,
+          env: ctx.processEnvironment,
+          humanInteractionHandler: ctx.request.humanInteractionHandler,
+          logger: ctx.logger,
+          managedConfig,
+          mcpServerUrl: expertToolsMcpRegistration.url,
+          permissionMode: options.permissionMode ?? DEFAULT_CLAUDE_CODE_PERMISSION_MODE,
+          pluginDir,
+          compactionHookRelay,
+          sessionDir,
+          spawn: options.spawn,
+          startupMessages: state.sessionId === "" ? ctx.agentContext.startupMessages : [],
+          state,
+          systemPrompt: ctx.agentContext.systemPrompt,
+          tokenCounter: options.tokenCounter,
+        });
       },
       readSession(session) {
         return {
@@ -263,22 +277,8 @@ export function createClaudeCodeRuntime(
       cancelTurn(session) {
         cancelClaudeCodeTurn(session);
       },
-      async closeSession(session, ctx) {
+      closeSession(session) {
         cancelClaudeCodeTurn(session);
-        const cleanup = await Promise.allSettled([
-          disposeClaudeRuntimeResources(
-            session.expertToolsMcpRegistration,
-            session.mcpToolRegistryLease,
-            ctx.logger,
-          ),
-          session.compactionHookRelay.close(),
-        ]);
-        const errors = cleanup.flatMap((result) =>
-          result.status === "rejected" ? [result.reason as unknown] : [],
-        );
-        if (errors.length > 0) {
-          throw new AggregateError(errors, "Claude Code Runtime cleanup failed.");
-        }
       },
     },
     {
@@ -339,34 +339,4 @@ function createClaudeCodeRuntimeCanUse(
       ...(options.executablePath === undefined ? {} : { executablePath: options.executablePath }),
       ...(options.env === undefined ? {} : { env: options.env }),
     });
-}
-
-async function disposeClaudeRuntimeResources(
-  expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined,
-  mcpToolRegistryLease: McpToolRegistryLease | undefined,
-  logger: PragmaLogger,
-): Promise<void> {
-  const results = await Promise.allSettled([
-    expertToolsMcpRegistration?.dispose() ?? Promise.resolve(),
-    mcpToolRegistryLease?.release() ?? Promise.resolve(),
-  ]);
-  const errors = results.flatMap((result) =>
-    result.status === "rejected" ? [result.reason as unknown] : [],
-  );
-
-  if (errors.length === 0) {
-    return;
-  }
-
-  logger.error(
-    "runtime.claude_cleanup_failed",
-    "Claude Code runtime cleanup failed",
-    new AggregateError(errors),
-  );
-
-  if (errors.length === 1) {
-    throw errors[0];
-  }
-
-  throw new AggregateError(errors, "Claude Code runtime session cleanup failed.");
 }

--- a/packages/runtime/claude-code/src/session.ts
+++ b/packages/runtime/claude-code/src/session.ts
@@ -29,8 +29,11 @@ import {
   createRuntimeContextWindowUsage,
   createUsageFromTokenCounts,
   defaultRuntimeTokenCounter,
+  BoundedRuntimeOutputBuffer,
   hasNonZeroUsage,
   readFirstTokenCount,
+  RuntimeProcessSupervisor,
+  terminateRuntimeProcess,
 } from "@pragma/core";
 
 import type { ManagedClaudeCodeConfig } from "./claude-config.ts";
@@ -529,18 +532,9 @@ async function runClaudeCodeProcess({
 }): Promise<ClaudeProcessRunResult> {
   const userInput = await createClaudeCodeUserInput(promptParts, attachments);
   const child = (spawn ?? defaultSpawn)(executablePath, args, { cwd, env });
-  let exited = false;
-  const exitPromise = new Promise<{
-    readonly code: number | null;
-    readonly signal: NodeJS.Signals | null;
-  }>((resolve, reject) => {
-    child.once("error", reject);
-    child.once("exit", (code, signal) => {
-      exited = true;
-      resolve({ code, signal });
-    });
-  });
-  onProcessStarted(child, exitPromise, () => exited);
+  const supervisor = new RuntimeProcessSupervisor(child);
+  const exitPromise = supervisor.exit;
+  onProcessStarted(child, exitPromise, supervisor.hasExited);
 
   let outputText = "";
   let usage: AgentMessageUsage | undefined;
@@ -548,7 +542,7 @@ async function runClaudeCodeProcess({
   let latestAssistantUsage: AgentMessageUsage | undefined;
   let latestAssistantModel: string | undefined;
   let contextWindowUsage: RuntimeContextWindowUsage | undefined;
-  let stderrTail = "";
+  const stderrTail = new BoundedRuntimeOutputBuffer(STDERR_TAIL_LIMIT);
   let finalResultSeen = false;
   let hasSeenPartialTextDelta = false;
   let hasSeenPartialThinkingDelta = false;
@@ -560,7 +554,7 @@ async function runClaudeCodeProcess({
 
   child.stderr.setEncoding("utf8");
   child.stderr.on("data", (chunk: string) => {
-    stderrTail = `${stderrTail}${chunk}`.slice(-STDERR_TAIL_LIMIT);
+    stderrTail.append(chunk);
     logger.debug("runtime.claude_stderr", "Claude Code stderr", { chunk });
   });
 
@@ -662,7 +656,7 @@ async function runClaudeCodeProcess({
         if (event["is_error"] === true) {
           throw createClaudeCodeRuntimeError(
             resultText ?? "Claude Code returned an error result.",
-            stderrTail,
+            stderrTail.text(),
           );
         }
       }
@@ -677,10 +671,10 @@ async function runClaudeCodeProcess({
     await terminateClaudeCodeProcess({
       process: child,
       exitPromise,
-      hasExited: () => exited,
+      hasExited: supervisor.hasExited,
       logger,
     });
-    throw normalizeClaudeCodeProcessError(error, stderrTail);
+    throw normalizeClaudeCodeProcessError(error, stderrTail.text());
   } finally {
     closeClaudeCodeInput(child);
     onProcessClosed(child);
@@ -689,12 +683,15 @@ async function runClaudeCodeProcess({
   if (exit.code !== 0) {
     throw createClaudeCodeRuntimeError(
       `Claude Code exited with code ${exit.code ?? "null"}${exit.signal === null ? "" : ` and signal ${exit.signal}`}.`,
-      stderrTail,
+      stderrTail.text(),
     );
   }
 
   if (!finalResultSeen && outputText.trim() === "") {
-    throw createClaudeCodeRuntimeError("Claude Code completed without a result.", stderrTail);
+    throw createClaudeCodeRuntimeError(
+      "Claude Code completed without a result.",
+      stderrTail.text(),
+    );
   }
 
   return {
@@ -775,38 +772,18 @@ async function terminateClaudeCodeProcess({
   readonly hasExited: () => boolean;
   readonly logger: PragmaLogger;
 }): Promise<void> {
-  if (hasExited()) {
-    return;
-  }
-
-  process.kill("SIGTERM");
-  if (await waitForClaudeCodeExit(exitPromise)) {
-    return;
-  }
-
-  logger.warn(
-    "runtime.claude_force_kill",
-    "Claude Code did not exit after SIGTERM; sending SIGKILL.",
-  );
-  process.kill("SIGKILL");
-  await waitForClaudeCodeExit(exitPromise);
-}
-
-async function waitForClaudeCodeExit(
-  exitPromise: Promise<{
-    readonly code: number | null;
-    readonly signal: NodeJS.Signals | null;
-  }>,
-): Promise<boolean> {
-  return await Promise.race([
-    exitPromise.then(
-      () => true,
-      () => true,
-    ),
-    new Promise<boolean>((resolve) => {
-      setTimeout(() => resolve(false), PROCESS_TERMINATION_GRACE_MS);
-    }),
-  ]);
+  await terminateRuntimeProcess({
+    process,
+    exit: exitPromise,
+    hasExited,
+    graceMs: PROCESS_TERMINATION_GRACE_MS,
+    onForceKill: () => {
+      logger.warn(
+        "runtime.claude_force_kill",
+        "Claude Code did not exit after SIGTERM; sending SIGKILL.",
+      );
+    },
+  });
 }
 
 function normalizeClaudeCodeProcessError(error: unknown, stderrTail: string): Error {

--- a/packages/runtime/claude-code/src/types.ts
+++ b/packages/runtime/claude-code/src/types.ts
@@ -1,6 +1,6 @@
 import type {
   RuntimeCanUseResult,
-  RuntimeAdapterDescriptor,
+  RuntimeDriverDescriptorOverride,
   RuntimeCommandSpawn,
   RuntimeModel,
   RuntimeSessionRestoreHandler,
@@ -10,17 +10,12 @@ import type {
 } from "@pragma/core";
 
 export type ClaudeCodeRuntimePermissionMode =
-  | "default"
-  | "acceptEdits"
-  | "plan"
-  | "auto"
-  | "dontAsk"
-  | "bypassPermissions";
+  "default" | "acceptEdits" | "plan" | "auto" | "dontAsk" | "bypassPermissions";
 
 export type ClaudeCodeRuntimeSpawn = RuntimeCommandSpawn;
 
 export interface ClaudeCodeRuntimeAdapterOptions {
-  readonly descriptor?: Partial<RuntimeAdapterDescriptor> | undefined;
+  readonly descriptor?: RuntimeDriverDescriptorOverride | undefined;
   readonly executablePath?: string | undefined;
   readonly env?: NodeJS.ProcessEnv | undefined;
   readonly defaultModelName?: string | undefined;

--- a/packages/runtime/claude-code/test/adapter-contract.test.ts
+++ b/packages/runtime/claude-code/test/adapter-contract.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { describeRuntimeConformance } from "@pragma/core/testing/vitest";
 import { createClaudeCodeRuntime } from "../src/index.ts";
+
+describeRuntimeConformance("Claude Code", { createRuntime: createClaudeCodeRuntime });
 
 describe("Claude Code Runtime contract", () => {
   it("declares split Session lifecycle capabilities without unsafe steer", () => {

--- a/packages/runtime/codex/package.json
+++ b/packages/runtime/codex/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint src test",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
+    "test:core": "vitest run --passWithNoTests test/adapter-contract.test.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/runtime/codex/src/adapter.ts
+++ b/packages/runtime/codex/src/adapter.ts
@@ -9,7 +9,9 @@ import type {
 } from "@pragma/core";
 import {
   createMcpToolRegistryPool,
+  defineRuntimeFeatures,
   defineRuntimeDriver,
+  runtimeFeature,
   type PragmaLogger,
   type RuntimeSessionPersistenceSpec,
 } from "@pragma/core";
@@ -46,12 +48,11 @@ const CODEX_LOCAL_RUNTIME_DESCRIPTOR = {
   capabilities: {
     targets: ["agent"],
     executionLocations: ["local"],
-    supportsAbort: true,
-    supportsMcp: true,
-    supportsStreaming: true,
-    supportsContextCompactionEvents: true,
   },
 };
+
+const CODEX_EVIDENCE_PENDING =
+  "Implemented in the adapter; an executed Runtime probe evidence bundle is not recorded yet.";
 
 const DEFAULT_CODEX_CLIENT_INFO = {
   name: "pragma_codex_runtime",
@@ -61,8 +62,6 @@ const DEFAULT_CODEX_CLIENT_INFO = {
 
 interface CodexDriverSession extends CodexNativeSession {
   readonly logger: PragmaLogger;
-  readonly mcpToolRegistryLease: McpToolRegistryLease;
-  readonly expertToolsMcpRegistration: CodexExpertToolsMcpSessionRegistration;
 }
 
 export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): RuntimeAdapter {
@@ -80,10 +79,44 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
     },
   };
   const listModels = options.listModels ?? createCodexModelDiscovery(options);
+  const implemented = () => runtimeFeature.degraded(CODEX_EVIDENCE_PENDING);
+  const features = defineRuntimeFeatures({
+    availability: implemented(),
+    authentication: implemented(),
+    modelDiscovery: implemented(),
+    modelSelection: implemented(),
+    thinking: implemented(),
+    freshSession: implemented(),
+    resume: implemented(),
+    systemPrompt: implemented(),
+    startupMessages: implemented(),
+    textStreaming: implemented(),
+    reasoningStreaming: implemented(),
+    nativeToolLifecycle: implemented(),
+    mcp: implemented(),
+    permissions: implemented(),
+    userInteraction: implemented(),
+    skills: implemented(),
+    attachmentImage: implemented(),
+    attachmentFile: implemented(),
+    attachmentDirectory: implemented(),
+    usage: implemented(),
+    contextWindow: implemented(),
+    compaction: runtimeFeature.degraded(CODEX_EVIDENCE_PENDING, {
+      compactionModes: ["manual", "events"],
+    }),
+    cancellation: implemented(),
+    steering: runtimeFeature.unsupported(
+      "Codex app-server exposes no safe active-turn steering API.",
+    ),
+    close: implemented(),
+    cleanup: implemented(),
+  });
 
   return defineRuntimeDriver(
     {
       descriptor,
+      features,
       canUse: createCodexRuntimeCanUse(options),
       listModels,
       outputRetryLimit: options.outputRetryLimit,
@@ -140,7 +173,12 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
           ctx.logger,
           "mcp_tool_registry",
           sessionStartedAt,
-          async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
+          async () =>
+            await ctx.resources.acquire(
+              "codex.mcp-registry",
+              async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
+              async (lease) => await lease.release(),
+            ),
         );
         let mcpToolRegistry: McpToolRegistry | undefined;
         let mcpToolRegistryLease: McpToolRegistryLease | undefined;
@@ -164,20 +202,28 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
                   async () =>
                     await nativeSessionFileExists(join(codex.home, "sessions"), state.threadId),
                 ),
-            timedCodexPhase(ctx.logger, "mcp_tool_registration", sessionStartedAt, async () =>
-              registerCodexExpertToolsMcpSession({
-                agent: ctx.agent,
-                getContext: () => ctx.lifecycle.currentContext,
-                humanInteractionHandler: ctx.request.humanInteractionHandler,
-                logger: ctx.logger,
-                mcpTools: mcpToolRegistry!.tools,
-                state: toolRuntimeState,
-                executionContext: ctx.request.executionContext,
-              }),
+            timedCodexPhase(
+              ctx.logger,
+              "mcp_tool_registration",
+              sessionStartedAt,
+              async () =>
+                await ctx.resources.acquire(
+                  "codex.mcp-registration",
+                  async () =>
+                    await registerCodexExpertToolsMcpSession({
+                      agent: ctx.agent,
+                      getContext: () => ctx.lifecycle.currentContext,
+                      humanInteractionHandler: ctx.request.humanInteractionHandler,
+                      logger: ctx.logger,
+                      mcpTools: mcpToolRegistry!.tools,
+                      state: toolRuntimeState,
+                      executionContext: ctx.request.executionContext,
+                    }),
+                  async (registration) => await registration.dispose(),
+                ),
             ),
           ]);
           if (!restoreExists) {
-            await registration.dispose();
             throw new Error(`Codex runtime session file was not found: ${state.threadId}.`);
           }
           expertToolsMcpRegistration = registration;
@@ -257,24 +303,10 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
                 : [],
             }),
             logger: ctx.logger,
-            mcpToolRegistryLease,
-            expertToolsMcpRegistration,
           };
         } catch (error) {
-          if (mcpToolRegistryLease === undefined) {
-            const registry = await Promise.allSettled([registryLeasePromise]);
-            if (registry[0]?.status === "fulfilled") {
-              mcpToolRegistryLease = registry[0].value;
-              mcpToolRegistry = registry[0].value.registry;
-            }
-          }
           try {
-            await disposeCodexRuntimeResources(
-              client,
-              expertToolsMcpRegistration,
-              mcpToolRegistryLease,
-              ctx.logger,
-            );
+            await client?.close();
           } catch (cleanupError) {
             throw new AggregateError(
               [error, cleanupError],
@@ -332,13 +364,8 @@ export function createCodexRuntime(options: CodexRuntimeAdapterOptions = {}): Ru
           await session.client.interruptTurn(session.state.threadId).catch(() => undefined);
         }
       },
-      async closeSession(session, ctx) {
-        await disposeCodexRuntimeResources(
-          session.client,
-          session.expertToolsMcpRegistration,
-          session.mcpToolRegistryLease,
-          ctx.logger,
-        );
+      async closeSession(session) {
+        await session.client.close();
       },
     },
     {
@@ -420,38 +447,6 @@ function createCodexRuntimeCanUse(
       ...(options.executablePath === undefined ? {} : { executablePath: options.executablePath }),
       ...(options.env === undefined ? {} : { env: options.env }),
     });
-}
-
-async function disposeCodexRuntimeResources(
-  client: CodexAppServerClient | undefined,
-  expertToolsMcpRegistration: CodexExpertToolsMcpSessionRegistration | undefined,
-  mcpToolRegistryLease: McpToolRegistryLease | undefined,
-  logger: PragmaLogger,
-): Promise<void> {
-  const results = await Promise.allSettled([
-    Promise.resolve().then(() => client?.close()),
-    expertToolsMcpRegistration?.dispose() ?? Promise.resolve(),
-    mcpToolRegistryLease?.release() ?? Promise.resolve(),
-  ]);
-  const errors = results.flatMap((result) =>
-    result.status === "rejected" ? [result.reason as unknown] : [],
-  );
-
-  if (errors.length === 0) {
-    return;
-  }
-
-  logger.error(
-    "runtime.codex_cleanup_failed",
-    "Codex runtime cleanup failed",
-    new AggregateError(errors),
-  );
-
-  if (errors.length === 1) {
-    throw errors[0];
-  }
-
-  throw new AggregateError(errors, "Codex runtime session cleanup failed.");
 }
 
 async function startOrResumeThread({

--- a/packages/runtime/codex/src/types.ts
+++ b/packages/runtime/codex/src/types.ts
@@ -1,6 +1,6 @@
 import type {
   RuntimeCanUseResult,
-  RuntimeAdapterDescriptor,
+  RuntimeDriverDescriptorOverride,
   RuntimeCommandSpawn,
   RuntimeModel,
   RuntimeSessionRestoreHandler,
@@ -22,7 +22,7 @@ export interface CodexRuntimeClientInfo {
 export type CodexRuntimeSpawn = RuntimeCommandSpawn;
 
 export interface CodexRuntimeAdapterOptions {
-  readonly descriptor?: Partial<RuntimeAdapterDescriptor> | undefined;
+  readonly descriptor?: RuntimeDriverDescriptorOverride | undefined;
   readonly executablePath?: string | undefined;
   readonly appServerArgs?: readonly string[] | undefined;
   /**

--- a/packages/runtime/codex/test/adapter-contract.test.ts
+++ b/packages/runtime/codex/test/adapter-contract.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { describeRuntimeConformance } from "@pragma/core/testing/vitest";
 import { createCodexRuntime } from "../src/index.ts";
+
+describeRuntimeConformance("Codex", { createRuntime: createCodexRuntime });
 
 describe("Codex Runtime contract", () => {
   it("declares split Session lifecycle capabilities without unsafe steer", () => {

--- a/packages/runtime/codex/test/session.test.ts
+++ b/packages/runtime/codex/test/session.test.ts
@@ -250,6 +250,7 @@ describe("Codex turn completion", () => {
         },
       ],
       startupMessages: [{ role: "user", content: "always-on context" }],
+      preparedFeatures: {},
       signal: new AbortController().signal,
       source: {
         kind: "runtime",
@@ -336,6 +337,7 @@ describe("Codex turn completion", () => {
       prompt: "hello",
       attachments: [],
       startupMessages: [],
+      preparedFeatures: {},
       signal: new AbortController().signal,
       source: {
         kind: "runtime",
@@ -381,6 +383,7 @@ describe("Codex turn completion", () => {
         prompt: "hello",
         attachments: [],
         startupMessages: [],
+        preparedFeatures: {},
         signal: new AbortController().signal,
         source: {
           kind: "runtime",
@@ -438,6 +441,7 @@ describe("Codex turn completion", () => {
       prompt: "hello",
       attachments: [],
       startupMessages: [],
+      preparedFeatures: {},
       signal: new AbortController().signal,
       source: {
         kind: "runtime",

--- a/packages/runtime/pi/package.json
+++ b/packages/runtime/pi/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src test",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
+    "test:core": "vitest run --passWithNoTests test/adapter-contract.test.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/runtime/pi/src/adapter.ts
+++ b/packages/runtime/pi/src/adapter.ts
@@ -10,8 +10,6 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type {
-  McpToolRegistry,
-  McpToolRegistryLease,
   PragmaLogger,
   ResolvedModelProvider,
   RuntimeAdapter,
@@ -20,7 +18,9 @@ import type {
 } from "@pragma/core";
 import {
   createMcpToolRegistryPool,
+  defineRuntimeFeatures,
   defineRuntimeDriver,
+  runtimeFeature,
   type RuntimeSessionPersistenceSpec,
 } from "@pragma/core";
 
@@ -58,16 +58,13 @@ const CLOUD_PI_RUNTIME_DESCRIPTOR = {
   capabilities: {
     targets: ["agent"],
     executionLocations: ["cloud"],
-    supportsAbort: true,
-    supportsMcp: true,
-    supportsStreaming: true,
-    supportsContextCompactionEvents: true,
   },
 };
 
-interface PiDriverSession extends PiNativeSession {
-  readonly mcpToolRegistryLease: McpToolRegistryLease;
-}
+const PI_EVIDENCE_PENDING =
+  "Implemented in the adapter; an executed Runtime probe evidence bundle is not recorded yet.";
+
+type PiDriverSession = PiNativeSession;
 
 export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): RuntimeAdapter {
   const modelProviderConverter = createPiModelProviderConverter();
@@ -81,10 +78,46 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
       ...options.descriptor?.capabilities,
     },
   };
+  const implemented = () => runtimeFeature.degraded(PI_EVIDENCE_PENDING);
+  const features = defineRuntimeFeatures({
+    availability: implemented(),
+    authentication: implemented(),
+    modelDiscovery: implemented(),
+    modelSelection: implemented(),
+    thinking: implemented(),
+    freshSession: implemented(),
+    resume: implemented(),
+    systemPrompt: implemented(),
+    startupMessages: implemented(),
+    textStreaming: implemented(),
+    reasoningStreaming: implemented(),
+    nativeToolLifecycle: implemented(),
+    mcp: implemented(),
+    permissions: implemented(),
+    userInteraction: implemented(),
+    skills: implemented(),
+    attachmentImage: implemented(),
+    attachmentFile: implemented(),
+    attachmentDirectory: implemented(),
+    usage: implemented(),
+    contextWindow: implemented(),
+    compaction: runtimeFeature.degraded(PI_EVIDENCE_PENDING, {
+      compactionModes: ["manual", "events"],
+    }),
+    cancellation: implemented(),
+    steering: implemented(),
+    close: implemented(),
+    cleanup: implemented(),
+  });
 
   return defineRuntimeDriver(
     {
       descriptor,
+      features,
+      canUse: () => ({
+        usable: true,
+        details: { executionMode: "in-process" },
+      }),
       listModels: async () =>
         normalizePiRuntimeModels(
           (await options.modelProviders?.listProviders())?.flatMap((provider) =>
@@ -115,12 +148,6 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
         const sessionStartedAt = performance.now();
         const selectedModel = ctx.request.modelSelection?.model;
         const selectedProviderId = selectedModel?.providerId;
-        const registeredProviderPromise =
-          selectedProviderId === undefined
-            ? Promise.resolve(undefined)
-            : timedPiPhase(ctx.logger, "model_provider_resolve", sessionStartedAt, async () =>
-                options.modelProviders?.resolveProvider(selectedProviderId),
-              );
         const cwd = ctx.workspace;
         const settingsManager = SettingsManager.create(cwd);
         const compactionKeepRecentTokens = settingsManager.getCompactionKeepRecentTokens();
@@ -136,68 +163,41 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
           sessionStartedAt,
           async () => await loader.reload(),
         );
-        const mcpRegistryPromise = timedPiPhase(
-          ctx.logger,
-          "mcp_tool_registry",
-          sessionStartedAt,
-          async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
-        );
-        const sessionManagerPromise = timedPiPhase(
-          ctx.logger,
-          "session_manager",
-          sessionStartedAt,
-          async () =>
-            await createPiSessionManager(
-              cwd,
-              ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("pi"),
-              ctx.request.runtimeSession?.id,
+        const [registeredProvider, , mcpToolRegistryLease, piSessionManagerResult] =
+          await Promise.all([
+            selectedProviderId === undefined
+              ? Promise.resolve(undefined)
+              : timedPiPhase(ctx.logger, "model_provider_resolve", sessionStartedAt, async () =>
+                  options.modelProviders?.resolveProvider(selectedProviderId),
+                ),
+            resourceReloadPromise,
+            timedPiPhase(
+              ctx.logger,
+              "mcp_tool_registry",
+              sessionStartedAt,
+              async () =>
+                await ctx.resources.acquire(
+                  "pi.mcp-registry",
+                  async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
+                  async (lease) => await lease.release(),
+                ),
             ),
-        );
-        let registeredProvider: Awaited<typeof registeredProviderPromise>;
-        try {
-          registeredProvider = await registeredProviderPromise;
-        } catch (error) {
-          const preparation = await Promise.allSettled([
-            resourceReloadPromise,
-            mcpRegistryPromise,
-            sessionManagerPromise,
+            timedPiPhase(
+              ctx.logger,
+              "session_manager",
+              sessionStartedAt,
+              async () =>
+                await createPiSessionManager(
+                  cwd,
+                  ctx.persistence.spec?.sessionDir ?? ctx.paths.runtimeSessionDir("pi"),
+                  ctx.request.runtimeSession?.id,
+                ),
+            ),
           ]);
-          const lease = preparation[1];
-          if (lease?.status === "fulfilled") {
-            const cleanupError = await piRegistryCleanupError(lease.value);
-            if (cleanupError !== undefined) {
-              throw new AggregateError(
-                [error, cleanupError],
-                "Model provider resolution and cleanup failed.",
-                { cause: error },
-              );
-            }
-          }
-          throw error;
-        }
         if (selectedProviderId !== undefined && registeredProvider === undefined) {
-          const providerError = new Error(
-            `Model provider is not registered: ${selectedProviderId}`,
-          );
-          const preparation = await Promise.allSettled([
-            resourceReloadPromise,
-            mcpRegistryPromise,
-            sessionManagerPromise,
-          ]);
-          const lease = preparation[1];
-          if (lease?.status === "fulfilled") {
-            const cleanupError = await piRegistryCleanupError(lease.value);
-            if (cleanupError !== undefined) {
-              throw new AggregateError(
-                [providerError, cleanupError],
-                "Model provider validation and cleanup failed.",
-                { cause: providerError },
-              );
-            }
-          }
-          throw providerError;
+          throw new Error(`Model provider is not registered: ${selectedProviderId}`);
         }
-        const modelRuntimePromise = timedPiPhase(
+        const modelRuntimeResult = await timedPiPhase(
           ctx.logger,
           "model_runtime",
           sessionStartedAt,
@@ -208,35 +208,6 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
                 : [modelProviderConverter.convertProvider(registeredProvider)],
             ),
         );
-        let modelRuntimeResult: Awaited<ReturnType<typeof createPiModelRuntime>>;
-        let mcpToolRegistryLease: McpToolRegistryLease;
-        let mcpToolRegistry: McpToolRegistry;
-        let piSessionManagerResult: Awaited<ReturnType<typeof createPiSessionManager>>;
-        try {
-          const preparation = await Promise.all([
-            modelRuntimePromise,
-            mcpRegistryPromise,
-            sessionManagerPromise,
-            resourceReloadPromise,
-          ]);
-          modelRuntimeResult = preparation[0];
-          mcpToolRegistryLease = preparation[1];
-          mcpToolRegistry = mcpToolRegistryLease.registry;
-          piSessionManagerResult = preparation[2];
-        } catch (error) {
-          const lease = await Promise.allSettled([mcpRegistryPromise]);
-          if (lease[0]?.status === "fulfilled") {
-            const cleanupError = await piRegistryCleanupError(lease[0].value);
-            if (cleanupError !== undefined) {
-              throw new AggregateError(
-                [error, cleanupError],
-                "Runtime preparation and cleanup failed.",
-                { cause: error },
-              );
-            }
-          }
-          throw error;
-        }
         let session: AgentSession | undefined;
         try {
           const { modelRegistry, modelRuntime } = modelRuntimeResult;
@@ -245,7 +216,7 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
           const resolvedTools = createResolvedPiTools({
             agent: ctx.agent,
             cwd,
-            mcpTools: mcpToolRegistry.tools,
+            mcpTools: mcpToolRegistryLease.registry.tools,
             parentSystemPrompt: ctx.agentContext.systemPrompt,
             streamState,
             lifecycle: ctx.lifecycle,
@@ -305,39 +276,24 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
             mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
           });
 
-          return {
-            ...createPiNativeSession({
-              agent: ctx.agent,
-              session,
-              streamState,
-              models: {
-                defaultModel: selectedModel,
-                modelRegistry,
-                modelRuntime,
-              },
-              compactionKeepRecentTokens,
-              startupMessages: piSessionManagerResult.resumedExistingSession
-                ? []
-                : ctx.agentContext.startupMessages,
-              tokenCounter: options.tokenCounter,
-              tokenModelIdentity: piTokenModelIdentity(registeredProvider, selectedModel),
-            }),
-            mcpToolRegistryLease,
-          };
+          return createPiNativeSession({
+            agent: ctx.agent,
+            session,
+            streamState,
+            models: {
+              defaultModel: selectedModel,
+              modelRegistry,
+              modelRuntime,
+            },
+            compactionKeepRecentTokens,
+            startupMessages: piSessionManagerResult.resumedExistingSession
+              ? []
+              : ctx.agentContext.startupMessages,
+            tokenCounter: options.tokenCounter,
+            tokenModelIdentity: piTokenModelIdentity(registeredProvider, selectedModel),
+          });
         } catch (error) {
-          const cleanupErrors = (
-            await Promise.allSettled([
-              Promise.resolve().then(() => session?.dispose()),
-              mcpToolRegistryLease.release(),
-            ])
-          ).flatMap((result) => (result.status === "rejected" ? [result.reason as unknown] : []));
-          if (cleanupErrors.length > 0) {
-            throw new AggregateError(
-              [error, ...cleanupErrors],
-              "Runtime initialization and cleanup failed.",
-              { cause: error },
-            );
-          }
+          session?.dispose();
           throw error;
         }
       },
@@ -378,7 +334,6 @@ export function createPiRuntime(options: CloudPiRuntimeAdapterOptions = {}): Run
       },
       async closeSession(session) {
         session.session.dispose();
-        await session.mcpToolRegistryLease.release();
       },
     },
     {
@@ -432,11 +387,6 @@ function logPiPhase(
 
 function piElapsedMs(startedAt: number): number {
   return Math.round((performance.now() - startedAt) * 100) / 100;
-}
-
-async function piRegistryCleanupError(lease: McpToolRegistryLease): Promise<unknown | undefined> {
-  const [result] = await Promise.allSettled([lease.release()]);
-  return result?.status === "rejected" ? result.reason : undefined;
 }
 
 export function createPiSessionBashTool(options: {

--- a/packages/runtime/pi/src/types.ts
+++ b/packages/runtime/pi/src/types.ts
@@ -1,6 +1,6 @@
 import type {
   PragmaLogger,
-  RuntimeAdapterDescriptor,
+  RuntimeDriverDescriptorOverride,
   RuntimeSessionRestoreHandler,
   RuntimeSessionSyncCallback,
   RuntimeEventEmitter,
@@ -42,7 +42,7 @@ export interface PiModelProviderConfig {
 }
 
 export interface CloudPiRuntimeAdapterOptions {
-  readonly descriptor?: Partial<RuntimeAdapterDescriptor> | undefined;
+  readonly descriptor?: RuntimeDriverDescriptorOverride | undefined;
   readonly modelProviders?: ModelProviderRegistry | undefined;
   readonly outputParser?: <TOutput>(text: string) => TOutput;
   readonly outputRetryLimit?: number | undefined;

--- a/packages/runtime/pi/test/adapter-contract.test.ts
+++ b/packages/runtime/pi/test/adapter-contract.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { describeRuntimeConformance } from "@pragma/core/testing/vitest";
 import { createPiRuntime } from "../src/index.ts";
+
+describeRuntimeConformance("PI", { createRuntime: createPiRuntime });
 
 describe("PI Runtime contract", () => {
   it("declares split Session lifecycle capabilities with safe steer", () => {

--- a/packages/runtime/pi/test/startup-messages.test.ts
+++ b/packages/runtime/pi/test/startup-messages.test.ts
@@ -198,6 +198,7 @@ function createTurn(
     prompt: "user prompt",
     attachments,
     startupMessages,
+    preparedFeatures: {},
     signal: new AbortController().signal,
     source: { kind: "runtime", runId: "run-1", path: [] },
     stream: {

--- a/packages/runtime/qodercli/package.json
+++ b/packages/runtime/qodercli/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint src test",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
+    "test:core": "vitest run --passWithNoTests test/adapter-contract.test.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/runtime/qodercli/src/adapter.ts
+++ b/packages/runtime/qodercli/src/adapter.ts
@@ -4,12 +4,12 @@ import { join } from "node:path";
 import {
   createMcpToolRegistryPool,
   defaultRuntimeTokenCounter,
+  defineRuntimeFeatures,
   defineRuntimeDriver,
   registerExpertToolsMcpSession,
+  runtimeFeature,
   type ExpertToolsMcpSessionRegistration,
   type ExpertToolRuntimeState,
-  type McpToolRegistry,
-  type McpToolRegistryLease,
   type PragmaLogger,
   type RuntimeAdapter,
   type RuntimeSessionPersistenceSpec,
@@ -41,17 +41,13 @@ const QODER_DESCRIPTOR = {
   capabilities: {
     targets: ["agent"],
     executionLocations: ["local"],
-    supportsAbort: true,
-    supportsMcp: true,
-    supportsStreaming: true,
-    supportsContextCompactionEvents: true,
   },
 };
 
-interface QoderDriverSession extends QoderNativeSession {
-  readonly mcpToolRegistryLease: McpToolRegistryLease;
-  readonly expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration;
-}
+const QODER_EVIDENCE_PENDING =
+  "Implemented in the adapter; an executed Runtime probe evidence bundle is not recorded yet.";
+
+type QoderDriverSession = QoderNativeSession;
 
 export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {}): RuntimeAdapter {
   const mcpToolRegistries = options.mcpToolRegistryPool ?? createMcpToolRegistryPool();
@@ -65,10 +61,42 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
     },
   };
   const listModels = options.listModels ?? createQoderCliModelDiscovery(options);
+  const implemented = () => runtimeFeature.degraded(QODER_EVIDENCE_PENDING);
+  const features = defineRuntimeFeatures({
+    availability: implemented(),
+    authentication: implemented(),
+    modelDiscovery: implemented(),
+    modelSelection: implemented(),
+    thinking: implemented(),
+    freshSession: implemented(),
+    resume: implemented(),
+    systemPrompt: implemented(),
+    startupMessages: implemented(),
+    textStreaming: implemented(),
+    reasoningStreaming: implemented(),
+    nativeToolLifecycle: implemented(),
+    mcp: implemented(),
+    permissions: implemented(),
+    userInteraction: implemented(),
+    skills: implemented(),
+    attachmentImage: implemented(),
+    attachmentFile: implemented(),
+    attachmentDirectory: implemented(),
+    usage: implemented(),
+    contextWindow: implemented(),
+    compaction: runtimeFeature.degraded(QODER_EVIDENCE_PENDING, {
+      compactionModes: ["manual", "events"],
+    }),
+    cancellation: implemented(),
+    steering: runtimeFeature.unsupported("Qoder CLI SDK exposes no safe active-turn steering API."),
+    close: implemented(),
+    cleanup: implemented(),
+  });
 
   return defineRuntimeDriver(
     {
       descriptor,
+      features,
       canUse: options.canUse ?? (() => canUseQoderCliRuntime(options)),
       listModels,
       outputRetryLimit: options.outputRetryLimit,
@@ -113,99 +141,94 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
           ctx.logger,
           "mcp_tool_registry",
           sessionStartedAt,
-          async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
+          async () =>
+            await ctx.resources.acquire(
+              "qodercli.mcp-registry",
+              async () => await mcpToolRegistries.acquire(ctx.agent.mcp),
+              async (lease) => await lease.release(),
+            ),
         );
-        let managedConfig: Awaited<ReturnType<typeof prepareManagedQoderConfig>>;
-        let plugin: Awaited<ReturnType<typeof materializeQoderSkillPlugin>>;
-        let mcpToolRegistry: McpToolRegistry | undefined;
-        let mcpToolRegistryLease: McpToolRegistryLease | undefined;
-        try {
-          const prepared = await Promise.all([configPromise, pluginPromise, registryLeasePromise]);
-          [managedConfig, plugin, mcpToolRegistryLease] = prepared;
-          mcpToolRegistry = mcpToolRegistryLease.registry;
-        } catch (error) {
-          const registry = await Promise.allSettled([registryLeasePromise]);
-          if (registry[0]?.status === "fulfilled") await registry[0].value.release();
-          throw error;
-        }
+        const [managedConfig, plugin, mcpToolRegistryLease] = await Promise.all([
+          configPromise,
+          pluginPromise,
+          registryLeasePromise,
+        ]);
+        const mcpToolRegistry = mcpToolRegistryLease.registry;
         const restoredRuntimeSessionId =
           ctx.persistence.restoredRuntimeSessionId ?? ctx.request.runtimeSession?.id ?? "";
         const toolRuntimeState: ExpertToolRuntimeState = {};
-        let expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration | undefined;
 
-        try {
-          if (
-            restoredRuntimeSessionId !== "" &&
-            !(await timedQoderPhase(
-              ctx.logger,
-              "restore_session_lookup",
-              sessionStartedAt,
-              async () =>
-                await nativeSessionFileExists(
-                  join(managedConfig.configDir, "projects"),
-                  restoredRuntimeSessionId,
-                ),
-            ))
-          ) {
-            throw new Error(
-              `Qoder CLI runtime session file was not found: ${restoredRuntimeSessionId}.`,
-            );
-          }
-          expertToolsMcpRegistration = await timedQoderPhase(
+        if (
+          restoredRuntimeSessionId !== "" &&
+          !(await timedQoderPhase(
             ctx.logger,
-            "mcp_tool_registration",
+            "restore_session_lookup",
             sessionStartedAt,
             async () =>
-              await registerExpertToolsMcpSession({
-                agent: ctx.agent,
-                getContext: () => ctx.lifecycle.currentContext,
-                humanInteractionHandler: ctx.request.humanInteractionHandler,
-                logger: ctx.logger,
-                mcpTools: mcpToolRegistry.tools,
-                state: toolRuntimeState,
-                executionContext: ctx.request.executionContext,
-              }),
+              await nativeSessionFileExists(
+                join(managedConfig.configDir, "projects"),
+                restoredRuntimeSessionId,
+              ),
+          ))
+        ) {
+          throw new Error(
+            `Qoder CLI runtime session file was not found: ${restoredRuntimeSessionId}.`,
           );
-          ctx.logger.info("runtime.qodercli_session_ready", "Qoder Session preparation completed", {
-            elapsedMs: qoderElapsedMs(sessionStartedAt),
-            systemPromptCharacters: ctx.agentContext.systemPrompt.length,
-            toolCount: mcpToolRegistry.tools.length,
-            mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
-            mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
-            mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
-          });
-          return {
-            agent: ctx.agent,
-            auth: resolveQoderAuth(options),
-            executablePath: resolveQoderCliExecutablePath(options),
-            env: { ...ctx.processEnvironment },
-            configDir: managedConfig.configDir,
-            externalCommandsCacheDir: managedConfig.externalCommandsCacheDir,
-            mcpServerUrl: expertToolsMcpRegistration.url,
-            plugin,
-            logger: ctx.logger,
-            humanInteractionHandler: ctx.request.humanInteractionHandler,
-            permissionMode: options.permissionMode ?? "default",
-            defaultModelName: ctx.request.modelSelection?.model.modelId ?? options.defaultModelName,
-            defaultThinkingLevel:
-              ctx.request.modelSelection?.thinkingLevel ?? options.defaultThinkingLevel,
-            contextWindowOverride: options.contextWindowTokens,
-            compactModelName: options.compactModelName,
-            systemPrompt: ctx.agentContext.systemPrompt,
-            toolRuntimeState,
-            tokenCounter: options.tokenCounter ?? defaultRuntimeTokenCounter,
-            messages: [],
-            toolNames: new Map(),
-            pendingStartupMessages:
-              restoredRuntimeSessionId === "" ? ctx.agentContext.startupMessages : [],
-            sessionId: restoredRuntimeSessionId,
-            mcpToolRegistryLease,
-            expertToolsMcpRegistration,
-          };
-        } catch (error) {
-          await disposeResources(expertToolsMcpRegistration, mcpToolRegistryLease);
-          throw error;
         }
+        const expertToolsMcpRegistration: ExpertToolsMcpSessionRegistration = await timedQoderPhase(
+          ctx.logger,
+          "mcp_tool_registration",
+          sessionStartedAt,
+          async () =>
+            await ctx.resources.acquire(
+              "qodercli.mcp-registration",
+              async () =>
+                await registerExpertToolsMcpSession({
+                  agent: ctx.agent,
+                  getContext: () => ctx.lifecycle.currentContext,
+                  humanInteractionHandler: ctx.request.humanInteractionHandler,
+                  logger: ctx.logger,
+                  mcpTools: mcpToolRegistry.tools,
+                  state: toolRuntimeState,
+                  executionContext: ctx.request.executionContext,
+                }),
+              async (registration) => await registration.dispose(),
+            ),
+        );
+        ctx.logger.info("runtime.qodercli_session_ready", "Qoder Session preparation completed", {
+          elapsedMs: qoderElapsedMs(sessionStartedAt),
+          systemPromptCharacters: ctx.agentContext.systemPrompt.length,
+          toolCount: mcpToolRegistry.tools.length,
+          mcpOpenedConnections: mcpToolRegistryLease.stats.openedConnections,
+          mcpReusedConnections: mcpToolRegistryLease.stats.reusedConnections,
+          mcpCoalescedConnections: mcpToolRegistryLease.stats.coalescedConnections,
+        });
+        return {
+          agent: ctx.agent,
+          auth: resolveQoderAuth(options),
+          executablePath: resolveQoderCliExecutablePath(options),
+          env: { ...ctx.processEnvironment },
+          configDir: managedConfig.configDir,
+          externalCommandsCacheDir: managedConfig.externalCommandsCacheDir,
+          mcpServerUrl: expertToolsMcpRegistration.url,
+          plugin,
+          logger: ctx.logger,
+          humanInteractionHandler: ctx.request.humanInteractionHandler,
+          permissionMode: options.permissionMode ?? "default",
+          defaultModelName: ctx.request.modelSelection?.model.modelId ?? options.defaultModelName,
+          defaultThinkingLevel:
+            ctx.request.modelSelection?.thinkingLevel ?? options.defaultThinkingLevel,
+          contextWindowOverride: options.contextWindowTokens,
+          compactModelName: options.compactModelName,
+          systemPrompt: ctx.agentContext.systemPrompt,
+          toolRuntimeState,
+          tokenCounter: options.tokenCounter ?? defaultRuntimeTokenCounter,
+          messages: [],
+          toolNames: new Map(),
+          pendingStartupMessages:
+            restoredRuntimeSessionId === "" ? ctx.agentContext.startupMessages : [],
+          sessionId: restoredRuntimeSessionId,
+        };
       },
       readSession(session) {
         return {
@@ -225,7 +248,6 @@ export function createQoderCliRuntime(options: QoderCliRuntimeAdapterOptions = {
       cancelTurn: cancelQoderTurn,
       async closeSession(session) {
         await closeQoderSession(session);
-        await disposeResources(session.expertToolsMcpRegistration, session.mcpToolRegistryLease);
       },
     },
     {
@@ -276,16 +298,4 @@ function assertProvider(providerId: string | undefined): void {
   if (providerId !== undefined && providerId !== "qoder") {
     throw new Error("Qoder CLI runtime only supports provider qoder.");
   }
-}
-
-async function disposeResources(
-  registration: ExpertToolsMcpSessionRegistration | undefined,
-  registryLease: McpToolRegistryLease | undefined,
-): Promise<void> {
-  const results = await Promise.allSettled([registration?.dispose(), registryLease?.release()]);
-  const errors = results.flatMap((result) =>
-    result.status === "rejected" ? [result.reason as unknown] : [],
-  );
-  if (errors.length === 1) throw errors[0];
-  if (errors.length > 1) throw new AggregateError(errors, "Qoder runtime cleanup failed.");
 }

--- a/packages/runtime/qodercli/src/types.ts
+++ b/packages/runtime/qodercli/src/types.ts
@@ -1,5 +1,5 @@
 import type {
-  RuntimeAdapterDescriptor,
+  RuntimeDriverDescriptorOverride,
   RuntimeCanUseResult,
   RuntimeModel,
   RuntimeSessionRestoreHandler,
@@ -16,7 +16,7 @@ export type QoderCliRuntimeAuth =
   | { readonly type: "access-token-env"; readonly envVar?: string | undefined };
 
 export interface QoderCliRuntimeAdapterOptions {
-  readonly descriptor?: Partial<RuntimeAdapterDescriptor> | undefined;
+  readonly descriptor?: RuntimeDriverDescriptorOverride | undefined;
   readonly executablePath?: string | undefined;
   readonly env?: NodeJS.ProcessEnv | undefined;
   readonly auth?: QoderCliRuntimeAuth | undefined;

--- a/packages/runtime/qodercli/test/adapter-contract.test.ts
+++ b/packages/runtime/qodercli/test/adapter-contract.test.ts
@@ -1,0 +1,7 @@
+import { describeRuntimeConformance } from "@pragma/core/testing/vitest";
+
+import { createQoderCliRuntime } from "../src/adapter.ts";
+
+describeRuntimeConformance("Qoder CLI", {
+  createRuntime: createQoderCliRuntime,
+});

--- a/packages/runtime/qodercli/test/adapter.test.ts
+++ b/packages/runtime/qodercli/test/adapter.test.ts
@@ -9,6 +9,7 @@ import type {
   RuntimeDriverSessionContext,
   RuntimeSessionReadContext,
 } from "@pragma/core";
+import { assertRuntimeConformance, RuntimeResourceScope } from "@pragma/core";
 import { describe, expect, it, vi } from "vitest";
 
 import { createQoderCliRuntime } from "../src/adapter.ts";
@@ -58,6 +59,7 @@ describe("Qoder CLI Runtime adapter", () => {
       canUse: () => ({ usable: true }),
       listModels: async () => [],
     });
+    expect(() => assertRuntimeConformance(adapter)).not.toThrow();
 
     expect(adapter.descriptor).toMatchObject({
       id: "qodercli-local",
@@ -177,7 +179,8 @@ function createSessionContext(
       restoredRuntimeSessionId,
       checkpoint: vi.fn(async () => undefined),
     },
-    prepared: {},
+    resources: new RuntimeResourceScope("qodercli-adapter-test"),
+    preparedFeatures: {},
     sessionInfo: {},
   } as unknown as RuntimeDriverSessionContext;
 }

--- a/packages/runtime/qodercli/test/session.test.ts
+++ b/packages/runtime/qodercli/test/session.test.ts
@@ -120,6 +120,7 @@ function createTurn(
     prompt: "user prompt",
     attachments: [],
     startupMessages,
+    preparedFeatures: {},
     signal: new AbortController().signal,
     source: { kind: "runtime", runId: "run-1", path: [] },
     stream: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       '@pragma/runtime-pi':
         specifier: workspace:*
         version: link:../packages/runtime/pi
+      '@pragma/runtime-qodercli':
+        specifier: workspace:*
+        version: link:../packages/runtime/qodercli
       cac:
         specifier: ^7.0.0
         version: 7.0.0


### PR DESCRIPTION
## Summary

- introduce a closed, mandatory Runtime feature catalog with `supported`, `degraded`, `unsupported`, and `notApplicable` states, lifecycle placement validation, and capabilities derived by Core
- add Core-owned session/turn lifecycle hooks, resource scopes, process supervision, and deterministic cleanup
- adopt the framework across PI, Codex, Claude Code, Qoder CLI, and Antigravity, with Antigravity serving as the complete reference integration
- add reusable conformance suites, a real Runtime probe CLI, redacted evidence archives, generated integration checklists, and CI drift enforcement
- document the architecture and decision in ADR 041

## Why

Runtime adapters previously declared and implemented behavior independently, which made integration gaps, cleanup drift, and unsupported capability claims difficult to detect. This establishes one evidence-backed contract for feature status, hook ownership, resource cleanup, and adapter conformance.

## Impact

`RuntimeAdapter.features` is now required, advertised capabilities are derived from the feature set, and new adapters must declare every catalog slot and pass the shared conformance suite. Features that require authenticated live verification remain `degraded` until a real probe archive supports promoting them; this PR does not fabricate live evidence.

## Validation

- `pnpm check`
- `PRAGMA_LOG_LEVEL=error CI=true pnpm test:all` — 22/22 tasks passed
- `CI=true pnpm build` — 22/22 tasks passed
- `pnpm runtime:features:check`
- `git diff --check`

Closes #170