### PR TITLE
Fix Mission chat review findings

### DIFF
--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -1443,6 +1443,87 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     });
   });
 
+  it("deduplicates a persisted assistant message against its active live projection", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-chat-live-durable-"));
+    temporaryPaths.push(root);
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture()],
+    });
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Return one answer",
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(
+        snapshot.resources.find((resource) => resource.kind === "Expert")!,
+      ),
+    });
+    let releaseTurn = (): void => undefined;
+    const turnCanFinish = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn(_session, turn) {
+        turn.stream.write({
+          runId: turn.runId,
+          source: turn.source,
+          type: "message.delta",
+          payload: { role: "assistant", contentType: "text", delta: "Only once" },
+        });
+        await turnCanFinish;
+        return { outputText: "Only once", runtimeSessionId: "runtime" };
+      },
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const originalUpdateExecution = missions.updateExecution.bind(missions);
+    let terminalUpdateEntered = (): void => undefined;
+    const terminalUpdateStarted = new Promise<void>((resolve) => {
+      terminalUpdateEntered = resolve;
+    });
+    let releaseTerminalUpdate = (): void => undefined;
+    const terminalUpdateCanFinish = new Promise<void>((resolve) => {
+      releaseTerminalUpdate = resolve;
+    });
+    vi.spyOn(missions, "updateExecution").mockImplementation(async (...args) => {
+      if (args[1].status === "succeeded") {
+        terminalUpdateEntered();
+        await terminalUpdateCanFinish;
+      }
+      return await originalUpdateExecution(...args);
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome: join(root, "state"),
+      runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
+    });
+
+    await runner.run(mission.id);
+    releaseTurn();
+    await terminalUpdateStarted;
+    try {
+      const chat = await runner.getChat({ id: mission.id, limit: 50 });
+      expect(
+        chat.entries.filter((entry) => entry.kind === "assistant" && entry.content === "Only once"),
+      ).toHaveLength(1);
+    } finally {
+      releaseTerminalUpdate();
+    }
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("succeeded"),
+      { timeout: settlementTimeoutMs },
+    );
+  });
+
   it("compiles and runs the resource pinned by a Mission", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-mission-runner-"));
     temporaryPaths.push(root);
@@ -2390,6 +2471,105 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     expect(await expertSessions.listPrompts(sessionId)).toHaveLength(1);
   });
 
