### PR TITLE
chore(release): prepare v0.2.11

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pragma/desktop",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "productName": "Pragma",


### PR DESCRIPTION
## Release

- Bump `@pragma/desktop` from `0.2.10` to `0.2.11`.
- Local checks passed: `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`.
- After merge, push tag `v0.2.11` to trigger the desktop release workflow.