### PR TITLE
fix(memory): prevent repeated skill extraction failures

### DIFF
--- a/apps/desktop/src/main/features/memory/memory-curator.ts
+++ b/apps/desktop/src/main/features/memory/memory-curator.ts
@@ -438,6 +438,12 @@ async function runCuratorMission(input: {
       .at(-1);
     if (content === undefined) throw new Error("memory_curator_output_missing");
     const runtimeOutput = await input.options.runner.getTerminalRuntimeOutputDiagnostic(mission.id);
+    if (skillDraftSession?.beginRepairExhausted() === true) {
+      throw Object.assign(new Error("skill_draft_begin_repair_exhausted"), {
+        code: "skill_draft_begin_repair_exhausted",
+        retryable: true,
+      });
+    }
     if (skillDraftSession?.repairExhausted() === true) {
       throw Object.assign(new Error("skill_draft_repair_exhausted"), {
         code: "skill_draft_repair_exhausted",

--- a/packages/built-in-agents/src/memory-curator.ts
+++ b/packages/built-in-agents/src/memory-curator.ts
@@ -7,6 +7,7 @@ import {
   SEMANTIC_MEMORY_CURATOR_PROMPT_VERSION,
   SKILL_MEMORY_CURATOR_PROMPT_VERSION,
   SemanticExtractionOutputSchema,
+  inspectSkillSourceEligibility,
   mergeMemoryEvidenceOmissionStats,
   selectBoundedMemoryEvidence,
   type EpisodicMemoryExtractor,
@@ -24,6 +25,7 @@ import {
   type MemoryExtractionOutputDiagnostic,
   type SkillExtractionInput,
   type SkillExtractionOutput,
+  type SkillSourceSnapshot,
 } from "@pragma/shared";
 
 import { inspectStructuredJson } from "./structured-output.ts";
@@ -298,11 +300,22 @@ export function renderKnowledgeExtractionPrompt(
 export function renderSkillExtractionPrompt(
   input: Parameters<SkillMemoryExtractor["extract"]>[0],
 ): string {
-  return enforcePromptLimit(
-    [
+  const render = (sources: readonly SkillSourceSnapshot[]): string => {
+    const eligibility = inspectSkillSourceEligibility(sources);
+    return [
       "Extract at most three complete, reusable Skill candidates from these curated Memory sources.",
       "A Skill is a coherent executable workflow, not a fact, isolated tip, command fragment, or one-off success. Merge related steps into one Skill and return retain=false when the pattern is fragmentary.",
       "Every candidate must cite at least three distinct high-value Episodic ids across at least two conversations; at least two must have succeeded or recovered successfully. Semantic sources may support but never satisfy this threshold.",
+      "Host-computed source eligibility is authoritative; do not try to satisfy an ineligible input by repeating the same draft request.",
+      "Source eligibility:",
+      JSON.stringify({
+        eligible: eligibility.eligible,
+        highValueEpisodicCount: eligibility.highValueEpisodicCount,
+        conversationCount: eligibility.conversationCount,
+        successfulOrRecoveredCount: eligibility.successfulOrRecoveredCount,
+        qualifyingSourceRefs: eligibility.qualifyingSourceRefs,
+      }),
+      'When eligible is false, do not call begin_skill_draft; return exactly {"retain":false,"reason":"insufficient-independent-sources"}.',
       "Generate SKILL.md plus optional references/*.md. Scripts are optional and must be dependency-free Node 22 ESM under scripts/*.mjs with node:test coverage under tests/*.test.mjs.",
       "For each candidate create at least three source replay expectations and one clearly non-applicable boundary case.",
       'Compare only existingTargets. Use revise only for one clear match, ambiguous for two or more plausible matches, otherwise create. Never invent a binding id. route is always an object: use {"type":"create"}; use {"type":"revise","bindingId":"an existing binding UUID"}; or use {"type":"ambiguous","bindingIds":["existing binding UUID 1","existing binding UUID 2"]}.',
@@ -314,9 +327,39 @@ export function renderSkillExtractionPrompt(
       "Existing Memory Skills:",
       JSON.stringify(input.existingTargets),
       "Sources:",
-      JSON.stringify(input.sources),
-    ].join("\n\n"),
-  );
+      JSON.stringify(sources),
+    ].join("\n\n");
+  };
+  const selected = selectSkillPromptSources(input, render);
+  return enforcePromptLimit(render(selected));
+}
+
+function selectSkillPromptSources(
+  input: Parameters<SkillMemoryExtractor["extract"]>[0],
+  render: (sources: readonly SkillSourceSnapshot[]) => string,
+): readonly SkillSourceSnapshot[] {
+  const candidates = input.sources
+    .map((source, index) => ({ source, index }))
+    .toSorted(
+      (left, right) =>
+        skillSourcePriority(left.source) - skillSourcePriority(right.source) ||
+        left.index - right.index,
+    );
+  const selected: Array<{ readonly source: SkillSourceSnapshot; readonly index: number }> = [];
+  for (const candidate of candidates) {
+    const next = [...selected.map((item) => item.source), candidate.source];
+    if (Buffer.byteLength(render(next)) > DEFAULT_MEMORY_STORAGE_POLICY.extractionPromptMaxBytes) {
+      continue;
+    }
+    selected.push(candidate);
+  }
+  return selected.toSorted((left, right) => left.index - right.index).map((item) => item.source);
+}
+
+function skillSourcePriority(source: SkillSourceSnapshot): number {
+  if (source.ref.kind === "episodic" && (source.valueScore ?? 0) >= 0.85) return 0;
+  if (source.ref.kind === "episodic") return 1;
+  return 2;
 }
 
 function curatorOutputDiagnostic(

--- a/packages/built-in-agents/src/skill-draft.ts
+++ b/packages/built-in-agents/src/skill-draft.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { ExpertAgentManagedTool, ExpertAgentToolCallResult } from "@pragma/core";
-import { validateSkillExtractionCandidate } from "@pragma/memory";
+import { inspectSkillSourceEligibility, validateSkillExtractionCandidate } from "@pragma/memory";
 import {
   SkillExtractionCandidateSchema,
   SkillPackageFileSchema,
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { validateGeneratedSkillPackage } from "./skill-validation.ts";
 
 const MAX_DRAFTS = 3;
+const MAX_BEGIN_VALIDATION_ATTEMPTS = 3;
 const MAX_SUBMIT_ATTEMPTS = 3;
 
 const CandidateContentSchema = SkillExtractionCandidateSchema.shape.content;
@@ -120,13 +121,21 @@ export interface SkillDraftToolError {
 export interface SkillDraftSession {
   readonly tools: readonly ExpertAgentManagedTool<string, ExpertAgentToolCallResult>[];
   output(): SkillExtractionOutput | undefined;
+  beginRepairExhausted(): boolean;
   repairExhausted(): boolean;
 }
 
 export function createSkillDraftSession(input: SkillExtractionInput): SkillDraftSession {
   const drafts = new Map<string, SkillDraft>();
   const accepted: SkillExtractionCandidate[] = [];
+  const eligibility = inspectSkillSourceEligibility(input.sources);
+  const failedBeginFingerprints = new Set<string>();
+  let beginValidationAttempts = 0;
+  let beginExhausted = false;
   let exhausted = false;
+  let terminalOutput: SkillExtractionOutput | undefined = eligibility.eligible
+    ? undefined
+    : { retain: false, reason: "insufficient-independent-sources" };
   let toolQueue: Promise<void> = Promise.resolve();
   const enqueue = (
     operation: () => Promise<ExpertAgentToolCallResult>,
@@ -138,13 +147,35 @@ export function createSkillDraftSession(input: SkillExtractionInput): SkillDraft
     );
     return result;
   };
+  const recordBeginFailure = (
+    issues: readonly SkillDraftToolError[],
+    fingerprint?: string,
+  ): boolean => {
+    beginValidationAttempts += 1;
+    const repeated = fingerprint !== undefined && failedBeginFingerprints.has(fingerprint);
+    if (fingerprint !== undefined) failedBeginFingerprints.add(fingerprint);
+    const terminal =
+      !eligibility.eligible || repeated || beginValidationAttempts >= MAX_BEGIN_VALIDATION_ATTEMPTS;
+    if (terminal) {
+      beginExhausted = true;
+      terminalOutput = {
+        retain: false,
+        reason:
+          !eligibility.eligible || issues.some((issue) => issue.code === "source_threshold_not_met")
+            ? "insufficient-independent-sources"
+            : "no-reusable-skill",
+      };
+    }
+    return terminal;
+  };
 
   const begin = managedTool(
     "begin_skill_draft",
-    'Begin one Skill candidate draft after validating its metadata, provenance, and route. route must be an object: {"type":"create"}; {"type":"revise","bindingId":"<existing UUID>"}; or {"type":"ambiguous","bindingIds":["<existing UUID>","<existing UUID>"]}.',
+    'Begin one Skill candidate draft only after the host-computed source eligibility check passes. The candidate must cite at least three high-value Episodic sources across two conversations, including two successful or recovered outcomes. route must be an object: {"type":"create"}; {"type":"revise","bindingId":"<existing UUID>"}; or {"type":"ambiguous","bindingIds":["<existing UUID>","<existing UUID>"]}.',
     BeginSkillDraftInputSchema,
     async (args) => {
       if (exhausted) return failure([repairBudgetError()], true);
+      if (beginExhausted) return failure([beginBudgetError()], false, true);
       if (drafts.size >= MAX_DRAFTS) {
         return failure([
           {
@@ -155,7 +186,11 @@ export function createSkillDraftSession(input: SkillExtractionInput): SkillDraft
         ]);
       }
       const parsed = BeginSkillDraftInputSchema.safeParse(args);
-      if (!parsed.success) return failure(zodErrors(parsed.error));
+      if (!parsed.success) {
+        const errors = zodErrors(parsed.error);
+        const terminal = recordBeginFailure(errors);
+        return failure(terminal ? [...errors, beginBudgetError()] : errors, false, terminal);
+      }
       const probe = SkillExtractionCandidateSchema.parse({
         ...parsed.data,
         content: {
@@ -169,7 +204,10 @@ export function createSkillDraftSession(input: SkillExtractionInput): SkillDraft
         input.existingTargets,
         new Set(accepted.map((candidate) => candidate.content.normalizedKey)),
       );
-      if (issues.length > 0) return failure(issues);
+      if (issues.length > 0) {
+        const terminal = recordBeginFailure(issues, JSON.stringify(parsed.data));
+        return failure(terminal ? [...issues, beginBudgetError()] : issues, false, terminal);
+      }
       const draftId = randomUUID();
       drafts.set(draftId, {
         id: draftId,
@@ -283,7 +321,8 @@ export function createSkillDraftSession(input: SkillExtractionInput): SkillDraft
   return {
     tools: [begin, put, submit],
     output: () =>
-      accepted.length === 0 ? undefined : { retain: true as const, candidates: accepted },
+      accepted.length === 0 ? terminalOutput : { retain: true as const, candidates: accepted },
+    beginRepairExhausted: () => beginExhausted && eligibility.eligible && accepted.length === 0,
     repairExhausted: () => exhausted,
   };
 }
@@ -318,9 +357,15 @@ function success(value: unknown): ExpertAgentToolCallResult {
 function failure(
   errors: readonly SkillDraftToolError[],
   repairExhausted = false,
+  terminal = false,
 ): ExpertAgentToolCallResult {
-  const value = { ok: false as const, errors, ...(repairExhausted ? { repairExhausted } : {}) };
-  return { text: JSON.stringify(value), details: value };
+  const value = {
+    ok: false as const,
+    errors,
+    ...(repairExhausted ? { repairExhausted } : {}),
+    ...(terminal ? { terminal } : {}),
+  };
+  return { text: JSON.stringify(value), isError: terminal || repairExhausted, details: value };
 }
 
 function zodErrors(error: z.ZodError): readonly SkillDraftToolError[] {
@@ -379,5 +424,13 @@ function repairBudgetError(): SkillDraftToolError {
     path: "draftId",
     code: "skill_draft_repair_exhausted",
     message: `The Skill draft exhausted its ${MAX_SUBMIT_ATTEMPTS} submission attempts.`,
+  };
+}
+
+function beginBudgetError(): SkillDraftToolError {
+  return {
+    path: "sourceRefs",
+    code: "skill_draft_begin_repair_exhausted",
+    message: `The Skill draft begin validation exhausted its ${MAX_BEGIN_VALIDATION_ATTEMPTS} attempts or received a repeated invalid request.`,
   };
 }

--- a/packages/built-in-agents/test/memory-curator.test.ts
+++ b/packages/built-in-agents/test/memory-curator.test.ts
@@ -1,4 +1,8 @@
-import type { MemoryExtractorProfile, MemoryExtractorProfileStore } from "@pragma/memory";
+import {
+  DEFAULT_MEMORY_STORAGE_POLICY,
+  type MemoryExtractorProfile,
+  type MemoryExtractorProfileStore,
+} from "@pragma/memory";
 import {
   MemoryEvidenceEnvelopeSchema,
   type SkillExtractionInput,
@@ -9,6 +13,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createBuiltInMemoryCurator,
   renderEpisodicExtractionPrompt,
+  renderSkillExtractionPrompt,
   type MemoryCuratorExecutionPort,
 } from "../src/memory-curator.ts";
 import { createSkillDraftSession } from "../src/skill-draft.ts";
@@ -178,6 +183,113 @@ describe("Memory Curator Evidence prompts", () => {
 });
 
 describe("Memory Curator Skill drafts", () => {
+  it("shows the host-computed source eligibility before asking for a draft", () => {
+    const eligiblePrompt = renderSkillExtractionPrompt(skillInput());
+    expect(eligiblePrompt).toContain('"eligible":true');
+    expect(eligiblePrompt).toContain('"highValueEpisodicCount":3');
+    expect(eligiblePrompt).toContain('"conversationCount":2');
+    expect(eligiblePrompt).toContain('"successfulOrRecoveredCount":2');
+
+    const ineligiblePrompt = renderSkillExtractionPrompt(ineligibleSkillInput());
+    expect(ineligiblePrompt).toContain('"eligible":false');
+    expect(ineligiblePrompt).toContain(
+      'return exactly {"retain":false,"reason":"insufficient-independent-sources"}',
+    );
+  });
+
+  it("returns an MCP-visible error and a clean rejection when evidence cannot meet the threshold", async () => {
+    const input = ineligibleSkillInput();
+    const session = createSkillDraftSession(input);
+    const begin = session.tools.find((tool) => tool.name === "begin_skill_draft")!;
+
+    expect(session.output()).toEqual({
+      retain: false,
+      reason: "insufficient-independent-sources",
+    });
+    const result = await begin.call(metadata(input), undefined);
+
+    expect(result).toMatchObject({
+      isError: true,
+      details: { ok: false, terminal: true },
+    });
+    expect(result.text).toContain("source_threshold_not_met");
+    expect(session.output()).toEqual({
+      retain: false,
+      reason: "insufficient-independent-sources",
+    });
+
+    const repeated = await begin.call(metadata(input), undefined);
+    expect(repeated).toMatchObject({
+      isError: true,
+      details: { ok: false, terminal: true },
+    });
+    expect(repeated.text).toContain("skill_draft_begin_repair_exhausted");
+  });
+
+  it("terminates a repeated invalid begin request instead of retrying it forever", async () => {
+    const session = createSkillDraftSession(skillInput());
+    const begin = session.tools.find((tool) => tool.name === "begin_skill_draft")!;
+    const request = {
+      ...metadata(),
+      route: { type: "revise" as const, bindingId: "00000000-0000-4000-8000-000000000099" },
+    };
+
+    const first = await begin.call(request, undefined);
+    expect(first).toMatchObject({ isError: false, details: { ok: false } });
+    expect(first.details).not.toHaveProperty("terminal", true);
+
+    const repeated = await begin.call(request, undefined);
+    expect(repeated).toMatchObject({
+      isError: true,
+      details: { ok: false, terminal: true },
+    });
+    expect(session.output()).toEqual({ retain: false, reason: "no-reusable-skill" });
+  });
+
+  it("keeps an already begun draft repairable after begin validation exhaustion", async () => {
+    const session = createSkillDraftSession(skillInput());
+    const begin = session.tools.find((tool) => tool.name === "begin_skill_draft")!;
+    const put = session.tools.find((tool) => tool.name === "put_skill_file")!;
+    const submit = session.tools.find((tool) => tool.name === "submit_skill_draft")!;
+    const begun = await begin.call(metadata(), undefined);
+    const draftId = (begun.details as { draftId: string }).draftId;
+    const invalidRequest = {
+      ...metadata(),
+      route: { type: "revise" as const, bindingId: "00000000-0000-4000-8000-000000000099" },
+    };
+
+    await begin.call(invalidRequest, undefined);
+    await begin.call(invalidRequest, undefined);
+    expect(session.beginRepairExhausted()).toBe(true);
+
+    await put.call(
+      {
+        draftId,
+        path: "SKILL.md",
+        content:
+          "---\nname: resilient-skill\ndescription: A reusable resilient workflow.\n---\n\n# Skill",
+      },
+      undefined,
+    );
+    const submitted = await submit.call({ draftId }, undefined);
+    expect(submitted).toMatchObject({ details: { ok: true } });
+    expect(submitted.isError).not.toBe(true);
+    expect(session.output()).toMatchObject({ retain: true });
+    expect(session.beginRepairExhausted()).toBe(false);
+  });
+
+  it("keeps the Skill prompt within its byte budget when source records are large", () => {
+    const input = skillInput();
+    const prompt = renderSkillExtractionPrompt({
+      ...input,
+      sources: input.sources.map((source) => ({ ...source, body: "x".repeat(24_000) })),
+    });
+
+    expect(Buffer.byteLength(prompt)).toBeLessThanOrEqual(
+      DEFAULT_MEMORY_STORAGE_POLICY.extractionPromptMaxBytes,
+    );
+  });
+
   it("exposes a single-object route schema and accepts a valid runtime tool call", async () => {
     const session = createSkillDraftSession(skillInput());
     const begin = session.tools.find((tool) => tool.name === "begin_skill_draft")!;
@@ -444,7 +556,7 @@ function skillInput(): SkillExtractionInput {
   };
 }
 
-function metadata() {
+function metadata(input: SkillExtractionInput = skillInput()) {
   return {
     content: {
       normalizedKey: "workflow.resilient",
@@ -463,8 +575,19 @@ function metadata() {
         forbiddenBehaviors: ["Force the workflow."],
       },
     },
-    sourceRefs: skillInput().sources.map((source) => source.ref),
+    sourceRefs: input.sources.map((source) => source.ref),
     route: { type: "create" as const },
+  };
+}
+
+function ineligibleSkillInput(): SkillExtractionInput {
+  const input = skillInput();
+  return {
+    ...input,
+    sources: input.sources.map((source) => ({
+      ...source,
+      conversationRef: { type: "pragma.mission", id: "mission-a" },
+    })),
   };
 }
 

--- a/packages/memory/src/skill/module.ts
+++ b/packages/memory/src/skill/module.ts
@@ -121,23 +121,29 @@ export async function createSkillMemoryModule(options: {
           await store.complete(job, "rejected", now());
           return;
         }
-        if (!skillSourceThresholdMet(sources)) {
-          await store.complete(job, "rejected", now());
-          return;
-        }
         const expertRefs = producerExpertRefs(job.rootRef, sources);
         if (expertRefs.length === 0) {
           await store.complete(job, "rejected", now());
           return;
         }
-        for (const expertRef of expertRefs) {
+        const eligibleExpertSources = expertRefs
+          .map((expertRef) => ({
+            expertRef,
+            sources: sourcesForExpert(sources, expertRef),
+          }))
+          .filter(({ sources: expertSources }) => skillSourceThresholdMet(expertSources));
+        if (eligibleExpertSources.length === 0) {
+          await store.complete(job, "rejected", now());
+          return;
+        }
+        for (const { expertRef, sources: expertSources } of eligibleExpertSources) {
           phase = "target_read";
           const existingTargets = await options.targetReader.listTargets({ expertRef });
           const input = SkillExtractionInputSchema.parse({
             schemaVersion: "pragma.memory-skill-extraction-input/v1",
             jobId: job.id,
             rootRef: job.rootRef,
-            sources: sourcesForExpert(sources, expertRef),
+            sources: expertSources,
             existingTargets,
           });
           if (!(await store.isClaimCurrent(job))) return;
@@ -223,16 +229,30 @@ function groupTerminalSignals(
 }
 
 function boundSources(sources: readonly SkillSourceSnapshot[]): readonly SkillSourceSnapshot[] {
-  const selected: SkillSourceSnapshot[] = [];
-  for (const source of sources.slice(0, MAX_SOURCE_REVISIONS)) {
-    if (
-      Buffer.byteLength(JSON.stringify([...selected, source])) >
-      DEFAULT_MEMORY_STORAGE_POLICY.extractionPromptMaxBytes
+  const candidates = sources
+    .map((source, index) => ({ source, index }))
+    .toSorted(
+      (left, right) =>
+        sourcePriority(left.source) - sourcePriority(right.source) || left.index - right.index,
     )
-      break;
-    selected.push(source);
+    .slice(0, MAX_SOURCE_REVISIONS);
+  const selected: Array<{ readonly source: SkillSourceSnapshot; readonly index: number }> = [];
+  for (const candidate of candidates) {
+    if (
+      Buffer.byteLength(
+        JSON.stringify([...selected.map((item) => item.source), candidate.source]),
+      ) > DEFAULT_MEMORY_STORAGE_POLICY.extractionPromptMaxBytes
+    )
+      continue;
+    selected.push(candidate);
   }
-  return selected;
+  return selected.toSorted((left, right) => left.index - right.index).map((item) => item.source);
+}
+
+function sourcePriority(source: SkillSourceSnapshot): number {
+  if (source.ref.kind === "episodic" && (source.valueScore ?? 0) >= 0.85) return 0;
+  if (source.ref.kind === "episodic") return 1;
+  return 2;
 }
 
 function producerExpertRefs(

--- a/packages/memory/src/skill/source-reader.ts
+++ b/packages/memory/src/skill/source-reader.ts
@@ -1,4 +1,8 @@
-import { SkillSourceSnapshotSchema, type MemorySubjectRef, type SkillSourceSnapshot } from "@pragma/shared";
+import {
+  SkillSourceSnapshotSchema,
+  type MemorySubjectRef,
+  type SkillSourceSnapshot,
+} from "@pragma/shared";
 
 import type { EpisodicMemoryStore } from "../episodic/store.ts";
 import type { SemanticMemoryStore } from "../semantic/store.ts";
@@ -17,7 +21,10 @@ export function createSkillSourceReader(options: {
 }): SkillSourceReader {
   return {
     async listEligibleSources(input) {
-      const [episodes, facts] = await Promise.all([options.episodic.list(), options.semantic.list()]);
+      const [episodes, facts] = await Promise.all([
+        options.episodic.list(),
+        options.semantic.list(),
+      ]);
       const episodic = episodes
         .filter(
           (episode) =>
@@ -77,12 +84,17 @@ export function createSkillSourceReader(options: {
             sensitivity: fact.sensitivity,
           }),
         );
-      return [...episodic, ...semantic]
-        .toSorted(
-          (left, right) =>
-            right.observedAt.localeCompare(left.observedAt) || sourceKey(left).localeCompare(sourceKey(right)),
-        )
-        .slice(0, input.limit);
+      const sortByObservedAt = (left: SkillSourceSnapshot, right: SkillSourceSnapshot): number =>
+        right.observedAt.localeCompare(left.observedAt) ||
+        sourceKey(left).localeCompare(sourceKey(right));
+
+      // Episodic sources are the authority for the Skill evidence threshold.
+      // Keep them ahead of Semantic context before applying the shared limit so
+      // supporting facts cannot crowd out the evidence that makes extraction possible.
+      return [...episodic.toSorted(sortByObservedAt), ...semantic.toSorted(sortByObservedAt)].slice(
+        0,
+        input.limit,
+      );
     },
   };
 }

--- a/packages/memory/src/skill/validation.ts
+++ b/packages/memory/src/skill/validation.ts
@@ -1,8 +1,20 @@
 import type {
   ExistingMemorySkillTarget,
   SkillExtractionCandidate,
+  SkillSourceRevisionRef,
   SkillSourceSnapshot,
 } from "@pragma/shared";
+
+export const SKILL_SOURCE_THRESHOLD_MESSAGE =
+  "The candidate must cite three high-value Episodic sources across two conversations, including two successful or recovered outcomes.";
+
+export interface SkillSourceEligibility {
+  readonly eligible: boolean;
+  readonly highValueEpisodicCount: number;
+  readonly conversationCount: number;
+  readonly successfulOrRecoveredCount: number;
+  readonly qualifyingSourceRefs: readonly SkillSourceRevisionRef[];
+}
 
 export interface SkillCandidateValidationIssue {
   readonly path: string;
@@ -15,7 +27,9 @@ export interface SkillCandidateValidationIssue {
   readonly message: string;
 }
 
-export function skillSourceThresholdMet(sources: readonly SkillSourceSnapshot[]): boolean {
+export function inspectSkillSourceEligibility(
+  sources: readonly SkillSourceSnapshot[],
+): SkillSourceEligibility {
   const currentEpisodes = new Map<string, SkillSourceSnapshot>();
   for (const source of sources) {
     if (source.ref.kind !== "episodic") continue;
@@ -39,7 +53,19 @@ export function skillSourceThresholdMet(sources: readonly SkillSourceSnapshot[])
   const successful = episodes.filter(
     (source) => source.outcome === "succeeded" || source.hasSuccessfulRecovery,
   );
-  return episodes.length >= 3 && conversations.size >= 2 && successful.length >= 2;
+  return {
+    eligible: episodes.length >= 3 && conversations.size >= 2 && successful.length >= 2,
+    highValueEpisodicCount: episodes.length,
+    conversationCount: conversations.size,
+    successfulOrRecoveredCount: successful.length,
+    qualifyingSourceRefs: episodes
+      .map((source) => source.ref)
+      .toSorted((left, right) => left.id.localeCompare(right.id) || left.revision - right.revision),
+  };
+}
+
+export function skillSourceThresholdMet(sources: readonly SkillSourceSnapshot[]): boolean {
+  return inspectSkillSourceEligibility(sources).eligible;
 }
 
 export function validateSkillExtractionCandidate(
@@ -64,8 +90,7 @@ export function validateSkillExtractionCandidate(
     issues.push({
       path: "sourceRefs",
       code: "source_threshold_not_met",
-      message:
-        "The candidate must cite three high-value Episodic sources across two conversations, including two successful or recovered outcomes.",
+      message: SKILL_SOURCE_THRESHOLD_MESSAGE,
     });
   }
 

--- a/packages/memory/test/skill-learning-threshold.test.ts
+++ b/packages/memory/test/skill-learning-threshold.test.ts
@@ -1,7 +1,7 @@
 import type { SkillSourceSnapshot } from "@pragma/shared";
 import { describe, expect, it } from "vitest";
 
-import { skillSourceThresholdMet } from "../src/index.ts";
+import { inspectSkillSourceEligibility, skillSourceThresholdMet } from "../src/index.ts";
 
 function episode(
   id: string,
@@ -28,6 +28,26 @@ function episode(
 }
 
 describe("Skill learning threshold", () => {
+  it("reports the evidence counts and qualifying refs used by the threshold", () => {
+    const eligibility = inspectSkillSourceEligibility([
+      episode("one", "conversation-a"),
+      episode("two", "conversation-a"),
+      episode("three", "conversation-b", "failed"),
+    ]);
+
+    expect(eligibility).toEqual({
+      eligible: true,
+      highValueEpisodicCount: 3,
+      conversationCount: 2,
+      successfulOrRecoveredCount: 2,
+      qualifyingSourceRefs: [
+        { kind: "episodic", id: "one", revision: 1 },
+        { kind: "episodic", id: "three", revision: 1 },
+        { kind: "episodic", id: "two", revision: 1 },
+      ],
+    });
+  });
+
   it("accepts three high-value episodes from two conversations with two successes", () => {
     expect(
       skillSourceThresholdMet([

--- a/packages/memory/test/skill-memory.test.ts
+++ b/packages/memory/test/skill-memory.test.ts
@@ -48,6 +48,36 @@ describe("Skill learning extraction", () => {
     module.close();
   });
 
+  it("extracts only from producer Experts whose own evidence meets the threshold", async () => {
+    const sourceRevisions = [
+      episode("expert-a-one", "conversation-a", "succeeded", "expert-a"),
+      episode("expert-a-two", "conversation-a", "succeeded", "expert-a"),
+      episode("expert-a-three", "conversation-a", "succeeded", "expert-a"),
+      episode("expert-b-one", "conversation-b", "succeeded", "expert-b"),
+      episode("expert-b-two", "conversation-b", "succeeded", "expert-b"),
+      episode("expert-b-three", "conversation-c", "failed", "expert-b"),
+    ];
+    const extract = vi.fn<SkillMemoryExtractor["extract"]>(async (input) => {
+      expect(
+        input.sources.every((source) => source.producerRefs.some((ref) => ref.id === "expert-b")),
+      ).toBe(true);
+      return {
+        output: { retain: false, reason: "no-reusable-skill" },
+        provenance: provenance(),
+      };
+    });
+    const module = await createModule(sourceRevisions, { extract });
+
+    await schedule(module, sourceRevisions);
+    await module.runBackgroundOnce?.();
+
+    expect(extract).toHaveBeenCalledOnce();
+    expect(await module.store.listJobs()).toEqual([
+      expect.objectContaining({ status: "completed", completion: "rejected" }),
+    ]);
+    module.close();
+  });
+
   it("filters a candidate below the source threshold and completes without user attention", async () => {
     const sourceRevisions = sources();
     const submit = vi.fn(async () => undefined);
@@ -403,13 +433,14 @@ function episode(
   id: string,
   conversationId: string,
   outcome: SkillSourceSnapshot["outcome"],
+  expertId = "expert-a",
 ): SkillSourceSnapshot {
   return {
     ref: { kind: "episodic", id, revision: 1 },
-    rootRef: ref("pragma.expert", "expert-a"),
+    rootRef: ref("pragma.expert", expertId),
     conversationRef: ref("pragma.mission", conversationId),
     sourceExecutionIds: [`execution-${id}`],
-    producerRefs: [ref("pragma.expert", "expert-a")],
+    producerRefs: [ref("pragma.expert", expertId)],
     title: `Episode ${id}`,
     body: "A reusable multi-step workflow was completed.",
     outcome,

--- a/packages/memory/test/skill-source-reader.test.ts
+++ b/packages/memory/test/skill-source-reader.test.ts
@@ -1,0 +1,113 @@
+import type { EpisodicMemoryRecord } from "../src/episodic/schema.ts";
+import { createSkillSourceReader } from "../src/skill/source-reader.ts";
+import type { SemanticFact } from "@pragma/shared";
+import { describe, expect, it } from "vitest";
+
+const rootRef = { type: "pragma.expert", id: "expert-a" } as const;
+
+describe("Skill source reader", () => {
+  it("reserves the source limit for Episodic evidence before Semantic support", async () => {
+    const reader = createSkillSourceReader({
+      episodic: {
+        list: async () => [
+          episode("episode-old", "2026-08-01T00:00:00.000Z"),
+          episode("episode-new", "2026-08-03T00:00:00.000Z"),
+          episode("episode-mid", "2026-08-02T00:00:00.000Z"),
+        ],
+      },
+      semantic: {
+        list: async () => [fact("fact-new", "2026-08-04T00:00:00.000Z")],
+      },
+    });
+
+    const sources = await reader.listEligibleSources({
+      rootRef,
+      limit: 3,
+      now: new Date("2026-08-05T00:00:00.000Z"),
+    });
+
+    expect(sources.map((source) => source.ref)).toEqual([
+      { kind: "episodic", id: "episode-new", revision: 1 },
+      { kind: "episodic", id: "episode-mid", revision: 1 },
+      { kind: "episodic", id: "episode-old", revision: 1 },
+    ]);
+  });
+});
+
+function episode(id: string, updatedAt: string): EpisodicMemoryRecord {
+  return {
+    schemaVersion: "pragma.memory-episodic/v3",
+    id,
+    revision: 1,
+    conversationRef: { type: "pragma.mission", id: `mission-${id}` },
+    sourceExecutionIds: [`execution-${id}`],
+    sourceUpdatedAt: updatedAt,
+    executionId: `execution-${id}`,
+    terminalMessageId: `message-${id}`,
+    rootRefs: [rootRef],
+    producerRefs: [rootRef],
+    language: "en",
+    goal: { text: "Complete a reusable workflow.", evidenceRefs: [`evidence-${id}`] },
+    summary: { text: "The workflow completed.", evidenceRefs: [`evidence-${id}`] },
+    attempts: [],
+    failuresAndRecoveries: [],
+    outcome: {
+      status: "succeeded",
+      summary: "Completed",
+      evidenceRefs: [`evidence-${id}`],
+    },
+    artifactRefs: [],
+    evidenceRefs: [`evidence-${id}`],
+    visibility: { mode: "host-private" },
+    sensitivity: "internal",
+    bindings: [{ consumerRef: rootRef, recall: "allow", export: "allow", permissionRevision: 1 }],
+    valueScore: 0.9,
+    status: "active",
+    extractor: {
+      curatorRef: "pragma.memory.curator",
+      promptVersion: "episodic/v1",
+      profileRevision: 1,
+      runtimeId: "runtime-a",
+      providerId: "provider-a",
+      modelId: "model-a",
+      extractedAt: updatedAt,
+    },
+    createdAt: updatedAt,
+    updatedAt,
+  };
+}
+
+function fact(id: string, observedAt: string): SemanticFact {
+  return {
+    schemaVersion: "pragma.memory-semantic/v1",
+    id,
+    revision: 1,
+    statement: "A supporting fact.",
+    subjectRefs: [rootRef],
+    predicate: "workflow.preference",
+    normalizedValue: "supporting",
+    conflictMode: "compatible",
+    confidence: 0.9,
+    observedAt,
+    evidenceRefs: [`evidence-${id}`],
+    conflictsWith: [],
+    supersedes: [],
+    status: "active",
+    visibility: { mode: "host-private" },
+    sensitivity: "internal",
+    bindings: [{ consumerRef: rootRef, recall: "allow", export: "allow", permissionRevision: 1 }],
+    rootRefs: [rootRef],
+    producerRefs: [rootRef],
+    extractor: {
+      curatorRef: "pragma.memory.curator",
+      promptVersion: "semantic/v1",
+      profileRevision: 1,
+      runtimeId: "runtime-a",
+      providerId: "provider-a",
+      modelId: "model-a",
+      extractedAt: observedAt,
+    },
+    createdAt: observedAt,
+    updatedAt: observedAt,
+  };
+}


### PR DESCRIPTION
## Summary

- Add host-computed Skill evidence eligibility and per-Expert source filtering.
- Preserve high-value Episodic evidence while enforcing source and prompt byte budgets.
- Make Skill draft validation feedback structured and distinguish repairable failures from terminal failures.
- Bound repeated `begin_skill_draft` retries and surface exhausted repairs as an observable Memory job failure.

## Root cause

Skill extraction repeatedly attempted `begin_skill_draft` even when the selected evidence could not satisfy the source threshold. The host preflight, per-Expert source groups, and model-visible prompt did not share one authoritative eligibility decision, so the model could receive an apparently successful tool call with `source_threshold_not_met` and repeat the same request without a terminal signal.

## Impact

This keeps eligible evidence flowing to the extractor, prevents lower-value sources from consuming the bounded input budget, gives the model actionable repair feedback, and stops unrecoverable retries from being recorded as silent or misleading rejections.

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm --filter @pragma/memory test`
- `pnpm --filter @pragma/built-in-agents test`
- Desktop memory tests
- `git diff --cached --check`

Closes #188