+  it("retries durable human-wait synchronization after a transient read failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pragma-mission-human-resync-"));
+    temporaryPaths.push(root);
+    const pragmaHome = join(root, "state");
+    const project = createPragmaProjectStore({ projectsPath: join(root, "projects") });
+    const snapshot = await project.publish({
+      expectedRevision: 0,
+      resources: [runtimeFixture(), expertFixture(), approvalAfterExpertFlowFixture()],
+    });
+    const flow = snapshot.resources.find((resource) => resource.kind === "Flow")!;
+    const missions = createMissionStore({ missionsPath: join(root, "missions") });
+    const mission = await missions.create({
+      workspace: { path: root, basename: "workspace" },
+      goal: "Prepare and request approval",
+      flowInput: {},
+      project: { id: snapshot.projectId, revision: snapshot.revision },
+      executor: missionExecutorSnapshot(flow),
+    });
+    let releasePreparation = (): void => undefined;
+    const preparationCanFinish = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    const runtime = defineRuntimeTestDriver<never, { id: string }>({
+      descriptor: { id: "fake", kind: "fake", displayName: "Fake" },
+      createSession: () => ({ id: "runtime" }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn() {
+        await preparationCanFinish;
+        return { outputText: "prepared", runtimeSessionId: "runtime" };
+      },
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const executionStore = createFileExecutionStore({ pragmaHome });
+    const originalListEvents = StoredExecutionView.prototype.listEvents;
+    let initialSeedFinished = (): void => undefined;
+    const initialSeedComplete = new Promise<void>((resolve) => {
+      initialSeedFinished = resolve;
+    });
+    let listEventsCalls = 0;
+    vi.spyOn(StoredExecutionView.prototype, "listEvents").mockImplementation(async function (
+      this: StoredExecutionView,
+      options?: Parameters<StoredExecutionView["listEvents"]>[0],
+    ) {
+      listEventsCalls += 1;
+      if (listEventsCalls === 2) throw new Error("transient event-log read failure");
+      const page = await originalListEvents.call(this, options);
+      if (listEventsCalls === 1) initialSeedFinished();
+      return page;
+    });
+    const originalSubscribeEvents = StoredExecutionView.prototype.subscribeEvents;
+    let releaseEventSubscription = (): void => undefined;
+    const eventSubscriptionCanStart = new Promise<void>((resolve) => {
+      releaseEventSubscription = resolve;
+    });
+    vi.spyOn(StoredExecutionView.prototype, "subscribeEvents").mockImplementation(async function (
+      this: StoredExecutionView,
+      options?: Parameters<StoredExecutionView["subscribeEvents"]>[0],
+    ) {
+      await eventSubscriptionCanStart;
+      return await originalSubscribeEvents.call(this, options);
+    });
+    const runner = createMissionRunner({
+      missions,
+      project,
+      capabilityStore: {} as CapabilityStore,
+      capabilityCredentials: {} as CapabilityCredentialStore,
+      capabilitiesPath: join(root, "capabilities"),
+      pragmaHome,
+      executionStore,
+      runtimes: createStaticRuntimeResolver({ runtimes: [runtime], defaultRuntimeId: "fake" }),
+      loggerProvider: createNoopLoggerProvider(),
+    });
+
+    await runner.run(mission.id);
+    await initialSeedComplete;
+    releasePreparation();
+    await vi.waitFor(
+      async () => {
+        const executionId = (await missions.get(mission.id)).execution?.id;
+        expect(executionId).toBeDefined();
+        expect(
+          (await executionStore.readEvents(executionId!)).some(
+            (event) => event.type === "human.requested",
+          ),
+        ).toBe(true);
+      },
+      { timeout: settlementTimeoutMs },
+    );
+    expect((await missions.get(mission.id)).execution?.status).toBe("running");
+    releaseEventSubscription();
+
+    await vi.waitFor(
+      async () => expect((await missions.get(mission.id)).execution?.status).toBe("waiting"),
+      { timeout: settlementTimeoutMs },
+    );
+    expect(listEventsCalls).toBeGreaterThanOrEqual(3);
+  });
+
   it("round-trips a Flow human interaction with globally unique resource IDs", async () => {
     const root = await mkdtemp(join(tmpdir(), "pragma-mission-human-"));
     temporaryPaths.push(root);
@@ -3113,6 +3293,43 @@ function approvalFlowFixture(): PragmaFlowResource {
         },
         loops: {},
         transitions: { approve: { end: true } },
+      },
+    },
+  };
+}
+
+function approvalAfterExpertFlowFixture(): PragmaFlowResource {
+  return {
+    apiVersion: "pragma/v4",
+    kind: "Flow",
+    metadata: {
+      id: "3tshk7gb32ckdfj3",
+      name: "Prepared Review",
+      description: "Prepares work before requesting approval",
+      tags: [],
+    },
+    spec: {
+      limits: { maxNodeVisits: 10 },
+      graph: {
+        start: "prepare",
+        steps: {
+          prepare: {
+            expert: { ref: "expert:1xddvess309a6gme" },
+            prompt: { segments: [{ text: "Prepare the release" }] },
+          },
+          approve: {
+            human: {
+              selectionMode: "single",
+              prompt: { segments: [{ text: "Approve the prepared release?" }] },
+              options: [
+                { value: "ship", label: "Ship" },
+                { value: "hold", label: "Hold" },
+              ],
+            },
+          },
+        },
+        loops: {},
+        transitions: { prepare: "approve", approve: { end: true } },
       },
     },
   };

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -232,9 +232,9 @@ export async function compactExpertSessionContext(
 interface LiveMissionChat {
   readonly executionId: string;
   readonly entries: MissionChatEntry[];
+  readonly messageOrdinals: Map<string, number>;
   close: () => Promise<void>;
   readDurableEntries: (timelineSequence: number) => Promise<readonly MissionChatEntry[]>;
-  sequence: number;
 }
 
 type ExecutorNameResolver = (executorId: string) => string | undefined;
@@ -931,7 +931,7 @@ export function createMissionRunner(options: {
             ({
               executionId: item.executionId,
               entries: [],
-              sequence: 0,
+              messageOrdinals: new Map(),
               close: async () => undefined,
               readDurableEntries: async () => [],
             } satisfies LiveMissionChat);
@@ -2427,6 +2427,14 @@ function observeMissionHumanWaitingStatus(input: {
   let observedWaiting: boolean | undefined;
   let updates = Promise.resolve();
 
+  const enqueueUpdate = (update: () => Promise<void>): Promise<void> => {
+    const result = updates.then(update);
+    // Keep the serialization queue usable after a transient failure while preserving the rejected
+    // result for callers such as the event subscription retry loop.
+    updates = result.catch(() => undefined);
+    return result;
+  };
+
   const persistStatus = async (): Promise<void> => {
     const waiting = pending.size > 0;
     if (waiting === observedWaiting) return;
@@ -2460,25 +2468,23 @@ function observeMissionHumanWaitingStatus(input: {
         "Mission human-input waiting status could not be initialized.",
         { error, missionId: input.missionId, executionId: input.execution.executionId },
       );
+      throw error;
     }
   };
-  const seed = resync();
+  void enqueueUpdate(resync).catch(() => undefined);
 
   const onEvent = (event: ExecutionEvent): void => {
     if (event.type !== "human.requested" && event.type !== "human.responded") return;
-    updates = updates
-      .catch(() => undefined)
-      .then(async () => {
-        await seed;
-        const interactionId = String(
-          (event.data as { readonly interactionId?: unknown }).interactionId ?? "",
-        );
-        if (interactionId === "") return;
-        if (event.type === "human.requested") pending.add(interactionId);
-        else pending.delete(interactionId);
-        await persistStatus();
-      });
-    void updates.catch((error: unknown) => {
+    const update = enqueueUpdate(async () => {
+      const interactionId = String(
+        (event.data as { readonly interactionId?: unknown }).interactionId ?? "",
+      );
+      if (interactionId === "") return;
+      if (event.type === "human.requested") pending.add(interactionId);
+      else pending.delete(interactionId);
+      await persistStatus();
+    });
+    void update.catch((error: unknown) => {
       input.logger.warn(
         "mission.human_wait_status_update_failed",
         "Mission human-input waiting status could not be updated.",
@@ -2489,14 +2495,8 @@ function observeMissionHumanWaitingStatus(input: {
 
   return {
     onEvent,
-    resync: () => {
-      updates = updates.catch(() => undefined).then(resync);
-      return updates;
-    },
-    drain: async () => {
-      await seed;
-      await updates;
-    },
+    resync: () => enqueueUpdate(resync),
+    drain: async () => await updates,
   };
 }
 
@@ -2822,6 +2822,7 @@ function workTaskInputContent(input: unknown): string {
 
 function messageRecordsToChatEntries(records: readonly AgentMessageRecord[]): MissionChatEntry[] {
   const entries: MissionChatEntry[] = [];
+  const messageOrdinals = new Map<string, number>();
   for (const record of [...records].sort((left, right) => left.sequence - right.sequence)) {
     const base = {
       executionId: record.executionId,
@@ -2834,7 +2835,7 @@ function messageRecordsToChatEntries(records: readonly AgentMessageRecord[]): Mi
         if (content.type === "thinking" && content.thinking !== "") {
           entries.push({
             ...base,
-            id: `${record.executionId}:${record.invocationId}:${record.sequence}:${index}`,
+            id: durableMessageEntryId(record, "thinking", index, messageOrdinals),
             kind: "thinking",
             content: truncate(content.thinking, 200_000),
             streaming: false,
@@ -2842,7 +2843,7 @@ function messageRecordsToChatEntries(records: readonly AgentMessageRecord[]): Mi
         } else if (content.type === "text" && content.text !== "") {
           entries.push({
             ...base,
-            id: `${record.executionId}:${record.invocationId}:${record.sequence}:${index}`,
+            id: durableMessageEntryId(record, "assistant", index, messageOrdinals),
             kind: "assistant",
             content: truncate(content.text, 200_000),
             streaming: false,
@@ -2894,6 +2895,31 @@ function messageRecordsToChatEntries(records: readonly AgentMessageRecord[]): Mi
   return entries;
 }
 
+function durableMessageEntryId(
+  record: AgentMessageRecord,
+  kind: "assistant" | "thinking",
+  contentIndex: number,
+  ordinals: Map<string, number>,
+): string {
+  if (record.runId === undefined) {
+    return `${record.executionId}:${record.invocationId}:${record.sequence}:${contentIndex}`;
+  }
+  return nextMessageEntryId(record.executionId, record.invocationId, record.runId, kind, ordinals);
+}
+
+function nextMessageEntryId(
+  executionId: string,
+  invocationId: string,
+  runId: string,
+  kind: "assistant" | "thinking",
+  ordinals: Map<string, number>,
+): string {
+  const key = JSON.stringify([executionId, invocationId, runId, kind]);
+  const ordinal = ordinals.get(key) ?? 0;
+  ordinals.set(key, ordinal + 1);
+  return `message:${executionId}:${invocationId}:${runId}:${kind}:${ordinal}`;
+}
+
 function createMissionExecutorNameResolver(
   mission: Pick<Mission, "executor">,
   names: ReadonlyMap<string, string>,
@@ -2928,7 +2954,7 @@ function observeMissionChat(
   const chat: LiveMissionChat = {
     executionId: execution.executionId,
     entries: [],
-    sequence: 0,
+    messageOrdinals: new Map(),
     close: async () => undefined,
     readDurableEntries: async () => [],
   };
@@ -3220,7 +3246,13 @@ function consumeLiveChatOutput(
     } else {
       const entry = {
         ...base,
-        id: `${item.executionId}:${item.invocationId}:thinking:${chat.sequence++}`,
+        id: nextMessageEntryId(
+          item.executionId,
+          item.invocationId,
+          item.runId,
+          "thinking",
+          chat.messageOrdinals,
+        ),
         kind: "thinking" as const,
         content: truncate(content, 200_000),
         streaming: true,
@@ -3267,7 +3299,13 @@ function consumeLiveChatOutput(
     } else if (content !== "") {
       const entry = {
         ...base,
-        id: `${item.executionId}:${item.invocationId}:answer:${chat.sequence++}`,
+        id: nextMessageEntryId(
+          item.executionId,
+          item.invocationId,
+          item.runId,
+          "assistant",
+          chat.messageOrdinals,
+        ),
         kind: "assistant" as const,
         content: truncate(content, 200_000),
         streaming: item.delta !== undefined,
@@ -3364,7 +3402,13 @@ function consumeLiveChatOutput(
     ) {
       const entry = {
         ...base,
-        id: `${item.executionId}:${item.invocationId}:result:${chat.sequence++}`,
+        id: nextMessageEntryId(
+          item.executionId,
+          item.invocationId,
+          item.runId,
+          "assistant",
+          chat.messageOrdinals,
+        ),
         kind: "assistant" as const,
         content,
         streaming: false,


### PR DESCRIPTION
## Summary

- give durable and live assistant/thinking entries the same stable identity derived from the Runtime run and per-kind ordinal
- propagate failed human-wait resynchronization to the event subscription retry loop while keeping the serialized update queue recoverable
- add regressions for live/durable duplicate answers and missed pre-subscription human requests after a transient event-log read failure

## Root cause

PR #176 merged durable active-execution history with the live projection by entry ID, but the two sources generated unrelated IDs for the same assistant message. It also logged and swallowed human-wait resynchronization failures, so the subscription stayed open without retrying a durable seed that had missed a pre-subscription event.

## Impact

Active Mission chat no longer renders a persisted answer twice, and Missions recover their `waiting` status after transient event-log read failures instead of remaining stuck as `running`.

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm --filter @pragma/desktop test` (131 files, 801 tests)
- MissionRunner suite (24 tests)

Follow-up to #176 and its unresolved Codex review findings.