### PR TITLE
fix(desktop): preserve mission history during human-input waits

### DIFF
--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -14,6 +14,7 @@ import {
   readRuntimeSessionRecord,
   RuntimeContextCompactionNotNeededError,
   StoredExecutionView,
+  withFileLock,
   type ExpertSession,
   type RuntimeDriverSessionContext,
   type RuntimeContextWindowUsage,
@@ -854,6 +855,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     expect(interrupted.execution?.status).toBe("cancelled");
     expect(cancelTurn).toHaveBeenCalledTimes(1);
     const settledChat = await runner.getChat({ id: mission.id, limit: 50 });
+    expect(settledChat.syncIssues).toBeUndefined();
     expect(settledChat.execution?.interruptible).toBe(false);
     expect(settledChat.entries).toEqual(
       expect.arrayContaining([
@@ -2276,6 +2278,28 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         },
       ],
     }));
+    await executions.appendEvent(executionId, executionId, "invocation.message.appended", {
+      runId: "persisted-before-restart",
+      source: { kind: "agent", runId: "persisted-before-restart", path: [] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Choose the environment to continue." }],
+        api: "test",
+        provider: "test",
+        model: "test-model",
+        usage: {
+          measurement: "reported",
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "toolUse",
+        timestamp: Date.parse(startedAt) + 1,
+      },
+    });
     await executions.appendEvent(
       executionId,
       executionId,
@@ -2324,6 +2348,15 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     const resumed = await runner.run(mission.id);
     expect(resumed.execution).toMatchObject({ id: executionId, status: "waiting", sessionId });
     expect(runtimeStarts).toBe(0);
+    await expect(runner.getChat({ id: mission.id, limit: 50 })).resolves.toMatchObject({
+      entries: [
+        expect.objectContaining({ kind: "user", content: mission.goal }),
+        expect.objectContaining({
+          kind: "assistant",
+          content: "Choose the environment to continue.",
+        }),
+      ],
+    });
     const interactions = await runner.listHumanInteractions(mission.id);
     expect(interactions).toEqual([
       expect.objectContaining({
@@ -2331,6 +2364,13 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         request: expect.objectContaining({ kind: "question" }),
       }),
     ]);
+    await expect(
+      withFileLock(
+        new PragmaPaths({ pragmaHome }).executionLock(executionId),
+        async () => "available",
+        { timeoutMs: 100, operation: "test.human-wait-read" },
+      ),
+    ).resolves.toBe("available");
 
     await runner.respondToHumanInteraction({
       missionId: mission.id,

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -24,6 +24,7 @@ import {
   readRuntimeContextCompactionProgressData,
   RUNTIME_CONTEXT_COMPACTION_STAGES,
   type AgentMessageRecord,
+  type ExecutionView,
   type ExecutionWorkRecord,
   type ExecutionOutputItem,
   type FileExecutionStore,
@@ -59,6 +60,7 @@ import type {
   ExpertAgentStreamEvent,
   ExpertPromptAttachment,
   AgentMessageUsage,
+  ExecutionEvent,
   RuntimeContextRecord,
   RuntimeEnvironmentBinding,
 } from "@pragma/shared";
@@ -231,6 +233,7 @@ interface LiveMissionChat {
   readonly executionId: string;
   readonly entries: MissionChatEntry[];
   close: () => Promise<void>;
+  readDurableEntries: (timelineSequence: number) => Promise<readonly MissionChatEntry[]>;
   sequence: number;
 }
 
@@ -499,6 +502,7 @@ export function createMissionRunner(options: {
   const pendingOperations = new Map<string, PendingMissionOperation>();
   const chatListeners = new Set<(notification: MissionChatNotification) => void>();
   const chatRevisions = new Map<string, number>();
+  const degradedChatSync = new Set<string>();
   const liveChats = new Map<string, LiveMissionChat>();
   const liveContextWindows = new Map<string, RuntimeContextWindowUsage>();
   const workListeners = new Set<(notification: MissionWorkNotification) => void>();
@@ -864,6 +868,15 @@ export function createMissionRunner(options: {
       input.executorMetadata.avatarIds,
     );
     let firstProjectionLogged = false;
+    const humanWaitingObserver = observeMissionHumanWaitingStatus({
+      missions: options.missions,
+      missionId,
+      execution: input.handle,
+      startedAt: input.startedAt,
+      inputMessageId: input.inputMessageId,
+      sessionId: input.sessionId,
+      logger,
+    });
     const live = observeMissionChat(
       input.handle,
       (patches) => {
@@ -886,6 +899,15 @@ export function createMissionRunner(options: {
         }
       },
       () => invalidateChat(missionId, audience),
+      humanWaitingObserver.onEvent,
+      humanWaitingObserver.resync,
+      (channel, error) => {
+        logger.warn(
+          "mission.chat_subscription_failed",
+          `Mission ${channel} subscription failed and will retry.`,
+          { error, missionId, executionId: input.handle.executionId, channel },
+        );
+      },
       (item) => {
         if (item.channel === "telemetry" && item.parentInvocationId === undefined) {
           const payload = asRecord(item.value);
@@ -911,6 +933,7 @@ export function createMissionRunner(options: {
               entries: [],
               sequence: 0,
               close: async () => undefined,
+              readDurableEntries: async () => [],
             } satisfies LiveMissionChat);
           byRecord.set(recordId, output);
           liveWorkOutputs.set(missionId, byRecord);
@@ -938,7 +961,10 @@ export function createMissionRunner(options: {
       input.handle,
       input.startedAt,
       input.inputMessageId,
-      input.onFinished ?? (() => undefined),
+      async () => {
+        await humanWaitingObserver.drain();
+        await input.onFinished?.();
+      },
       input.sessionId,
       logger,
       async () => {
@@ -1600,17 +1626,22 @@ export function createMissionRunner(options: {
     const mission = await options.missions.get(input.id);
     const timeline = await options.missions.readTimelinePage(mission.id, input);
     const capturedLive = liveChats.get(mission.id);
-    const entries = await readMissionChatHistory(
+    const history = await readMissionChatHistory(
       timeline.turns,
       executionStore,
       options.missions,
       mission.id,
-      capturedLive?.executionId,
+      capturedLive,
     );
+    const entries = history.entries;
+    const syncIssues = [...history.syncIssues];
 
     const executorMetadata = await getExecutorMetadataOrFallback(mission, "historical");
     const current = active.get(mission.id);
-    const pendingInteractions = await listMissionPendingHumanInteractions(mission);
+    const pendingInteractions = await listMissionPendingHumanInteractions(mission).catch(() => {
+      syncIssues.push(missionChatSyncIssue("pending_interactions"));
+      return [];
+    });
 
     // Keep using the projection captured before history was read. The execution may settle across
     // the awaits above; looking it up again would omit both durable history (which was skipped for
@@ -1622,13 +1653,20 @@ export function createMissionRunner(options: {
     // it again immediately before the revision so a snapshot cannot pair a stale `running` state
     // with the terminal invalidation revision.
     const latestMission = await options.missions.get(mission.id);
-    const contextWindow = await getContextWindowState(latestMission);
+    const contextWindow = await getContextWindowState(latestMission).catch(() => {
+      syncIssues.push(missionChatSyncIssue("context_window"));
+      return undefined;
+    });
     const revision = chatRevisions.get(mission.id) ?? 0;
     const resolveExecutorName = createMissionExecutorNameResolver(mission, executorMetadata.names);
     const resolveExecutorAvatarId = createMissionExecutorAvatarIdResolver(
       executorMetadata.avatarIds,
     );
-    const presentedEntries = entries.map((entry) => {
+    // Durable recovery entries are appended before the live projection. Keep the live value for
+    // stable IDs so richer streaming fields (for example the full tool error) win without
+    // duplicating the row.
+    const mergedEntries = [...new Map(entries.map((entry) => [entry.id, entry])).values()];
+    const presentedEntries = mergedEntries.map((entry) => {
       if (entry.executorId === undefined) return entry;
       const executorAvatarId = entry.executorAvatarId ?? resolveExecutorAvatarId(entry.executorId);
       if (entry.executorName !== undefined && entry.executorAvatarId !== undefined) return entry;
@@ -1640,6 +1678,30 @@ export function createMissionRunner(options: {
         ...(executorAvatarId === undefined ? {} : { executorAvatarId }),
       };
     });
+    const uniqueSyncIssues = [
+      ...new Map(syncIssues.map((issue) => [issue.section, issue])).values(),
+    ];
+    if (uniqueSyncIssues.length > 0) {
+      if (!degradedChatSync.has(mission.id)) {
+        logger.warn(
+          "mission.chat_sync_degraded",
+          "Mission chat is using partial state while Execution data is unavailable.",
+          {
+            missionId: mission.id,
+            executionId: latestMission.execution?.id,
+            code: "execution_state_unavailable",
+            retryable: true,
+            sections: uniqueSyncIssues.map((issue) => issue.section),
+          },
+        );
+      }
+      degradedChatSync.add(mission.id);
+    } else if (degradedChatSync.delete(mission.id)) {
+      logger.info("mission.chat_sync_recovered", "Mission chat state synchronization recovered.", {
+        missionId: mission.id,
+        executionId: latestMission.execution?.id,
+      });
+    }
     return {
       missionId: mission.id,
       revision,
@@ -1657,6 +1719,7 @@ export function createMissionRunner(options: {
       },
       pendingInteractions,
       ...(contextWindow === undefined ? {} : { contextWindow }),
+      ...(uniqueSyncIssues.length === 0 ? {} : { syncIssues: uniqueSyncIssues }),
       ...(latestMission.execution === undefined
         ? {}
         : {
@@ -2052,6 +2115,7 @@ export function createMissionRunner(options: {
       trackOperation(id, { kind: "delete", promise: deleting });
       await deleting;
       chatRevisions.delete(id);
+      degradedChatSync.delete(id);
       workRevisions.delete(id);
       liveWorkOutputs.delete(id);
       liveContextWindows.delete(id);
@@ -2286,8 +2350,6 @@ function observeExecution(
     readonly executionId: string;
     readonly result: Promise<unknown>;
     readonly getState: () => Promise<{ readonly status: string }>;
-    readonly listEvents: MutableExecution["listEvents"];
-    readonly getMessageHistory: MutableExecution["getMessageHistory"];
   },
   startedAt: string,
   inputMessageId: string,
@@ -2296,55 +2358,6 @@ function observeExecution(
   logger?: import("@pragma/core").PragmaLogger,
   onTerminal?: (() => void | Promise<void>) | undefined,
 ): Promise<void> {
-  let lastObservedStatus: string | undefined;
-  const probe = setInterval(() => {
-    void execution
-      .getState()
-      .then(async (state) => {
-        const waiting = state.status === "waiting" || (await hasPendingHumanInteraction(execution));
-        if (!waiting) {
-          const resumed = lastObservedStatus === "waiting" && state.status === "running";
-          lastObservedStatus = state.status;
-          if (resumed) {
-            await missions.updateExecution(
-              missionId,
-              {
-                id: execution.executionId,
-                inputMessageId,
-                ...(sessionId === undefined ? {} : { sessionId }),
-                status: "running",
-                startedAt,
-              },
-              {
-                executionId: execution.executionId,
-                statuses: ["queued", "running", "waiting"],
-              },
-            );
-          }
-          return;
-        }
-        if (lastObservedStatus === "waiting") return;
-        lastObservedStatus = "waiting";
-        await missions.updateExecution(
-          missionId,
-          {
-            id: execution.executionId,
-            inputMessageId,
-            ...(sessionId === undefined ? {} : { sessionId }),
-            status: "waiting",
-            startedAt,
-          },
-          {
-            executionId: execution.executionId,
-            statuses: ["queued", "running", "waiting"],
-          },
-        );
-      })
-      .catch(() => {
-        // The result observer below records terminal failures.
-      });
-  }, 500);
-  probe.unref();
   return (async () => {
     let status: "succeeded" | "failed" | "cancelled" = "succeeded";
     let failure: unknown;
@@ -2394,7 +2407,97 @@ function observeExecution(
         statuses: ["queued", "running", "waiting"],
       },
     );
-  })().finally(() => clearInterval(probe));
+  })();
+}
+
+function observeMissionHumanWaitingStatus(input: {
+  readonly missions: MissionStore;
+  readonly missionId: string;
+  readonly execution: MutableExecution;
+  readonly startedAt: string;
+  readonly inputMessageId: string;
+  readonly sessionId?: string | undefined;
+  readonly logger: PragmaLogger;
+}): {
+  readonly onEvent: (event: ExecutionEvent) => void;
+  readonly resync: () => Promise<void>;
+  readonly drain: () => Promise<void>;
+} {
+  const pending = new Set<string>();
+  let observedWaiting: boolean | undefined;
+  let updates = Promise.resolve();
+
+  const persistStatus = async (): Promise<void> => {
+    const waiting = pending.size > 0;
+    if (waiting === observedWaiting) return;
+    await input.missions.updateExecution(
+      input.missionId,
+      {
+        id: input.execution.executionId,
+        inputMessageId: input.inputMessageId,
+        ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+        status: waiting ? "waiting" : "running",
+        startedAt: input.startedAt,
+      },
+      {
+        executionId: input.execution.executionId,
+        statuses: ["queued", "running", "waiting"],
+      },
+    );
+    observedWaiting = waiting;
+  };
+
+  const resync = async (): Promise<void> => {
+    try {
+      const interactions = await listPendingHumanInteractions(input.execution);
+      pending.clear();
+      for (const interaction of interactions) pending.add(interaction.interactionId);
+      observedWaiting = undefined;
+      await persistStatus();
+    } catch (error) {
+      input.logger.warn(
+        "mission.human_wait_status_seed_failed",
+        "Mission human-input waiting status could not be initialized.",
+        { error, missionId: input.missionId, executionId: input.execution.executionId },
+      );
+    }
+  };
+  const seed = resync();
+
+  const onEvent = (event: ExecutionEvent): void => {
+    if (event.type !== "human.requested" && event.type !== "human.responded") return;
+    updates = updates
+      .catch(() => undefined)
+      .then(async () => {
+        await seed;
+        const interactionId = String(
+          (event.data as { readonly interactionId?: unknown }).interactionId ?? "",
+        );
+        if (interactionId === "") return;
+        if (event.type === "human.requested") pending.add(interactionId);
+        else pending.delete(interactionId);
+        await persistStatus();
+      });
+    void updates.catch((error: unknown) => {
+      input.logger.warn(
+        "mission.human_wait_status_update_failed",
+        "Mission human-input waiting status could not be updated.",
+        { error, missionId: input.missionId, executionId: input.execution.executionId },
+      );
+    });
+  };
+
+  return {
+    onEvent,
+    resync: () => {
+      updates = updates.catch(() => undefined).then(resync);
+      return updates;
+    },
+    drain: async () => {
+      await seed;
+      await updates;
+    },
+  };
 }
 
 async function persistMissionExecutionProjection(
@@ -2416,11 +2519,14 @@ async function persistMissionExecutionProjection(
   }
   if (matched === undefined)
     throw new Error(`Mission timeline is missing Execution ${executionId}.`);
-  const entries = await readMissionChatHistory([matched], executionStore, missions, missionId);
+  const history = await readMissionChatHistory([matched], executionStore, missions, missionId);
+  if (history.syncIssues.length > 0) {
+    throw new Error(`Execution history could not be projected: ${executionId}.`);
+  }
   await missions.writeExecutionProjection(
     missionId,
     executionId,
-    entries.filter((entry) => entry.kind !== "user"),
+    history.entries.filter((entry) => entry.kind !== "user"),
   );
   await executionStore.archive(executionId);
 }
@@ -2430,9 +2536,13 @@ async function readMissionChatHistory(
   executionStore: ReturnType<typeof createFileExecutionStore>,
   missions: MissionStore,
   missionId: string,
-  activeExecutionId?: string,
-): Promise<MissionChatEntry[]> {
+  activeChat?: LiveMissionChat,
+): Promise<{
+  readonly entries: MissionChatEntry[];
+  readonly syncIssues: MissionChatSyncIssue[];
+}> {
   const entries: MissionChatEntry[] = [];
+  const syncIssues: MissionChatSyncIssue[] = [];
   for (const turn of turns) {
     entries.push({
       id: turn.message.id,
@@ -2443,7 +2553,16 @@ async function readMissionChatHistory(
       createdAt: turn.message.createdAt,
       ...(turn.executionId === undefined ? {} : { executionId: turn.executionId }),
     });
-    if (turn.executionId === undefined || turn.executionId === activeExecutionId) continue;
+    if (turn.executionId === undefined) continue;
+
+    if (turn.executionId === activeChat?.executionId) {
+      try {
+        entries.push(...(await activeChat.readDurableEntries(turn.sequence)));
+      } catch {
+        syncIssues.push(missionChatSyncIssue("history"));
+      }
+      continue;
+    }
 
     const view = new StoredExecutionView(turn.executionId, executionStore);
     const state = await view.getState().catch(() => undefined);
@@ -2453,6 +2572,7 @@ async function readMissionChatHistory(
         entries.push(...projection);
         continue;
       }
+      syncIssues.push(missionChatSyncIssue("history"));
       entries.push({
         id: `missing:${turn.executionId}`,
         timelineSequence: turn.sequence,
@@ -2464,8 +2584,6 @@ async function readMissionChatHistory(
       });
       continue;
     }
-    if (["queued", "running", "waiting"].includes(state.status)) continue;
-
     let histories;
     let activityEntries;
     try {
@@ -2481,6 +2599,7 @@ async function readMissionChatHistory(
         entries.push(...projection);
         continue;
       }
+      syncIssues.push(missionChatSyncIssue("history"));
       entries.push({
         id: `missing:${turn.executionId}`,
         timelineSequence: turn.sequence,
@@ -2504,9 +2623,13 @@ async function readMissionChatHistory(
         })),
         ...activityEntries,
       ].toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
+      isFinalExecutionStatus(state.status),
     );
     entries.push(...richEntries);
-    if (!richEntries.some((entry) => entry.kind === "assistant")) {
+    if (
+      isFinalExecutionStatus(state.status) &&
+      !richEntries.some((entry) => entry.kind === "assistant")
+    ) {
       entries.push({
         id: `result:${turn.executionId}`,
         timelineSequence: turn.sequence,
@@ -2518,11 +2641,17 @@ async function readMissionChatHistory(
       });
     }
   }
-  return entries;
+  return { entries, syncIssues };
+}
+
+type MissionChatSyncIssue = NonNullable<MissionChatSnapshot["syncIssues"]>[number];
+
+function missionChatSyncIssue(section: MissionChatSyncIssue["section"]): MissionChatSyncIssue {
+  return { code: "execution_state_unavailable", section, retryable: true };
 }
 
 async function readHistoricalRuntimeActivityEntries(
-  view: StoredExecutionView,
+  view: Pick<ExecutionView, "executionId" | "listEvents">,
   timelineSequence: number,
   rootInvocationId: string,
 ): Promise<MissionChatEntry[]> {
@@ -2639,7 +2768,11 @@ function readErrorMessage(error: unknown): string {
   return error === undefined ? "" : String(error).trim();
 }
 
-function finalizeHistoricalChatEntries(entries: readonly MissionChatEntry[]): MissionChatEntry[] {
+function finalizeHistoricalChatEntries(
+  entries: readonly MissionChatEntry[],
+  executionTerminal = true,
+): MissionChatEntry[] {
+  if (!executionTerminal) return [...entries];
   return entries.map((entry) =>
     entry.kind === "tool" && entry.status === "running"
       ? {
@@ -2785,6 +2918,9 @@ function observeMissionChat(
   execution: MutableExecution & { readonly result: Promise<unknown> },
   onOutput: (patches: readonly MissionChatPatch[]) => void,
   onInvalidate: () => void,
+  onEvent: (event: ExecutionEvent) => void,
+  onEventResync: () => Promise<void>,
+  onSubscriptionError: (channel: "output" | "events", error: unknown) => void,
   onItem: (item: ExecutionOutputItem) => void,
   resolveExecutorName: ExecutorNameResolver,
   resolveExecutorAvatarId: ExecutorAvatarIdResolver,
@@ -2794,13 +2930,24 @@ function observeMissionChat(
     entries: [],
     sequence: 0,
     close: async () => undefined,
+    readDurableEntries: async () => [],
   };
   let closed = false;
-  const outputSubscription = execution.subscribeOutput({ scope: { kind: "all" } });
-  const eventSubscription = execution.subscribeEvents({ scope: { kind: "all" } });
-  const outputTask = outputSubscription
-    .then(async (subscription) => {
+  let durableEntries: Promise<readonly MissionChatEntry[]> | undefined;
+  chat.readDurableEntries = (timelineSequence) => {
+    durableEntries ??= readDurableMissionChatEntries(execution, timelineSequence).catch((error) => {
+      durableEntries = undefined;
+      throw error;
+    });
+    return durableEntries;
+  };
+  let outputSubscription: Awaited<ReturnType<MutableExecution["subscribeOutput"]>> | undefined;
+  let eventSubscription: Awaited<ReturnType<MutableExecution["subscribeEvents"]>> | undefined;
+  const outputTask = (async () => {
+    while (!closed) {
       try {
+        const subscription = await execution.subscribeOutput({ scope: { kind: "all" } });
+        outputSubscription = subscription;
         for await (const item of subscription) {
           if (closed) break;
           onItem(item);
@@ -2811,16 +2958,27 @@ function observeMissionChat(
           if (patches.length > 0) onOutput(patches);
           if (isTerminalContextCompactionOutput(item)) onInvalidate();
         }
+        return;
+      } catch (error) {
+        if (!closed) {
+          onSubscriptionError("output", error);
+          await missionSubscriptionRetryDelay();
+        }
       } finally {
-        await subscription.close();
+        await outputSubscription?.close();
+        outputSubscription = undefined;
       }
-    })
-    .catch(() => undefined);
-  const eventTask = eventSubscription
-    .then(async (subscription) => {
+    }
+  })();
+  const eventTask = (async () => {
+    while (!closed) {
       try {
+        const subscription = await execution.subscribeEvents({ scope: { kind: "all" } });
+        eventSubscription = subscription;
+        await onEventResync();
         for await (const event of subscription) {
           if (closed) break;
+          onEvent(event);
           if (
             event.type === "human.requested" ||
             event.type === "human.responded" ||
@@ -2829,23 +2987,53 @@ function observeMissionChat(
             onInvalidate();
           }
         }
+        return;
+      } catch (error) {
+        if (!closed) {
+          onSubscriptionError("events", error);
+          await missionSubscriptionRetryDelay();
+        }
       } finally {
-        await subscription.close();
+        await eventSubscription?.close();
+        eventSubscription = undefined;
       }
-    })
-    .catch(() => undefined);
+    }
+  })();
   chat.close = async () => {
     if (closed) return;
     closed = true;
-    const subscriptions = await Promise.allSettled([outputSubscription, eventSubscription]);
-    await Promise.allSettled(
-      subscriptions.flatMap((subscription) =>
-        subscription.status === "fulfilled" ? [subscription.value.close()] : [],
-      ),
-    );
+    await Promise.allSettled([outputSubscription?.close(), eventSubscription?.close()]);
     await Promise.allSettled([outputTask, eventTask]);
   };
   return chat;
+}
+
+async function readDurableMissionChatEntries(
+  execution: ExecutionView,
+  timelineSequence: number,
+): Promise<readonly MissionChatEntry[]> {
+  const state = await execution.getState();
+  const histories = await execution.getMessageHistory({ scope: { kind: "all" } });
+  const activityEntries = await readHistoricalRuntimeActivityEntries(
+    execution,
+    timelineSequence,
+    state.rootInvocationId,
+  );
+  return finalizeHistoricalChatEntries(
+    [
+      ...messageRecordsToChatEntries(
+        histories
+          .flatMap((history) => history.messages)
+          .filter((record) => record.source?.parentSessionId === undefined),
+      ).map((entry) => ({ ...entry, timelineSequence })),
+      ...activityEntries,
+    ].toSorted((left, right) => left.createdAt.localeCompare(right.createdAt)),
+    isFinalExecutionStatus(state.status),
+  );
+}
+
+async function missionSubscriptionRetryDelay(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 250));
 }
 
 function isVisibleTextProjectionPatch(patch: MissionChatPatch): boolean {

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -265,6 +265,9 @@ export const missions = {
   chat: "Chat",
   loadEarlier: "Load earlier messages",
   loadingEarlier: "Loading…",
+  chatSyncUnavailable:
+    "Some conversation state is temporarily unavailable. Existing messages are preserved.",
+  retryChatSync: "Retry",
   resumeToManage: "Resume this execution to manage it",
   reopenToContinue: "Reopen this mission to continue the conversation",
   flowContinues: "Flow input continues through workflow steps",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -256,6 +256,8 @@ export const missions = {
   chat: "对话",
   loadEarlier: "加载更早的消息",
   loadingEarlier: "加载中…",
+  chatSyncUnavailable: "部分对话状态暂时无法读取，现有消息已保留。",
+  retryChatSync: "重试",
   resumeToManage: "恢复此执行后进行管理",
   reopenToContinue: "重新打开此任务以继续对话",
   flowContinues: "流程输入将继续传递给工作流步骤",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -256,6 +256,8 @@ export const missions = {
   chat: "對話",
   loadEarlier: "載入較早的訊息",
   loadingEarlier: "載入中…",
+  chatSyncUnavailable: "部分對話狀態暫時無法讀取，現有訊息已保留。",
+  retryChatSync: "重試",
   resumeToManage: "繼續此執行後進行管理",
   reopenToContinue: "重新開啟此任務以繼續對話",
   flowContinues: "流程輸入將繼續傳遞給工作流程步驟",

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -16,6 +16,7 @@ import {
   ContextWindowControl,
   DEFAULT_MISSION_MEMORY_VIEW,
   groupMissionConversationEntries,
+  mergeLatestChatPage,
   MissionContextOperationEntry,
   MissionChatEntryView,
   startMissionContextOperation,
@@ -806,6 +807,64 @@ describe("Mission work conversation", () => {
 });
 
 describe("Mission chat patches", () => {
+  it("preserves known history and interaction state when a refresh is degraded", () => {
+    const current: MissionChatSnapshot = {
+      missionId: "00000000-0000-4000-8000-000000000000",
+      revision: 1,
+      entries: [
+        {
+          id: "answer",
+          kind: "assistant",
+          content: "Previously loaded answer",
+          streaming: false,
+          createdAt: "2026-07-11T00:00:00.000Z",
+        },
+      ],
+      page: {},
+      pendingInteractions: [
+        {
+          interactionId: "question",
+          request: {
+            kind: "question",
+            questions: [
+              {
+                question: "Continue?",
+                header: "Continue",
+                kind: "single_choice",
+                options: [{ label: "Yes", description: "Continue." }],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const degraded: MissionChatSnapshot = {
+      missionId: current.missionId,
+      revision: 2,
+      entries: [],
+      page: {},
+      pendingInteractions: [],
+      syncIssues: [
+        {
+          code: "execution_state_unavailable",
+          section: "history",
+          retryable: true,
+        },
+        {
+          code: "execution_state_unavailable",
+          section: "pending_interactions",
+          retryable: true,
+        },
+      ],
+    };
+
+    expect(mergeLatestChatPage(current, degraded)).toMatchObject({
+      revision: 2,
+      entries: [{ id: "answer", content: "Previously loaded answer" }],
+      pendingInteractions: [{ interactionId: "question" }],
+    });
+  });
+
   it("applies streaming deltas without replacing the accumulated entry", () => {
     const snapshot: MissionChatSnapshot = {
       missionId: "00000000-0000-4000-8000-000000000000",

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -218,6 +218,7 @@ export function MissionsPage(props: {
   const selectedMissionIdsRef = useRef<Partial<Record<MissionListSource, string>>>(
     initialState.selectedMissionIds,
   );
+  const missionChatCacheRef = useRef(new Map<string, MissionChatSnapshot>());
   const initialRunStartedRef = useRef(false);
   const hadInitialMemoryStateRef = useRef(props.initialMemoryState !== undefined);
   const removedMissionIdsRef = useRef(new Set<string>());
@@ -528,7 +529,9 @@ export function MissionsPage(props: {
       <div className="mission-main">
         {selectedMission !== null ? (
           <MissionDetailFragment
+            key={selectedMission.id}
             mission={selectedMission}
+            chatCache={missionChatCacheRef.current}
             initialThinkingRequestId={
               initialRunRequest?.missionId === selectedMission.id
                 ? initialRunRequest.requestId
@@ -1235,6 +1238,7 @@ export const DEFAULT_MISSION_MEMORY_VIEW: MissionMemoryView = "activity";
 
 export function MissionDetailFragment(props: {
   readonly mission: Mission;
+  readonly chatCache?: Map<string, MissionChatSnapshot> | undefined;
   readonly initialThinkingRequestId?: string | undefined;
   readonly error?: string | null | undefined;
   readonly onDismissError?: (() => void) | undefined;
@@ -1260,7 +1264,9 @@ export function MissionDetailFragment(props: {
   const [tab, setTab] = useState<"chat" | "work" | "board" | "memory">("chat");
   const [memoryView, setMemoryView] = useState<MissionMemoryView>(DEFAULT_MISSION_MEMORY_VIEW);
   const [workspaceAvailable, setWorkspaceAvailable] = useState<boolean | null>(null);
-  const [chat, setChat] = useState<MissionChatSnapshot | null>(null);
+  const [chat, setChat] = useState<MissionChatSnapshot | null>(
+    () => props.chatCache?.get(props.mission.id) ?? null,
+  );
   const [workRecords, setWorkRecords] = useState<readonly MissionWorkRecord[]>([]);
   const [workLoading, setWorkLoading] = useState(false);
   const [workConversation, setWorkConversation] = useState<MissionWorkConversationSnapshot | null>(
@@ -1308,6 +1314,8 @@ export function MissionDetailFragment(props: {
   const [responding, setResponding] = useState(false);
   const [loadingEarlier, setLoadingEarlier] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
+  const [chatSyncError, setChatSyncError] = useState<string | null>(null);
+  const [chatRefreshRevision, setChatRefreshRevision] = useState(0);
   const [humanQuestionIndex, setHumanQuestionIndex] = useState(0);
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
   const [humanNotes, setHumanNotes] = useState<Record<string, string>>({});
@@ -1396,11 +1404,17 @@ export function MissionDetailFragment(props: {
     };
   }, [props.mission.id]);
   const prependScrollHeightRef = useRef<number | null>(null);
-  const updateChat = useCallback((update: SetStateAction<MissionChatSnapshot | null>) => {
-    const next = typeof update === "function" ? update(chatRef.current) : update;
-    chatRef.current = next;
-    setChat(next);
-  }, []);
+  const updateChat = useCallback(
+    (update: SetStateAction<MissionChatSnapshot | null>) => {
+      const next = typeof update === "function" ? update(chatRef.current) : update;
+      chatRef.current = next;
+      if (next !== null && next.missionId === props.mission.id) {
+        props.chatCache?.set(props.mission.id, next);
+      }
+      setChat(next);
+    },
+    [props.chatCache, props.mission.id],
+  );
   const executionStatus = chat?.execution?.status ?? props.mission.execution?.status;
   const executionActive =
     executionStatus !== undefined && ["queued", "running", "waiting"].includes(executionStatus);
@@ -1568,8 +1582,9 @@ export function MissionDetailFragment(props: {
 
   useEffect(() => {
     const api = desktopApi();
-    updateChat(null);
+    updateChat(props.chatCache?.get(props.mission.id) ?? null);
     setHistoryError(null);
+    setChatSyncError(null);
     setHumanQuestionIndex(0);
     followLatestRef.current = true;
     setShowJumpToLatest(false);
@@ -1657,10 +1672,16 @@ export function MissionDetailFragment(props: {
           const merged = mergeLatestChatPage(chatRef.current, snapshot);
           const drained = drainPending(merged);
           updateChat(drained.snapshot);
+          setChatSyncError(
+            snapshot.syncIssues === undefined ? null : t("chatSyncUnavailable", { ns: "missions" }),
+          );
           if (drained.needsRefresh) refreshQueued = true;
         }
       } catch (loadError) {
-        if (!cancelled) console.error("Failed to refresh Mission chat.", loadError);
+        if (!cancelled) {
+          console.error("Failed to refresh Mission chat.", loadError);
+          setChatSyncError(errorMessage(loadError));
+        }
       } finally {
         refreshing = false;
         if (refreshQueued && !cancelled) {
@@ -1702,7 +1723,7 @@ export function MissionDetailFragment(props: {
       firstTokenPaintFramesRef.current.clear();
       unsubscribe();
     };
-  }, [props.mission.id, updateChat]);
+  }, [chatRefreshRevision, props.chatCache, props.mission.id, t, updateChat]);
 
   useLayoutEffect(() => {
     const api = desktopApi();
@@ -2470,6 +2491,17 @@ export function MissionDetailFragment(props: {
                       : t("loadEarlier", { ns: "missions" })}
                   </button>
                 ) : null}
+                {chatSyncError === null ? null : (
+                  <div className="mission-history-error" role="alert">
+                    <span>{chatSyncError}</span>
+                    <button
+                      type="button"
+                      onClick={() => setChatRefreshRevision((current) => current + 1)}
+                    >
+                      {t("retryChatSync", { ns: "missions" })}
+                    </button>
+                  </div>
+                )}
                 {historyError === null ? null : (
                   <p className="mission-history-error" role="alert">
                     {historyError}
@@ -4293,11 +4325,12 @@ function truncateChatStream(value: string, maxLength: number): string {
   return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
-function mergeLatestChatPage(
+export function mergeLatestChatPage(
   current: MissionChatSnapshot | null,
   latest: MissionChatSnapshot,
 ): MissionChatSnapshot {
-  if (current === null) return latest;
+  if (current === null || current.missionId !== latest.missionId) return latest;
+  const unavailableSections = new Set(latest.syncIssues?.map((issue) => issue.section) ?? []);
   const latestOldest = latest.page.oldestSequence;
   const retainedOlder =
     latestOldest === undefined
@@ -4305,7 +4338,21 @@ function mergeLatestChatPage(
       : current.entries.filter(
           (entry) => entry.timelineSequence !== undefined && entry.timelineSequence < latestOldest,
         );
-  return { ...latest, entries: uniqueChatEntries([...retainedOlder, ...latest.entries]) };
+  const retainedUnavailableHistory = unavailableSections.has("history") ? current.entries : [];
+  return {
+    ...latest,
+    entries: uniqueChatEntries([
+      ...retainedOlder,
+      ...retainedUnavailableHistory,
+      ...latest.entries,
+    ]),
+    pendingInteractions: unavailableSections.has("pending_interactions")
+      ? current.pendingInteractions
+      : latest.pendingInteractions,
+    ...(unavailableSections.has("context_window") && current.contextWindow !== undefined
+      ? { contextWindow: current.contextWindow }
+      : {}),
+  };
 }
 
 function prependChatPage(

--- a/apps/desktop/src/renderer/src/styles/features/missions/base.css
+++ b/apps/desktop/src/renderer/src/styles/features/missions/base.css
@@ -1309,6 +1309,10 @@
 }
 
 .mission-history-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
   max-width: 560px;
   margin-right: auto;
   margin-left: auto;
@@ -1319,6 +1323,17 @@
   color: #9d3f34;
   font-size: 12px;
   text-align: center;
+}
+
+.mission-history-error button {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 650;
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .mission-jump-latest {

--- a/apps/desktop/src/shared/contracts/contracts.test.ts
+++ b/apps/desktop/src/shared/contracts/contracts.test.ts
@@ -971,6 +971,13 @@ describe("mission contracts", () => {
         ],
         page: { oldestSequence: 1, newestSequence: 1 },
         pendingInteractions: [],
+        syncIssues: [
+          {
+            code: "execution_state_unavailable",
+            section: "history",
+            retryable: true,
+          },
+        ],
         execution: {
           id: "00000000-0000-4000-8000-000000000010",
           status: "running",

--- a/apps/desktop/src/shared/contracts/missions.ts
+++ b/apps/desktop/src/shared/contracts/missions.ts
@@ -509,6 +509,12 @@ export const MissionContextCompactionResultSchema = z.object({
   contextWindow: MissionContextWindowStateSchema,
 });
 
+export const MissionChatSyncIssueSchema = z.object({
+  code: z.literal("execution_state_unavailable"),
+  section: z.enum(["history", "pending_interactions", "context_window"]),
+  retryable: z.literal(true),
+});
+
 export const MissionChatSnapshotSchema = z.object({
   missionId: MissionIdSchema,
   revision: z.number().int().nonnegative(),
@@ -521,6 +527,7 @@ export const MissionChatSnapshotSchema = z.object({
   pendingInteractions: z.array(MissionHumanInteractionSchema),
   execution: MissionChatExecutionSchema.optional(),
   contextWindow: MissionContextWindowStateSchema.optional(),
+  syncIssues: z.array(MissionChatSyncIssueSchema).max(3).optional(),
 });
 
 export const MissionChatPatchSchema = z.discriminatedUnion("type", [

--- a/packages/core/src/execution/execution-store.ts
+++ b/packages/core/src/execution/execution-store.ts
@@ -187,6 +187,14 @@ export function createFileExecutionStore(
   } = {},
 ): FileExecutionStore {
   const paths = new PragmaPaths(options);
+  const withExecutionLock = async <TValue>(
+    executionId: string,
+    operation: string,
+    action: () => Promise<TValue>,
+  ): Promise<TValue> =>
+    await withFileLock(paths.executionLock(executionId), action, {
+      operation: `execution.${operation}`,
+    });
 
   const store: FileExecutionStore = {
     async recoverPendingCanonicalEvents(input = {}) {
@@ -220,8 +228,11 @@ export function createFileExecutionStore(
           continue;
         }
         try {
-          const result = await withFileLock(paths.executionLock(executionId), async () =>
-            recoverCanonicalHandoffsForExecution(paths, executionId, options.canonicalEventFeed!),
+          const result = await withExecutionLock(
+            executionId,
+            "recover-canonical-events",
+            async () =>
+              recoverCanonicalHandoffsForExecution(paths, executionId, options.canonicalEventFeed!),
           );
           recovered += result.recovered;
           if (result.deliveryFailure !== undefined) {
@@ -254,13 +265,13 @@ export function createFileExecutionStore(
       };
     },
     async delete(executionId) {
-      await withFileLock(paths.executionLock(executionId), async () => {
+      await withExecutionLock(executionId, "delete", async () => {
         await rm(paths.executionRoot(executionId), { recursive: true, force: true });
         await rm(paths.executionArchive(executionId), { force: true });
       });
     },
     async archive(executionId) {
-      await withFileLock(paths.executionLock(executionId), async () => {
+      await withExecutionLock(executionId, "archive", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         const state = await requireExecution(paths, executionId);
         if (!isTerminalExecutionStatus(state.status)) {
@@ -284,7 +295,7 @@ export function createFileExecutionStore(
     },
     async create(record, root) {
       void stableStringify({ record, root });
-      await withFileLock(paths.executionLock(record.executionId), async () => {
+      await withExecutionLock(record.executionId, "create", async () => {
         await prepareExecution(paths, record.executionId, options.canonicalEventFeed);
         if ((await readJsonIfExists(paths.executionState(record.executionId))) !== undefined) {
           throw new Error(`Execution already exists: ${record.executionId}`);
@@ -304,7 +315,7 @@ export function createFileExecutionStore(
     },
 
     async get(executionId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "get", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         const value = await readJsonIfExists(paths.executionState(executionId));
         if (value === undefined) return undefined;
@@ -326,7 +337,7 @@ export function createFileExecutionStore(
     async commit(request) {
       if (request.commitId.trim() === "") throw new Error("Execution commitId must not be empty.");
       const signature = commitSignature(request);
-      return await withFileLock(paths.executionLock(request.executionId), async () => {
+      return await withExecutionLock(request.executionId, "commit", async () => {
         await prepareExecution(paths, request.executionId, options.canonicalEventFeed);
         const commits = await readCommitRecords(paths, request.executionId);
         const duplicate = commits.find((commit) => commit.commitId === request.commitId);
@@ -441,7 +452,7 @@ export function createFileExecutionStore(
     },
 
     async claimRecovery(executionId, claimId, leaseMs) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "claim-recovery", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         const current = await requireExecution(paths, executionId);
         const value = current.state[EXECUTION_RECOVERY_CLAIM_STATE_KEY];
@@ -477,7 +488,7 @@ export function createFileExecutionStore(
     },
 
     async getInvocation(executionId, invocationId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "get-invocation", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         return (await readInvocations(paths, executionId)).find(
           (invocation) => invocation.invocationId === invocationId,
@@ -486,28 +497,28 @@ export function createFileExecutionStore(
     },
 
     async listInvocations(executionId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "list-invocations", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         return await readInvocations(paths, executionId);
       });
     },
 
     async getAgent(executionId, agentId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "get-agent", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         return (await readAgents(paths, executionId)).find((agent) => agent.agentId === agentId);
       });
     },
 
     async listAgents(executionId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "list-agents", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         return await readAgents(paths, executionId);
       });
     },
 
     async getContext(executionId, contextId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "get-context", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         return (await readContexts(paths, executionId)).find(
           (context) => context.contextId === contextId,
@@ -516,7 +527,7 @@ export function createFileExecutionStore(
     },
 
     async listContexts(executionId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "list-contexts", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         return await readContexts(paths, executionId);
       });
@@ -531,7 +542,7 @@ export function createFileExecutionStore(
     },
 
     async getTree(executionId) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "get-tree", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         const value = await readJsonIfExists(paths.executionState(executionId));
         if (value === undefined) return undefined;
@@ -552,7 +563,7 @@ export function createFileExecutionStore(
     },
 
     async readEvents(executionId, after) {
-      return await withFileLock(paths.executionLock(executionId), async () => {
+      return await withExecutionLock(executionId, "read-events", async () => {
         await prepareExecution(paths, executionId, options.canonicalEventFeed);
         return filterAfter(await readExecutionEvents(paths, executionId), executionId, after);
       });

--- a/packages/core/src/execution/execution-view.ts
+++ b/packages/core/src/execution/execution-view.ts
@@ -120,46 +120,56 @@ export class StoredExecutionView implements ExecutionView {
     options: SubscribeOutputOptions = {},
   ): Promise<ExecutionOutputSubscription> {
     const source = getExecutionLiveBus(this.store).subscribe(this.executionId);
-    const state = await this.getState();
-    if (isTerminal(state.status)) await source.close();
-    const rootInvocationId = state.rootInvocationId;
-    const channels = options.channels === undefined ? undefined : new Set(options.channels);
-    return filterSubscription(
-      source,
-      (item) =>
-        matchesOutputScope(item, rootInvocationId, options.scope) &&
-        (channels?.has(item.channel) ?? true),
-    );
+    try {
+      const state = await this.getState();
+      if (isTerminal(state.status)) await source.close();
+      const rootInvocationId = state.rootInvocationId;
+      const channels = options.channels === undefined ? undefined : new Set(options.channels);
+      return filterSubscription(
+        source,
+        (item) =>
+          matchesOutputScope(item, rootInvocationId, options.scope) &&
+          (channels?.has(item.channel) ?? true),
+      );
+    } catch (error) {
+      await source.close();
+      throw error;
+    }
   }
 
   async subscribeEvents(
     options: { readonly scope?: InvocationScope } = {},
   ): Promise<ExecutionEventSubscription> {
     const source = getExecutionLiveBus(this.store).subscribeEvents(this.executionId);
-    const state = await this.getState();
-    if (isTerminal(state.status)) await source.close();
-    const invocations = await this.store.listInvocations(this.executionId);
-    const matchesByInvocationId = new Map(
-      invocations.map((invocation) => [
-        invocation.invocationId,
-        matchesInvocationScope(invocation, state.rootInvocationId, options.scope),
-      ]),
-    );
-    return filterEventSubscription(source, async (event) => {
-      const cached = matchesByInvocationId.get(event.invocationId);
-      if (cached !== undefined) return cached;
-      if (options.scope?.kind === "all") return true;
-      if (options.scope?.kind === "root") return event.invocationId === state.rootInvocationId;
-      if (options.scope?.kind === "invocation") {
-        return event.invocationId === options.scope.invocationId;
-      }
-      const invocation = await this.store.getInvocation(this.executionId, event.invocationId);
-      const matches =
-        invocation !== undefined &&
-        matchesInvocationScope(invocation, state.rootInvocationId, options.scope);
-      matchesByInvocationId.set(event.invocationId, matches);
-      return matches;
-    });
+    try {
+      const state = await this.getState();
+      if (isTerminal(state.status)) await source.close();
+      const invocations = await this.store.listInvocations(this.executionId);
+      const matchesByInvocationId = new Map(
+        invocations.map((invocation) => [
+          invocation.invocationId,
+          matchesInvocationScope(invocation, state.rootInvocationId, options.scope),
+        ]),
+      );
+      return filterEventSubscription(source, async (event) => {
+        const cached = matchesByInvocationId.get(event.invocationId);
+        if (cached !== undefined) return cached;
+        if (options.scope?.kind === "all") return true;
+        if (options.scope?.kind === "root") return event.invocationId === state.rootInvocationId;
+        if (options.scope?.kind === "invocation") {
+          return event.invocationId === options.scope.invocationId;
+        }
+        const invocation = await this.store.getInvocation(this.executionId, event.invocationId);
+        const matches =
+          invocation !== undefined &&
+          matchesInvocationScope(invocation, state.rootInvocationId, options.scope);
+        matchesByInvocationId.set(event.invocationId, matches);
+        return matches;
+      });
+    } catch (error) {
+      await source.close();
+      throw error;
+    }
   }
 
   async getMessageHistory(

--- a/packages/core/src/execution/expert-runner.ts
+++ b/packages/core/src/execution/expert-runner.ts
@@ -760,8 +760,14 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
     depth,
     runtime.descriptor.id,
   );
-  const humanInteractionHandler = async (request: ExpertAgentHumanRequest) =>
-    await options.controller.requestHumanInteraction(options.invocationId, request);
+  const humanInteractionHandler = async (request: ExpertAgentHumanRequest) => {
+    const resumeDelegation = options.delegationPermit?.suspend();
+    try {
+      return await options.controller.requestHumanInteraction(options.invocationId, request);
+    } finally {
+      await resumeDelegation?.();
+    }
+  };
   const invocationLoggerProvider = options.loggerProvider?.withScope({
     executionId: options.executionId,
     invocationId: options.invocationId,

--- a/packages/core/src/storage/file-lock.ts
+++ b/packages/core/src/storage/file-lock.ts
@@ -4,8 +4,15 @@ import { dirname, join } from "node:path";
 
 interface LocalLockWaiter {
   cancelled: boolean;
+  readonly operation?: string | undefined;
   timeout?: ReturnType<typeof setTimeout> | undefined;
   readonly grant: () => void;
+}
+
+interface LocalLockState {
+  acquiredAt: number;
+  operation?: string | undefined;
+  readonly waiters: LocalLockWaiter[];
 }
 
 interface FileLockOwner {
@@ -14,6 +21,37 @@ interface FileLockOwner {
   readonly processId: number;
   readonly processStartedAt: number;
   readonly acquiredAt: number;
+  readonly operation?: string | undefined;
+}
+
+export interface FileLockOptions {
+  readonly timeoutMs?: number | undefined;
+  readonly staleMs?: number | undefined;
+  readonly operation?: string | undefined;
+}
+
+export class FileLockTimeoutError extends Error {
+  readonly code = "pragma_file_lock_timeout";
+  readonly lockDir: string;
+  readonly contention: "local" | "active" | "possibly-orphaned";
+  readonly heldMs?: number | undefined;
+  readonly operation?: string | undefined;
+
+  constructor(
+    message: string,
+    lockDir: string,
+    contention: "local" | "active" | "possibly-orphaned",
+    heldMs?: number | undefined,
+    operation?: string | undefined,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "FileLockTimeoutError";
+    this.lockDir = lockDir;
+    this.contention = contention;
+    this.heldMs = heldMs;
+    this.operation = operation;
+  }
 }
 
 type LockContention =
@@ -21,9 +59,7 @@ type LockContention =
   | {
       readonly kind: "possibly-orphaned";
       readonly reason:
-        | "missing-owner-metadata"
-        | "owner-process-exited"
-        | "owner-status-unavailable";
+        "missing-owner-metadata" | "owner-process-exited" | "owner-status-unavailable";
     };
 
 type LockGeneration =
@@ -33,16 +69,16 @@ type LockGeneration =
 const OWNER_FILE_NAME = "owner.json";
 const RECLAIM_DIRECTORY_NAME = ".reclaim";
 const CURRENT_PROCESS_STARTED_AT = Date.now() - Math.floor(process.uptime() * 1_000);
-const localLockWaiters = new Map<string, LocalLockWaiter[]>();
+const localLocks = new Map<string, LocalLockState>();
 
 export async function withFileLock<TValue>(
   lockDir: string,
   operation: () => Promise<TValue>,
-  options: { readonly timeoutMs?: number; readonly staleMs?: number } = {},
+  options: FileLockOptions = {},
 ): Promise<TValue> {
   const timeoutMs = options.timeoutMs ?? 10_000;
   const startedAt = Date.now();
-  const releaseLocalLock = await acquireLocalLock(lockDir, startedAt, timeoutMs);
+  const releaseLocalLock = await acquireLocalLock(lockDir, startedAt, timeoutMs, options.operation);
   try {
     return await withCrossProcessFileLock(lockDir, operation, options, startedAt);
   } finally {
@@ -53,7 +89,7 @@ export async function withFileLock<TValue>(
 async function withCrossProcessFileLock<TValue>(
   lockDir: string,
   operation: () => Promise<TValue>,
-  options: { readonly timeoutMs?: number; readonly staleMs?: number },
+  options: FileLockOptions,
   startedAt: number,
 ): Promise<TValue> {
   const timeoutMs = options.timeoutMs ?? 10_000;
@@ -98,6 +134,7 @@ async function withCrossProcessFileLock<TValue>(
     processId: process.pid,
     processStartedAt: CURRENT_PROCESS_STARTED_AT,
     acquiredAt: Date.now(),
+    ...(options.operation === undefined ? {} : { operation: options.operation }),
   };
   const ownerPath = join(lockDir, OWNER_FILE_NAME);
   let ownerFile: Awaited<ReturnType<typeof open>> | undefined;
@@ -141,26 +178,30 @@ async function acquireLocalLock(
   lockDir: string,
   startedAt: number,
   timeoutMs: number,
+  operation: string | undefined,
 ): Promise<() => void> {
-  const waiters = localLockWaiters.get(lockDir);
-  if (waiters === undefined) {
-    localLockWaiters.set(lockDir, []);
+  const state = localLocks.get(lockDir);
+  if (state === undefined) {
+    localLocks.set(lockDir, { acquiredAt: Date.now(), operation, waiters: [] });
   } else {
     const remainingMs = timeoutMs - (Date.now() - startedAt);
-    if (remainingMs <= 0) throw localLockTimeout(lockDir);
+    if (remainingMs <= 0) throw localLockTimeout(lockDir, state);
     await new Promise<void>((resolve, reject) => {
       const waiter: LocalLockWaiter = {
         cancelled: false,
+        operation,
         grant: () => {
           if (waiter.cancelled) return;
           if (waiter.timeout !== undefined) clearTimeout(waiter.timeout);
+          state.acquiredAt = Date.now();
+          state.operation = waiter.operation;
           resolve();
         },
       };
-      waiters.push(waiter);
+      state.waiters.push(waiter);
       waiter.timeout = setTimeout(() => {
         waiter.cancelled = true;
-        reject(localLockTimeout(lockDir));
+        reject(localLockTimeout(lockDir, state));
       }, remainingMs);
     });
   }
@@ -169,11 +210,11 @@ async function acquireLocalLock(
   return () => {
     if (released) return;
     released = true;
-    const queued = localLockWaiters.get(lockDir);
+    const current = localLocks.get(lockDir);
     while (true) {
-      const next = queued?.shift();
+      const next = current?.waiters.shift();
       if (next === undefined) {
-        localLockWaiters.delete(lockDir);
+        localLocks.delete(lockDir);
         return;
       }
       if (!next.cancelled) {
@@ -184,8 +225,16 @@ async function acquireLocalLock(
   };
 }
 
-function localLockTimeout(lockDir: string): Error {
-  return new Error(`Timed out waiting for Pragma in-process file lock: ${lockDir}`);
+function localLockTimeout(lockDir: string, state: LocalLockState): FileLockTimeoutError {
+  const heldMs = Math.max(0, Date.now() - state.acquiredAt);
+  const operation = state.operation;
+  return new FileLockTimeoutError(
+    `Timed out waiting for Pragma in-process file lock: ${lockDir} (held ${heldMs}ms${operation === undefined ? "" : ` by ${operation}`})`,
+    lockDir,
+    "local",
+    heldMs,
+    operation,
+  );
 }
 
 async function assessLock(
@@ -285,7 +334,8 @@ async function readLockOwner(ownerPath: string): Promise<FileLockOwner | undefin
       typeof candidate.processStartedAt !== "number" ||
       !Number.isFinite(candidate.processStartedAt) ||
       typeof candidate.acquiredAt !== "number" ||
-      !Number.isFinite(candidate.acquiredAt)
+      !Number.isFinite(candidate.acquiredAt) ||
+      (candidate.operation !== undefined && typeof candidate.operation !== "string")
     ) {
       return undefined;
     }
@@ -330,10 +380,19 @@ async function pathStaleness(
   }
 }
 
-function lockTimeout(lockDir: string, contention: LockContention, cause: unknown): Error {
+function lockTimeout(
+  lockDir: string,
+  contention: LockContention,
+  cause: unknown,
+): FileLockTimeoutError {
   if (contention.kind === "active") {
-    return new Error(
-      `Timed out waiting for active Pragma file lock: ${lockDir} (owner PID ${contention.owner.processId})`,
+    const heldMs = Math.max(0, Date.now() - contention.owner.acquiredAt);
+    return new FileLockTimeoutError(
+      `Timed out waiting for active Pragma file lock: ${lockDir} (owner PID ${contention.owner.processId}, held ${heldMs}ms${contention.owner.operation === undefined ? "" : ` by ${contention.owner.operation}`})`,
+      lockDir,
+      "active",
+      heldMs,
+      contention.owner.operation,
       { cause },
     );
   }
@@ -343,11 +402,13 @@ function lockTimeout(lockDir: string, contention: LockContention, cause: unknown
       : contention.reason === "owner-process-exited"
         ? "owner process no longer exists"
         : "owner process status could not be confirmed";
-  return new Error(
+  return new FileLockTimeoutError(
     `Timed out waiting for possibly orphaned Pragma file lock: ${lockDir} (${reason})`,
-    {
-      cause,
-    },
+    lockDir,
+    "possibly-orphaned",
+    undefined,
+    undefined,
+    { cause },
   );
 }
 

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -3321,6 +3321,115 @@ describe("Expert lifecycle orchestration", () => {
     expect(result.stats.maxActive).toBeGreaterThanOrEqual(3);
   });
 
+  it("releases a delegated concurrency permit while an Expert waits for human input", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-human-wait-permit-"));
+    let markSecondStarted!: () => void;
+    const secondStarted = new Promise<void>((resolve) => {
+      markSecondStarted = resolve;
+    });
+    const runtime = defineRuntimeDriver<never, FakeSession>({
+      features: createRuntimeTestFeatures({ enabled: ["close"] }),
+      descriptor: { id: "human-wait-permit", kind: "fake", displayName: "Human wait" },
+      createSession: (context) => ({ context, id: `native-${context.systemSessionId}` }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn(session, turn) {
+        const expertId = session.context.agent.id;
+        if (expertId === "member-a") {
+          const handler = session.context.request.humanInteractionHandler;
+          if (handler === undefined) throw new Error("Human interaction handler is missing.");
+          await handler({
+            kind: "user_question",
+            toolName: "askUserQuestion",
+            toolCallId: "member-a-question",
+            questions: [
+              {
+                question: "Continue?",
+                header: "Continue",
+                kind: "single_choice",
+                options: [{ label: "Yes", description: "Continue." }],
+              },
+            ],
+          });
+          return { outputText: "member-a:continued", runtimeSessionId: session.id };
+        }
+        if (expertId === "member-b") {
+          markSecondStarted();
+          return { outputText: "member-b:completed", runtimeSessionId: session.id };
+        }
+        if (turn.rawQuery.startsWith("[Pragma orchestration continuation]")) {
+          return { outputText: "lead:completed", runtimeSessionId: session.id };
+        }
+        const execution = session.context.request.executionContext;
+        const call = async (name: string, input: unknown) => {
+          const tool = session.context.agent.tools?.find((candidate) => candidate.name === name);
+          if (tool === undefined) throw new Error(`Missing orchestration tool: ${name}`);
+          const result = await tool.call(input, turn.signal, { execution });
+          if (result.isError === true) throw new Error(result.text);
+          return result.details as Record<string, unknown>;
+        };
+        const first = await call("spawn_expert", { expertId: "member-a", prompt: "first" });
+        const second = await call("spawn_expert", { expertId: "member-b", prompt: "second" });
+        await call("wait_experts", {
+          invocationIds: [first["invocationId"], second["invocationId"]],
+        });
+        return { outputText: "lead:waiting", runtimeSessionId: session.id };
+      },
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: runtime.descriptor.id,
+      }),
+    });
+    const members = await Promise.all(
+      ["member-a", "member-b"].map(
+        async (id) =>
+          await defineExpert({
+            id,
+            name: id,
+            description: id,
+            tags: [],
+            scope: "test",
+            workspace: home,
+            pragmaHome: home,
+          }),
+      ),
+    );
+    const launcher = createAgentLauncher({ experts: members, maxConcurrency: 1, maxDepth: 1 });
+    const lead = await defineExpert({
+      id: "lead",
+      name: "Lead",
+      description: "Lead",
+      tags: [],
+      scope: "test",
+      workspace: home,
+      pragmaHome: home,
+      tools: launcher.tools,
+    });
+    const session = await app.experts.createSession(lead);
+    const turn = await session.prompt("coordinate", { requestId: "human-wait-permit" });
+    const request = await waitForHumanRequest(turn, 0);
+
+    await expect(
+      Promise.race([
+        secondStarted.then(() => "started"),
+        new Promise<string>((_, reject) =>
+          setTimeout(() => reject(new Error("Second Expert did not start.")), 1_000),
+        ),
+      ]),
+    ).resolves.toBe("started");
+    await turn.respondToHumanInteraction(
+      String((request.data as { interactionId?: unknown }).interactionId),
+      { kind: "user_question", answered: true, answers: { "Continue?": "Yes" } },
+      { requestId: "human-wait-response" },
+    );
+    await expect(turn.result).resolves.toBe("lead:waiting");
+    await session.close();
+  });
+
   it("never exceeds the configured child concurrency limit", async () => {
     const result = await runScenario("concurrency", ["member-a", "member-b", "member-c"]);
     expect(result.tree.children).toHaveLength(3);
@@ -3787,7 +3896,7 @@ function sessionRootContext(
 }
 
 async function waitForHumanRequest(
-  execution: FlowExecution,
+  execution: Pick<FlowExecution, "listEvents">,
   index: number,
 ): Promise<ExecutionEvent> {
   let requested: ExecutionEvent | undefined;

--- a/packages/core/test/file-lock.test.ts
+++ b/packages/core/test/file-lock.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { withFileLock } from "../src/storage/file-lock.ts";
+import { FileLockTimeoutError, withFileLock } from "../src/storage/file-lock.ts";
 
 describe("withFileLock", () => {
   it("serializes heavily contended lock directory creation and removal", async () => {
@@ -90,15 +90,23 @@ describe("withFileLock", () => {
     const holdFirst = new Promise<void>((resolve) => {
       releaseFirst = resolve;
     });
-    const first = withFileLock(lockDir, async () => {
-      markFirstEntered();
-      await holdFirst;
-    });
+    const first = withFileLock(
+      lockDir,
+      async () => {
+        markFirstEntered();
+        await holdFirst;
+      },
+      { operation: "execution.read-events" },
+    );
     await firstEntered;
 
-    await expect(withFileLock(lockDir, async () => undefined, { timeoutMs: 20 })).rejects.toThrow(
-      "in-process file lock",
-    );
+    const timeout = withFileLock(lockDir, async () => undefined, { timeoutMs: 20 });
+    await expect(timeout).rejects.toBeInstanceOf(FileLockTimeoutError);
+    await expect(timeout).rejects.toMatchObject({
+      code: "pragma_file_lock_timeout",
+      contention: "local",
+      operation: "execution.read-events",
+    });
     const next = withFileLock(lockDir, async () => "continued");
     releaseFirst();
 


### PR DESCRIPTION
## Summary

- release delegated concurrency permits while an Expert waits for human input
- replace overlapping Mission status polling with event-driven waiting-state tracking and retry failed live subscriptions
- preserve durable and cached chat history when execution-state reads temporarily fail
- restore active execution history and pending input across Desktop restart
- add structured file-lock timeout diagnostics and operation attribution

## Root cause

Human-input waits were observed through repeated execution reads while the same execution was actively mutating state. Lock contention could make chat refresh fail, and the renderer treated the failed refresh as an empty snapshot. Delegated Experts also retained their concurrency permit while waiting for a user response, preventing other team members from progressing.

## User impact

Mission history remains visible during transient state synchronization failures, pending questions remain resumable after restart, and other Experts can continue working while one Expert waits for user input. The UI exposes a recoverable synchronization error and retry action instead of clearing the conversation.

## Validation

- Core execution, event-log, and file-lock tests: 96 passed
- Desktop Mission runner, renderer, and contract tests: 117 passed
- `pnpm check`
- `pnpm build`
- Desktop main/preload/style bundle verification
- `git diff --check`

Closes #173