### PR TITLE
Add task and automation tabs to Missions

### DIFF
--- a/apps/desktop/src/main/bootstrap/application-container.ts
+++ b/apps/desktop/src/main/bootstrap/application-container.ts
@@ -22,6 +22,7 @@ import {
   createPragmaAgentTools,
 } from "@pragma/built-in-agents";
 import { MEMORY_CURATOR_REF } from "@pragma/memory";
+import { isUserFacingMissionOrigin } from "../../shared/contracts/index.ts";
 
 import { installAutomationHandlers } from "../features/automations/automation-ipc.ts";
 import { createAutomationService } from "../features/automations/automation-service.ts";
@@ -679,7 +680,7 @@ export async function createDesktopApplicationContainer(
       await memoryPlane.deleteExecutionState(executionIds);
     },
     onExecutionLinked: async ({ mission, executionId }) => {
-      if (mission.origin.type !== "user") return;
+      if (!isUserFacingMissionOrigin(mission.origin)) return;
       await memoryPlane.registerMemoryExecutionContext({
         executionId,
         missionId: mission.id,
@@ -687,14 +688,14 @@ export async function createDesktopApplicationContainer(
       });
     },
     onMissionActivity: async ({ mission }) => {
-      if (mission.origin.type !== "user") return;
+      if (!isUserFacingMissionOrigin(mission.origin)) return;
       await memoryPlane.setMemoryConversationState({
         missionId: mission.id,
         state: "active",
       });
     },
     onExecutionTerminal: async ({ mission }) => {
-      if (mission.origin.type !== "user") return;
+      if (!isUserFacingMissionOrigin(mission.origin)) return;
       await memoryPlane.setMemoryConversationState({
         missionId: mission.id,
         state: mission.lifecycleStatus === "completed" ? "completed" : "active",
@@ -956,6 +957,7 @@ export async function createDesktopApplicationContainer(
     project: pragmaProjectStore,
     getWindow: options.getWindow,
     runner: missionRunner,
+    getAutomationMissionSources: () => automationService.listMissionSources(),
     getDefaultToolPermissionMode: getToolPermissionMode,
     getDefaultWorkspace: async () =>
       (await desktopSettings.getSnapshot(options.getPreferredSystemLanguages())).defaultWorkspace,

--- a/apps/desktop/src/main/features/automations/automation-service.ts
+++ b/apps/desktop/src/main/features/automations/automation-service.ts
@@ -48,6 +48,7 @@ export interface AutomationService {
   stop(): void;
   listAdapters(): readonly AutomationAdapterOption[];
   list(): Promise<AutomationSummary[]>;
+  listMissionSources(): Promise<ReadonlyMap<string, string>>;
   save(input: SaveAutomation): Promise<AutomationSummary>;
   delete(input: DeleteAutomation): Promise<void>;
   trigger(ref: string): Promise<AutomationSummary>;
@@ -305,6 +306,7 @@ export function createAutomationService(options: {
       executorRef: resource.spec.route.executor.ref,
       missionInput: automationMissionInput(resource),
       toolPermissionMode: binding.toolPermissionMode,
+      origin: { type: "automation", automationRef: canonicalPragmaResourceRef(resource) },
       ...(binding.modelOverride === undefined ? {} : { modelOverride: binding.modelOverride }),
     });
   };
@@ -436,11 +438,57 @@ export function createAutomationService(options: {
     }));
   };
 
+  const backfillMissionSourcesForBinding = async (
+    ref: string,
+    binding: AutomationBinding,
+  ): Promise<ReadonlyMap<string, string>> => {
+    const state = await options.store.getState(ref, binding.generation);
+    const sources = new Map<string, string>();
+    if (state.missionId !== undefined) sources.set(state.missionId, ref);
+    for (const event of state.queue) sources.set(event.missionId, ref);
+    for (const run of state.runs) {
+      if (run.missionId !== undefined) sources.set(run.missionId, ref);
+    }
+    await Promise.all(
+      [...sources].map(async ([missionId, automationRef]) => {
+        try {
+          await options.missions.backfillAutomationOrigin(missionId, automationRef);
+        } catch (error) {
+          if (error instanceof MissionStoreError && error.code === "mission_not_found") return;
+          throw error;
+        }
+      }),
+    );
+    return sources;
+  };
+
+  const listMissionSources = async (): Promise<ReadonlyMap<string, string>> => {
+    const resources = (await options.project.get()).resources.filter(
+      (resource): resource is PragmaAutomationResource => resource.kind === "Automation",
+    );
+    const sources = new Map<string, string>();
+    await Promise.all(
+      resources.map(async (resource) => {
+        const ref = canonicalPragmaResourceRef(resource);
+        const binding = await options.store.getBinding(ref);
+        if (binding === undefined) return;
+        for (const [missionId, automationRef] of await backfillMissionSourcesForBinding(
+          ref,
+          binding,
+        )) {
+          sources.set(missionId, automationRef);
+        }
+      }),
+    );
+    return sources;
+  };
+
   return {
     async start() {
       if (running) return;
       running = true;
       try {
+        await listMissionSources();
         await reconcile();
       } catch (error) {
         running = false;
@@ -471,6 +519,9 @@ export function createAutomationService(options: {
       );
       return await Promise.all(resources.map(summaryFor));
     },
+    async listMissionSources() {
+      return await listMissionSources();
+    },
     async save(input) {
       const resource = PragmaAutomationResourceSchema.parse(input.resource);
       if (resource.spec.adapter !== SCHEDULE_ADAPTER) {
@@ -500,6 +551,9 @@ export function createAutomationService(options: {
               ? { modelOverride: undefined }
               : { modelOverride: input.binding.modelOverride }),
           });
+      if (rotateGeneration && previousBinding !== undefined) {
+        await backfillMissionSourcesForBinding(ref, previousBinding);
+      }
       const snapshot = await options.project.upsert({
         baseRevision: input.expectedProjectRevision,
         resource,
@@ -532,6 +586,8 @@ export function createAutomationService(options: {
     },
     async delete(input) {
       clearTimer(input.ref);
+      const binding = await options.store.getBinding(input.ref);
+      if (binding !== undefined) await backfillMissionSourcesForBinding(input.ref, binding);
       await options.project.remove({
         baseRevision: input.expectedProjectRevision,
         ref: input.ref,
@@ -572,6 +628,7 @@ export function createAutomationService(options: {
       if (resource === undefined) throw new Error(`Automation not found: ${ref}.`);
       const previous = await options.store.getBinding(ref);
       if (previous === undefined) throw new Error(`Automation binding not found: ${ref}.`);
+      await backfillMissionSourcesForBinding(ref, previous);
       const binding = createAutomationBinding({
         automationRef: ref,
         previous,

--- a/apps/desktop/src/main/features/automations/automations.test.ts
+++ b/apps/desktop/src/main/features/automations/automations.test.ts
@@ -110,7 +110,7 @@ describe("Automation Service", () => {
     await expect(service.start()).rejects.toThrow("revision unavailable");
     await expect(service.start()).resolves.toBeUndefined();
 
-    expect(get).toHaveBeenCalledTimes(2);
+    expect(get).toHaveBeenCalledTimes(3);
     service.stop();
   });
 
@@ -149,6 +149,96 @@ describe("Automation Service", () => {
       kind: "auto",
       value: "Review the release.",
     });
+  });
+
+  it("persists recoverable legacy Automation Mission sources", async () => {
+    const now = "2026-07-23T08:00:00.000Z";
+    const resource = PragmaAutomationResourceSchema.parse({
+      apiVersion: "pragma/v4",
+      kind: "Automation",
+      metadata: {
+        id: "m9a8n9nxvvyb4j01",
+        name: "Legacy review",
+        description: "Migrates its existing Mission source",
+        tags: [],
+      },
+      spec: {
+        adapter: "pragma.automation.schedule@v1",
+        binding: "binding:desktop-automation",
+        config: {
+          trigger: { kind: "calendar", frequency: "daily", time: "09:00", timezone: "UTC" },
+        },
+        enabled: true,
+        route: {
+          executor: { ref: "expert:t9ne4d8njvvxv2ea" },
+          input: { kind: "prompt", value: "Review the release." },
+        },
+        interaction: { mode: "new-mission" },
+        delivery: { adapter: "pragma.automation.delivery.local@v1" },
+      },
+    });
+    const ref = "automation:m9a8n9nxvvyb4j01";
+    const binding = createAutomationBinding({
+      automationRef: ref,
+      rotateGeneration: true,
+      workspace: { path: "/tmp", basename: "tmp" },
+      toolPermissionMode: "request-approval",
+    });
+    const backfillAutomationOrigin = vi.fn<MissionStore["backfillAutomationOrigin"]>(
+      async () => ({}) as Awaited<ReturnType<MissionStore["backfillAutomationOrigin"]>>,
+    );
+    const service = createAutomationService({
+      paths: new PragmaPaths({ pragmaHome: "/tmp/pragma-automation-source-backfill-test" }),
+      project: {
+        get: vi.fn(async () => ({
+          schemaVersion: "pragma.project-snapshot/v3",
+          projectId: "studio",
+          revision: 1,
+          resources: [resource],
+          diagnostics: [],
+        })),
+      } as unknown as PragmaProjectStore,
+      store: {
+        getBinding: vi.fn(async () => binding),
+        getState: vi.fn(async () => ({
+          schemaVersion: "pragma.automation-state/v1",
+          automationRef: ref,
+          generation: binding.generation,
+          missionId: "7b143dfa-16d9-45dd-8275-839565ac691f",
+          queue: [
+            {
+              eventId: "queued-event",
+              scheduledFor: now,
+              missionId: "2ad8b3f3-76d5-42f7-aad0-072b9c89f430",
+              createdAt: now,
+            },
+          ],
+          runs: [
+            {
+              eventId: "legacy-event",
+              scheduledFor: now,
+              status: "dispatched",
+              missionId: "d8e672d1-2dc9-4f46-bcbe-e26417141396",
+              createdAt: now,
+              updatedAt: now,
+            },
+          ],
+          updatedAt: now,
+        })),
+      } as unknown as AutomationStore,
+      missions: { backfillAutomationOrigin } as unknown as MissionStore,
+      creator: {} as MissionCreator,
+      runner: {} as MissionRunner,
+    });
+
+    await expect(service.listMissionSources()).resolves.toEqual(
+      new Map([
+        ["7b143dfa-16d9-45dd-8275-839565ac691f", ref],
+        ["2ad8b3f3-76d5-42f7-aad0-072b9c89f430", ref],
+        ["d8e672d1-2dc9-4f46-bcbe-e26417141396", ref],
+      ]),
+    );
+    expect(backfillAutomationOrigin).toHaveBeenCalledTimes(3);
   });
 
   it("queues a manual trigger through the normal Automation event pipeline", async () => {

--- a/apps/desktop/src/main/features/missions/mission-context-store-browser.ts
+++ b/apps/desktop/src/main/features/missions/mission-context-store-browser.ts
@@ -13,6 +13,7 @@ import {
 import { canonicalPragmaResourceRef, type PragmaResource } from "@pragma/interpreter/ast";
 
 import {
+  isUserFacingMissionOrigin,
   MissionContextStoreContentSchema,
   MissionContextStoreDescriptorSchema,
   MissionContextStoreEntrySchema,
@@ -689,7 +690,7 @@ async function scopeAvailability(
 
 async function userMission(missions: MissionStore, missionId: string): Promise<Mission> {
   const mission = await missions.get(missionId);
-  if (mission.origin.type !== "user") throw codedError("mission_not_found");
+  if (!isUserFacingMissionOrigin(mission.origin)) throw codedError("mission_not_found");
   return mission;
 }
 

--- a/apps/desktop/src/main/features/missions/mission-creator.ts
+++ b/apps/desktop/src/main/features/missions/mission-creator.ts
@@ -26,6 +26,7 @@ export interface MissionCreator {
     readonly attachments?: readonly ExpertPromptAttachment[] | undefined;
     readonly toolPermissionMode?: DesktopToolPermissionMode | undefined;
     readonly modelOverride?: MissionModelOverride | undefined;
+    readonly origin?: Mission["origin"] | undefined;
   }): Promise<Mission>;
 }
 
@@ -96,6 +97,7 @@ export function createMissionCreator(options: {
         executor,
         ...(input.attachments === undefined ? {} : { attachments: input.attachments }),
         ...(input.modelOverride === undefined ? {} : { modelOverride: input.modelOverride }),
+        ...(input.origin === undefined ? {} : { origin: input.origin }),
         toolPermissionMode:
           input.toolPermissionMode ?? (await options.getDefaultToolPermissionMode()),
       });

--- a/apps/desktop/src/main/features/missions/mission-ipc.ts
+++ b/apps/desktop/src/main/features/missions/mission-ipc.ts
@@ -23,6 +23,9 @@ import {
   SendMissionMessageSchema,
   UpdateMissionOptionsSchema,
   UpdateHomeExecutorPreferenceSchema,
+  isUserFacingMissionOrigin,
+  type Mission,
+  type MissionSummary,
   type PickMissionAttachmentsResult,
   type DesktopToolPermissionMode,
 } from "../../../shared/contracts/index.ts";
@@ -50,6 +53,7 @@ export function installMissionHandlers(options: {
   readonly homeExecutors: HomeExecutorCatalog;
   readonly project: PragmaProjectStore;
   readonly runner: MissionRunner;
+  readonly getAutomationMissionSources: () => Promise<ReadonlyMap<string, string>>;
   readonly getWindow: () => BrowserWindow | null;
   readonly getDefaultToolPermissionMode: () =>
     DesktopToolPermissionMode | Promise<DesktopToolPermissionMode>;
@@ -65,6 +69,8 @@ export function installMissionHandlers(options: {
       }) => Promise<void>)
     | undefined;
 }): void {
+  let legacyAutomationMissionSources: ReadonlyMap<string, string> = new Map();
+  let legacyAutomationMissionSourcesRequest: Promise<ReadonlyMap<string, string>> | undefined;
   const imageDrafts = createMissionImageDraftStore({ temporaryRoot: options.temporaryRoot });
   installMissionAttachmentProtocol(options.missions, imageDrafts);
   const getCreationDefaults = async () => {
@@ -81,11 +87,30 @@ export function installMissionHandlers(options: {
       toolPermissionMode: await options.getDefaultToolPermissionMode(),
     });
   };
-  const publishMission = (mission: Awaited<ReturnType<MissionStore["get"]>>): void => {
-    if (mission.origin.type !== "user") return;
+  const ensureLegacyAutomationMissionSources = async (): Promise<void> => {
+    legacyAutomationMissionSourcesRequest ??= options.getAutomationMissionSources();
+    try {
+      legacyAutomationMissionSources = await legacyAutomationMissionSourcesRequest;
+    } catch (error) {
+      legacyAutomationMissionSourcesRequest = undefined;
+      throw error;
+    }
+  };
+  const sourceForMission = (mission: Mission): MissionSummary["source"] => {
+    if (mission.origin.type === "automation") {
+      return { type: "automation", automationRef: mission.origin.automationRef };
+    }
+    const automationRef = legacyAutomationMissionSources.get(mission.id);
+    return automationRef === undefined ? { type: "task" } : { type: "automation", automationRef };
+  };
+  const publishMission = async (
+    mission: Awaited<ReturnType<MissionStore["get"]>>,
+  ): Promise<void> => {
+    if (!isUserFacingMissionOrigin(mission.origin)) return;
     publishMissionUpdate(() => options.getWindow()?.webContents ?? null, {
       kind: "upsert",
       mission,
+      source: sourceForMission(mission),
     });
   };
   const publishRemoval = (missionId: string): void => {
@@ -94,18 +119,28 @@ export function installMissionHandlers(options: {
       missionId,
     });
   };
-  const getUserMission = async (id: string) => {
+  const getManagedMission = async (id: string) => {
+    await ensureLegacyAutomationMissionSources();
     const mission = await options.missions.get(id);
-    if (mission.origin.type !== "user") throw new Error("mission_not_found");
+    if (!isUserFacingMissionOrigin(mission.origin)) throw new Error("mission_not_found");
     return mission;
   };
-  const assertUserMission = async (id: string): Promise<string> => {
-    await getUserMission(id);
+  const assertManagedMission = async (id: string): Promise<string> => {
+    await getManagedMission(id);
     return id;
   };
-  ipcMain.handle("missions:list", () => options.missions.list());
+  ipcMain.handle("missions:list", async () => {
+    await ensureLegacyAutomationMissionSources();
+    return (await options.missions.list()).map((mission) => {
+      if (mission.source.type === "automation") return mission;
+      const automationRef = legacyAutomationMissionSources.get(mission.id);
+      return automationRef === undefined
+        ? mission
+        : { ...mission, source: { type: "automation" as const, automationRef } };
+    });
+  });
   ipcMain.handle("missions:get", (_event, id: unknown) =>
-    getUserMission(MissionIdSchema.parse(id)),
+    getManagedMission(MissionIdSchema.parse(id)),
   );
   ipcMain.handle("missions:executors:list", async () =>
     MissionExecutorOptionSchema.array().parse(await options.executors.list()),
@@ -126,7 +161,7 @@ export function installMissionHandlers(options: {
   ipcMain.handle("missions:model-options:get", async (_event, input: unknown) => {
     const { executorRef, missionId } = MissionModelOptionsRequestSchema.parse(input);
     if (missionId === undefined) return await options.executors.getModelOptions(executorRef);
-    const mission = await getUserMission(missionId);
+    const mission = await getManagedMission(missionId);
     const [runtimeBinding, project] = await Promise.all([
       options.runner.getRuntimeBinding(missionId),
       options.project.openRevision(mission.project.revision),
@@ -216,88 +251,88 @@ export function installMissionHandlers(options: {
       options.recordWorkspaceUsage(parsed.workspace),
       options.homeExecutors.recordUsage(parsed.executor.ref, parsed.workspace),
     ]);
-    publishMission(mission);
+    await publishMission(mission);
     return mission;
   });
   ipcMain.handle("missions:run", (_event, input: unknown) =>
     runDesktopMutation(async () => {
       const mission = await options.runner.run(
-        await assertUserMission(MissionActionSchema.parse(input).id),
+        await assertManagedMission(MissionActionSchema.parse(input).id),
       );
-      publishMission(mission);
+      await publishMission(mission);
       return mission;
     }),
   );
   ipcMain.handle("missions:options:update", (_event, input: unknown) =>
     runDesktopMutation(async () => {
       const parsed = UpdateMissionOptionsSchema.parse(input);
-      await assertUserMission(parsed.id);
+      await assertManagedMission(parsed.id);
       const mission = await options.runner.updateOptions(parsed);
-      publishMission(mission);
+      await publishMission(mission);
       return mission;
     }),
   );
   ipcMain.handle("missions:message:send", (_event, input: unknown) =>
     runDesktopMutation(async () => {
       const parsed = SendMissionMessageSchema.parse(input);
-      await assertUserMission(parsed.id);
+      await assertManagedMission(parsed.id);
       const mission = await options.runner.sendMessage(parsed);
       await imageDrafts.discard(parsed.attachments.map((attachment) => attachment.id));
-      publishMission(mission);
+      await publishMission(mission);
       return mission;
     }),
   );
   ipcMain.handle("missions:chat:get", async (_event, input: unknown) => {
     const parsed = GetMissionChatSchema.parse(input);
-    await assertUserMission(parsed.id);
+    await assertManagedMission(parsed.id);
     return await options.runner.getChat(parsed);
   });
   ipcMain.handle("missions:context:compact", (_event, input: unknown) =>
     runDesktopMutation(
       async () =>
         await options.runner.compactContext(
-          await assertUserMission(MissionActionSchema.parse(input).id),
+          await assertManagedMission(MissionActionSchema.parse(input).id),
         ),
     ),
   );
   ipcMain.handle("missions:interrupt", (_event, input: unknown) =>
     runDesktopMutation(async () => {
       const mission = await options.runner.interrupt(
-        await assertUserMission(MissionActionSchema.parse(input).id),
+        await assertManagedMission(MissionActionSchema.parse(input).id),
       );
-      publishMission(mission);
+      await publishMission(mission);
       return mission;
     }),
   );
   ipcMain.handle(
     "missions:work:get",
     async (_event, input: unknown) =>
-      await options.runner.getWork(await assertUserMission(MissionActionSchema.parse(input).id)),
+      await options.runner.getWork(await assertManagedMission(MissionActionSchema.parse(input).id)),
   );
   ipcMain.handle("missions:work:conversation:get", async (_event, input: unknown) => {
     const parsed = GetMissionWorkConversationSchema.parse(input);
-    await assertUserMission(parsed.id);
+    await assertManagedMission(parsed.id);
     return await options.runner.getWorkConversation(parsed);
   });
   ipcMain.handle(
     "missions:human:list",
     async (_event, input: unknown) =>
       await options.runner.listHumanInteractions(
-        await assertUserMission(MissionActionSchema.parse(input).id),
+        await assertManagedMission(MissionActionSchema.parse(input).id),
       ),
   );
   ipcMain.handle("missions:human:respond", async (_event, input: unknown) => {
     return await runDesktopMutation(async () => {
       const parsed = RespondMissionHumanInteractionSchema.parse(input);
-      await assertUserMission(parsed.missionId);
+      await assertManagedMission(parsed.missionId);
       return await options.runner.respondToHumanInteraction(parsed);
     });
   });
   ipcMain.handle("missions:complete", async (_event, input: unknown) => {
-    const missionId = await assertUserMission(MissionActionSchema.parse(input).id);
+    const missionId = await assertManagedMission(MissionActionSchema.parse(input).id);
     const mission = await options.missions.markComplete(missionId);
     if (
-      mission.origin.type === "user" &&
+      isUserFacingMissionOrigin(mission.origin) &&
       !(
         mission.execution !== undefined &&
         ["queued", "running", "waiting"].includes(mission.execution.status)
@@ -308,22 +343,22 @@ export function installMissionHandlers(options: {
         state: "completed",
       });
     }
-    publishMission(mission);
+    await publishMission(mission);
     return mission;
   });
   ipcMain.handle("missions:reopen", async (_event, input: unknown) => {
-    const missionId = await assertUserMission(MissionActionSchema.parse(input).id);
+    const missionId = await assertManagedMission(MissionActionSchema.parse(input).id);
     const mission = await options.missions.reopen(missionId);
-    if (mission.origin.type === "user") {
+    if (isUserFacingMissionOrigin(mission.origin)) {
       await options.onMissionLifecycleChange?.({ missionId: mission.id, state: "active" });
     }
-    publishMission(mission);
+    await publishMission(mission);
     return mission;
   });
   ipcMain.handle("missions:delete", (_event, input: unknown) =>
     runDesktopMutation(async () => {
       const missionId = MissionActionSchema.parse(input).id;
-      await assertUserMission(missionId);
+      await assertManagedMission(missionId);
       await options.runner.delete(missionId);
       publishRemoval(missionId);
     }),
@@ -332,7 +367,8 @@ export function installMissionHandlers(options: {
     forwardMissionChatNotification({
       notification,
       getSender: () => options.getWindow()?.webContents ?? null,
-      refreshMissionSummary: async (missionId) => publishMission(await getUserMission(missionId)),
+      refreshMissionSummary: async (missionId) =>
+        await publishMission(await getManagedMission(missionId)),
       reportSummaryRefreshFailure: (error, missionId) => {
         console.warn(
           JSON.stringify({

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -67,24 +67,25 @@ import {
   RuntimeContextWindowUsageSchema,
 } from "@pragma/shared";
 
-import type {
-  Mission,
-  MissionChatEntry,
-  MissionChatPatch,
-  MissionChatSnapshot,
-  MissionChatUpdate,
-  MissionChatQuery,
-  MissionContextCompactionResult,
-  MissionContextWindowState,
-  MissionHumanInteraction,
-  MissionModelOverride,
-  MissionWorkConversationSnapshot,
-  MissionWorkRecord,
-  MissionWorkSnapshot,
-  MissionWorkUpdate,
-  GetMissionWorkConversation,
-  DesktopToolPermissionMode,
-  UpdateMissionOptions,
+import {
+  isUserFacingMissionOrigin,
+  type Mission,
+  type MissionChatEntry,
+  type MissionChatPatch,
+  type MissionChatSnapshot,
+  type MissionChatUpdate,
+  type MissionChatQuery,
+  type MissionContextCompactionResult,
+  type MissionContextWindowState,
+  type MissionHumanInteraction,
+  type MissionModelOverride,
+  type MissionWorkConversationSnapshot,
+  type MissionWorkRecord,
+  type MissionWorkSnapshot,
+  type MissionWorkUpdate,
+  type GetMissionWorkConversation,
+  type DesktopToolPermissionMode,
+  type UpdateMissionOptions,
 } from "../../../shared/contracts/index.ts";
 import type { CapabilityCredentialStore } from "../capabilities/capability-credential-store.ts";
 import type { CapabilityStore } from "../capabilities/capability-store.ts";
@@ -199,7 +200,7 @@ interface ActiveMissionExecution {
 }
 
 function missionSurfaceAudience(mission: Pick<Mission, "origin">): MissionSurfaceAudience {
-  return mission.origin.type === "user" ? "user" : "internal";
+  return isUserFacingMissionOrigin(mission.origin) ? "user" : "internal";
 }
 
 export async function compactExpertSessionContext(
@@ -340,7 +341,7 @@ export function createMissionRunner(options: {
     }
   };
   const createExecutionContext = async (mission: Mission): Promise<MissionExecutionContext> => {
-    const systemMission = mission.origin.type !== "user";
+    const systemMission = !isUserFacingMissionOrigin(mission.origin);
     let toolPermissionMode = mission.toolPermissionMode;
     const runtimes: RuntimeResolver = {
       getDefaultRuntimeId: async () =>

--- a/apps/desktop/src/main/features/missions/mission-store.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-store.test.ts
@@ -349,7 +349,7 @@ describe("mission store", () => {
     expect(reopened.completedAt).toBeUndefined();
   });
 
-  it("keeps system Memory Missions out of the user Mission list", async () => {
+  it("lists user and Automation Missions while keeping system Memory Missions internal", async () => {
     const root = await temporaryRoot();
     const store = createMissionStore({ missionsPath: join(root, "missions") });
     const user = await store.create({
@@ -365,11 +365,55 @@ describe("mission store", () => {
       executor: missionExecutorSnapshot(expertFixture()),
       origin: { type: "system-memory", jobId: "memory-job" },
     });
+    const automation = await store.create({
+      workspace: { path: join(root, "workspace"), basename: "workspace" },
+      goal: "Scheduled review",
+      project: { id: "studio", revision: 1 },
+      executor: missionExecutorSnapshot(expertFixture()),
+      origin: { type: "automation", automationRef: "automation:m9a8n9nxvvyb4j01" },
+    });
 
-    await expect(store.list()).resolves.toEqual([expect.objectContaining({ id: user.id })]);
+    await expect(store.list()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: automation.id,
+          source: { type: "automation", automationRef: "automation:m9a8n9nxvvyb4j01" },
+        }),
+        expect.objectContaining({ id: user.id, source: { type: "task" } }),
+      ]),
+    );
     await expect(store.get(internal.id)).resolves.toMatchObject({
       origin: { type: "system-memory" },
     });
+  });
+
+  it("persists a recoverable legacy Automation origin without changing Mission recency", async () => {
+    const root = await temporaryRoot();
+    const store = createMissionStore({ missionsPath: join(root, "missions") });
+    const legacy = await store.create({
+      workspace: { path: join(root, "workspace"), basename: "workspace" },
+      goal: "Legacy scheduled review",
+      project: { id: "studio", revision: 1 },
+      executor: missionExecutorSnapshot(expertFixture()),
+    });
+
+    const migrated = await store.backfillAutomationOrigin(
+      legacy.id,
+      "automation:m9a8n9nxvvyb4j01",
+    );
+
+    expect(migrated).toMatchObject({
+      id: legacy.id,
+      origin: { type: "automation", automationRef: "automation:m9a8n9nxvvyb4j01" },
+      updatedAt: legacy.updatedAt,
+    });
+    await expect(store.list()).resolves.toEqual([
+      expect.objectContaining({
+        id: legacy.id,
+        source: { type: "automation", automationRef: "automation:m9a8n9nxvvyb4j01" },
+        updatedAt: legacy.updatedAt,
+      }),
+    ]);
   });
 
   it("limits rule-based titles derived from the Mission goal", async () => {

--- a/apps/desktop/src/main/features/missions/mission-store.ts
+++ b/apps/desktop/src/main/features/missions/mission-store.ts
@@ -25,12 +25,14 @@ import { z } from "zod";
 
 import {
   MissionIdSchema,
+  MissionOriginSchema,
   MissionSchema,
   MissionV3Schema,
   MissionV4Schema,
   MissionV5Schema,
   MissionV6Schema,
   MissionTimelineRecordSchema,
+  isUserFacingMissionOrigin,
   MissionAttachmentsManifestSchema,
   MissionChatEntrySchema,
   MissionUserMessageSchema,
@@ -69,6 +71,7 @@ export interface MissionStore {
   list(): Promise<MissionSummary[]>;
   resolveExecutionTitles(executionIds: readonly string[]): Promise<ReadonlyMap<string, string>>;
   get(id: string): Promise<Mission>;
+  backfillAutomationOrigin(id: string, automationRef: string): Promise<Mission>;
   getAttachments(id: string): Promise<readonly ExpertPromptAttachment[]>;
   create(input: {
     readonly id?: string | undefined;
@@ -546,7 +549,7 @@ export function createMissionStore(options: { readonly missionsPath: string }): 
         );
         const missions = await Promise.all(directories.map((entry) => readMission(entry.name)));
         return missions
-          .filter((mission) => mission.origin.type === "user")
+          .filter((mission) => isUserFacingMissionOrigin(mission.origin))
           .map(toMissionSummary)
           .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt));
       } catch (error) {
@@ -596,6 +599,33 @@ export function createMissionStore(options: { readonly missionsPath: string }): 
     },
     async get(id) {
       return await readMission(MissionIdSchema.parse(id));
+    },
+    async backfillAutomationOrigin(id, automationRef) {
+      const parsedId = MissionIdSchema.parse(id);
+      const parsedOrigin = MissionOriginSchema.parse({ type: "automation", automationRef });
+      if (parsedOrigin.type !== "automation") throw new Error("Invalid Automation origin.");
+      return await withMissionLock(parsedId, async () => {
+        await recoverPendingTransactions(parsedId);
+        const current = await readMissionUnlocked(parsedId);
+        if (current.origin.type === "automation") {
+          if (current.origin.automationRef !== parsedOrigin.automationRef) {
+            throw new MissionStoreError(
+              "config_invalid",
+              `Mission ${parsedId} is already owned by ${current.origin.automationRef}.`,
+            );
+          }
+          return current;
+        }
+        if (current.origin.type !== "user") {
+          throw new MissionStoreError(
+            "config_invalid",
+            `Mission ${parsedId} is not a user-facing legacy Automation Mission.`,
+          );
+        }
+        const updated = MissionSchema.parse({ ...current, origin: parsedOrigin });
+        await writeYamlAtomically(manifestPath(parsedId), updated);
+        return updated;
+      });
     },
     async getAttachments(id) {
       const parsedId = MissionIdSchema.parse(id);
@@ -1082,6 +1112,10 @@ function toMissionSummary(mission: Mission): MissionSummary {
     workspace: { basename: mission.workspace.basename },
     executor: { kind: mission.executor.kind, name: mission.executor.name },
     ...(mission.execution === undefined ? {} : { execution: { status: mission.execution.status } }),
+    source:
+      mission.origin.type === "automation"
+        ? { type: "automation", automationRef: mission.origin.automationRef }
+        : { type: "task" },
     lifecycleStatus: mission.lifecycleStatus,
     updatedAt: mission.updatedAt,
   };

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -1,6 +1,11 @@
 export const missions = {
   title: "Missions",
   newMission: "New mission",
+  missionSources: "Mission sources",
+  sourceTabs: {
+    task: "Tasks",
+    automation: "Automation",
+  },
   start: "Start a mission",
   search: "Search missions",
   loading: "Loading missions…",
@@ -43,7 +48,9 @@ export const missions = {
   completed: "Completed",
   noWaitingInput: "No missions need input",
   noActive: "No active missions",
+  noActiveAutomations: "No active automation missions",
   noCompleted: "No completed missions",
+  noCompletedAutomations: "No completed automation missions",
   loadMoreMissions: "Load more",
   pinMission: "Pin mission",
   unpinMission: "Unpin mission",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -1,6 +1,11 @@
 export const missions = {
   title: "任务",
   newMission: "新建任务",
+  missionSources: "任务来源",
+  sourceTabs: {
+    task: "任务",
+    automation: "自动化",
+  },
   start: "开始任务",
   search: "搜索任务",
   loading: "正在加载任务…",
@@ -40,7 +45,9 @@ export const missions = {
   completed: "已完成",
   noWaitingInput: "暂无待输入的任务",
   noActive: "暂无进行中的任务",
+  noActiveAutomations: "暂无进行中的自动化任务",
   noCompleted: "暂无已完成的任务",
+  noCompletedAutomations: "暂无已完成的自动化任务",
   loadMoreMissions: "加载更多",
   pinMission: "置顶任务",
   unpinMission: "取消置顶",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -1,6 +1,11 @@
 export const missions = {
   title: "任務",
   newMission: "新增任務",
+  missionSources: "任務來源",
+  sourceTabs: {
+    task: "任務",
+    automation: "自動化",
+  },
   start: "開始任務",
   search: "搜尋任務",
   loading: "正在載入任務…",
@@ -40,7 +45,9 @@ export const missions = {
   completed: "已完成",
   noWaitingInput: "暫無待輸入的任務",
   noActive: "暫無進行中的任務",
+  noActiveAutomations: "暫無進行中的自動化任務",
   noCompleted: "暫無已完成的任務",
+  noCompletedAutomations: "暫無已完成的自動化任務",
   loadMoreMissions: "載入更多",
   pinMission: "置頂任務",
   unpinMission: "取消置頂",

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -119,10 +119,58 @@ describe("MissionsPage", () => {
     );
 
     expect(html).toContain("New mission");
+    expect(html).toContain('aria-label="Mission sources"');
+    expect(html).toMatch(/aria-selected="true"[^>]*>Tasks<\/button>/);
+    expect(html).toMatch(/aria-selected="false"[^>]*>Automation<\/button>/);
     expect(html).toContain('aria-label="Resize navigation"');
     expect(html).not.toContain("mission-create-selectors");
     expect(html).not.toContain("Needs input");
     expect(html).not.toContain("No missions need input");
+  });
+
+  it("shows only the selected Mission source in the rail", () => {
+    const task = missionSummaryFixture({
+      id: "task-mission",
+      title: "Manual review",
+      updatedAt: "2026-07-11T00:00:02.000Z",
+    });
+    const automation = missionSummaryFixture({
+      id: "automation-mission",
+      title: "Scheduled review",
+      source: {
+        type: "automation",
+        automationRef: "automation:m9a8n9nxvvyb4j01",
+      },
+      updatedAt: "2026-07-11T00:00:01.000Z",
+    });
+    const taskHtml = renderToStaticMarkup(
+      <MissionsPage
+        initialMemoryState={{
+          missions: [task, automation],
+          selectedMission: null,
+          selectedMissionId: null,
+          activeSource: "task",
+        }}
+        onCreate={() => undefined}
+      />,
+    );
+    const automationHtml = renderToStaticMarkup(
+      <MissionsPage
+        initialMemoryState={{
+          missions: [task, automation],
+          selectedMission: null,
+          selectedMissionId: null,
+          activeSource: "automation",
+        }}
+        onCreate={() => undefined}
+      />,
+    );
+
+    expect(taskHtml).toContain("Manual review");
+    expect(taskHtml).not.toContain("Scheduled review");
+    expect(automationHtml).toContain("Scheduled review");
+    expect(automationHtml).not.toContain("Manual review");
+    expect(automationHtml).toContain("mission-source-tabs is-automation");
   });
 
   it("offers the shared attachment picker in the Mission chat composer", () => {
@@ -1386,6 +1434,7 @@ function missionSummaryFixture(input: {
   readonly title: string;
   readonly lifecycleStatus?: MissionSummary["lifecycleStatus"] | undefined;
   readonly status?: NonNullable<MissionSummary["execution"]>["status"] | undefined;
+  readonly source?: MissionSummary["source"] | undefined;
   readonly updatedAt: string;
 }): MissionSummary {
   return {
@@ -1394,6 +1443,7 @@ function missionSummaryFixture(input: {
     workspace: { basename: "expert-mesh" },
     executor: { kind: "expert", name: "Product Designer" },
     ...(input.status === undefined ? {} : { execution: { status: input.status } }),
+    source: input.source ?? { type: "task" },
     lifecycleStatus: input.lifecycleStatus ?? "active",
     updatedAt: input.updatedAt,
   };

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -115,11 +115,17 @@ export interface MissionsPageMemoryState {
   readonly missions: readonly MissionSummary[];
   readonly selectedMission: Mission | null;
   readonly selectedMissionId: string | null;
+  readonly activeSource?: MissionListSource | undefined;
+  readonly selectedMissionIds?: Partial<Record<MissionListSource, string>> | undefined;
 }
 
 interface MissionsPageInitialState extends MissionsPageMemoryState {
   readonly hasResolvedInitialLoad: boolean;
+  readonly activeSource: MissionListSource;
+  readonly selectedMissionIds: Partial<Record<MissionListSource, string>>;
 }
+
+export type MissionListSource = "task" | "automation";
 
 export function resolveMissionsPageInitialState(input: {
   readonly initialMission?: Mission | undefined;
@@ -127,20 +133,34 @@ export function resolveMissionsPageInitialState(input: {
 }): MissionsPageInitialState {
   const cachedMissions = input.memoryState?.missions ?? [];
   if (input.initialMission !== undefined) {
+    const source = missionListSourceForMission(input.initialMission);
     return {
       missions: upsertMissionSummary(cachedMissions, missionToSummary(input.initialMission)),
       selectedMission: input.initialMission,
       selectedMissionId: input.initialMission.id,
+      activeSource: source,
+      selectedMissionIds: {
+        ...input.memoryState?.selectedMissionIds,
+        [source]: input.initialMission.id,
+      },
       hasResolvedInitialLoad: true,
     };
   }
   if (input.memoryState !== undefined) {
-    return { ...input.memoryState, hasResolvedInitialLoad: true };
+    const activeSource = input.memoryState.activeSource ?? "task";
+    return {
+      ...input.memoryState,
+      activeSource,
+      selectedMissionIds: input.memoryState.selectedMissionIds ?? {},
+      hasResolvedInitialLoad: true,
+    };
   }
   return {
     missions: [],
     selectedMission: null,
     selectedMissionId: null,
+    activeSource: "task",
+    selectedMissionIds: {},
     hasResolvedInitialLoad: false,
   };
 }
@@ -170,6 +190,7 @@ export function MissionsPage(props: {
   const [selectedMissionId, setSelectedMissionId] = useState<string | null>(
     initialState.selectedMissionId,
   );
+  const [activeSource, setActiveSource] = useState<MissionListSource>(initialState.activeSource);
   const [hasResolvedInitialLoad, setHasResolvedInitialLoad] = useState(
     initialState.hasResolvedInitialLoad,
   );
@@ -193,12 +214,21 @@ export function MissionsPage(props: {
       : null,
   );
   const selectedMissionIdRef = useRef<string | null>(initialState.selectedMissionId);
+  const activeSourceRef = useRef<MissionListSource>(initialState.activeSource);
+  const selectedMissionIdsRef = useRef<Partial<Record<MissionListSource, string>>>(
+    initialState.selectedMissionIds,
+  );
   const initialRunStartedRef = useRef(false);
   const hadInitialMemoryStateRef = useRef(props.initialMemoryState !== undefined);
   const removedMissionIdsRef = useRef(new Set<string>());
-  const missionUpdatesDuringRefreshRef = useRef(new Map<string, Mission | null>());
+  const missionUpdatesDuringRefreshRef = useRef(
+    new Map<
+      string,
+      { readonly mission: Mission; readonly source: MissionSummary["source"] } | null
+    >(),
+  );
 
-  const replaceMission = useCallback((updated: Mission) => {
+  const replaceMission = useCallback((updated: Mission, source?: MissionSummary["source"]) => {
     if (
       updated.execution !== undefined &&
       !["queued", "running", "waiting"].includes(updated.execution.status)
@@ -215,7 +245,10 @@ export function MissionsPage(props: {
     setSelectedMission((current) =>
       current?.id === updated.id && updated.updatedAt >= current.updatedAt ? updated : current,
     );
-    setMissions((current) => upsertMissionSummary(current, missionToSummary(updated)));
+    setMissions((current) => {
+      const knownSource = current.find((mission) => mission.id === updated.id)?.source;
+      return upsertMissionSummary(current, missionToSummary(updated, source ?? knownSource));
+    });
   }, []);
 
   const updatePinnedMissionIds = useCallback((update: (current: readonly string[]) => string[]) => {
@@ -226,32 +259,47 @@ export function MissionsPage(props: {
     });
   }, []);
 
-  const openMission = useCallback(async (id: string, options?: { readonly silent?: boolean }) => {
-    selectedMissionIdRef.current = id;
-    setSelectedMissionId(id);
-    setSelectedMission((current) => (current?.id === id ? current : null));
-    if (!options?.silent) setError(null);
-    writeLastOpenedMissionId(typeof window === "undefined" ? undefined : window.localStorage, id);
-    const api = desktopApi();
-    if (api === undefined) return;
-    try {
-      const mission = await api.getMission(id);
-      if (selectedMissionIdRef.current === id) {
-        setSelectedMission((current) =>
-          current === null || mission.updatedAt >= current.updatedAt ? mission : current,
-        );
+  const openMission = useCallback(
+    async (
+      id: string,
+      options?: { readonly silent?: boolean; readonly source?: MissionListSource },
+    ) => {
+      const source = options?.source ?? activeSourceRef.current;
+      selectedMissionIdsRef.current = { ...selectedMissionIdsRef.current, [source]: id };
+      selectedMissionIdRef.current = id;
+      setSelectedMissionId(id);
+      setSelectedMission((current) => (current?.id === id ? current : null));
+      if (!options?.silent) setError(null);
+      writeLastOpenedMissionId(typeof window === "undefined" ? undefined : window.localStorage, id);
+      const api = desktopApi();
+      if (api === undefined) return;
+      try {
+        const mission = await api.getMission(id);
+        if (selectedMissionIdRef.current === id) {
+          setSelectedMission((current) =>
+            current === null || mission.updatedAt >= current.updatedAt ? mission : current,
+          );
+        }
+      } catch (loadError) {
+        if (selectedMissionIdRef.current === id && !options?.silent) {
+          setError(errorMessage(loadError));
+        }
       }
-    } catch (loadError) {
-      if (selectedMissionIdRef.current === id && !options?.silent) {
-        setError(errorMessage(loadError));
-      }
-    }
-  }, []);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!hasResolvedInitialLoad) return;
-    props.onMemoryStateChange?.({ missions, selectedMission, selectedMissionId });
+    props.onMemoryStateChange?.({
+      missions,
+      selectedMission,
+      selectedMissionId,
+      activeSource,
+      selectedMissionIds: selectedMissionIdsRef.current,
+    });
   }, [
+    activeSource,
     hasResolvedInitialLoad,
     missions,
     props.onMemoryStateChange,
@@ -264,19 +312,12 @@ export function MissionsPage(props: {
     if (api === undefined) return;
     return api.subscribeMissionUpdates((update) => {
       if (update.kind === "upsert") {
-        if (update.mission.origin.type !== "user") {
-          missionUpdatesDuringRefreshRef.current.set(update.mission.id, null);
-          setMissions((current) => current.filter((mission) => mission.id !== update.mission.id));
-          if (selectedMissionIdRef.current === update.mission.id) {
-            selectedMissionIdRef.current = null;
-            setSelectedMissionId(null);
-            setSelectedMission(null);
-          }
-          return;
-        }
         if (removedMissionIdsRef.current.has(update.mission.id)) return;
-        missionUpdatesDuringRefreshRef.current.set(update.mission.id, update.mission);
-        replaceMission(update.mission);
+        missionUpdatesDuringRefreshRef.current.set(update.mission.id, {
+          mission: update.mission,
+          source: update.source,
+        });
+        replaceMission(update.mission, update.source);
         return;
       }
       writeMissionDraft(
@@ -337,7 +378,9 @@ export function MissionsPage(props: {
         if (cancelled) return;
         const refreshedMissions = [...missionUpdatesDuringRefreshRef.current.values()].reduce(
           (current, updated) =>
-            updated === null ? current : upsertMissionSummary(current, missionToSummary(updated)),
+            updated === null
+              ? current
+              : upsertMissionSummary(current, missionToSummary(updated.mission, updated.source)),
           storedMissions.filter(
             (mission) =>
               !removedMissionIdsRef.current.has(mission.id) &&
@@ -353,8 +396,11 @@ export function MissionsPage(props: {
               .map((mission) => mission.id),
           ),
         );
-        let missionId = selectedMissionIdRef.current;
-        if (missionId !== null && !refreshedMissions.some((mission) => mission.id === missionId)) {
+        const sourceMissions = refreshedMissions.filter(
+          (mission) => missionListSourceForSummary(mission) === activeSourceRef.current,
+        );
+        let missionId = selectedMissionIdsRef.current[activeSourceRef.current] ?? null;
+        if (missionId !== null && !sourceMissions.some((mission) => mission.id === missionId)) {
           selectedMissionIdRef.current = null;
           setSelectedMissionId(null);
           setSelectedMission(null);
@@ -364,10 +410,13 @@ export function MissionsPage(props: {
           const lastOpenedId = readLastOpenedMissionId(
             typeof window === "undefined" ? undefined : window.localStorage,
           );
-          missionId = selectPreferredMissionId(refreshedMissions, lastOpenedId);
+          missionId = selectPreferredMissionId(sourceMissions, lastOpenedId);
         }
         if (missionId !== null) {
-          await openMission(missionId, { silent: hadInitialMemoryStateRef.current });
+          await openMission(missionId, {
+            silent: hadInitialMemoryStateRef.current,
+            source: activeSourceRef.current,
+          });
         } else {
           writeLastOpenedMissionId(
             typeof window === "undefined" ? undefined : window.localStorage,
@@ -390,13 +439,41 @@ export function MissionsPage(props: {
 
   const visibleMissions = useMemo(() => {
     const query = search.trim().toLocaleLowerCase();
-    if (query === "") return missions;
-    return missions.filter((mission) =>
+    const sourceMissions = missions.filter(
+      (mission) => missionListSourceForSummary(mission) === activeSource,
+    );
+    if (query === "") return sourceMissions;
+    return sourceMissions.filter((mission) =>
       [mission.title, mission.workspace.basename, mission.executor.name].some((value) =>
         value.toLocaleLowerCase().includes(query),
       ),
     );
-  }, [missions, search]);
+  }, [activeSource, missions, search]);
+
+  const changeSource = useCallback(
+    (nextSource: MissionListSource) => {
+      if (nextSource === activeSourceRef.current) return;
+      activeSourceRef.current = nextSource;
+      setActiveSource(nextSource);
+      setError(null);
+      const sourceMissions = missions.filter(
+        (mission) => missionListSourceForSummary(mission) === nextSource,
+      );
+      const rememberedId = selectedMissionIdsRef.current[nextSource];
+      const missionId =
+        rememberedId !== undefined && sourceMissions.some((mission) => mission.id === rememberedId)
+          ? rememberedId
+          : sourceMissions[0]?.id;
+      if (missionId === undefined) {
+        selectedMissionIdRef.current = null;
+        setSelectedMissionId(null);
+        setSelectedMission(null);
+        return;
+      }
+      void openMission(missionId, { source: nextSource });
+    },
+    [missions, openMission],
+  );
   if (!hasResolvedInitialLoad) {
     return <MissionsPageSkeleton label={t("loading", { ns: "missions" })} railWidth={railWidth} />;
   }
@@ -407,13 +484,17 @@ export function MissionsPage(props: {
     >
       <MissionRail
         missions={visibleMissions}
+        source={activeSource}
         search={search}
         now={now}
         pinnedMissionIds={pinnedMissionIds}
         selectedMissionId={selectedMissionId}
         onSearch={setSearch}
+        onSourceChange={changeSource}
         onCreate={props.onCreate}
-        onOpen={(summary) => openMission(summary.id)}
+        onOpen={(summary) =>
+          openMission(summary.id, { source: missionListSourceForSummary(summary) })
+        }
         onTogglePin={(summary) =>
           updatePinnedMissionIds((current) => togglePinnedMissionId(current, summary.id))
         }
@@ -578,11 +659,13 @@ export function MissionsPage(props: {
                   selectedMissionIdRef.current = null;
                   setSelectedMissionId(null);
                   setSelectedMission(null);
-                  const fallback = storedMissions[0];
+                  const fallback = storedMissions.find(
+                    (mission) => missionListSourceForSummary(mission) === activeSourceRef.current,
+                  );
                   if (fallback === undefined) {
                     writeLastOpenedMissionId(window.localStorage, null);
                   } else {
-                    openMission(fallback.id);
+                    openMission(fallback.id, { source: activeSourceRef.current });
                   }
                 }
                 setDeleteCandidate(null);
@@ -615,6 +698,7 @@ export function MissionsPageSkeleton(props: {
       <aside className="mission-skeleton-rail" aria-hidden="true">
         <span className="mission-skeleton-block mission-skeleton-title" />
         <span className="mission-skeleton-block mission-skeleton-button" />
+        <span className="mission-skeleton-block mission-skeleton-source-tabs" />
         <span className="mission-skeleton-block mission-skeleton-search" />
         {[0, 1].map((group) => (
           <div className="mission-skeleton-group" key={group}>
@@ -647,11 +731,13 @@ export function MissionsPageSkeleton(props: {
 
 function MissionRail(props: {
   readonly missions: readonly MissionSummary[];
+  readonly source: MissionListSource;
   readonly search: string;
   readonly now: number;
   readonly pinnedMissionIds: readonly string[];
   readonly selectedMissionId: string | null;
   readonly onSearch: (value: string) => void;
+  readonly onSourceChange: (source: MissionListSource) => void;
   readonly onCreate: () => void;
   readonly onOpen: (mission: MissionSummary) => void;
   readonly onTogglePin: (mission: MissionSummary) => void;
@@ -750,6 +836,31 @@ function MissionRail(props: {
           <Plus size={18} aria-hidden="true" />
           {t("newMission")}
         </button>
+        <div
+          className={`mission-source-tabs is-${props.source}`}
+          role="tablist"
+          aria-label={t("missionSources")}
+        >
+          <span className="mission-source-indicator" aria-hidden="true" />
+          <button
+            type="button"
+            role="tab"
+            aria-selected={props.source === "task"}
+            className={props.source === "task" ? "is-active" : undefined}
+            onClick={() => props.onSourceChange("task")}
+          >
+            {t("sourceTabs.task")}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={props.source === "automation"}
+            className={props.source === "automation" ? "is-active" : undefined}
+            onClick={() => props.onSourceChange("automation")}
+          >
+            {t("sourceTabs.automation")}
+          </button>
+        </div>
         <div className="mission-search-slot" aria-hidden={searchCollapsed ? "true" : undefined}>
           <label className="mission-search" ref={searchRef}>
             <MagnifyingGlass size={18} aria-hidden="true" />
@@ -782,7 +893,7 @@ function MissionRail(props: {
       ) : null}
       <MissionRailGroup
         label={t("active")}
-        emptyLabel={t("noActive")}
+        emptyLabel={t(props.source === "automation" ? "noActiveAutomations" : "noActive")}
         missions={missionGroups.active.visibleMissions}
         hiddenCount={missionGroups.active.hiddenCount}
         now={props.now}
@@ -796,7 +907,7 @@ function MissionRail(props: {
       />
       <MissionRailGroup
         label={t("completed")}
-        emptyLabel={t("noCompleted")}
+        emptyLabel={t(props.source === "automation" ? "noCompletedAutomations" : "noCompleted")}
         variant="completed"
         missions={missionGroups.completed.visibleMissions}
         hiddenCount={missionGroups.completed.hiddenCount}
@@ -4357,13 +4468,27 @@ export function missionStatusLabel(mission: Mission | MissionSummary, preparing 
   }
 }
 
-function missionToSummary(mission: Mission): MissionSummary {
+function missionListSourceForMission(mission: Mission): MissionListSource {
+  return mission.origin.type === "automation" ? "automation" : "task";
+}
+
+export function missionListSourceForSummary(mission: MissionSummary): MissionListSource {
+  return mission.source.type === "automation" ? "automation" : "task";
+}
+
+function missionToSummary(
+  mission: Mission,
+  source: MissionSummary["source"] = mission.origin.type === "automation"
+    ? { type: "automation", automationRef: mission.origin.automationRef }
+    : { type: "task" },
+): MissionSummary {
   return {
     id: mission.id,
     title: mission.title,
     workspace: { basename: mission.workspace.basename },
     executor: { kind: mission.executor.kind, name: mission.executor.name },
     ...(mission.execution === undefined ? {} : { execution: { status: mission.execution.status } }),
+    source,
     lifecycleStatus: mission.lifecycleStatus,
     updatedAt: mission.updatedAt,
   };

--- a/apps/desktop/src/renderer/src/styles/features/missions/base.css
+++ b/apps/desktop/src/renderer/src/styles/features/missions/base.css
@@ -509,6 +509,7 @@
 }
 
 .mission-skeleton-button,
+.mission-skeleton-source-tabs,
 .mission-skeleton-search {
   width: 100%;
   height: 36px;
@@ -518,6 +519,11 @@
 .mission-skeleton-search {
   margin-top: 14px;
   background-color: var(--surface);
+}
+
+.mission-skeleton-source-tabs {
+  margin-top: 12px;
+  border-radius: 10px;
 }
 
 .mission-skeleton-group {
@@ -647,6 +653,67 @@
   height: 36px;
   margin-top: 14px;
   border: 0;
+}
+
+.mission-source-tabs {
+  position: relative;
+  display: grid;
+  height: 36px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 12px;
+  padding: 3px;
+  border: 1px solid rgb(88 121 104 / 8%);
+  border-radius: 10px;
+  background: rgb(88 121 104 / 8%);
+  isolation: isolate;
+}
+
+.mission-source-indicator {
+  position: absolute;
+  z-index: 0;
+  top: 3px;
+  bottom: 3px;
+  left: 3px;
+  width: calc(50% - 3px);
+  border: 1px solid rgb(88 121 104 / 8%);
+  border-radius: 8px;
+  background: var(--ui-surface);
+  box-shadow: 0 1px 3px rgb(20 38 29 / 8%);
+  transform: translateX(0);
+  transition: transform 210ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.mission-source-tabs.is-automation .mission-source-indicator {
+  transform: translateX(100%);
+}
+
+.mission-source-tabs > button {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 590;
+  transition: color 160ms ease;
+}
+
+.mission-source-tabs > button:hover {
+  color: var(--text);
+}
+
+.mission-source-tabs > button.is-active {
+  color: var(--text);
+  font-weight: 680;
+}
+
+.mission-source-tabs > button:focus-visible {
+  outline: 0;
+  box-shadow: inset 0 0 0 2px var(--ui-focus);
 }
 
 .mission-search {
@@ -1343,6 +1410,8 @@
   .studio-asset-row,
   .mission-row,
   .mission-row-open,
+  .mission-source-indicator,
+  .mission-source-tabs > button,
   .mission-search-slot,
   .flow-palette-item,
   .flow-step-node,

--- a/apps/desktop/src/shared/contracts/missions.ts
+++ b/apps/desktop/src/shared/contracts/missions.ts
@@ -10,6 +10,7 @@ import {
 } from "@pragma/shared";
 import {
   canonicalPragmaResourceRef,
+  PragmaAutomationRefSchema,
   type PragmaInvocableResource,
   type PragmaResource,
 } from "@pragma/interpreter/ast";
@@ -174,6 +175,10 @@ export const MissionV5Schema = MissionBaseSchema.extend({
 export const MissionOriginSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("user") }),
   z.object({
+    type: z.literal("automation"),
+    automationRef: PragmaAutomationRefSchema,
+  }),
+  z.object({
     type: z.literal("system-memory"),
     jobId: z.string().min(1),
   }),
@@ -239,6 +244,13 @@ export const MissionSummarySchema = z.object({
     name: z.string().trim().min(1).max(120),
   }),
   execution: z.object({ status: MissionExecutionStatusSchema }).optional(),
+  source: z.discriminatedUnion("type", [
+    z.object({ type: z.literal("task") }),
+    z.object({
+      type: z.literal("automation"),
+      automationRef: PragmaAutomationRefSchema,
+    }),
+  ]),
   lifecycleStatus: MissionLifecycleStatusSchema,
   updatedAt: z.string().datetime(),
 });
@@ -247,12 +259,17 @@ export const MissionUpdateSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("upsert"),
     mission: MissionSchema,
+    source: MissionSummarySchema.shape.source,
   }),
   z.object({
     kind: z.literal("remove"),
     missionId: MissionIdSchema,
   }),
 ]);
+
+export function isUserFacingMissionOrigin(origin: z.infer<typeof MissionOriginSchema>): boolean {
+  return origin.type === "user" || origin.type === "automation";
+}
 
 export const CreateMissionSchema = z.object({
   workspace: z.string().trim().min(1).max(2_000),


### PR DESCRIPTION
## Summary

- add animated Task and Automation source tabs to the Mission rail without changing the existing New Task button
- classify Automation-created Missions with an authoritative persisted origin and reuse the existing Mission list/detail lifecycle controls
- keep per-tab selection state and provide localized empty states in English, Simplified Chinese, and Traditional Chinese
- migrate recoverable legacy Automation Mission origins before state rotation, reset, or deletion

## Why

Mission management previously mixed manually created tasks with Automation runs. This change gives Automation runs a dedicated view while preserving the existing Mission detail experience, including messages, run, interrupt, completion, and reopen behavior.

The legacy compatibility path persists any recoverable Automation association into the Mission manifest so renderer updates and deep-link/open flows do not disagree about the owning tab.

## Validation

- `pnpm --filter @pragma/desktop exec vitest run src/main/features/automations/automations.test.ts src/main/features/missions/mission-store.test.ts src/main/features/missions/mission-context-store-browser.test.ts src/main/features/missions/mission-creator.test.ts src/main/features/missions/mission-runner.test.ts src/renderer/src/pages/missions/MissionsPage.test.tsx` — 110 tests passed
- `pnpm check` — passed across all 22 workspace packages
- `pnpm build` — passed across all 22 workspace packages
- Desktop renderer style ownership, main bundle, and preload bridge verification passed

## Review

Claude Code reviewed the initial uncommitted diff. All four evidence-backed findings were independently verified and fixed: legacy source persistence, pre-list update classification, initial Mission source consistency, and timestamp-order-dependent testing.