### PR TITLE
Refactor expert delegation and invocation-scoped messaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -640,8 +640,8 @@ RuntimeAdapter
 Expert API 设计要求：
 
 - `defineExpert()` 是单专家唯一创建入口，负责异步插件加载、inline plugin entry 合并、日志初始化和实例归一化。
-- `createAgentLauncher()` 为普通 Expert 创建可显式注入的 `spawn_expert`、`wait_experts`、
-  `list_agents`、`followup_expert`、`steer_expert`、`interrupt_expert` 工具集；子 Invocation 的执行、Context、
+- `createAgentLauncher()` 为普通 Expert 创建可显式注入的 `delegate_expert`、`wait_experts`、
+  `list_agents`、`message_expert`、`steer_expert`、`interrupt_expert` 工具集；子 Invocation 的执行、Context、
   并发、深度、事件和 Usage 机制必须与 ExpertTeam 共用，不另建隐藏 Session 路径。
 - `defineExpertTeam()` 声明由 coordinator 统一接收外部 prompt 的特殊 Expert。
 - ExpertTeam 运行时按成员权限策略生成相同的生命周期工具集；coordinator 在当前 Team Execution 内

--- a/apps/desktop/src/main/features/missions/mission-runner.test.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.test.ts
@@ -1530,7 +1530,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
       readSession: (session) => ({ runtimeSessionId: session.id }),
       async startTurn(session, turn) {
         const tools = session.context.agent.tools ?? [];
-        const spawn = tools.find((tool) => tool.name === "spawn_expert");
+        const spawn = tools.find((tool) => tool.name === "delegate_expert");
         const wait = tools.find((tool) => tool.name === "wait_experts");
         const callReviewer = tools.find((tool) => tool.name === "call_reviewer");
         let output = `${session.context.agent.id}:${turn.rawQuery}`;
@@ -1540,7 +1540,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
           session.context.agent.id === writer.metadata.id
         ) {
           const spawned = await spawn.call(
-            { expertId: reviewer.metadata.id, prompt: "Team review" },
+            { expertId: reviewer.metadata.id, task: "Team review" },
             turn.signal,
             { execution: session.context.request.executionContext },
           );
@@ -2918,7 +2918,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     });
     await executions.create(
       {
-        schemaVersion: "pragma.execution/v9",
+        schemaVersion: "pragma.execution/v10",
         executionId,
         version: 0,
         kind: "expert-turn",
@@ -2938,6 +2938,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         executorId: expert.id,
         contextId,
         status: "running",
+        pendingExpertMessages: [],
         input: mission.goal,
         createdAt: startedAt,
         updatedAt: startedAt,
@@ -3454,7 +3455,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
     });
     await executions.create(
       {
-        schemaVersion: "pragma.execution/v9",
+        schemaVersion: "pragma.execution/v10",
         executionId,
         version: 0,
         kind: "expert-turn",
@@ -3474,6 +3475,7 @@ describe("MissionRunner", { timeout: 15_000 }, () => {
         executorId: expertResource.metadata.id,
         contextId,
         status: "running",
+        pendingExpertMessages: [],
         input: mission.goal,
         createdAt: now,
         updatedAt: now,

--- a/apps/desktop/src/main/features/missions/mission-runner.ts
+++ b/apps/desktop/src/main/features/missions/mission-runner.ts
@@ -2280,6 +2280,7 @@ export function createMissionRunner(options: {
             runId: task.runId,
             ...(task.sequence === undefined ? {} : { sequence: task.sequence }),
             status: task.status,
+            ...(task.waitReason === undefined ? {} : { waitReason: task.waitReason }),
             inputSummary: formatValue(task.input, 500),
             ...(outputSummary === undefined ? {} : { outputSummary }),
             ...(task.error === undefined ? {} : { error: formatValue(task.error, 10_000) }),
@@ -2315,6 +2316,7 @@ export function createMissionRunner(options: {
           ...(avatarId === undefined ? {} : { avatarId }),
           origin: record.origin,
           status: record.status,
+          ...(record.waitReason === undefined ? {} : { waitReason: record.waitReason }),
           tasks,
           summary: latest?.outputSummary ?? latest?.inputSummary ?? title,
           createdAt: record.createdAt,
@@ -2955,6 +2957,7 @@ function observeMissionHumanWaitingStatus(input: {
 } {
   const pending = new Set<string>();
   let observedWaiting: boolean | undefined;
+  let observedWaitReason: "experts" | "human_input" | undefined;
   let updates = Promise.resolve();
 
   const enqueueUpdate = (update: () => Promise<void>): Promise<void> => {
@@ -2965,9 +2968,12 @@ function observeMissionHumanWaitingStatus(input: {
     return result;
   };
 
-  const persistStatus = async (): Promise<void> => {
-    const waiting = pending.size > 0;
-    if (waiting === observedWaiting) return;
+  const persistStatus = async (
+    invocationWaitReason?: "experts" | "human_input" | undefined,
+  ): Promise<void> => {
+    const waitReason = pending.size > 0 ? "human_input" : invocationWaitReason;
+    const waiting = waitReason !== undefined;
+    if (waiting === observedWaiting && waitReason === observedWaitReason) return;
     await input.missions.updateExecution(
       input.missionId,
       {
@@ -2975,6 +2981,7 @@ function observeMissionHumanWaitingStatus(input: {
         inputMessageId: input.inputMessageId,
         ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
         status: waiting ? "waiting" : "running",
+        ...(waitReason === undefined ? {} : { waitReason }),
         startedAt: input.startedAt,
       },
       {
@@ -2983,6 +2990,7 @@ function observeMissionHumanWaitingStatus(input: {
       },
     );
     observedWaiting = waiting;
+    observedWaitReason = waitReason;
   };
 
   const resync = async (): Promise<void> => {
@@ -2990,8 +2998,10 @@ function observeMissionHumanWaitingStatus(input: {
       const interactions = await listPendingHumanInteractions(input.execution);
       pending.clear();
       for (const interaction of interactions) pending.add(interaction.interactionId);
+      const tree = await input.execution.getTree();
       observedWaiting = undefined;
-      await persistStatus();
+      observedWaitReason = undefined;
+      await persistStatus(tree.invocation.waitReason);
     } catch (error) {
       input.logger.warn(
         "mission.human_wait_status_seed_failed",
@@ -3004,15 +3014,17 @@ function observeMissionHumanWaitingStatus(input: {
   void enqueueUpdate(resync).catch(() => undefined);
 
   const onEvent = (event: ExecutionEvent): void => {
-    if (event.type !== "human.requested" && event.type !== "human.responded") return;
+    if (
+      event.type !== "human.requested" &&
+      event.type !== "human.responded" &&
+      event.type !== "human.waiting" &&
+      event.type !== "human.resumed" &&
+      !event.type.startsWith("expert.children.")
+    ) {
+      return;
+    }
     const update = enqueueUpdate(async () => {
-      const interactionId = String(
-        (event.data as { readonly interactionId?: unknown }).interactionId ?? "",
-      );
-      if (interactionId === "") return;
-      if (event.type === "human.requested") pending.add(interactionId);
-      else pending.delete(interactionId);
-      await persistStatus();
+      await resync();
     });
     void update.catch((error: unknown) => {
       input.logger.warn(

--- a/apps/desktop/src/main/features/missions/mission-store.ts
+++ b/apps/desktop/src/main/features/missions/mission-store.ts
@@ -1241,7 +1241,16 @@ function toMissionSummary(mission: Mission): MissionSummary {
     title: mission.title,
     workspace: { basename: mission.workspace.basename },
     executor: { kind: mission.executor.kind, name: mission.executor.name },
-    ...(mission.execution === undefined ? {} : { execution: { status: mission.execution.status } }),
+    ...(mission.execution === undefined
+      ? {}
+      : {
+          execution: {
+            status: mission.execution.status,
+            ...(mission.execution.waitReason === undefined
+              ? {}
+              : { waitReason: mission.execution.waitReason }),
+          },
+        }),
     source:
       mission.origin.type === "automation"
         ? { type: "automation", automationRef: mission.origin.automationRef }

--- a/apps/desktop/src/main/features/usage/usage-store.test.ts
+++ b/apps/desktop/src/main/features/usage/usage-store.test.ts
@@ -388,6 +388,7 @@ function invocationTree(): Invocation[] {
     rootInvocationId: "flow-invocation",
     contextId: "context-1",
     status: "running" as const,
+    pendingExpertMessages: [],
     input: {},
     createdAt: "2026-01-02T12:00:00.000Z",
     updatedAt: "2026-01-02T12:00:00.000Z",

--- a/apps/desktop/src/renderer/src/App.test.tsx
+++ b/apps/desktop/src/renderer/src/App.test.tsx
@@ -12,7 +12,7 @@ describe("App", () => {
   it("renders the mission creation Home by default", () => {
     const html = renderToStaticMarkup(<App />);
 
-    expect(html).toContain("Start a mission");
+    expect(html).toContain('aria-label="Start mission"');
     expect(html).toContain("What can I help you with?");
     expect(html).toContain('aria-label="Mission options"');
     expect(html).toContain('aria-label="Tool permissions"');

--- a/apps/desktop/src/renderer/src/components/SidebarResizeHandle.test.tsx
+++ b/apps/desktop/src/renderer/src/components/SidebarResizeHandle.test.tsx
@@ -9,15 +9,15 @@ describe("SidebarResizeHandle", () => {
     const html = renderToStaticMarkup(
       <SidebarResizeHandle
         label="Resize navigation"
-        width={280}
+        width={175}
         preference={SIDEBAR_WIDTH_PREFERENCES.main}
         onResize={() => undefined}
       />,
     );
 
     expect(html).toContain('role="separator"');
-    expect(html).toContain('aria-valuemin="200"');
-    expect(html).toContain('aria-valuemax="360"');
-    expect(html).toContain('aria-valuenow="280"');
+    expect(html).toContain('aria-valuemin="150"');
+    expect(html).toContain('aria-valuemax="200"');
+    expect(html).toContain('aria-valuenow="175"');
   });
 });

--- a/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/en/missions.ts
@@ -368,6 +368,8 @@ export const missions = {
   statusQueued: "Queued",
   statusWorking: "Working",
   statusNeedsInput: "Needs input",
+  statusWaitingExperts: "Waiting for experts",
+  statusWaiting: "Waiting",
   statusSucceeded: "Succeeded",
   statusCancelled: "Cancelled",
   statusReady: "Ready",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hans/missions.ts
@@ -356,6 +356,8 @@ export const missions = {
   statusQueued: "排队中",
   statusWorking: "工作中",
   statusNeedsInput: "需要输入",
+  statusWaitingExperts: "等待专家",
+  statusWaiting: "等待中",
   statusSucceeded: "成功",
   statusCancelled: "已取消",
   statusReady: "就绪",

--- a/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
+++ b/apps/desktop/src/renderer/src/i18n/resources/zh-Hant/missions.ts
@@ -356,6 +356,8 @@ export const missions = {
   statusQueued: "排隊中",
   statusWorking: "工作中",
   statusNeedsInput: "需要輸入",
+  statusWaitingExperts: "等待專家",
+  statusWaiting: "等待中",
   statusSucceeded: "成功",
   statusCancelled: "已取消",
   statusReady: "就緒",

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.test.tsx
@@ -38,6 +38,8 @@ import {
   missionWorkCallOrder,
   missionWorkGridEdgePath,
   missionWorkRecordTitle,
+  missionStatusLabel,
+  workStatusLabel,
   resolveMissionsPageInitialState,
   resolveMissionRailGroups,
   resolveMissionSearchCollapsed,
@@ -51,6 +53,20 @@ import {
 } from "./MissionsPage.tsx";
 
 describe("MissionsPage", () => {
+  it("distinguishes expert waits, human input, and legacy waiting states", async () => {
+    await i18n.changeLanguage("en");
+    expect(workStatusLabel("waiting", "experts")).toBe("Waiting for experts");
+    expect(workStatusLabel("waiting", "human_input")).toBe("Needs input");
+    expect(workStatusLabel("waiting")).toBe("Waiting");
+
+    const mission = missionFixture("expert");
+    expect(
+      missionStatusLabel({
+        ...mission,
+        execution: { ...mission.execution!, status: "waiting", waitReason: "experts" },
+      }),
+    ).toBe("Waiting for experts");
+  });
   it("keeps a preparing queued message out of the conversation until delivery is known", () => {
     const requestId = "00000000-0000-4000-8000-000000000012";
     const entry = {

--- a/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/missions/MissionsPage.tsx
@@ -3589,7 +3589,11 @@ export function MissionWorkGrid(props: {
                       else cardRefs.current.set(record.recordId, element);
                     }}
                     type="button"
-                    aria-label={[title, workStatusLabel(record.status), callOrderLabel]
+                    aria-label={[
+                      title,
+                      workStatusLabel(record.status, record.waitReason),
+                      callOrderLabel,
+                    ]
                       .filter(Boolean)
                       .join(", ")}
                     onClick={() => props.onSelect(record.recordId)}
@@ -3611,7 +3615,7 @@ export function MissionWorkGrid(props: {
                     </span>
                     <strong>{title}</strong>
                     <small>
-                      {workStatusLabel(record.status)}
+                      {workStatusLabel(record.status, record.waitReason)}
                       {record.tasks.length > 1
                         ? ` · ${t("conversationTurns", { count: record.tasks.length })}`
                         : ""}
@@ -4528,7 +4532,7 @@ export function MissionWorkDrawer(props: {
             <small>{t("agentConversation", { ns: "missions" })}</small>
             <h2 id="mission-work-drawer-title">{missionWorkRecordTitle(props.record)}</h2>
             <p>
-              {workStatusLabel(props.record.status)} ·{" "}
+              {workStatusLabel(props.record.status, props.record.waitReason)} ·{" "}
               {t("readOnlyConversation", { ns: "missions" })}
               {props.record.status === "running" || props.record.status === "waiting" ? (
                 <span className="mission-work-streaming">
@@ -5341,14 +5345,21 @@ export function missionWorkInputSenderName(
     : missionWorkRecordTitle(parent);
 }
 
-function workStatusLabel(status: MissionWorkRecord["status"]): string {
+export function workStatusLabel(
+  status: MissionWorkRecord["status"],
+  waitReason?: MissionWorkRecord["waitReason"],
+): string {
   switch (status) {
     case "queued":
       return i18n.t("statusQueued", { ns: "missions" });
     case "running":
       return i18n.t("statusWorking", { ns: "missions" });
     case "waiting":
-      return i18n.t("statusNeedsInput", { ns: "missions" });
+      return waitReason === "experts"
+        ? i18n.t("statusWaitingExperts", { ns: "missions" })
+        : waitReason === "human_input"
+          ? i18n.t("statusNeedsInput", { ns: "missions" })
+          : i18n.t("statusWaiting", { ns: "missions" });
     case "succeeded":
       return i18n.t("statusSucceeded", { ns: "missions" });
     case "failed":
@@ -5374,7 +5385,11 @@ export function missionStatusLabel(mission: Mission | MissionSummary, preparing 
     case "running":
       return i18n.t("statusWorking", { ns: "missions" });
     case "waiting":
-      return i18n.t("statusNeedsInput", { ns: "missions" });
+      return mission.execution.waitReason === "experts"
+        ? i18n.t("statusWaitingExperts", { ns: "missions" })
+        : mission.execution.waitReason === "human_input"
+          ? i18n.t("statusNeedsInput", { ns: "missions" })
+          : i18n.t("statusWaiting", { ns: "missions" });
     case "succeeded":
       return i18n.t("statusSucceeded", { ns: "missions" });
     case "failed":

--- a/apps/desktop/src/shared/contracts/missions.ts
+++ b/apps/desktop/src/shared/contracts/missions.ts
@@ -80,6 +80,7 @@ export const MissionWorkTaskSchema = z.object({
     "cancelled",
     "interrupted",
   ]),
+  waitReason: z.enum(["experts", "human_input"]).optional(),
   inputSummary: z.string().max(500),
   outputSummary: z.string().max(1_000).optional(),
   error: z.string().max(10_000).optional(),
@@ -98,6 +99,7 @@ export const MissionWorkRecordSchema = z.object({
   avatarId: z.string().min(1).optional(),
   origin: z.enum(["core", "runtime"]),
   status: MissionWorkTaskSchema.shape.status,
+  waitReason: MissionWorkTaskSchema.shape.waitReason,
   tasks: z.array(MissionWorkTaskSchema),
   summary: z.string().max(1_000),
   createdAt: z.string().datetime(),
@@ -138,6 +140,7 @@ const MissionBaseSchema = z.object({
       inputMessageId: z.string().uuid(),
       sessionId: z.string().uuid().optional(),
       status: MissionExecutionStatusSchema,
+      waitReason: z.enum(["experts", "human_input"]).optional(),
       startedAt: z.string().datetime(),
       finishedAt: z.string().datetime().optional(),
       error: z.string().max(10_000).optional(),
@@ -284,7 +287,12 @@ export const MissionSummarySchema = z.object({
     kind: z.enum(["expert", "team", "flow"]),
     name: z.string().trim().min(1).max(120),
   }),
-  execution: z.object({ status: MissionExecutionStatusSchema }).optional(),
+  execution: z
+    .object({
+      status: MissionExecutionStatusSchema,
+      waitReason: z.enum(["experts", "human_input"]).optional(),
+    })
+    .optional(),
   source: z.discriminatedUnion("type", [
     z.object({ type: z.literal("task") }),
     z.object({

--- a/docs/adr/042-invocation-scoped-expert-messaging.md
+++ b/docs/adr/042-invocation-scoped-expert-messaging.md
@@ -1,0 +1,39 @@
+# ADR 042: Invocation-scoped Expert messaging
+
+- Status: Accepted
+- Date: 2026-08-22
+
+## Context
+
+旧的后续任务工具同时承担“创建后续任务”和“向运行中专家通信”两种含义。成员之间把通信实现为
+新的子 Invocation 时，会额外形成 Join 依赖；双向通信因此可能把两个本应独立运行的 Invocation 连接成
+等待环，并且消息可能在目标任务结束后错误进入同一 Agent 的下一项任务。
+
+## Decision
+
+Pragma 将任务委派和运行中通信拆成两个协议：
+
+- `delegate_expert({ expertId, task })` 创建新的 AgentInstance、Runtime Context 和 Invocation；
+- `delegate_expert({ agentId, task })` 复用既有 AgentInstance 与 Context，创建 FIFO Invocation；
+- `message_expert({ agentId, invocationId, message })` 只写入该 Agent 当前明确 active Invocation 的 Inbox；
+- `steer_expert({ agentId, invocationId, message })` 只尝试立即注入当前 Runtime turn，不提供排队降级；
+- `wait_experts` 只 Join 当前 Invocation 直接委派的 Invocation。
+
+Invocation 是可调度、可等待、可恢复的工作单。AgentInstance 是串行执行线程，同一时刻只有一个
+`activeInvocationId`；一个 Runtime Context 可以被该 Agent 的多个 Invocation 顺序复用。
+
+任务依赖由两类边组成：调用者到直接委派任务的 Join 边，以及同一 Agent 后序任务到前序非终态任务的
+FIFO 边。提交委派前必须验证完整 Wait-for Graph 无环。Message 不创建 Invocation、不成为 Join 边，也不
+跨 Invocation 投递。
+
+消息接受和 Invocation 终结使用同一 Execution 乐观版本边界。消息先提交时，终结提交必须冲突并在下一
+安全边界消费 Inbox；终结先提交时，消息返回 `stale_invocation`。接受的消息以 canonical 顺序批量消费，
+产生 `expert.message.accepted` 与 `expert.message.consumed` 审计事件。
+
+## Consequences
+
+- Agent 选择工具时只需判断“新任务、可靠安全边界消息、立即 steer”三种意图。
+- 双向消息不会改变 Wait-for Graph，原有通信型死锁被消除。
+- 调用方必须保存并提交准确的 `invocationId`；不能只凭长期 `agentId` 向未来任务投递。
+- 需要新结果时必须委派新的 Invocation；消息本身不能被 `wait_experts` 等待。
+- 这是 breaking change；不保留旧任务工具或 steer fallback 别名。

--- a/docs/architecture/agent-core-architecture.md
+++ b/docs/architecture/agent-core-architecture.md
@@ -8,9 +8,10 @@ Core 分为声明、执行、Runtime 和存储四个边界：
 3. ExpertTurn 与 FlowExecution 共享 ExecutionStore、InvocationTree 和单一 Canonical Event Log。
 4. Runtime driver 明确拆分 create、restore、start turn、steer、cancel turn 和 close session。
 
-Expert 不包装成单节点 Flow。普通 Expert 与 ExpertTeam 共用异步编排机制：`spawn_expert` 创建
-Execution-scoped AgentInstance 和首个 Invocation，`followup_expert` 在相同 Agent Context 上追加
-FIFO Invocation，`wait_experts` 按 Invocation ID 汇合结果。`list_agents` 和 `interrupt_expert`
+Expert 不包装成单节点 Flow。普通 Expert 与 ExpertTeam 共用异步编排机制：`delegate_expert`
+按 `expertId` 创建 Execution-scoped AgentInstance，或按 `agentId` 在相同 Agent Context 上追加
+FIFO Invocation；`wait_experts` 按 Invocation ID 汇合结果。`message_expert` 向明确的 active
+Invocation Inbox 投递安全边界消息，`steer_expert` 尝试立即影响 Runtime turn。`list_agents` 和 `interrupt_expert`
 只管理当前调用者直接创建的 Agent。
 
 两种声明方式只负责提供不同治理配置：
@@ -33,7 +34,7 @@ ExpertSession 根 Expert 不属于 delegation：Session 创建时同步建立唯
 `InvocationService` 统一承担 Invocation 的可靠创建、状态迁移和 Canonical Event 原子提交。
 Flow Scheduler 保留静态图遍历、按 `nodeId + visit` 幂等的循环访问、reduce 和 transition；同一节点
 被条件回边再次访问时创建新的 Invocation，恢复时按访问序号重放既有 Invocation。
-`ExpertOrchestrator` 保留 Agent ownership、FIFO、并发、深度、wait、followup、interrupt 和终结屏障策略。
+`ExpertOrchestrator` 保留 Agent ownership、FIFO、并发、深度、wait、message、steer、interrupt 和终结屏障策略。
 
 Flow 回边后会为新的 Invocation 再次调用 step resolver：返回旧 `contextId` 就沿用 coordinator 的
 Runtime Session，返回新 ID 就隔离。Team 成员由 delegation resolver 独立决定，因此可以实现
@@ -50,8 +51,8 @@ Flow Scheduler / ExpertOrchestrator
 ```
 
 RuntimeContextRecord、AgentInstance 与 Invocation 是三个不同身份：Context 保存 Runtime 对话与 snapshot，
-AgentInstance 表示当前 owner Context 下可接收 followup 的线程，
-Invocation 表示该线程上的一次任务。一个 Agent 同时最多运行一个 Invocation，不同 Agent 可并行。
+AgentInstance 表示当前 owner Context 下串行执行的线程，Invocation 表示该线程上的一次可调度、可等待、
+可恢复任务。一个 Agent 同时最多运行一个 active Invocation，不同 Agent 可并行。
 Invocation 的 `agentTaskSequence` 是 FIFO 的唯一顺序源，不另存一份易漂移的 queue 数组。
 ExpertSession 以 Session Context Registry 作为跨 prompt 的 Context/snapshot 来源；每个 prompt 的
 Execution 只物化本轮 AgentInstance、Invocation 及其 Context binding，因此跨 prompt 复用 Context

--- a/docs/articles/05-unified-execution-model.md
+++ b/docs/articles/05-unified-execution-model.md
@@ -17,10 +17,11 @@ Expert 定义角色范围、指令、Runtime、模型、Capability、ContextStor
 普通 Expert 还可以通过显式注入的生命周期工具调用已授权的其他 Expert：
 
 ```text
-spawn_expert
+delegate_expert
 wait_experts
 list_agents
-followup_expert
+message_expert
+steer_expert
 interrupt_expert
 ```
 
@@ -43,7 +44,7 @@ Flow 负责确定性控制：输入映射、状态归约、条件路由、循环
 一种常见的“统一”方式，是把所有 Expert 调用都包装成只有一个节点的 Flow。表面上对象数量变少了，实际上会产生错误抽象：
 
 - 普通对话也要背负 Flow graph 和 scheduler 语义；
-- 子 Agent 的线程、follow-up 和 wait 被伪装成工作流节点；
+- 子 Agent 的线程、消息和 wait 被伪装成工作流节点；
 - Runtime Context 复用与静态图节点复用混在一起；
 - Team 委派很难表达动态产生的子任务。
 

--- a/docs/usage/agents.md
+++ b/docs/usage/agents.md
@@ -50,13 +50,16 @@ const coordinator = await defineExpert({
 const session = await app.experts.createSession(coordinator);
 ```
 
-launcher 向模型公开 `spawn_expert`、`wait_experts`、`list_agents`、`followup_expert` 和
-`interrupt_expert`。`spawn_expert` 先原子落盘再立即返回
-`{ agentId, invocationId, contextId, disposition }`；多个 agent 可以并行运行。Resolver 返回同一
-Context 时，dispatch 会原子归并到同一 agent 并按 FIFO 串行；默认 resolver 每次创建新 Context。
+launcher 向模型公开 `delegate_expert`、`wait_experts`、`list_agents`、`message_expert`、
+`steer_expert` 和 `interrupt_expert`。`delegate_expert` 使用 `expertId` 时创建 AgentInstance，使用
+`agentId` 时在既有 Context 上追加 FIFO Invocation；两者都先原子落盘再立即返回
+`{ agentId, invocationId, contextId, disposition }`。`message_expert` 只向目标明确的 active
+Invocation Inbox 投递消息，`steer_expert` 只尝试立即影响当前 Runtime turn；两者都不会创建任务。
+Resolver 返回同一 Context 时，dispatch 会原子归并到同一 agent 并按 FIFO 串行；默认 resolver 每次创建新 Context。
 `wait_experts` 按精确的
 Invocation ID 收集结果；等待超时最小 30 秒、默认 10 分钟、最大 60 分钟。父 Invocation 即使遗漏
-wait，也会在终结屏障等待未 join 的子任务并续跑综合。
+wait，也会在终结屏障等待未 join 的直接子任务并续跑综合。任务边和同 Agent FIFO 边共同构成
+无环 Wait-for Graph；消息边不进入该图。
 
 ExpertTeam 使用完全相同的配置入口：`delegation.contextId`。Resolver 只能从当前 owner 的兼容
 Context 候选中选择；相同字符串不能跨 ExpertSession/FlowExecution，也不能切换 Expert 或 Runtime。

--- a/examples/README.md
+++ b/examples/README.md
@@ -249,7 +249,7 @@ Subagent 示例也使用同一套多 Agent TUI。主视图默认只展示 Main A
 ```
 
 Main Agent 的提示词没有写死 Research Agent id，也没有强制每轮委派。`createAgentLauncher()` 会把
-可用 Expert 的 `id`、`name` 和 `description` 注入 `spawn_expert` 工具描述，模型据此判断何时
+可用 Expert 的 `id`、`name` 和 `description` 注入 `delegate_expert` 工具描述，模型据此判断何时
 委派。Research Agent 的 description 明确覆盖架构分析、实现追踪和代码搜索，因此这类问题预期会
 自动路由给它。简单对话则应由 Main Agent 自己回答。
 

--- a/examples/src/experts/subagents/delegation.ts
+++ b/examples/src/experts/subagents/delegation.ts
@@ -34,7 +34,7 @@ const mainAgent = await createExampleExpert(
   [
     "You are the primary assistant responsible for understanding the user's goal and delivering the final answer.",
     "Answer in the same language as the user unless asked otherwise.",
-    "When an available Expert is a better match for a focused subtask, use spawn_expert based on the Expert descriptions exposed by that tool.",
+    "When an available Expert is a better match for a focused subtask, use delegate_expert based on the Expert descriptions exposed by that tool.",
     "Give the spawned Expert a self-contained research question, use wait_experts for its invocation, then synthesize its evidence instead of merely forwarding its response.",
     "Handle simple conversational questions yourself; users should not need to know Expert ids or request delegation explicitly.",
   ].join("\n"),

--- a/examples/src/experts/teams/delegation.ts
+++ b/examples/src/experts/teams/delegation.ts
@@ -13,7 +13,7 @@ const lead = await createExampleExpert(
     "You lead a repository engineering review team and are responsible for the final answer.",
     "Answer in the same language as the user unless asked otherwise.",
     "Use the available team Experts when their descriptions match focused parts of the user's request.",
-    "For broad reviews, call spawn_expert once for each independent investigation before calling wait_experts with all returned invocation ids.",
+    "For broad reviews, call delegate_expert once for each independent investigation before calling wait_experts with all returned invocation ids.",
     "Give each Expert a self-contained task, compare their evidence, resolve disagreements, and synthesize an actionable conclusion.",
     "Handle simple questions yourself; users should not need to know team member ids or request delegation explicitly.",
   ].join("\n"),

--- a/examples/test/expert-console-tui.test.ts
+++ b/examples/test/expert-console-tui.test.ts
@@ -176,6 +176,7 @@ function tree(executorId: string, status: string, children: unknown[] = []) {
       executorId,
       contextId: `${executorId}-context`,
       status,
+      pendingExpertMessages: [],
       input: "prompt",
       createdAt: now,
       updatedAt: now,

--- a/examples/test/flow-console-tui.test.ts
+++ b/examples/test/flow-console-tui.test.ts
@@ -381,6 +381,7 @@ function tree(
       definition: { id: overrides.nodeId ?? invocationId, kind },
       contextId: overrides.contextId ?? invocationId,
       status,
+      pendingExpertMessages: [],
       input: overrides.input ?? null,
       createdAt: now,
       updatedAt: now,

--- a/packages/core/src/agent/agent-launcher.ts
+++ b/packages/core/src/agent/agent-launcher.ts
@@ -17,10 +17,10 @@ export interface CreateAgentLauncherOptions {
 }
 
 export type ExpertLifecycleToolName =
-  | "spawn_expert"
+  | "delegate_expert"
   | "wait_experts"
   | "list_agents"
-  | "followup_expert"
+  | "message_expert"
   | "steer_expert"
   | "interrupt_expert";
 
@@ -126,8 +126,8 @@ function createLifecycleTools(
     contextId: definition.contextId,
     runtimeByExpert: new Map(definition.runtimeByExpert),
   });
-  const spawnable = [
-    "Spawnable Experts:",
+  const delegatable = [
+    "Delegatable Experts:",
     ...frozen.experts
       .filter((expert) => frozen.spawnExpertIds.has(expert.id))
       .map((expert) => `- ${expert.id}: ${expert.name}. ${expert.description}`),
@@ -137,17 +137,26 @@ function createLifecycleTools(
   ): AgentLifecycleTool => ({ ...value, [agentDelegationDefinition]: frozen });
 
   const tools: AgentLifecycleTool[] = [];
-  if (frozen.spawnExpertIds.size > 0) {
+  if (frozen.spawnExpertIds.size > 0 || frozen.interactExpertIds.size > 0) {
     tools.push(
       tool({
-        name: "spawn_expert",
-        description: `Spawn an Expert task in the background and return its agent and invocation ids immediately.\n${spawnable}`,
-        inputSchema: objectSchema({ expertId: { type: "string" }, prompt: { type: "string" } }, [
-          "expertId",
-          "prompt",
-        ]),
+        name: "delegate_expert",
+        description: `Delegate a trackable task to either a new Expert or an existing Agent and return its agent and invocation ids immediately. Provide exactly one of expertId or agentId.\n${delegatable}`,
+        inputSchema: objectSchema(
+          {
+            expertId: { type: "string" },
+            agentId: { type: "string" },
+            task: { type: "string" },
+          },
+          ["task"],
+        ),
         call: async (args, signal, context) =>
-          await invoke("spawn_expert", signal, context?.execution?.spawnExpert, readSpawn(args)),
+          await invoke(
+            "delegate_expert",
+            signal,
+            context?.execution?.delegateExpert,
+            readDelegate(args),
+          ),
       }),
     );
   }
@@ -199,18 +208,23 @@ function createLifecycleTools(
   if (frozen.spawnExpertIds.size > 0 || frozen.interactExpertIds.size > 0) {
     tools.push(
       tool({
-        name: "followup_expert",
-        description: "Queue a new FIFO task on an existing Expert instance.",
-        inputSchema: objectSchema({ agentId: { type: "string" }, prompt: { type: "string" } }, [
-          "agentId",
-          "prompt",
-        ]),
+        name: "message_expert",
+        description:
+          "Queue a message for an existing Agent's exact active Invocation. The message is consumed at the next safe boundary and never spills into a later Invocation.",
+        inputSchema: objectSchema(
+          {
+            agentId: { type: "string" },
+            invocationId: { type: "string" },
+            message: { type: "string" },
+          },
+          ["agentId", "invocationId", "message"],
+        ),
         call: async (args, signal, context) =>
           await invoke(
-            "followup_expert",
+            "message_expert",
             signal,
-            context?.execution?.followupExpert,
-            readFollowup(args),
+            context?.execution?.messageExpert,
+            readMessage(args),
           ),
       }),
     );
@@ -218,15 +232,14 @@ function createLifecycleTools(
       tool({
         name: "steer_expert",
         description:
-          "Guide an existing Agent's active task now. Unsupported steering is rejected unless fallback is followup.",
+          "Immediately guide an existing Agent's exact active Invocation. Unsupported steering is rejected and never queued.",
         inputSchema: objectSchema(
           {
             agentId: { type: "string" },
             invocationId: { type: "string" },
             message: { type: "string" },
-            fallback: { type: "string", enum: ["reject", "followup"], default: "reject" },
           },
-          ["agentId", "message"],
+          ["agentId", "invocationId", "message"],
         ),
         call: async (args, signal, context) =>
           await invoke("steer_expert", signal, context?.execution?.steerExpert, readSteer(args)),
@@ -237,8 +250,7 @@ function createLifecycleTools(
     tools.push(
       tool({
         name: "interrupt_expert",
-        description:
-          "Interrupt only the current task of an Expert while preserving queued follow-ups.",
+        description: "Interrupt only the current task of an Expert while preserving queued tasks.",
         inputSchema: objectSchema(
           {
             agentId: { type: "string" },
@@ -281,12 +293,19 @@ function objectSchema(properties: Record<string, unknown>, required: readonly st
   return { type: "object", properties, required, additionalProperties: false };
 }
 
-function readSpawn(value: unknown): { expertId: string; prompt: string } {
+function readDelegate(
+  value: unknown,
+): { expertId: string; task: string } | { agentId: string; task: string } {
   const record = readRecord(value);
-  return {
-    expertId: readString(record["expertId"], "expertId"),
-    prompt: readString(record["prompt"], "prompt"),
-  };
+  const expertId = record["expertId"];
+  const agentId = record["agentId"];
+  if ((expertId === undefined) === (agentId === undefined)) {
+    throw new Error("Exactly one of expertId or agentId is required.");
+  }
+  const task = readString(record["task"], "task");
+  return expertId === undefined
+    ? { agentId: readString(agentId, "agentId"), task }
+    : { expertId: readString(expertId, "expertId"), task };
 }
 
 function readList(value: unknown): { expertId?: string; cursor?: string; limit?: number } {
@@ -302,22 +321,14 @@ function readList(value: unknown): { expertId?: string; cursor?: string; limit?:
 
 function readSteer(value: unknown): {
   agentId: string;
-  invocationId?: string;
+  invocationId: string;
   message: string;
-  fallback?: "reject" | "followup";
 } {
   const record = readRecord(value);
-  const fallback = record["fallback"];
-  if (fallback !== undefined && fallback !== "reject" && fallback !== "followup") {
-    throw new Error("fallback must be reject or followup.");
-  }
   return {
     agentId: readString(record["agentId"], "agentId"),
-    ...(record["invocationId"] === undefined
-      ? {}
-      : { invocationId: readString(record["invocationId"], "invocationId") }),
+    invocationId: readString(record["invocationId"], "invocationId"),
     message: readString(record["message"], "message"),
-    ...(fallback === undefined ? {} : { fallback }),
   };
 }
 
@@ -354,11 +365,16 @@ function readWait(value: unknown): {
   };
 }
 
-function readFollowup(value: unknown): { agentId: string; prompt: string } {
+function readMessage(value: unknown): {
+  agentId: string;
+  invocationId: string;
+  message: string;
+} {
   const record = readRecord(value);
   return {
     agentId: readString(record["agentId"], "agentId"),
-    prompt: readString(record["prompt"], "prompt"),
+    invocationId: readString(record["invocationId"], "invocationId"),
+    message: readString(record["message"], "message"),
   };
 }
 

--- a/packages/core/src/execution/execution-store.ts
+++ b/packages/core/src/execution/execution-store.ts
@@ -33,6 +33,7 @@ import {
 import {
   executionRecordMigrationChain,
   migrateExecutionInvocationsV5ToV6,
+  migrateExecutionInvocationsV9ToV10,
   migrateInvocationUsageV7ToV8,
 } from "../storage/migrations/execution/index.ts";
 import { encodePragmaPathSegment, PragmaPaths } from "../storage/pragma-paths.ts";
@@ -381,7 +382,7 @@ export function createFileExecutionStore(
           request.contextPatches ?? [],
           now,
         );
-        assertAgentContextBindings(nextAgents, nextContexts);
+        assertAgentContextBindings(nextAgents, nextContexts, nextInvocations);
         const existingEvents = await readExecutionEvents(paths, request.executionId);
         const materialized = materializeEvents(
           request.executionId,
@@ -394,14 +395,14 @@ export function createFileExecutionStore(
         const nextExecution = ExecutionRecordSchema.parse({
           ...current,
           ...request.executionPatch,
-          schemaVersion: "pragma.execution/v9",
+          schemaVersion: "pragma.execution/v10",
           executionId: request.executionId,
           version: current.version + 1,
           lastAppliedSequence: lastSequence,
           updatedAt: now,
         });
         const journal = ExecutionCommitJournalSchema.parse({
-          schemaVersion: "pragma.execution-transaction/v10",
+          schemaVersion: "pragma.execution-transaction/v11",
           commitId: request.commitId,
           signature,
           execution: nextExecution,
@@ -630,8 +631,22 @@ function applyContextChanges(
 function assertAgentContextBindings(
   agents: readonly AgentInstance[],
   contexts: readonly RuntimeContextRecord[],
+  invocations: readonly Invocation[],
 ): void {
+  for (const invocation of invocations) {
+    if (
+      isTerminalExecutionStatus(invocation.status) &&
+      invocation.pendingExpertMessages.length > 0
+    ) {
+      throw new Error(
+        `Terminal Invocation cannot retain pending Expert messages: ${invocation.invocationId}.`,
+      );
+    }
+  }
   const contextById = new Map(contexts.map((context) => [context.contextId, context]));
+  const invocationById = new Map(
+    invocations.map((invocation) => [invocation.invocationId, invocation]),
+  );
   const agentByOwnedContext = new Map<string, string>();
   for (const agent of agents) {
     const context = contextById.get(agent.contextId);
@@ -647,6 +662,15 @@ function assertAgentContextBindings(
       throw new Error(`Runtime Context ${agent.contextId} already belongs to Agent ${existing}.`);
     }
     agentByOwnedContext.set(key, agent.agentId);
+    if (agent.activeInvocationId !== undefined) {
+      const active = invocationById.get(agent.activeInvocationId);
+      if (active === undefined || active.agentId !== agent.agentId) {
+        throw new Error(`Agent active Invocation binding conflict: ${agent.activeInvocationId}.`);
+      }
+      if (isTerminalExecutionStatus(active.status)) {
+        throw new Error(`Agent active Invocation cannot be terminal: ${agent.activeInvocationId}.`);
+      }
+    }
   }
 }
 
@@ -681,11 +705,13 @@ function applyInvocationChanges(
   for (const change of patches) {
     const invocation = byId.get(change.invocationId);
     if (invocation === undefined) throw new Error(`Invocation not found: ${change.invocationId}`);
+    const nextStatus = change.patch.status ?? invocation.status;
     byId.set(
       change.invocationId,
       InvocationSchema.parse({
         ...invocation,
         ...change.patch,
+        ...(nextStatus === "waiting" ? {} : { waitReason: undefined }),
         invocationId: change.invocationId,
         updatedAt: change.patch.updatedAt ?? now,
       }),
@@ -1110,10 +1136,14 @@ async function migrateExecutionState(paths: PragmaPaths, executionId: string): P
   const usageMigratedInvocations = Array.isArray(storedInvocations)
     ? storedInvocations.map(migrateInvocationUsageV7ToV8)
     : storedInvocations;
-  const invocations =
+  const handoffMigratedInvocations =
     upgraded.fromVersion === 5
       ? migrateExecutionInvocationsV5ToV6(usageMigratedInvocations)
-      : InvocationSchema.array().parse(usageMigratedInvocations);
+      : usageMigratedInvocations;
+  const invocations =
+    upgraded.fromVersion <= 9
+      ? migrateExecutionInvocationsV9ToV10(handoffMigratedInvocations)
+      : InvocationSchema.array().parse(handoffMigratedInvocations);
   await applyAtomicStateMigration({
     aggregateRoot: paths.executionRoot(executionId),
     journalFile: paths.executionMigration(executionId),

--- a/packages/core/src/execution/execution-work-history.ts
+++ b/packages/core/src/execution/execution-work-history.ts
@@ -4,17 +4,13 @@ import {
   type AgentMessageRecord,
   type ExecutionStatus,
   type Invocation,
+  type InvocationWaitReason,
 } from "@pragma/shared";
 
 import type { ExecutionStore } from "./execution-store.ts";
 
 export type ExecutionWorkRecordKind =
-  | "root"
-  | "agent"
-  | "runtime-agent"
-  | "flow"
-  | "task"
-  | "human-task";
+  "root" | "agent" | "runtime-agent" | "flow" | "task" | "human-task";
 
 export interface ExecutionWorkTask {
   readonly taskId: string;
@@ -23,6 +19,7 @@ export interface ExecutionWorkTask {
   readonly runId: string;
   readonly sequence?: number | undefined;
   readonly status: ExecutionStatus;
+  readonly waitReason?: InvocationWaitReason | undefined;
   readonly input?: unknown;
   readonly output?: unknown;
   readonly error?: unknown;
@@ -40,6 +37,7 @@ export interface ExecutionWorkRecord {
   readonly contextId?: string | undefined;
   readonly origin: "core" | "runtime";
   readonly status: ExecutionStatus;
+  readonly waitReason?: InvocationWaitReason | undefined;
   readonly tasks: readonly ExecutionWorkTask[];
   readonly createdAt: string;
   readonly updatedAt: string;
@@ -72,7 +70,7 @@ interface RuntimeEventProjection {
 
 interface RuntimeDispatch {
   readonly commandId: string;
-  delivery?: "followup" | "steer" | undefined;
+  delivery?: "followup" | "message" | "steer" | undefined;
   prompt?: string | undefined;
   readonly targetSessionIds: Set<string>;
 }
@@ -80,16 +78,19 @@ interface RuntimeDispatch {
 export class ExecutionWorkHistoryReader {
   constructor(private readonly store: ExecutionStore) {}
 
-  async listRecords(input: {
-    readonly executionIds: readonly string[];
-    readonly rootSessionId?: string | undefined;
-  }, preloadedData?: Map<
-    string,
-    {
-      readonly events: readonly import("@pragma/shared").ExecutionEvent[];
-      readonly invocations: readonly Invocation[];
-    }
-  >): Promise<readonly ExecutionWorkRecord[]> {
+  async listRecords(
+    input: {
+      readonly executionIds: readonly string[];
+      readonly rootSessionId?: string | undefined;
+    },
+    preloadedData?: Map<
+      string,
+      {
+        readonly events: readonly import("@pragma/shared").ExecutionEvent[];
+        readonly invocations: readonly Invocation[];
+      }
+    >,
+  ): Promise<readonly ExecutionWorkRecord[]> {
     const records = new Map<string, MutableWorkRecord>();
     const recordByInvocationId = new Map<string, string>();
     const runtimeRecordBySessionId = new Map<string, string>();
@@ -374,8 +375,12 @@ export class ExecutionWorkHistoryReader {
       preloadedData,
     );
     const record = records.find((candidate) => candidate.recordId === input.targetRecordId);
-    if (record === undefined) throw new Error(`Mission work record not found: ${input.targetRecordId}`);
-    const output = await this.readOutput({ executionIds: input.executionIds, record }, preloadedData);
+    if (record === undefined)
+      throw new Error(`Mission work record not found: ${input.targetRecordId}`);
+    const output = await this.readOutput(
+      { executionIds: input.executionIds, record },
+      preloadedData,
+    );
     return { records, output };
   }
 }
@@ -407,6 +412,7 @@ function invocationTask(executionId: string, invocation: Invocation): ExecutionW
       ? {}
       : { sequence: invocation.agentTaskSequence }),
     status: invocation.status,
+    ...(invocation.waitReason === undefined ? {} : { waitReason: invocation.waitReason }),
     input: invocation.input,
     ...(invocation.output === undefined ? {} : { output: invocation.output }),
     ...(invocation.error === undefined ? {} : { error: invocation.error }),
@@ -572,6 +578,16 @@ function finalizeRecord(record: MutableWorkRecord): ExecutionWorkRecord {
     }
     return left.createdAt.localeCompare(right.createdAt);
   });
+  const status =
+    record.origin === "runtime" &&
+    record.runtimeStatus !== undefined &&
+    (record.lastRuntimeRunOrder === undefined ||
+      (record.runtimeStatusOrder ?? -1) > record.lastRuntimeRunOrder)
+      ? record.runtimeStatus
+      : record.origin === "runtime"
+        ? aggregateRuntimeStatus(tasks)
+        : aggregateStatus(tasks);
+  const waitingTask = tasks.find((task) => task.status === "waiting");
   return {
     recordId: record.recordId,
     kind: record.kind,
@@ -583,15 +599,10 @@ function finalizeRecord(record: MutableWorkRecord): ExecutionWorkRecord {
     ...(record.executorId === undefined ? {} : { executorId: record.executorId }),
     ...(record.contextId === undefined ? {} : { contextId: record.contextId }),
     origin: record.origin,
-    status:
-      record.origin === "runtime" &&
-      record.runtimeStatus !== undefined &&
-      (record.lastRuntimeRunOrder === undefined ||
-        (record.runtimeStatusOrder ?? -1) > record.lastRuntimeRunOrder)
-        ? record.runtimeStatus
-        : record.origin === "runtime"
-          ? aggregateRuntimeStatus(tasks)
-          : aggregateStatus(tasks),
+    status,
+    ...(status !== "waiting" || waitingTask?.waitReason === undefined
+      ? {}
+      : { waitReason: waitingTask.waitReason }),
     tasks,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,

--- a/packages/core/src/execution/expert-orchestrator.ts
+++ b/packages/core/src/execution/expert-orchestrator.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import {
   InvocationOutputSchema,
@@ -15,7 +15,10 @@ import { fingerprintExpertExecutionDefinition } from "../agent/expert-definition
 import type { RuntimeModelSelection } from "../runtime/runtime-adapter.ts";
 import { summarizeRuntimeInput } from "../runtime/output.ts";
 import type { ExecutionStore } from "./execution-store.ts";
-import { ExecutionVersionConflictError } from "./execution-store.ts";
+import {
+  ExecutionFinalStatusConflictError,
+  ExecutionVersionConflictError,
+} from "./execution-store.ts";
 import { getExecutionLiveBus } from "./execution-live-bus.ts";
 import { InvocationService } from "./invocation-service.ts";
 import {
@@ -25,8 +28,8 @@ import {
 import type { ContextIdResolutionSource, ContextIdResolver } from "./context-id-resolver.ts";
 import { defineContextIdResolver } from "./context-id-resolver.ts";
 
-const followupContextIdResolver = defineContextIdResolver({
-  id: "pragma.context.agent-followup",
+const delegatedContextIdResolver = defineContextIdResolver({
+  id: "pragma.context.agent-delegation-existing",
   version: "v1",
   resolve: ({ freshContextId }) => freshContextId,
 });
@@ -63,6 +66,10 @@ export interface ExpertInteractionAccess {
   readonly isCoordinator: boolean;
 }
 
+type ExpertWaitWake =
+  | { readonly kind: "steer"; readonly requestId: string; readonly content: string }
+  | { readonly kind: "message" };
+
 export interface ExpertOrchestratorOptions {
   readonly executionId: string;
   readonly rootInvocationId: string;
@@ -82,10 +89,7 @@ export class ExpertOrchestrator {
   private readonly pumping = new Set<string>();
   private readonly activeJobs = new Map<string, Promise<void>>();
   private readonly joinedInvocationIds = new Set<string>();
-  private readonly steerWaiters = new Map<
-    string,
-    Set<(message: { readonly requestId: string; readonly content: string }) => boolean>
-  >();
+  private readonly steerWaiters = new Map<string, Set<(message: ExpertWaitWake) => boolean>>();
 
   constructor(private readonly options: ExpertOrchestratorOptions) {
     this.semaphore = new DelegationSemaphore(options.maxConcurrency);
@@ -220,11 +224,16 @@ export class ExpertOrchestrator {
           disposition: resolution.disposition,
         },
         status: "queued",
+        pendingExpertMessages: [],
         input: request.prompt,
         createdAt: now,
         updatedAt: now,
       };
       try {
+        assertWaitGraphAcyclic([
+          ...(await this.options.store.listInvocations(this.options.executionId)),
+          invocation,
+        ]);
         await invocations.ensureQueued({
           commitId: `agent-dispatch:${invocationId}`,
           expectedVersion: execution.version,
@@ -274,12 +283,15 @@ export class ExpertOrchestrator {
     }
   }
 
-  async followup(
+  async delegateExisting(
     access: ExpertInteractionAccess,
-    request: { readonly agentId: string; readonly prompt: string },
+    request: { readonly agentId: string; readonly task: string },
   ): Promise<{
     readonly agentId: string;
     readonly invocationId: string;
+    readonly expertId: string;
+    readonly contextId: string;
+    readonly disposition: "reused";
     readonly status: "queued";
   }> {
     while (true) {
@@ -300,7 +312,7 @@ export class ExpertOrchestrator {
         executionId: this.options.executionId,
         invocationId,
         parentInvocationId: access.callerInvocationId,
-        input: request.prompt,
+        input: request.task,
         state: execution.state,
         source: {
           kind: "expert-delegation",
@@ -313,11 +325,11 @@ export class ExpertOrchestrator {
         ownerContextId: agent.ownerContextId,
         expert: context.expert,
         runtime: context.runtime,
-        resolver: followupContextIdResolver,
+        resolver: delegatedContextIdResolver,
         freshContextId: context.contextId,
       });
       if (resolution.context.contextId !== agent.contextId) {
-        throw new Error(`Follow-up resolved a different Runtime Context: ${agent.agentId}.`);
+        throw new Error(`Delegation resolved a different Runtime Context: ${agent.agentId}.`);
       }
       const now = new Date().toISOString();
       const invocation: Invocation = {
@@ -334,13 +346,18 @@ export class ExpertOrchestrator {
           disposition: resolution.disposition,
         },
         status: "queued",
-        input: request.prompt,
+        pendingExpertMessages: [],
+        input: request.task,
         createdAt: now,
         updatedAt: now,
       };
       try {
+        assertWaitGraphAcyclic([
+          ...(await this.options.store.listInvocations(this.options.executionId)),
+          invocation,
+        ]);
         await new InvocationService(this.options.executionId, this.options.store).ensureQueued({
-          commitId: `agent-followup:${invocationId}`,
+          commitId: `agent-delegate:${invocationId}`,
           expectedVersion: execution.version,
           invocation,
           agentPatches: [
@@ -351,7 +368,7 @@ export class ExpertOrchestrator {
             ...resolution.events,
             {
               invocationId,
-              type: "agent.followup.queued",
+              type: "agent.delegated",
               data: {
                 agentId: agent.agentId,
                 taskSequence: agent.nextTaskSequence,
@@ -362,7 +379,14 @@ export class ExpertOrchestrator {
           ],
         });
         this.schedule(agent.agentId);
-        return { agentId: agent.agentId, invocationId, status: "queued" };
+        return {
+          agentId: agent.agentId,
+          invocationId,
+          expertId: agent.definition.id,
+          contextId: agent.contextId,
+          disposition: "reused",
+          status: "queued",
+        };
       } catch (error) {
         if (error instanceof ExecutionVersionConflictError) continue;
         throw error;
@@ -434,7 +458,8 @@ export class ExpertOrchestrator {
             truncated: queued.length > 20,
           },
           permissions: {
-            canFollowup: true,
+            canDelegate: true,
+            canMessage: active !== undefined,
             canSteer: true,
             canInterrupt: access.isCoordinator || agent.ownerContextId === access.ownerContextId,
           },
@@ -446,32 +471,148 @@ export class ExpertOrchestrator {
     };
   }
 
+  async message(
+    access: ExpertInteractionAccess,
+    request: { readonly agentId: string; readonly invocationId: string; readonly message: string },
+  ): Promise<{
+    readonly messageId: string;
+    readonly agentId: string;
+    readonly invocationId: string;
+    readonly status: "accepted";
+    readonly delivery: "safe_boundary";
+  }> {
+    const messageId = randomUUID();
+    while (true) {
+      const execution = await this.requireExecution();
+      const agent = await this.requireAccessibleAgent(access, request.agentId);
+      if (agent.lifecycle !== "open") {
+        throw new Error("agent_not_active: The Agent is closed.");
+      }
+      if (agent.activeInvocationId === undefined) {
+        throw new Error("agent_not_active: The Agent has no active Invocation.");
+      }
+      if (agent.activeInvocationId !== request.invocationId) {
+        throw new Error(
+          `stale_invocation: expected ${request.invocationId}, current is ${agent.activeInvocationId}.`,
+        );
+      }
+      const invocation = await this.options.store.getInvocation(
+        this.options.executionId,
+        request.invocationId,
+      );
+      if (
+        invocation === undefined ||
+        invocation.agentId !== agent.agentId ||
+        isTerminalExecutionStatus(invocation.status)
+      ) {
+        throw new Error("stale_invocation: The target Invocation is no longer active.");
+      }
+      const envelope = {
+        messageId,
+        senderInvocationId: access.callerInvocationId,
+        ...(access.callerAgentId === undefined ? {} : { senderAgentId: access.callerAgentId }),
+        content: request.message,
+        createdAt: new Date().toISOString(),
+      };
+      try {
+        await this.options.store.commit({
+          commitId: `expert-message-accepted:${messageId}`,
+          executionId: this.options.executionId,
+          expectedVersion: execution.version,
+          invocationPatches: [
+            {
+              invocationId: invocation.invocationId,
+              patch: {
+                pendingExpertMessages: [...invocation.pendingExpertMessages, envelope],
+              },
+            },
+          ],
+          events: [
+            {
+              invocationId: invocation.invocationId,
+              type: "expert.message.accepted",
+              data: {
+                ...envelope,
+                agentId: agent.agentId,
+                targetInvocationId: invocation.invocationId,
+              },
+            },
+          ],
+        });
+        this.wakeWait(agent.contextId, { kind: "message" });
+        return {
+          messageId,
+          agentId: agent.agentId,
+          invocationId: invocation.invocationId,
+          status: "accepted",
+          delivery: "safe_boundary",
+        };
+      } catch (error) {
+        if (error instanceof ExecutionVersionConflictError) continue;
+        throw error;
+      }
+    }
+  }
+
+  async takePendingMessages(invocationId: string): Promise<Invocation["pendingExpertMessages"]> {
+    while (true) {
+      const execution = await this.requireExecution();
+      const invocation = await this.options.store.getInvocation(
+        this.options.executionId,
+        invocationId,
+      );
+      if (invocation === undefined) throw new Error(`Invocation not found: ${invocationId}`);
+      const messages = invocation.pendingExpertMessages;
+      if (messages.length === 0) return [];
+      try {
+        await this.options.store.commit({
+          commitId: `expert-messages-consumed:${invocationId}:${createHash("sha256")
+            .update(messages.map((message) => message.messageId).join("\0"))
+            .digest("hex")}`,
+          executionId: this.options.executionId,
+          expectedVersion: execution.version,
+          invocationPatches: [{ invocationId, patch: { pendingExpertMessages: [] } }],
+          events: [
+            {
+              invocationId,
+              type: "expert.message.consumed",
+              data: { messageIds: messages.map((message) => message.messageId) },
+            },
+          ],
+        });
+        return messages;
+      } catch (error) {
+        if (error instanceof ExecutionVersionConflictError) continue;
+        throw error;
+      }
+    }
+  }
+
   async steer(
     access: ExpertInteractionAccess,
     request: {
       readonly agentId: string;
-      readonly invocationId?: string | undefined;
+      readonly invocationId: string;
       readonly message: string;
-      readonly fallback?: "reject" | "followup" | undefined;
     },
   ): Promise<unknown> {
     const agent = await this.requireAccessibleAgent(access, request.agentId);
     if (agent.lifecycle !== "open") throw new Error(`Agent is closed: ${agent.agentId}`);
     const activeInvocationId = agent.activeInvocationId;
-    if (request.invocationId !== undefined && request.invocationId !== activeInvocationId) {
+    if (request.invocationId !== activeInvocationId) {
       throw new Error(
         `Stale steer target: expected ${request.invocationId}, current is ${activeInvocationId ?? "idle"}.`,
       );
     }
     if (activeInvocationId === undefined) {
-      return await this.fallbackSteer(access, request, "agent_idle");
+      throw new Error("agent_not_active: The Agent has no active Invocation.");
     }
     const active = await this.options.store.getInvocation(
       this.options.executionId,
       activeInvocationId,
     );
     if (active === undefined || isTerminalExecutionStatus(active.status)) {
-      return await this.fallbackSteer(access, request, "turn_not_active");
+      throw new Error("stale_invocation: The target Invocation is no longer active.");
     }
     const requestId = randomUUID();
     await this.options.store.appendEvent(
@@ -516,33 +657,7 @@ export class ExpertOrchestrator {
       { requestId, agentId: agent.agentId, reason },
       `agent-steer-rejected:${requestId}`,
     );
-    return await this.fallbackSteer(access, request, reason);
-  }
-
-  private async fallbackSteer(
-    access: ExpertInteractionAccess,
-    request: {
-      readonly agentId: string;
-      readonly message: string;
-      readonly fallback?: "reject" | "followup" | undefined;
-    },
-    reason: "agent_idle" | "turn_not_active" | "runtime_unsupported",
-  ): Promise<unknown> {
-    if ((request.fallback ?? "reject") === "reject") {
-      throw new Error(`Expert steering rejected: ${reason}.`);
-    }
-    const queued = await this.followup(access, {
-      agentId: request.agentId,
-      prompt: request.message,
-    });
-    await this.options.store.appendEvent(
-      this.options.executionId,
-      queued.invocationId,
-      "agent.steer.fallback_queued",
-      { agentId: request.agentId, reason },
-      `agent-steer-fallback:${queued.invocationId}`,
-    );
-    return { outcome: "followup_queued", reason, ...queued };
+    throw new Error(`Expert steering rejected: ${reason}.`);
   }
 
   async wait(
@@ -559,13 +674,17 @@ export class ExpertOrchestrator {
     readonly timedOut: boolean;
     readonly completed: readonly unknown[];
     readonly pendingInvocationIds: readonly string[];
-    readonly wakeReason?: "steer" | undefined;
+    readonly wakeReason?: "steer" | "message" | undefined;
     readonly steer?: { readonly requestId: string; readonly content: string } | undefined;
   }> {
     await this.assertAccessibleInvocations(access, request.invocationIds);
     const resume = permit?.suspend();
     try {
-      const result = await this.waitForInvocations(access.ownerContextId, request);
+      const result = await this.waitForInvocations(
+        access.ownerContextId,
+        access.callerInvocationId,
+        request,
+      );
       for (const completed of result.completed) {
         this.joinedInvocationIds.add((completed as { invocationId: string }).invocationId);
       }
@@ -583,16 +702,15 @@ export class ExpertOrchestrator {
   ): Promise<{
     readonly completed: readonly unknown[];
     readonly pendingInvocationIds: readonly string[];
-    readonly wakeReason?: "steer" | undefined;
+    readonly wakeReason?: "steer" | "message" | undefined;
     readonly steer?: { readonly requestId: string; readonly content: string } | undefined;
   }> {
     const agents = await this.loadScopedAgents();
     const allInvocations = await this.options.store.listInvocations(this.options.executionId);
-    const descendants = collectDescendantInvocationIds(allInvocations, ownerInvocationId);
     const ids = allInvocations
       .filter(
         (invocation) =>
-          descendants.has(invocation.invocationId) &&
+          invocation.parentInvocationId === ownerInvocationId &&
           agents.some((agent) => agent.agentId === invocation.agentId),
       )
       .filter((invocation) => !this.joinedInvocationIds.has(invocation.invocationId))
@@ -606,10 +724,7 @@ export class ExpertOrchestrator {
     return result;
   }
 
-  wakeWait(
-    ownerContextId: string,
-    message: { readonly requestId: string; readonly content: string },
-  ): boolean {
+  wakeWait(ownerContextId: string, message: ExpertWaitWake): boolean {
     const waiters = this.steerWaiters.get(ownerContextId);
     if (waiters === undefined || waiters.size === 0) return false;
     return [...waiters].some((wake) => wake(message));
@@ -620,10 +735,9 @@ export class ExpertOrchestrator {
     if (agents.length === 0) return false;
     const ids = new Set(agents.map((agent) => agent.agentId));
     const invocations = await this.options.store.listInvocations(this.options.executionId);
-    const descendants = collectDescendantInvocationIds(invocations, ownerInvocationId);
     return invocations.some(
       (invocation) =>
-        descendants.has(invocation.invocationId) &&
+        invocation.parentInvocationId === ownerInvocationId &&
         invocation.agentId !== undefined &&
         ids.has(invocation.agentId) &&
         !this.joinedInvocationIds.has(invocation.invocationId),
@@ -657,31 +771,11 @@ export class ExpertOrchestrator {
         `Stale interrupt target: expected ${request.invocationId}, current is ${current.invocationId}.`,
       );
     }
-    if (current.status === "queued") {
-      await this.options.store.commit({
-        commitId: `agent-interrupted:${current.invocationId}`,
-        executionId: this.options.executionId,
-        invocationPatches: [
-          {
-            invocationId: current.invocationId,
-            patch: { status: "interrupted", error: request.reason },
-          },
-        ],
-        events: [
-          {
-            invocationId: current.invocationId,
-            type: "invocation.interrupted",
-            data: { agentId: agent.agentId, reason: request.reason },
-          },
-        ],
-      });
-      this.schedule(agent.agentId);
-    } else {
-      await this.options.interruptController.interruptInvocation(
-        current.invocationId,
-        request.reason,
-      );
-    }
+    await this.options.interruptController.interruptInvocation(
+      current.invocationId,
+      request.reason,
+    );
+    this.schedule(agent.agentId);
     return { agentId: agent.agentId, invocationId: current.invocationId, outcome: "interrupted" };
   }
 
@@ -855,6 +949,7 @@ export class ExpertOrchestrator {
 
   private async waitForInvocations(
     ownerContextId: string,
+    ownerInvocationId: string,
     request: {
       readonly invocationIds: readonly string[];
       readonly returnWhen?: "all" | "any" | undefined;
@@ -866,7 +961,7 @@ export class ExpertOrchestrator {
     readonly timedOut: boolean;
     readonly completed: readonly unknown[];
     readonly pendingInvocationIds: readonly string[];
-    readonly wakeReason?: "steer" | undefined;
+    readonly wakeReason?: "steer" | "message" | undefined;
     readonly steer?: { readonly requestId: string; readonly content: string } | undefined;
   }> {
     const returnWhen = request.returnWhen ?? "all";
@@ -875,14 +970,14 @@ export class ExpertOrchestrator {
     );
     const iterator = subscription[Symbol.asyncIterator]();
     const deadline = request.timeoutMs === undefined ? undefined : Date.now() + request.timeoutMs;
-    let steering: { readonly requestId: string; readonly content: string } | undefined;
+    let wakeMessage: ExpertWaitWake | undefined;
     let resolveSteer: (() => void) | undefined;
     const steerSignal = new Promise<void>((resolve) => {
       resolveSteer = resolve;
     });
-    const wake = (message: { readonly requestId: string; readonly content: string }) => {
-      if (steering !== undefined) return false;
-      steering = message;
+    const wake = (message: ExpertWaitWake) => {
+      if (wakeMessage !== undefined) return false;
+      wakeMessage = message;
       resolveSteer?.();
       return true;
     };
@@ -899,7 +994,12 @@ export class ExpertOrchestrator {
         const conditionMet =
           returnWhen === "all" ? completed.length === invocations.length : completed.length > 0;
         const timedOut = deadline !== undefined && Date.now() >= deadline;
-        if (conditionMet || timedOut || steering !== undefined) {
+        const ownerInvocation = await this.options.store.getInvocation(
+          this.options.executionId,
+          ownerInvocationId,
+        );
+        const hasPendingMessage = (ownerInvocation?.pendingExpertMessages.length ?? 0) > 0;
+        if (conditionMet || timedOut || wakeMessage !== undefined || hasPendingMessage) {
           waiters.delete(wake);
           if (waiters.size === 0) this.steerWaiters.delete(ownerContextId);
           return {
@@ -909,7 +1009,11 @@ export class ExpertOrchestrator {
             pendingInvocationIds: invocations
               .filter((invocation) => !isTerminalExecutionStatus(invocation.status))
               .map((invocation) => invocation.invocationId),
-            ...(steering === undefined ? {} : { wakeReason: "steer" as const, steer: steering }),
+            ...(wakeMessage === undefined && !hasPendingMessage
+              ? {}
+              : wakeMessage?.kind === "steer"
+                ? { wakeReason: "steer" as const, steer: wakeMessage }
+                : { wakeReason: "message" as const }),
           };
         }
         await Promise.race([waitForEvent(iterator, deadline, request.signal), steerSignal]);
@@ -931,8 +1035,8 @@ export class ExpertOrchestrator {
       const agent = invocation.agentId === undefined ? undefined : agents.get(invocation.agentId);
       if (
         agent === undefined ||
-        (!this.canAccessAgent(access, agent) &&
-          invocation.parentInvocationId !== access.callerInvocationId)
+        invocation.parentInvocationId !== access.callerInvocationId ||
+        !this.canAccessAgent(access, agent)
       ) {
         throw new Error(
           `Invocation is not accessible to the current Expert: ${invocation.invocationId}`,
@@ -1039,23 +1143,119 @@ export class ExpertOrchestrator {
   }
 
   private async failUnrecoverableJob(invocation: Invocation, message: string): Promise<void> {
-    await this.options.store.commit({
-      commitId: `agent-failed:${invocation.invocationId}`,
-      executionId: this.options.executionId,
-      invocationPatches: [
-        { invocationId: invocation.invocationId, patch: { status: "failed", error: { message } } },
-      ],
-      events: [
-        { invocationId: invocation.invocationId, type: "invocation.failed", data: { message } },
-      ],
-    });
+    while (true) {
+      const execution = await this.requireExecution();
+      const current = await this.options.store.getInvocation(
+        this.options.executionId,
+        invocation.invocationId,
+      );
+      if (current === undefined || isTerminalExecutionStatus(current.status)) return;
+      const agent =
+        current.agentId === undefined
+          ? undefined
+          : await this.options.store.getAgent(this.options.executionId, current.agentId);
+      try {
+        await this.options.store.commit({
+          commitId: `agent-failed:${current.invocationId}`,
+          executionId: this.options.executionId,
+          expectedVersion: execution.version,
+          invocationPatches: [
+            {
+              invocationId: current.invocationId,
+              patch: {
+                status: "failed",
+                waitReason: undefined,
+                pendingExpertMessages: [],
+                error: { message },
+              },
+            },
+          ],
+          ...(agent?.activeInvocationId === current.invocationId
+            ? {
+                agentPatches: [
+                  { agentId: agent.agentId, patch: { activeInvocationId: undefined } },
+                ],
+              }
+            : {}),
+          events: [
+            ...(current.pendingExpertMessages.length === 0
+              ? []
+              : [
+                  {
+                    invocationId: current.invocationId,
+                    type: "expert.message.consumed",
+                    data: {
+                      messageIds: current.pendingExpertMessages.map(
+                        (pendingMessage) => pendingMessage.messageId,
+                      ),
+                      terminalReason: "unrecoverable",
+                    },
+                  },
+                ]),
+            { invocationId: current.invocationId, type: "invocation.failed", data: { message } },
+          ],
+        });
+        return;
+      } catch (error) {
+        if (error instanceof ExecutionVersionConflictError) continue;
+        if (error instanceof ExecutionFinalStatusConflictError) return;
+        throw error;
+      }
+    }
   }
 
   private async scheduleRecoverableAgents(): Promise<void> {
     for (const agent of await this.loadScopedAgents()) {
-      if (agent.lifecycle === "open" && this.experts.has(agent.definition.id)) {
-        this.schedule(agent.agentId);
+      if (agent.lifecycle !== "open" || !this.experts.has(agent.definition.id)) continue;
+      if (
+        agent.activeInvocationId !== undefined &&
+        !this.activeJobs.has(agent.activeInvocationId)
+      ) {
+        while (true) {
+          const execution = await this.requireExecution();
+          const currentAgent = await this.options.store.getAgent(
+            this.options.executionId,
+            agent.agentId,
+          );
+          if (currentAgent?.activeInvocationId === undefined) break;
+          const invocation = await this.options.store.getInvocation(
+            this.options.executionId,
+            currentAgent.activeInvocationId,
+          );
+          try {
+            await this.options.store.commit({
+              commitId: `agent-recovered:${currentAgent.activeInvocationId}`,
+              executionId: this.options.executionId,
+              expectedVersion: execution.version,
+              ...(invocation === undefined || isTerminalExecutionStatus(invocation.status)
+                ? {}
+                : {
+                    invocationPatches: [
+                      {
+                        invocationId: invocation.invocationId,
+                        patch: { status: "queued", waitReason: undefined },
+                      },
+                    ],
+                  }),
+              agentPatches: [
+                { agentId: currentAgent.agentId, patch: { activeInvocationId: undefined } },
+              ],
+              events: [
+                {
+                  invocationId: currentAgent.activeInvocationId,
+                  type: "agent.task.recovered",
+                  data: { agentId: currentAgent.agentId },
+                },
+              ],
+            });
+            break;
+          } catch (error) {
+            if (error instanceof ExecutionVersionConflictError) continue;
+            throw error;
+          }
+        }
       }
+      this.schedule(agent.agentId);
     }
   }
 }
@@ -1128,6 +1328,64 @@ function collectDescendantInvocationIds(
     }
   }
   return descendants;
+}
+
+function assertWaitGraphAcyclic(invocations: readonly Invocation[]): void {
+  const edges = new Map<string, Set<string>>();
+  const addEdge = (from: string, to: string) => {
+    const targets = edges.get(from) ?? new Set<string>();
+    targets.add(to);
+    edges.set(from, targets);
+  };
+  for (const invocation of invocations) {
+    if (
+      invocation.parentInvocationId !== undefined &&
+      !isTerminalExecutionStatus(invocation.status)
+    ) {
+      addEdge(invocation.parentInvocationId, invocation.invocationId);
+    }
+  }
+  const byAgent = new Map<string, Invocation[]>();
+  for (const invocation of invocations) {
+    if (invocation.agentId === undefined || invocation.agentTaskSequence === undefined) continue;
+    const tasks = byAgent.get(invocation.agentId) ?? [];
+    tasks.push(invocation);
+    byAgent.set(invocation.agentId, tasks);
+  }
+  for (const tasks of byAgent.values()) {
+    const active = tasks
+      .filter((task) => !isTerminalExecutionStatus(task.status))
+      .sort((left, right) => left.agentTaskSequence! - right.agentTaskSequence!);
+    for (let index = 1; index < active.length; index += 1) {
+      addEdge(active[index]!.invocationId, active[index - 1]!.invocationId);
+    }
+  }
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const path: string[] = [];
+  const visit = (invocationId: string): string[] | undefined => {
+    if (visiting.has(invocationId)) {
+      const start = path.indexOf(invocationId);
+      return [...path.slice(start), invocationId];
+    }
+    if (visited.has(invocationId)) return undefined;
+    visiting.add(invocationId);
+    path.push(invocationId);
+    for (const target of edges.get(invocationId) ?? []) {
+      const cycle = visit(target);
+      if (cycle !== undefined) return cycle;
+    }
+    path.pop();
+    visiting.delete(invocationId);
+    visited.add(invocationId);
+    return undefined;
+  };
+  for (const invocation of invocations) {
+    const cycle = visit(invocation.invocationId);
+    if (cycle !== undefined) {
+      throw new Error(`expert_wait_cycle: ${cycle.join(" -> ")}`);
+    }
+  }
 }
 
 function summarizeInvocation(invocation: Invocation): unknown {

--- a/packages/core/src/execution/expert-orchestrator.ts
+++ b/packages/core/src/execution/expert-orchestrator.ts
@@ -554,7 +554,22 @@ export class ExpertOrchestrator {
     }
   }
 
-  async takePendingMessages(invocationId: string): Promise<Invocation["pendingExpertMessages"]> {
+  async readPendingMessages(invocationId: string): Promise<Invocation["pendingExpertMessages"]> {
+    const invocation = await this.options.store.getInvocation(
+      this.options.executionId,
+      invocationId,
+    );
+    if (invocation === undefined) throw new Error(`Invocation not found: ${invocationId}`);
+    return invocation.pendingExpertMessages;
+  }
+
+  async acknowledgePendingMessages(
+    invocationId: string,
+    messageIds: readonly string[],
+    terminalReason?: string,
+  ): Promise<void> {
+    const requestedIds = new Set(messageIds);
+    if (requestedIds.size === 0) return;
     while (true) {
       const execution = await this.requireExecution();
       const invocation = await this.options.store.getInvocation(
@@ -562,25 +577,40 @@ export class ExpertOrchestrator {
         invocationId,
       );
       if (invocation === undefined) throw new Error(`Invocation not found: ${invocationId}`);
-      const messages = invocation.pendingExpertMessages;
-      if (messages.length === 0) return [];
+      const messages = invocation.pendingExpertMessages.filter((message) =>
+        requestedIds.has(message.messageId),
+      );
+      if (messages.length === 0) return;
+      const acknowledgedIds = messages.map((message) => message.messageId);
       try {
         await this.options.store.commit({
           commitId: `expert-messages-consumed:${invocationId}:${createHash("sha256")
-            .update(messages.map((message) => message.messageId).join("\0"))
+            .update(acknowledgedIds.join("\0"))
             .digest("hex")}`,
           executionId: this.options.executionId,
           expectedVersion: execution.version,
-          invocationPatches: [{ invocationId, patch: { pendingExpertMessages: [] } }],
+          invocationPatches: [
+            {
+              invocationId,
+              patch: {
+                pendingExpertMessages: invocation.pendingExpertMessages.filter(
+                  (message) => !requestedIds.has(message.messageId),
+                ),
+              },
+            },
+          ],
           events: [
             {
               invocationId,
               type: "expert.message.consumed",
-              data: { messageIds: messages.map((message) => message.messageId) },
+              data: {
+                messageIds: acknowledgedIds,
+                ...(terminalReason === undefined ? {} : { terminalReason }),
+              },
             },
           ],
         });
-        return messages;
+        return;
       } catch (error) {
         if (error instanceof ExecutionVersionConflictError) continue;
         throw error;
@@ -883,7 +913,7 @@ export class ExpertOrchestrator {
   }): Promise<void> {
     try {
       await this.options.store.commit({
-        commitId: `agent-activated:${options.invocation.invocationId}`,
+        commitId: `agent-activated:${options.invocation.invocationId}:${randomUUID()}`,
         executionId: this.options.executionId,
         agentPatches: [
           {

--- a/packages/core/src/execution/expert-runner.ts
+++ b/packages/core/src/execution/expert-runner.ts
@@ -1032,17 +1032,19 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
   const recoveredMessages =
     invocation.waitReason === "human_input"
       ? []
-      : await orchestrator?.takePendingMessages(options.invocationId);
+      : await orchestrator?.readPendingMessages(options.invocationId);
+  let activeExpertMessages = recoveredMessages ?? [];
   let query =
-    recoveredMessages !== undefined && recoveredMessages.length > 0
-      ? formatExpertMessageContinuation(recoveredMessages)
+    activeExpertMessages.length > 0
+      ? formatExpertMessageContinuation(activeExpertMessages)
       : formattedPrompt;
-  let continuation = recoveredMessages !== undefined && recoveredMessages.length > 0 ? 1 : 0;
+  let continuation = activeExpertMessages.length > 0 ? 1 : 0;
   if (continuation > 0) {
     await appendUserMessage(
       options,
       query,
-      `invocation-message-continuation:${options.invocationId}:${continuation}`,
+      expertMessageHandoffEventId(options.invocationId, activeExpertMessages),
+      expertMessageHandoffTimestamp(activeExpertMessages),
     );
   }
   let invocationUsage = invocation.usage;
@@ -1057,7 +1059,11 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
         runId:
           continuation === 0
             ? (options.runtimeRunId ?? options.invocationId)
-            : `${options.runtimeRunId ?? options.invocationId}:continuation:${continuation}`,
+            : `${options.runtimeRunId ?? options.invocationId}:continuation:${
+                activeExpertMessages.length > 0
+                  ? expertMessageBatchId(activeExpertMessages)
+                  : continuation
+              }`,
         executionContext,
         humanInteractionHandler,
         modelSelection,
@@ -1068,16 +1074,23 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
       });
       invocationUsage = mergeUsage(invocationUsage, turn.usage);
       await persistSessionInfo(session, persistRuntimeSnapshot);
+      await orchestrator?.acknowledgePendingMessages(
+        options.invocationId,
+        activeExpertMessages.map((message) => message.messageId),
+      );
+      activeExpertMessages = [];
 
-      const pendingMessages = await orchestrator?.takePendingMessages(options.invocationId);
+      const pendingMessages = await orchestrator?.readPendingMessages(options.invocationId);
       if (pendingMessages !== undefined && pendingMessages.length > 0) {
         await appendInvocationFinalMessage(options, turn.runId, turn.finalMessage, undefined);
+        activeExpertMessages = pendingMessages;
         query = formatExpertMessageContinuation(pendingMessages);
         continuation += 1;
         await appendUserMessage(
           options,
           query,
-          `invocation-message-continuation:${options.invocationId}:${continuation}`,
+          expertMessageHandoffEventId(options.invocationId, activeExpertMessages),
+          expertMessageHandoffTimestamp(activeExpertMessages),
         );
         continue;
       }
@@ -1116,8 +1129,9 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
         };
         const waitMessages =
           waitResult.wakeReason === "message"
-            ? await orchestrator.takePendingMessages(options.invocationId)
+            ? await orchestrator.readPendingMessages(options.invocationId)
             : [];
+        activeExpertMessages = waitMessages;
         query =
           waitMessages.length > 0
             ? formatExpertMessageContinuation(waitMessages, result)
@@ -1161,7 +1175,12 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
         await appendUserMessage(
           options,
           query,
-          `invocation-continuation-message:${options.invocationId}:${continuation}`,
+          activeExpertMessages.length > 0
+            ? expertMessageHandoffEventId(options.invocationId, activeExpertMessages)
+            : `invocation-continuation-message:${options.invocationId}:${continuation}`,
+          activeExpertMessages.length > 0
+            ? expertMessageHandoffTimestamp(activeExpertMessages)
+            : undefined,
         );
         continue;
       }
@@ -1182,14 +1201,16 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
           throw new Error(`Invocation not found: ${options.invocationId}`);
         }
         if (currentInvocation.pendingExpertMessages.length > 0) {
-          const messages = await orchestrator?.takePendingMessages(options.invocationId);
+          const messages = await orchestrator?.readPendingMessages(options.invocationId);
           if (messages !== undefined && messages.length > 0) {
+            activeExpertMessages = messages;
             query = formatExpertMessageContinuation(messages);
             continuation += 1;
             await appendUserMessage(
               options,
               query,
-              `invocation-message-continuation:${options.invocationId}:${continuation}`,
+              expertMessageHandoffEventId(options.invocationId, activeExpertMessages),
+              expertMessageHandoffTimestamp(activeExpertMessages),
             );
             continue invocationLoop;
           }
@@ -1249,7 +1270,12 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
       );
     }
     while (true) {
-      await orchestrator?.takePendingMessages(options.invocationId);
+      const discardedMessages = await orchestrator?.readPendingMessages(options.invocationId);
+      await orchestrator?.acknowledgePendingMessages(
+        options.invocationId,
+        discardedMessages?.map((message) => message.messageId) ?? [],
+        "terminal",
+      );
       const currentExecution = await requireExecution(options.store, options.executionId);
       const latest = await options.store.getInvocation(options.executionId, options.invocationId);
       const status = options.controller.isCancelled()
@@ -2172,14 +2198,32 @@ async function appendUserMessage(
   options: RunExpertInvocationOptions,
   content: string,
   eventId: string,
+  timestamp = Date.now(),
 ): Promise<void> {
   await options.store.appendEvent(
     options.executionId,
     options.invocationId,
     "invocation.message.appended",
-    { message: { role: "user", content, timestamp: Date.now() } satisfies AgentMessage },
+    { message: { role: "user", content, timestamp } satisfies AgentMessage },
     eventId,
   );
+}
+
+function expertMessageBatchId(messages: Invocation["pendingExpertMessages"]): string {
+  return createHash("sha256")
+    .update(messages.map((message) => message.messageId).join("\0"))
+    .digest("hex");
+}
+
+function expertMessageHandoffEventId(
+  invocationId: string,
+  messages: Invocation["pendingExpertMessages"],
+): string {
+  return `invocation-message-continuation:${invocationId}:${expertMessageBatchId(messages)}`;
+}
+
+function expertMessageHandoffTimestamp(messages: Invocation["pendingExpertMessages"]): number {
+  return Math.max(...messages.map((message) => Date.parse(message.createdAt)));
 }
 
 async function persistSessionInfo(

--- a/packages/core/src/execution/expert-runner.ts
+++ b/packages/core/src/execution/expert-runner.ts
@@ -225,19 +225,62 @@ export class ExecutionController {
   }
 
   async interruptInvocation(invocationId: string, reason?: string): Promise<boolean> {
-    const invocation = await this.store.getInvocation(this.executionId, invocationId);
-    if (invocation === undefined) throw new Error(`Invocation not found: ${invocationId}`);
-    if (isTerminalExecutionStatus(invocation.status)) return false;
-    try {
-      await this.store.commit({
-        commitId: `invocation-interrupted:${invocationId}`,
-        executionId: this.executionId,
-        invocationPatches: [{ invocationId, patch: { status: "interrupted", error: reason } }],
-        events: [{ invocationId, type: "invocation.interrupted", data: { reason } }],
-      });
-    } catch (error) {
-      if (!(error instanceof ExecutionFinalStatusConflictError)) throw error;
-      return false;
+    while (true) {
+      const execution = await requireExecution(this.store, this.executionId);
+      const invocation = await this.store.getInvocation(this.executionId, invocationId);
+      if (invocation === undefined) throw new Error(`Invocation not found: ${invocationId}`);
+      if (isTerminalExecutionStatus(invocation.status)) return false;
+      const agent =
+        invocation.agentId === undefined
+          ? undefined
+          : await this.store.getAgent(this.executionId, invocation.agentId);
+      try {
+        await this.store.commit({
+          commitId: `invocation-interrupted:${invocationId}`,
+          executionId: this.executionId,
+          expectedVersion: execution.version,
+          invocationPatches: [
+            {
+              invocationId,
+              patch: {
+                status: "interrupted",
+                waitReason: undefined,
+                pendingExpertMessages: [],
+                error: reason,
+              },
+            },
+          ],
+          ...(agent?.activeInvocationId !== invocation.invocationId
+            ? {}
+            : {
+                agentPatches: [
+                  { agentId: agent.agentId, patch: { activeInvocationId: undefined } },
+                ],
+              }),
+          events: [
+            ...(invocation.pendingExpertMessages.length === 0
+              ? []
+              : [
+                  {
+                    invocationId,
+                    type: "expert.message.consumed",
+                    data: {
+                      messageIds: invocation.pendingExpertMessages.map(
+                        (message) => message.messageId,
+                      ),
+                      terminalReason: "interrupted",
+                    },
+                  },
+                ]),
+            { invocationId, type: "invocation.interrupted", data: { reason } },
+          ],
+        });
+        break;
+      } catch (error) {
+        if (error instanceof ExecutionVersionConflictError) continue;
+        if (error instanceof ExecutionFinalStatusConflictError) return false;
+        throw error;
+      }
     }
     const controller = this.invocationSignals.get(invocationId) ?? new AbortController();
     this.invocationSignals.set(invocationId, controller);
@@ -320,7 +363,17 @@ export class ExecutionController {
         this.executionId,
         interactionId,
       );
-      if (restoredResponse !== undefined) return restoredResponse;
+      if (restoredResponse !== undefined) {
+        await this.store.commit({
+          commitId: `human-resumed:${interactionId}`,
+          executionId: this.executionId,
+          invocationPatches: [
+            { invocationId, patch: { status: "running", waitReason: undefined } },
+          ],
+          events: [{ invocationId, type: "human.resumed", data: { interactionId } }],
+        });
+        return restoredResponse;
+      }
     } else {
       await this.store.appendEvent(
         this.executionId,
@@ -344,7 +397,21 @@ export class ExecutionController {
       );
       return automaticResponse;
     }
-    return await new Promise((resolve, reject) => {
+    await this.store.commit({
+      commitId: `human-waiting:${interactionId}`,
+      executionId: this.executionId,
+      invocationPatches: [
+        { invocationId, patch: { status: "waiting", waitReason: "human_input" } },
+      ],
+      events: [
+        {
+          invocationId,
+          type: "human.waiting",
+          data: { interactionId },
+        },
+      ],
+    });
+    const response = await new Promise<ExpertAgentHumanResponse>((resolve, reject) => {
       let settled = false;
       const cleanup = () => {
         signal.removeEventListener("abort", abort);
@@ -379,15 +446,22 @@ export class ExecutionController {
         (error: unknown) => pending.reject(error),
       );
     });
+    await this.store.commit({
+      commitId: `human-resumed:${interactionId}`,
+      executionId: this.executionId,
+      invocationPatches: [{ invocationId, patch: { status: "running", waitReason: undefined } }],
+      events: [{ invocationId, type: "human.resumed", data: { interactionId } }],
+    });
+    return response;
   }
 
   async respond(interactionId: string, response: unknown, requestId: string): Promise<void> {
-    const pending = this.pendingInteractions.get(interactionId);
-    if (pending?.requestId !== undefined) {
-      if (pending.requestId === requestId) return;
+    const initialPending = this.pendingInteractions.get(interactionId);
+    if (initialPending?.requestId !== undefined) {
+      if (initialPending.requestId === requestId) return;
       throw new Error(`Human interaction idempotency conflict: ${interactionId}`);
     }
-    if (pending !== undefined) pending.requestId = requestId;
+    if (initialPending !== undefined) initialPending.requestId = requestId;
     const parsedResponse = await persistHumanInteractionResponse(
       this.store,
       this.executionId,
@@ -395,7 +469,26 @@ export class ExecutionController {
       response,
       requestId,
     );
+    const pending = this.pendingInteractions.get(interactionId);
     if (pending !== undefined) {
+      pending.requestId = requestId;
+      await this.store.commit({
+        commitId: `human-resumed:${interactionId}`,
+        executionId: this.executionId,
+        invocationPatches: [
+          {
+            invocationId: pending.invocationId,
+            patch: { status: "running", waitReason: undefined },
+          },
+        ],
+        events: [
+          {
+            invocationId: pending.invocationId,
+            type: "human.resumed",
+            data: { interactionId },
+          },
+        ],
+      });
       this.pendingInteractions.delete(interactionId);
       pending.resolve(parsedResponse);
     }
@@ -415,16 +508,38 @@ export class ExecutionController {
     while (true) {
       const record = await this.store.get(this.executionId);
       if (record === undefined || isTerminalExecutionStatus(record.status)) return;
-      const invocationPatches = (await this.store.listInvocations(this.executionId))
-        .filter((invocation) => !isTerminalExecutionStatus(invocation.status))
-        .map((invocation) => ({
-          invocationId: invocation.invocationId,
-          patch: { status: "cancelled" as const, error: reason },
-        }));
+      const invocations = (await this.store.listInvocations(this.executionId)).filter(
+        (invocation) => !isTerminalExecutionStatus(invocation.status),
+      );
+      const invocationPatches = invocations.map((invocation) => ({
+        invocationId: invocation.invocationId,
+        patch: {
+          status: "cancelled" as const,
+          waitReason: undefined,
+          pendingExpertMessages: [],
+          error: reason,
+        },
+      }));
       const closure =
         this.options.closeContextsOnCancel === true
           ? await prepareExecutionContextClosure(this.store, this.executionId)
           : { contextPatches: [], agentPatches: [], events: [] };
+      const cancelledInvocationIds = new Set(
+        invocations.map((invocation) => invocation.invocationId),
+      );
+      const activeAgentPatches =
+        this.options.closeContextsOnCancel === true
+          ? []
+          : (await this.store.listAgents(this.executionId))
+              .filter(
+                (agent) =>
+                  agent.activeInvocationId !== undefined &&
+                  cancelledInvocationIds.has(agent.activeInvocationId),
+              )
+              .map((agent) => ({
+                agentId: agent.agentId,
+                patch: { activeInvocationId: undefined },
+              }));
       try {
         await this.store.commit({
           commitId: randomUUID(),
@@ -433,9 +548,25 @@ export class ExecutionController {
           executionPatch: { status: "cancelled", error: reason },
           invocationPatches,
           contextPatches: closure.contextPatches,
-          agentPatches: closure.agentPatches,
+          agentPatches: [...closure.agentPatches, ...activeAgentPatches],
           events: [
             ...closure.events,
+            ...invocations.flatMap((invocation) =>
+              invocation.pendingExpertMessages.length === 0
+                ? []
+                : [
+                    {
+                      invocationId: invocation.invocationId,
+                      type: "expert.message.consumed",
+                      data: {
+                        messageIds: invocation.pendingExpertMessages.map(
+                          (message) => message.messageId,
+                        ),
+                        terminalReason: "cancelled",
+                      },
+                    },
+                  ],
+            ),
             {
               invocationId: record.rootInvocationId,
               type: "execution.cancelled",
@@ -460,7 +591,15 @@ export class ExecutionController {
     contextId: string,
     request: { readonly requestId: string; readonly content: string; readonly targetRunId: string },
   ): Promise<void> {
-    if (this.orchestrators.get(contextId)?.wakeWait(contextId, request) === true) return;
+    if (
+      this.orchestrators.get(contextId)?.wakeWait(contextId, {
+        kind: "steer",
+        requestId: request.requestId,
+        content: request.content,
+      }) === true
+    ) {
+      return;
+    }
     const submission = await this.waitForRuntimeSubmission(contextId);
     await submission.session.steer(request);
   }
@@ -471,7 +610,13 @@ export class ExecutionController {
     readonly requestId: string;
     readonly content: string;
   }): Promise<"steered" | "waiting_continuation" | "not_active" | "unsupported"> {
-    if (this.orchestrators.get(request.contextId)?.wakeWait(request.contextId, request) === true) {
+    if (
+      this.orchestrators.get(request.contextId)?.wakeWait(request.contextId, {
+        kind: "steer",
+        requestId: request.requestId,
+        content: request.content,
+      }) === true
+    ) {
       return "waiting_continuation";
     }
     const submission = this.activeRuntimeSubmissions.get(request.invocationId);
@@ -743,7 +888,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
   }
   options.controller.addUsage(invocation.usage);
   await options.store.commit({
-    commitId: `invocation-started:${options.invocationId}`,
+    commitId: `invocation-started:${options.invocationId}:${randomUUID()}`,
     executionId: options.executionId,
     invocationPatches: [{ invocationId: options.invocationId, patch: { status: "running" } }],
     events: [
@@ -884,11 +1029,25 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
   });
   throwIfAborted(invocationSignal, options.invocationId);
 
-  let query = formattedPrompt;
-  let continuation = 0;
+  const recoveredMessages =
+    invocation.waitReason === "human_input"
+      ? []
+      : await orchestrator?.takePendingMessages(options.invocationId);
+  let query =
+    recoveredMessages !== undefined && recoveredMessages.length > 0
+      ? formatExpertMessageContinuation(recoveredMessages)
+      : formattedPrompt;
+  let continuation = recoveredMessages !== undefined && recoveredMessages.length > 0 ? 1 : 0;
+  if (continuation > 0) {
+    await appendUserMessage(
+      options,
+      query,
+      `invocation-message-continuation:${options.invocationId}:${continuation}`,
+    );
+  }
   let invocationUsage = invocation.usage;
   try {
-    while (true) {
+    invocationLoop: while (true) {
       const turn = await submitRuntimeTurn({
         options,
         invocation,
@@ -910,6 +1069,19 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
       invocationUsage = mergeUsage(invocationUsage, turn.usage);
       await persistSessionInfo(session, persistRuntimeSnapshot);
 
+      const pendingMessages = await orchestrator?.takePendingMessages(options.invocationId);
+      if (pendingMessages !== undefined && pendingMessages.length > 0) {
+        await appendInvocationFinalMessage(options, turn.runId, turn.finalMessage, undefined);
+        query = formatExpertMessageContinuation(pendingMessages);
+        continuation += 1;
+        await appendUserMessage(
+          options,
+          query,
+          `invocation-message-continuation:${options.invocationId}:${continuation}`,
+        );
+        continue;
+      }
+
       if (
         orchestrator !== undefined &&
         (await orchestrator.hasOwnedUnjoined(options.invocationId))
@@ -923,6 +1095,7 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
               invocationId: options.invocationId,
               patch: {
                 status: "waiting",
+                waitReason: "experts",
                 ...(invocationUsage === undefined ? {} : { usage: invocationUsage }),
               },
             },
@@ -941,33 +1114,46 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
           completed: waitResult.completed,
           discovery: await orchestrator.list(interactionAccess),
         };
+        const waitMessages =
+          waitResult.wakeReason === "message"
+            ? await orchestrator.takePendingMessages(options.invocationId)
+            : [];
         query =
-          waitResult.wakeReason === "steer" && waitResult.steer !== undefined
-            ? [
-                "[Pragma orchestration steer]",
-                "The user sent new guidance while you were waiting for attached Expert tasks.",
-                "The pending Expert tasks continue running. Handle the guidance now, then call wait_experts again when appropriate.",
-                `User guidance: ${waitResult.steer.content}`,
-                JSON.stringify(result, null, 2),
-              ].join("\n")
-            : [
-                "[Pragma orchestration continuation]",
-                "All attached Expert tasks are terminal. Synthesize their results into the final answer.",
-                "Do not spawn replacement tasks for work that is already complete.",
-                JSON.stringify(result, null, 2),
-              ].join("\n");
+          waitMessages.length > 0
+            ? formatExpertMessageContinuation(waitMessages, result)
+            : waitResult.wakeReason === "steer" && waitResult.steer !== undefined
+              ? [
+                  "[Pragma orchestration steer]",
+                  "The user sent new guidance while you were waiting for attached Expert tasks.",
+                  "The pending Expert tasks continue running. Handle the guidance now, then call wait_experts again when appropriate.",
+                  `User guidance: ${waitResult.steer.content}`,
+                  JSON.stringify(result, null, 2),
+                ].join("\n")
+              : [
+                  "[Pragma orchestration continuation]",
+                  "All attached Expert tasks are terminal. Synthesize their results into the final answer.",
+                  "Do not spawn replacement tasks for work that is already complete.",
+                  JSON.stringify(result, null, 2),
+                ].join("\n");
         continuation += 1;
         await options.store.commit({
           commitId: randomUUID(),
           executionId: options.executionId,
-          invocationPatches: [{ invocationId: options.invocationId, patch: { status: "running" } }],
+          invocationPatches: [
+            {
+              invocationId: options.invocationId,
+              patch: { status: "running", waitReason: undefined },
+            },
+          ],
           events: [
             {
               invocationId: options.invocationId,
               type:
-                waitResult.wakeReason === "steer"
-                  ? "expert.children.wait-steered"
-                  : "expert.children.completed",
+                waitMessages.length > 0
+                  ? "expert.children.message-received"
+                  : waitResult.wakeReason === "steer"
+                    ? "expert.children.wait-steered"
+                    : "expert.children.completed",
               data: result,
             },
           ],
@@ -986,31 +1172,68 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
         turn.output,
       );
       await appendInvocationFinalMessage(options, turn.runId, turn.finalMessage, invocationOutput);
-      await options.store.commit({
-        commitId: `invocation-succeeded:${options.invocationId}`,
-        executionId: options.executionId,
-        invocationPatches: [
-          {
-            invocationId: options.invocationId,
-            patch: {
-              status: "succeeded",
-              output: invocationOutput,
-              ...(invocationUsage === undefined ? {} : { usage: invocationUsage }),
-            },
-          },
-        ],
-        events: [
-          {
-            invocationId: options.invocationId,
-            type: "invocation.succeeded",
-            data: {
-              output: invocationOutput,
-              ...(invocationUsage === undefined ? {} : { usage: invocationUsage }),
-            },
-          },
-        ],
-      });
-      return invocationOutput;
+      while (true) {
+        const currentExecution = await requireExecution(options.store, options.executionId);
+        const currentInvocation = await options.store.getInvocation(
+          options.executionId,
+          options.invocationId,
+        );
+        if (currentInvocation === undefined) {
+          throw new Error(`Invocation not found: ${options.invocationId}`);
+        }
+        if (currentInvocation.pendingExpertMessages.length > 0) {
+          const messages = await orchestrator?.takePendingMessages(options.invocationId);
+          if (messages !== undefined && messages.length > 0) {
+            query = formatExpertMessageContinuation(messages);
+            continuation += 1;
+            await appendUserMessage(
+              options,
+              query,
+              `invocation-message-continuation:${options.invocationId}:${continuation}`,
+            );
+            continue invocationLoop;
+          }
+        }
+        try {
+          await options.store.commit({
+            commitId: `invocation-succeeded:${options.invocationId}`,
+            executionId: options.executionId,
+            expectedVersion: currentExecution.version,
+            invocationPatches: [
+              {
+                invocationId: options.invocationId,
+                patch: {
+                  status: "succeeded",
+                  waitReason: undefined,
+                  output: invocationOutput,
+                  ...(invocationUsage === undefined ? {} : { usage: invocationUsage }),
+                },
+              },
+            ],
+            ...(options.agentId === undefined
+              ? {}
+              : {
+                  agentPatches: [
+                    { agentId: options.agentId, patch: { activeInvocationId: undefined } },
+                  ],
+                }),
+            events: [
+              {
+                invocationId: options.invocationId,
+                type: "invocation.succeeded",
+                data: {
+                  output: invocationOutput,
+                  ...(invocationUsage === undefined ? {} : { usage: invocationUsage }),
+                },
+              },
+            ],
+          });
+          return invocationOutput;
+        } catch (error) {
+          if (error instanceof ExecutionVersionConflictError) continue;
+          throw error;
+        }
+      }
     }
   } catch (error) {
     let failure = error;
@@ -1025,27 +1248,48 @@ export async function runExpertInvocation(options: RunExpertInvocationOptions): 
         `Invocation ${options.invocationId} failed and its descendants could not be interrupted.`,
       );
     }
-    const latest = await options.store.getInvocation(options.executionId, options.invocationId);
-    const status = options.controller.isCancelled()
-      ? "cancelled"
-      : latest?.status === "interrupted"
-        ? "interrupted"
-        : "failed";
-    if (latest !== undefined && !isTerminalExecutionStatus(latest.status)) {
-      await options.store.commit({
-        commitId: `invocation-${status}:${options.invocationId}`,
-        executionId: options.executionId,
-        invocationPatches: [
-          { invocationId: options.invocationId, patch: { status, error: serializeError(failure) } },
-        ],
-        events: [
-          {
-            invocationId: options.invocationId,
-            type: `invocation.${status}`,
-            data: { message: failure instanceof Error ? failure.message : String(failure) },
-          },
-        ],
-      });
+    while (true) {
+      await orchestrator?.takePendingMessages(options.invocationId);
+      const currentExecution = await requireExecution(options.store, options.executionId);
+      const latest = await options.store.getInvocation(options.executionId, options.invocationId);
+      const status = options.controller.isCancelled()
+        ? "cancelled"
+        : latest?.status === "interrupted"
+          ? "interrupted"
+          : "failed";
+      if (latest === undefined || isTerminalExecutionStatus(latest.status)) break;
+      if (latest.pendingExpertMessages.length > 0) continue;
+      try {
+        await options.store.commit({
+          commitId: `invocation-${status}:${options.invocationId}`,
+          executionId: options.executionId,
+          expectedVersion: currentExecution.version,
+          invocationPatches: [
+            {
+              invocationId: options.invocationId,
+              patch: { status, waitReason: undefined, error: serializeError(failure) },
+            },
+          ],
+          ...(options.agentId === undefined
+            ? {}
+            : {
+                agentPatches: [
+                  { agentId: options.agentId, patch: { activeInvocationId: undefined } },
+                ],
+              }),
+          events: [
+            {
+              invocationId: options.invocationId,
+              type: `invocation.${status}`,
+              data: { message: failure instanceof Error ? failure.message : String(failure) },
+            },
+          ],
+        });
+        break;
+      } catch (commitError) {
+        if (commitError instanceof ExecutionVersionConflictError) continue;
+        throw commitError;
+      }
     }
     throw failure;
   } finally {
@@ -1061,6 +1305,33 @@ function executionRootSource(definition: { readonly kind: string; readonly id: s
         ? "pragma.flow"
         : "pragma.expert";
   return { type, id: definition.id };
+}
+
+function formatExpertMessageContinuation(
+  messages: Invocation["pendingExpertMessages"],
+  waitState?: unknown,
+): string {
+  return [
+    "[Pragma expert message continuation]",
+    "The following messages were accepted for this Invocation while it was active.",
+    "Incorporate them into the current task before producing the final result.",
+    JSON.stringify(
+      messages.map((message) => ({
+        messageId: message.messageId,
+        senderInvocationId: message.senderInvocationId,
+        ...(message.senderAgentId === undefined ? {} : { senderAgentId: message.senderAgentId }),
+        message: message.content,
+      })),
+      null,
+      2,
+    ),
+    ...(waitState === undefined
+      ? []
+      : [
+          "Attached Expert tasks may still be running. Handle the messages, then wait again when needed.",
+          JSON.stringify(waitState, null, 2),
+        ]),
+  ].join("\n");
 }
 
 async function executeAgentJob(
@@ -1120,13 +1391,29 @@ function createExecutionContext(
   if (delegation === undefined || orchestrator === undefined) return base;
   return {
     ...base,
-    spawnExpert: async (request: { readonly expertId: string; readonly prompt: string }) => {
+    delegateExpert: async (
+      request:
+        | { readonly expertId: string; readonly task: string }
+        | { readonly agentId: string; readonly task: string },
+    ) => {
+      if ("agentId" in request) {
+        return await orchestrator.delegateExisting(
+          {
+            ownerContextId: options.context.contextId,
+            callerInvocationId: options.invocationId,
+            ...(options.agentId === undefined ? {} : { callerAgentId: options.agentId }),
+            interactExpertIds: delegation.interactExpertIds,
+            isCoordinator: delegation.isCoordinator,
+          },
+          request,
+        );
+      }
       const expert = delegation.experts.find(
         (candidate) =>
           delegation.spawnExpertIds.has(candidate.id) && candidate.id === request.expertId,
       );
       if (expert === undefined) {
-        throw new Error(`Expert ${nativeExpert.id} may not spawn ${request.expertId}.`);
+        throw new Error(`Expert ${nativeExpert.id} may not delegate to ${request.expertId}.`);
       }
       const childRuntime = await bindDelegatedRuntime(options, delegation, expert, parentRuntimeId);
       return await orchestrator.spawn({
@@ -1135,7 +1422,7 @@ function createExecutionContext(
         parentAgentId: options.agentId,
         depth,
         expert,
-        prompt: request.prompt,
+        prompt: request.task,
         runtime: childRuntime,
         modelSelection: expert.models?.default,
         owner: options.owner,
@@ -1187,8 +1474,12 @@ function createExecutionContext(
         },
         request,
       ),
-    followupExpert: async (request: { readonly agentId: string; readonly prompt: string }) =>
-      await orchestrator.followup(
+    messageExpert: async (request: {
+      readonly agentId: string;
+      readonly invocationId: string;
+      readonly message: string;
+    }) =>
+      await orchestrator.message(
         {
           ownerContextId: options.context.contextId,
           callerInvocationId: options.invocationId,
@@ -1200,9 +1491,8 @@ function createExecutionContext(
       ),
     steerExpert: async (request: {
       readonly agentId: string;
-      readonly invocationId?: string | undefined;
+      readonly invocationId: string;
       readonly message: string;
-      readonly fallback?: "reject" | "followup" | undefined;
     }) =>
       await orchestrator.steer(
         {
@@ -1261,6 +1551,7 @@ async function invokeResourceFromExpert(
       definition: { id: target.id, kind: "flow" },
       contextId: invocationId,
       status: "queued",
+      pendingExpertMessages: [],
       input: request.input,
       createdAt: now,
       updatedAt: now,
@@ -1382,6 +1673,7 @@ async function invokeResourceFromExpert(
       disposition: contextResolution.disposition,
     },
     status: "queued",
+    pendingExpertMessages: [],
     input: request.input,
     createdAt: now,
     updatedAt: now,

--- a/packages/core/src/execution/expert-session-store.ts
+++ b/packages/core/src/execution/expert-session-store.ts
@@ -97,7 +97,7 @@ export function createFileExpertSessionStore(options: {
         const parsedRecord = ExpertSessionRecordSchema.parse(record);
         const rootContext = parsedRecord.contexts[parsedRecord.rootContextId]!;
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v8",
+          schemaVersion: "pragma.expert-session-transaction/v9",
           session: parsedRecord,
           prompts: [],
           events: [
@@ -192,7 +192,7 @@ export function createFileExpertSessionStore(options: {
             ),
           );
           const journal = ExpertSessionTransactionJournalSchema.parse({
-            schemaVersion: "pragma.expert-session-transaction/v8",
+            schemaVersion: "pragma.expert-session-transaction/v9",
             session: nextSession,
             prompts: nextPrompts,
             events: materializeSessionEvents(sessionId, events, [
@@ -238,7 +238,7 @@ export function createFileExpertSessionStore(options: {
         });
         const nextPrompts = PromptRequestSchema.array().parse([...prompts, prompt]);
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v8",
+          schemaVersion: "pragma.expert-session-transaction/v9",
           session: nextSession,
           prompts: nextPrompts,
           events: materializeSessionEvents(sessionId, events, [
@@ -290,7 +290,7 @@ export function createFileExpertSessionStore(options: {
         );
         const next = await action({ session: session.data, prompts });
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v8",
+          schemaVersion: "pragma.expert-session-transaction/v9",
           session: next.session,
           prompts: next.prompts,
           events: materializeSessionEvents(
@@ -333,7 +333,7 @@ export function createFileExpertSessionStore(options: {
           (await readJson(paths.expertSessionEvents(sessionId))) ?? [],
         );
         const journal = ExpertSessionTransactionJournalSchema.parse({
-          schemaVersion: "pragma.expert-session-transaction/v8",
+          schemaVersion: "pragma.expert-session-transaction/v9",
           session,
           prompts,
           events: materializeSessionEvents(sessionId, events, [

--- a/packages/core/src/execution/expert-session.ts
+++ b/packages/core/src/execution/expert-session.ts
@@ -53,7 +53,11 @@ import type {
   HostContextBindingsResolver,
 } from "../context-system/host-context-bindings.ts";
 import { RuntimeSessionPool } from "./runtime-session-pool.ts";
-import type { ExecutionStore } from "./execution-store.ts";
+import {
+  ExecutionFinalStatusConflictError,
+  ExecutionVersionConflictError,
+  type ExecutionStore,
+} from "./execution-store.ts";
 import {
   closeExecutionContexts,
   type ContextResolutionScopeSnapshot,
@@ -231,6 +235,70 @@ function validateDefinitionMigration(
   };
 }
 
+async function interruptRecoveringExecution(
+  store: ExecutionStore,
+  executionId: string,
+): Promise<void> {
+  while (true) {
+    const execution = await store.get(executionId);
+    if (execution === undefined || isFinal(execution.status)) return;
+    const invocations = (await store.listInvocations(executionId)).filter(
+      (invocation) => !isFinal(invocation.status),
+    );
+    const interruptedInvocationIds = new Set(
+      invocations.map((invocation) => invocation.invocationId),
+    );
+    const agentPatches = (await store.listAgents(executionId))
+      .filter(
+        (agent) =>
+          agent.activeInvocationId !== undefined &&
+          interruptedInvocationIds.has(agent.activeInvocationId),
+      )
+      .map((agent) => ({
+        agentId: agent.agentId,
+        patch: { activeInvocationId: undefined },
+      }));
+    try {
+      await store.commit({
+        commitId: `session-recovery-interrupted:${executionId}`,
+        executionId,
+        expectedVersion: execution.version,
+        executionPatch: { status: "interrupted" },
+        invocationPatches: invocations.map((invocation) => ({
+          invocationId: invocation.invocationId,
+          patch: {
+            status: "interrupted",
+            waitReason: undefined,
+            pendingExpertMessages: [],
+          },
+        })),
+        agentPatches,
+        events: invocations.flatMap((invocation) =>
+          invocation.pendingExpertMessages.length === 0
+            ? []
+            : [
+                {
+                  invocationId: invocation.invocationId,
+                  type: "expert.message.consumed",
+                  data: {
+                    messageIds: invocation.pendingExpertMessages.map(
+                      (message) => message.messageId,
+                    ),
+                    terminalReason: "interrupted",
+                  },
+                },
+              ],
+        ),
+      });
+      return;
+    } catch (error) {
+      if (error instanceof ExecutionVersionConflictError) continue;
+      if (error instanceof ExecutionFinalStatusConflictError) return;
+      throw error;
+    }
+  }
+}
+
 export class ExpertSessionManager {
   private readonly active = new Map<string, ExpertSessionImpl>();
 
@@ -353,6 +421,7 @@ export class ExpertSessionManager {
               await this.dependencies.executions.putInvocation(execution.executionId, {
                 ...invocation,
                 status: "waiting",
+                waitReason: "human_input",
                 updatedAt: new Date().toISOString(),
               });
             }
@@ -381,20 +450,7 @@ export class ExpertSessionManager {
         } else {
           const activeExecutionId = record.activeExecutionId;
           if (execution !== undefined && !isFinal(execution.status)) {
-            await this.dependencies.executions.update(execution.executionId, {
-              status: "interrupted",
-            });
-            for (const invocation of await this.dependencies.executions.listInvocations(
-              execution.executionId,
-            )) {
-              if (!isFinal(invocation.status)) {
-                await this.dependencies.executions.putInvocation(execution.executionId, {
-                  ...invocation,
-                  status: "interrupted",
-                  updatedAt: new Date().toISOString(),
-                });
-              }
-            }
+            await interruptRecoveringExecution(this.dependencies.executions, execution.executionId);
           }
           await this.dependencies.sessions.transact(request.sessionId, ({ session, prompts }) => ({
             result: undefined,
@@ -607,7 +663,7 @@ class ExpertSessionImpl implements ExpertSession {
       attachments.length === 0 ? content : createExpertPromptInput(content, attachments);
     const definitionKind = isExpertTeam(this.expert) ? "expert-team" : "expert";
     const execution: ExecutionRecord = {
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
       executionId: id,
       version: 0,
       kind: "expert-turn",
@@ -653,6 +709,7 @@ class ExpertSessionImpl implements ExpertSession {
         executorId: isExpertTeam(this.expert) ? this.expert.coordinator.id : this.expert.id,
         contextId: rootContextId,
         status: "queued",
+        pendingExpertMessages: [],
         input: storedInput,
         createdAt: now,
         updatedAt: now,
@@ -729,25 +786,10 @@ class ExpertSessionImpl implements ExpertSession {
       }));
       await this.controller?.cancel(reason);
       for (const prompt of pending) {
-        const execution = await this.dependencies.executions.get(prompt.executionId);
-        if (execution !== undefined && !isFinal(execution.status)) {
-          await this.dependencies.executions.update(prompt.executionId, {
-            status: "cancelled",
-            error: reason,
-          });
-          for (const invocation of await this.dependencies.executions.listInvocations(
-            prompt.executionId,
-          )) {
-            if (!isFinal(invocation.status)) {
-              await this.dependencies.executions.putInvocation(prompt.executionId, {
-                ...invocation,
-                status: "cancelled",
-                error: reason,
-                updatedAt: new Date().toISOString(),
-              });
-            }
-          }
-        }
+        await this.cancelPersistedExecution(
+          prompt.executionId,
+          reason ?? "Execution cancelled because the Session closed.",
+        );
       }
       await this.processing;
       const session = await this.getState();
@@ -1158,20 +1200,7 @@ class ExpertSessionImpl implements ExpertSession {
   private async cancelPersistedExecution(executionId: string, reason: string): Promise<void> {
     const execution = await this.dependencies.executions.get(executionId);
     if (execution === undefined || isFinal(execution.status)) return;
-    await this.dependencies.executions.update(executionId, {
-      status: "cancelled",
-      error: reason,
-    });
-    for (const invocation of await this.dependencies.executions.listInvocations(executionId)) {
-      if (!isFinal(invocation.status)) {
-        await this.dependencies.executions.putInvocation(executionId, {
-          ...invocation,
-          status: "cancelled",
-          error: reason,
-          updatedAt: new Date().toISOString(),
-        });
-      }
-    }
+    await new ExecutionController(executionId, this.dependencies.executions).cancel(reason);
   }
 
   private async getRootContext(state?: ExpertSessionRecord): Promise<RuntimeContextRecord> {

--- a/packages/core/src/flow/flow-execution.ts
+++ b/packages/core/src/flow/flow-execution.ts
@@ -113,7 +113,7 @@ export class FlowExecutionManager {
     await validateFlowRuntimeConfiguration(flow, this.runtimes, runtimeId);
     const now = new Date().toISOString();
     const record: ExecutionRecord = {
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
       executionId,
       version: 0,
       kind: "flow",
@@ -140,6 +140,7 @@ export class FlowExecutionManager {
       contextId: executionId,
       definition: record.definition,
       status: "queued",
+      pendingExpertMessages: [],
       input,
       createdAt: now,
       updatedAt: now,
@@ -198,24 +199,14 @@ export class FlowExecutionManager {
       this.executions,
       request.executionId,
     );
-    for (const invocation of await this.executions.listInvocations(request.executionId)) {
-      if (!isFinal(invocation.status) && invocation.status !== "waiting") {
-        await this.executions.putInvocation(request.executionId, {
-          ...invocation,
-          status: "interrupted",
-          updatedAt: new Date().toISOString(),
-        });
-      }
-    }
-    await this.executions.update(request.executionId, { status: "interrupted" });
-    const interrupted = await this.executions.listInvocations(request.executionId);
+    const recoverableInvocations = await this.executions.listInvocations(request.executionId);
     await this.executions.commit({
       commitId: `flow-recovery-prepared:${claimId}`,
       executionId: request.executionId,
       recoveryClaimId: claimId,
       executionPatch: { status: "queued" },
-      invocationPatches: interrupted
-        .filter((invocation) => invocation.status === "interrupted")
+      invocationPatches: recoverableInvocations
+        .filter((invocation) => !isFinal(invocation.status) && invocation.status !== "waiting")
         .map((invocation) => ({
           invocationId: invocation.invocationId,
           patch: { status: "queued" as const },
@@ -978,6 +969,7 @@ async function createStepInvocation(
         }
       : {}),
     status: "queued",
+    pendingExpertMessages: [],
     input,
     createdAt: now,
     updatedAt: now,

--- a/packages/core/src/runtime/driver.ts
+++ b/packages/core/src/runtime/driver.ts
@@ -1976,8 +1976,8 @@ class RuntimeExecutionBindings {
       get invokeResource() {
         return current().executionContext?.invokeResource;
       },
-      get spawnExpert() {
-        return current().executionContext?.spawnExpert;
+      get delegateExpert() {
+        return current().executionContext?.delegateExpert;
       },
       get waitExperts() {
         return current().executionContext?.waitExperts;
@@ -1985,8 +1985,8 @@ class RuntimeExecutionBindings {
       get listAgents() {
         return current().executionContext?.listAgents;
       },
-      get followupExpert() {
-        return current().executionContext?.followupExpert;
+      get messageExpert() {
+        return current().executionContext?.messageExpert;
       },
       get steerExpert() {
         return current().executionContext?.steerExpert;

--- a/packages/core/src/storage/migrations/execution-transaction/index.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/index.ts
@@ -3,22 +3,24 @@ import { executionTransactionV6ToV7Step } from "./steps/v6-to-v7.ts";
 import { executionTransactionV7ToV8Step } from "./steps/v7-to-v8.ts";
 import { executionTransactionV8ToV9Step } from "./steps/v8-to-v9.ts";
 import { executionTransactionV9ToV10Step } from "./steps/v9-to-v10.ts";
-import { ExecutionCommitJournalV10Schema, type ExecutionCommitJournalV10 } from "./schemas/v10.ts";
+import { executionTransactionV10ToV11Step } from "./steps/v10-to-v11.ts";
+import { ExecutionCommitJournalV11Schema, type ExecutionCommitJournalV11 } from "./schemas/v11.ts";
 
 export {
-  ExecutionCommitJournalV10Schema as ExecutionCommitJournalSchema,
-  type ExecutionCommitJournalV10 as ExecutionCommitJournal,
-} from "./schemas/v10.ts";
+  ExecutionCommitJournalV11Schema as ExecutionCommitJournalSchema,
+  type ExecutionCommitJournalV11 as ExecutionCommitJournal,
+} from "./schemas/v11.ts";
 
 export const executionCommitJournalMigrationChain =
-  defineStateMigrationChain<ExecutionCommitJournalV10>({
+  defineStateMigrationChain<ExecutionCommitJournalV11>({
     family: "pragma.execution-transaction",
-    currentVersion: 10,
-    currentSchema: ExecutionCommitJournalV10Schema,
+    currentVersion: 11,
+    currentSchema: ExecutionCommitJournalV11Schema,
     steps: [
       executionTransactionV6ToV7Step,
       executionTransactionV7ToV8Step,
       executionTransactionV8ToV9Step,
       executionTransactionV9ToV10Step,
+      executionTransactionV10ToV11Step,
     ],
   });

--- a/packages/core/src/storage/migrations/execution-transaction/schemas/v10.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/schemas/v10.ts
@@ -1,19 +1,19 @@
 import {
   AgentInstanceSchema,
   ExecutionEventSchema,
-  InvocationSchema,
   RuntimeContextRecordSchema,
 } from "@pragma/shared";
 import { z } from "zod";
 
 import { ExecutionRecordV9Schema } from "../../execution/schemas/v9.ts";
+import { InvocationV9Schema } from "../../execution/schemas/invocation-v9.ts";
 
 export const ExecutionCommitJournalV10Schema = z.object({
   schemaVersion: z.literal("pragma.execution-transaction/v10"),
   commitId: z.string().min(1),
   signature: z.string().length(64),
   execution: ExecutionRecordV9Schema,
-  invocations: InvocationSchema.array(),
+  invocations: InvocationV9Schema.array(),
   agents: AgentInstanceSchema.array(),
   contexts: RuntimeContextRecordSchema.array(),
   events: ExecutionEventSchema.array(),

--- a/packages/core/src/storage/migrations/execution-transaction/schemas/v11.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/schemas/v11.ts
@@ -1,0 +1,23 @@
+import {
+  AgentInstanceSchema,
+  ExecutionEventSchema,
+  InvocationSchema,
+  RuntimeContextRecordSchema,
+} from "@pragma/shared";
+import { z } from "zod";
+
+import { ExecutionRecordV10Schema } from "../../execution/schemas/v10.ts";
+
+export const ExecutionCommitJournalV11Schema = z.object({
+  schemaVersion: z.literal("pragma.execution-transaction/v11"),
+  commitId: z.string().min(1),
+  signature: z.string().length(64),
+  execution: ExecutionRecordV10Schema,
+  invocations: InvocationSchema.array(),
+  agents: AgentInstanceSchema.array(),
+  contexts: RuntimeContextRecordSchema.array(),
+  events: ExecutionEventSchema.array(),
+  eventIds: z.array(z.string().min(1)),
+});
+
+export type ExecutionCommitJournalV11 = z.infer<typeof ExecutionCommitJournalV11Schema>;

--- a/packages/core/src/storage/migrations/execution-transaction/steps/v10-to-v11.ts
+++ b/packages/core/src/storage/migrations/execution-transaction/steps/v10-to-v11.ts
@@ -1,0 +1,23 @@
+import { InvocationSchema } from "@pragma/shared";
+
+import type { StateMigrationStep } from "../../../state-migration.ts";
+import { executionV9ToV10Step } from "../../execution/steps/v9-to-v10.ts";
+import { ExecutionCommitJournalV10Schema } from "../schemas/v10.ts";
+import { ExecutionCommitJournalV11Schema } from "../schemas/v11.ts";
+
+export const executionTransactionV10ToV11Step = {
+  fromVersion: 10,
+  toVersion: 11,
+  inputSchema: ExecutionCommitJournalV10Schema,
+  migrate(value) {
+    const current = ExecutionCommitJournalV10Schema.parse(value);
+    return ExecutionCommitJournalV11Schema.parse({
+      ...current,
+      schemaVersion: "pragma.execution-transaction/v11",
+      execution: executionV9ToV10Step.migrate(current.execution),
+      invocations: current.invocations.map((invocation) =>
+        InvocationSchema.parse({ ...invocation, pendingExpertMessages: [] }),
+      ),
+    });
+  },
+} satisfies StateMigrationStep;

--- a/packages/core/src/storage/migrations/execution/index.ts
+++ b/packages/core/src/storage/migrations/execution/index.ts
@@ -5,19 +5,28 @@ import { executionV5ToV6Step } from "./steps/v5-to-v6.ts";
 import { executionV6ToV7Step } from "./steps/v6-to-v7.ts";
 import { executionV7ToV8Step } from "./steps/v7-to-v8.ts";
 import { executionV8ToV9Step } from "./steps/v8-to-v9.ts";
+import { executionV9ToV10Step } from "./steps/v9-to-v10.ts";
 
 export { ExecutionRecordV5Schema } from "./schemas/v5.ts";
 export { ExecutionRecordV6Schema } from "./schemas/v6.ts";
 export { ExecutionRecordV7Schema } from "./schemas/v7.ts";
 export { ExecutionRecordV8Schema } from "./schemas/v8.ts";
 export { ExecutionRecordV9Schema } from "./schemas/v9.ts";
+export { ExecutionRecordV10Schema } from "./schemas/v10.ts";
 export { migrateExecutionInvocationsV5ToV6 } from "./steps/v5-to-v6.ts";
 export { executionV5ToV6Step } from "./steps/v5-to-v6.ts";
 export { migrateInvocationUsageV7ToV8 } from "./steps/v7-to-v8.ts";
+export { migrateExecutionInvocationsV9ToV10 } from "./steps/v9-to-v10.ts";
 
 export const executionRecordMigrationChain = defineStateMigrationChain<ExecutionRecord>({
   family: "pragma.execution",
-  currentVersion: 9,
+  currentVersion: 10,
   currentSchema: ExecutionRecordSchema,
-  steps: [executionV5ToV6Step, executionV6ToV7Step, executionV7ToV8Step, executionV8ToV9Step],
+  steps: [
+    executionV5ToV6Step,
+    executionV6ToV7Step,
+    executionV7ToV8Step,
+    executionV8ToV9Step,
+    executionV9ToV10Step,
+  ],
 });

--- a/packages/core/src/storage/migrations/execution/schemas/invocation-v9.ts
+++ b/packages/core/src/storage/migrations/execution/schemas/invocation-v9.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+import { AgentMessageUsageV9Schema } from "./shared-v9.ts";
+
+const DefinitionReferenceV9Schema = z.object({
+  id: z.string().min(1),
+  kind: z.enum(["flow", "task", "human-task", "expert", "expert-team"]),
+});
+
+const ContextResolutionRecordV9Schema = z.object({
+  resolver: z.object({
+    id: z.string().min(1),
+    version: z.string().min(1),
+  }),
+  disposition: z.enum(["created", "reused"]),
+});
+
+export const InvocationV9Schema = z.object({
+  invocationId: z.string().min(1),
+  rootInvocationId: z.string().min(1),
+  parentInvocationId: z.string().min(1).optional(),
+  nodeId: z.string().min(1).optional(),
+  definition: DefinitionReferenceV9Schema,
+  executorId: z.string().min(1).optional(),
+  agentId: z.string().min(1).optional(),
+  agentTaskSequence: z.number().int().nonnegative().optional(),
+  contextId: z.string().min(1),
+  contextResolution: ContextResolutionRecordV9Schema.optional(),
+  status: z.enum([
+    "queued",
+    "running",
+    "waiting",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "interrupted",
+  ]),
+  input: z.unknown(),
+  output: z.unknown().optional(),
+  usage: AgentMessageUsageV9Schema.optional(),
+  error: z.unknown().optional(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type InvocationV9 = z.infer<typeof InvocationV9Schema>;

--- a/packages/core/src/storage/migrations/execution/schemas/shared-v9.ts
+++ b/packages/core/src/storage/migrations/execution/schemas/shared-v9.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const AgentMessageUsageV9Schema = z.object({
+  measurement: z.enum(["reported", "derived", "estimated", "unknown"]),
+  input: z.number().nonnegative(),
+  output: z.number().nonnegative(),
+  cacheRead: z.number().nonnegative(),
+  cacheWrite: z.number().nonnegative(),
+  cacheWrite1h: z.number().nonnegative().optional(),
+  totalTokens: z.number().nonnegative(),
+  cost: z.object({
+    input: z.number().nonnegative(),
+    output: z.number().nonnegative(),
+    cacheRead: z.number().nonnegative(),
+    cacheWrite: z.number().nonnegative(),
+    total: z.number().nonnegative(),
+  }),
+});
+
+const ContextOutputReferenceV9Schema = z.object({
+  namespace: z.string().min(1),
+  id: z.string().min(1),
+  revision: z.string().min(1),
+  sizeBytes: z.number().int().nonnegative(),
+  mediaType: z.string().min(1),
+});
+
+export const InvocationOutputV9Schema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("inline"), value: z.unknown() }),
+  z.object({
+    type: z.literal("context"),
+    summary: z.string(),
+    contexts: z.array(ContextOutputReferenceV9Schema).min(1),
+  }),
+]);

--- a/packages/core/src/storage/migrations/execution/schemas/v10.ts
+++ b/packages/core/src/storage/migrations/execution/schemas/v10.ts
@@ -1,9 +1,8 @@
+import { AgentMessageUsageSchema, InvocationOutputSchema } from "@pragma/shared";
 import { z } from "zod";
 
-import { AgentMessageUsageV9Schema, InvocationOutputV9Schema } from "./shared-v9.ts";
-
-export const ExecutionRecordV9Schema = z.object({
-  schemaVersion: z.literal("pragma.execution/v9"),
+export const ExecutionRecordV10Schema = z.object({
+  schemaVersion: z.literal("pragma.execution/v10"),
   executionId: z.string().min(1),
   version: z.number().int().nonnegative(),
   kind: z.enum(["expert-turn", "flow"]),
@@ -23,12 +22,12 @@ export const ExecutionRecordV9Schema = z.object({
   ]),
   input: z.unknown(),
   state: z.record(z.string(), z.unknown()).default({}),
-  output: InvocationOutputV9Schema.optional(),
-  usage: AgentMessageUsageV9Schema.optional(),
+  output: InvocationOutputSchema.optional(),
+  usage: AgentMessageUsageSchema.optional(),
   error: z.unknown().optional(),
   lastAppliedSequence: z.number().int().nonnegative(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });
 
-export type ExecutionRecordV9 = z.infer<typeof ExecutionRecordV9Schema>;
+export type ExecutionRecordV10 = z.infer<typeof ExecutionRecordV10Schema>;

--- a/packages/core/src/storage/migrations/execution/steps/v9-to-v10.ts
+++ b/packages/core/src/storage/migrations/execution/steps/v9-to-v10.ts
@@ -1,0 +1,30 @@
+import { InvocationSchema, type Invocation } from "@pragma/shared";
+
+import type { StateMigrationStep } from "../../../state-migration.ts";
+import { InvocationV9Schema } from "../schemas/invocation-v9.ts";
+import { ExecutionRecordV9Schema } from "../schemas/v9.ts";
+import { ExecutionRecordV10Schema } from "../schemas/v10.ts";
+
+export const executionV9ToV10Step = {
+  fromVersion: 9,
+  toVersion: 10,
+  inputSchema: ExecutionRecordV9Schema,
+  migrate(value) {
+    const current = ExecutionRecordV9Schema.parse(value);
+    return ExecutionRecordV10Schema.parse({
+      ...current,
+      schemaVersion: "pragma.execution/v10",
+    });
+  },
+} satisfies StateMigrationStep;
+
+export function migrateExecutionInvocationsV9ToV10(value: unknown): Invocation[] {
+  return InvocationV9Schema.array()
+    .parse(value)
+    .map((invocation) =>
+      InvocationSchema.parse({
+        ...invocation,
+        pendingExpertMessages: [],
+      }),
+    );
+}

--- a/packages/core/src/storage/migrations/expert-session-transaction/index.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/index.ts
@@ -3,25 +3,27 @@ import { expertSessionTransactionV4ToV5Step } from "./steps/v4-to-v5.ts";
 import { expertSessionTransactionV5ToV6Step } from "./steps/v5-to-v6.ts";
 import { expertSessionTransactionV6ToV7Step } from "./steps/v6-to-v7.ts";
 import { expertSessionTransactionV7ToV8Step } from "./steps/v7-to-v8.ts";
+import { expertSessionTransactionV8ToV9Step } from "./steps/v8-to-v9.ts";
 import {
-  ExpertSessionTransactionJournalV8Schema,
-  type ExpertSessionTransactionJournalV8,
-} from "./schemas/v8.ts";
+  ExpertSessionTransactionJournalV9Schema,
+  type ExpertSessionTransactionJournalV9,
+} from "./schemas/v9.ts";
 
 export {
-  ExpertSessionTransactionJournalV8Schema as ExpertSessionTransactionJournalSchema,
-  type ExpertSessionTransactionJournalV8 as ExpertSessionTransactionJournal,
-} from "./schemas/v8.ts";
+  ExpertSessionTransactionJournalV9Schema as ExpertSessionTransactionJournalSchema,
+  type ExpertSessionTransactionJournalV9 as ExpertSessionTransactionJournal,
+} from "./schemas/v9.ts";
 
 export const expertSessionTransactionMigrationChain =
-  defineStateMigrationChain<ExpertSessionTransactionJournalV8>({
+  defineStateMigrationChain<ExpertSessionTransactionJournalV9>({
     family: "pragma.expert-session-transaction",
-    currentVersion: 8,
-    currentSchema: ExpertSessionTransactionJournalV8Schema,
+    currentVersion: 9,
+    currentSchema: ExpertSessionTransactionJournalV9Schema,
     steps: [
       expertSessionTransactionV4ToV5Step,
       expertSessionTransactionV5ToV6Step,
       expertSessionTransactionV6ToV7Step,
       expertSessionTransactionV7ToV8Step,
+      expertSessionTransactionV8ToV9Step,
     ],
   });

--- a/packages/core/src/storage/migrations/expert-session-transaction/schemas/v8.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/schemas/v8.ts
@@ -1,7 +1,8 @@
-import { ExpertSessionEventSchema, InvocationSchema, PromptRequestSchema } from "@pragma/shared";
+import { ExpertSessionEventSchema, PromptRequestSchema } from "@pragma/shared";
 import { z } from "zod";
 
 import { ExecutionRecordV9Schema } from "../../execution/schemas/v9.ts";
+import { InvocationV9Schema } from "../../execution/schemas/invocation-v9.ts";
 import { ExpertSessionRecordV5Schema } from "../../expert-session/schemas/v5.ts";
 
 export const ExpertSessionTransactionJournalV8Schema = z
@@ -11,7 +12,7 @@ export const ExpertSessionTransactionJournalV8Schema = z
     prompts: PromptRequestSchema.array(),
     events: ExpertSessionEventSchema.array(),
     execution: ExecutionRecordV9Schema.optional(),
-    rootInvocation: InvocationSchema.optional(),
+    rootInvocation: InvocationV9Schema.optional(),
   })
   .refine(
     (journal) => (journal.execution === undefined) === (journal.rootInvocation === undefined),

--- a/packages/core/src/storage/migrations/expert-session-transaction/schemas/v9.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/schemas/v9.ts
@@ -1,0 +1,23 @@
+import { ExpertSessionEventSchema, InvocationSchema, PromptRequestSchema } from "@pragma/shared";
+import { z } from "zod";
+
+import { ExecutionRecordV10Schema } from "../../execution/schemas/v10.ts";
+import { ExpertSessionRecordV5Schema } from "../../expert-session/schemas/v5.ts";
+
+export const ExpertSessionTransactionJournalV9Schema = z
+  .object({
+    schemaVersion: z.literal("pragma.expert-session-transaction/v9"),
+    session: ExpertSessionRecordV5Schema,
+    prompts: PromptRequestSchema.array(),
+    events: ExpertSessionEventSchema.array(),
+    execution: ExecutionRecordV10Schema.optional(),
+    rootInvocation: InvocationSchema.optional(),
+  })
+  .refine(
+    (journal) => (journal.execution === undefined) === (journal.rootInvocation === undefined),
+    "ExpertSession transaction execution and rootInvocation must be provided together.",
+  );
+
+export type ExpertSessionTransactionJournalV9 = z.infer<
+  typeof ExpertSessionTransactionJournalV9Schema
+>;

--- a/packages/core/src/storage/migrations/expert-session-transaction/steps/v8-to-v9.ts
+++ b/packages/core/src/storage/migrations/expert-session-transaction/steps/v8-to-v9.ts
@@ -1,0 +1,28 @@
+import { InvocationSchema } from "@pragma/shared";
+
+import type { StateMigrationStep } from "../../../state-migration.ts";
+import { executionV9ToV10Step } from "../../execution/steps/v9-to-v10.ts";
+import { ExpertSessionTransactionJournalV8Schema } from "../schemas/v8.ts";
+import { ExpertSessionTransactionJournalV9Schema } from "../schemas/v9.ts";
+
+export const expertSessionTransactionV8ToV9Step = {
+  fromVersion: 8,
+  toVersion: 9,
+  inputSchema: ExpertSessionTransactionJournalV8Schema,
+  migrate(value) {
+    const current = ExpertSessionTransactionJournalV8Schema.parse(value);
+    return ExpertSessionTransactionJournalV9Schema.parse({
+      ...current,
+      schemaVersion: "pragma.expert-session-transaction/v9",
+      ...(current.execution === undefined || current.rootInvocation === undefined
+        ? {}
+        : {
+            execution: executionV9ToV10Step.migrate(current.execution),
+            rootInvocation: InvocationSchema.parse({
+              ...current.rootInvocation,
+              pendingExpertMessages: [],
+            }),
+          }),
+    });
+  },
+} satisfies StateMigrationStep;

--- a/packages/core/src/tools/managed-tool.ts
+++ b/packages/core/src/tools/managed-tool.ts
@@ -18,8 +18,12 @@ export interface ExpertToolExecutionContext {
         readonly signal?: AbortSignal | undefined;
       }) => Promise<unknown>)
     | undefined;
-  readonly spawnExpert?:
-    | ((request: { readonly expertId: string; readonly prompt: string }) => Promise<unknown>)
+  readonly delegateExpert?:
+    | ((
+        request:
+          | { readonly expertId: string; readonly task: string }
+          | { readonly agentId: string; readonly task: string },
+      ) => Promise<unknown>)
     | undefined;
   readonly waitExperts?:
     | ((request: {
@@ -36,15 +40,18 @@ export interface ExpertToolExecutionContext {
         readonly limit?: number;
       }) => Promise<unknown>)
     | undefined;
-  readonly followupExpert?:
-    | ((request: { readonly agentId: string; readonly prompt: string }) => Promise<unknown>)
+  readonly messageExpert?:
+    | ((request: {
+        readonly agentId: string;
+        readonly invocationId: string;
+        readonly message: string;
+      }) => Promise<unknown>)
     | undefined;
   readonly steerExpert?:
     | ((request: {
         readonly agentId: string;
-        readonly invocationId?: string | undefined;
+        readonly invocationId: string;
         readonly message: string;
-        readonly fallback?: "reject" | "followup" | undefined;
       }) => Promise<unknown>)
     | undefined;
   readonly interruptExpert?:

--- a/packages/core/test/canonical-event-feed.test.ts
+++ b/packages/core/test/canonical-event-feed.test.ts
@@ -289,7 +289,7 @@ async function createExecution(store: ReturnType<typeof createFileExecutionStore
   const timestamp = new Date().toISOString();
   const definition = { id: "flow", kind: "flow" as const };
   const execution: ExecutionRecord = {
-    schemaVersion: "pragma.execution/v9",
+    schemaVersion: "pragma.execution/v10",
     executionId: "execution",
     version: 0,
     kind: "flow",
@@ -308,6 +308,7 @@ async function createExecution(store: ReturnType<typeof createFileExecutionStore
     contextId: "root-context",
     definition,
     status: "running",
+    pendingExpertMessages: [],
     input: null,
     createdAt: timestamp,
     updatedAt: timestamp,

--- a/packages/core/test/context-resolution.test.ts
+++ b/packages/core/test/context-resolution.test.ts
@@ -215,7 +215,7 @@ async function createFixture(options: { readonly closeFirst?: boolean } = {}) {
   const expert = { id: "expert" };
   await store.create(
     {
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
       executionId: "execution",
       version: 0,
       kind: "flow",
@@ -263,6 +263,7 @@ function invocation(
     },
     contextId,
     status: invocationId === "root" ? "running" : "succeeded",
+    pendingExpertMessages: [],
     input: null,
     createdAt,
     updatedAt: createdAt,

--- a/packages/core/test/execution-event-log.test.ts
+++ b/packages/core/test/execution-event-log.test.ts
@@ -74,6 +74,7 @@ describe("Execution canonical event log", () => {
       definition: { id: "child", kind: "expert" },
       executorId: "child",
       status: "running",
+      pendingExpertMessages: [],
       input: null,
       createdAt: now,
       updatedAt: now,
@@ -685,7 +686,7 @@ async function fixture() {
   const timestamp = new Date().toISOString();
   const definition = { id: "flow", kind: "flow" as const };
   const execution: ExecutionRecord = {
-    schemaVersion: "pragma.execution/v9",
+    schemaVersion: "pragma.execution/v10",
     executionId: "execution",
     version: 0,
     kind: "flow",
@@ -704,6 +705,7 @@ async function fixture() {
     contextId: "root-context",
     definition,
     status: "running",
+    pendingExpertMessages: [],
     input: null,
     createdAt: timestamp,
     updatedAt: timestamp,

--- a/packages/core/test/execution-state-migration.test.ts
+++ b/packages/core/test/execution-state-migration.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -58,7 +59,7 @@ describe("Execution state migration", () => {
       },
     ]);
     await expect(readJson(paths.executionState("team-run"))).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
       output: { type: "inline", value: { summary: "cancelled team" } },
     });
     await expect(readJson(paths.executionInvocations("team-run"))).resolves.toMatchObject([
@@ -77,7 +78,7 @@ describe("Execution state migration", () => {
     const store = createFileExecutionStore({ pragmaHome: home });
     await store.create(
       {
-        schemaVersion: "pragma.execution/v9",
+        schemaVersion: "pragma.execution/v10",
         executionId: "current",
         version: 0,
         kind: "expert-turn",
@@ -97,6 +98,7 @@ describe("Execution state migration", () => {
         executorId: "expert",
         contextId: "context",
         status: "running",
+        pendingExpertMessages: [],
         input: "hello",
         createdAt: occurredAt,
         updatedAt: occurredAt,
@@ -105,10 +107,33 @@ describe("Execution state migration", () => {
     const before = await readFile(paths.executionState("current"), "utf8");
 
     await expect(store.get("current")).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
     });
 
     expect(await readFile(paths.executionState("current"), "utf8")).toBe(before);
+  });
+
+  it("migrates a v9 Invocation to an empty recoverable message Inbox", async () => {
+    const home = await temporaryRoot("pragma-execution-v9-");
+    const paths = new PragmaPaths({ pragmaHome: home });
+    const fixture = (await readJson(
+      fileURLToPath(new URL("./fixtures/execution-v9.json", import.meta.url)),
+    )) as Record<string, unknown>;
+    await writeJson(paths.executionState("v9-run"), fixture["execution"]);
+    await writeJson(paths.executionInvocations("v9-run"), fixture["invocations"]);
+    await writeJson(paths.executionAgents("v9-run"), fixture["agents"]);
+    await writeJson(paths.executionContexts("v9-run"), fixture["contexts"]);
+    await writeJson(paths.executionCommits("v9-run"), fixture["commits"]);
+    await mkdir(dirname(paths.executionEvents("v9-run")), { recursive: true });
+    await writeFile(paths.executionEvents("v9-run"), "", "utf8");
+
+    const store = createFileExecutionStore({ pragmaHome: home });
+    await expect(store.get("v9-run")).resolves.toMatchObject({
+      schemaVersion: "pragma.execution/v10",
+    });
+    await expect(store.listInvocations("v9-run")).resolves.toMatchObject([
+      { invocationId: "root", pendingExpertMessages: [] },
+    ]);
   });
 
   it("migrates v6 definitions without wrapping Invocation handoffs a second time", async () => {
@@ -133,7 +158,7 @@ describe("Execution state migration", () => {
     const store = createFileExecutionStore({ pragmaHome: home });
 
     await expect(store.get("v6-run")).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
       definition: { id: "team", kind: "expert-team" },
       output: { type: "inline", value: { summary: "v6 result" } },
     });
@@ -210,7 +235,7 @@ describe("Execution state migration", () => {
     await expect(
       createFileExecutionStore({ pragmaHome: home }).get("v7-usage"),
     ).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
       usage: {
         measurement: "unknown",
         input: 100,
@@ -237,7 +262,7 @@ describe("Execution state migration", () => {
     const home = await temporaryRoot("pragma-execution-future-");
     const paths = new PragmaPaths({ pragmaHome: home });
     const file = paths.executionState("future");
-    const future = { schemaVersion: "pragma.execution/v10", executionId: "future" };
+    const future = { schemaVersion: "pragma.execution/v11", executionId: "future" };
     await writeJson(file, future);
     const before = await readFile(file, "utf8");
 
@@ -291,7 +316,7 @@ describe("Execution state migration", () => {
 
     const store = createFileExecutionStore({ pragmaHome: home });
     await expect(store.get("journal-run")).resolves.toMatchObject({
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
       version: 1,
       status: "succeeded",
       output: { type: "inline", value: "journal result" },
@@ -300,6 +325,33 @@ describe("Execution state migration", () => {
       {
         output: { type: "inline", value: "journal invocation result" },
         usage: { measurement: "unknown", totalTokens: 10 },
+      },
+    ]);
+    await expect(readFile(transactionFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("upgrades and replays a real v10 pending transaction journal", async () => {
+    const home = await temporaryRoot("pragma-execution-transaction-v10-");
+    const paths = new PragmaPaths({ pragmaHome: home });
+    await writeLegacyExecution(paths, "journal-v10-run", { status: "running" });
+    const transactionFile = paths.executionTransaction("journal-v10-run");
+    const fixture = await readJson(
+      fileURLToPath(new URL("./fixtures/execution-transaction-v10.json", import.meta.url)),
+    );
+    await writeJson(transactionFile, fixture);
+
+    const store = createFileExecutionStore({ pragmaHome: home });
+    await expect(store.get("journal-v10-run")).resolves.toMatchObject({
+      schemaVersion: "pragma.execution/v10",
+      version: 1,
+      status: "succeeded",
+      output: { type: "inline", value: "journal-v10-result" },
+    });
+    await expect(store.listInvocations("journal-v10-run")).resolves.toMatchObject([
+      {
+        invocationId: "root",
+        status: "succeeded",
+        pendingExpertMessages: [],
       },
     ]);
     await expect(readFile(transactionFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });

--- a/packages/core/test/execution-system.test.ts
+++ b/packages/core/test/execution-system.test.ts
@@ -134,7 +134,7 @@ function createFakeRuntime(options: FakeRuntimeOptions = {}) {
         if (options.usage !== undefined) turn.stream.writeNative(options.usage);
         throw new Error("fake turn failed");
       }
-      const spawn = session.context.agent.tools?.find((tool) => tool.name === "spawn_expert");
+      const spawn = session.context.agent.tools?.find((tool) => tool.name === "delegate_expert");
       const wait = session.context.agent.tools?.find((tool) => tool.name === "wait_experts");
       const delegationTarget =
         options.delegationTargets?.[session.context.agent.id] ??
@@ -164,7 +164,7 @@ function createFakeRuntime(options: FakeRuntimeOptions = {}) {
         const spawned = await spawn.call(
           {
             expertId: delegationTarget,
-            prompt: "subtask",
+            task: "subtask",
           },
           turn.signal,
           { execution: session.context.request.executionContext },
@@ -284,8 +284,8 @@ function createOrchestrationRuntime(
           if (result.isError === true) throw new Error(result.text);
           return result.details as Record<string, unknown>;
         };
-        const spawn = async (expertId: string, prompt: string) =>
-          await call("spawn_expert", { expertId, prompt });
+        const spawn = async (expertId: string, task: string) =>
+          await call("delegate_expert", { expertId, task });
         const wait = async (ids: readonly string[]) =>
           await call("wait_experts", { invocationIds: ids });
 
@@ -323,9 +323,9 @@ function createOrchestrationRuntime(
           const first = await spawn("member", "first");
           const second = await spawn("member", "second");
           await wait([first["invocationId"] as string, second["invocationId"] as string]);
-          const followup = await call("followup_expert", {
+          const followup = await call("delegate_expert", {
             agentId: first["agentId"],
-            prompt: "followup-first",
+            task: "followup-first",
           });
           const result = await wait([followup["invocationId"] as string]);
           return {
@@ -350,7 +350,7 @@ function createOrchestrationRuntime(
         const agentId = first["agentId"] as string;
         if (scenario === "followup") {
           await wait([firstInvocationId]);
-          const second = await call("followup_expert", { agentId, prompt: "second" });
+          const second = await call("delegate_expert", { agentId, task: "second" });
           const result = await wait([second["invocationId"] as string]);
           return {
             outputText: `lead:${JSON.stringify(result["completed"])}`,
@@ -358,7 +358,7 @@ function createOrchestrationRuntime(
           };
         }
 
-        const second = await call("followup_expert", { agentId, prompt: "second" });
+        const second = await call("delegate_expert", { agentId, task: "second" });
         await call("interrupt_expert", {
           agentId,
           invocationId: firstInvocationId,
@@ -2248,7 +2248,7 @@ describe("ExpertSession", () => {
     );
     expect((await session.getState()).executionIds).toContain(executionId);
     expect(await executions.get(executionId)).toMatchObject({
-      schemaVersion: "pragma.execution/v9",
+      schemaVersion: "pragma.execution/v10",
     });
     expect((await session.getPromptQueue())[0]?.requestId).toBe("journal-request");
     expect((await session.listEvents()).items.map((event) => event.type)).toContain(
@@ -3452,7 +3452,7 @@ describe("Execution observation", () => {
     const now = new Date().toISOString();
     await writer.create(
       {
-        schemaVersion: "pragma.execution/v9",
+        schemaVersion: "pragma.execution/v10",
         executionId: "cross-process",
         version: 0,
         kind: "flow",
@@ -3471,6 +3471,7 @@ describe("Execution observation", () => {
         contextId: "root-context",
         definition: { id: "flow", kind: "flow" },
         status: "running",
+        pendingExpertMessages: [],
         input: null,
         createdAt: now,
         updatedAt: now,
@@ -3546,11 +3547,16 @@ describe("Expert lifecycle orchestration", () => {
     return { output, tree, events: events.items, stats };
   }
 
-  it("discovers permitted peer instances and explicitly falls back from unsupported steer", async () => {
+  it("rejects unsupported steer and accepts a safe-boundary message", async () => {
     const home = await mkdtemp(join(tmpdir(), "pragma-peer-collaboration-"));
+    const backendQueries: string[] = [];
     let markBackendStarted!: () => void;
     const backendStarted = new Promise<void>((resolve) => {
       markBackendStarted = resolve;
+    });
+    let releaseBackend!: () => void;
+    const backendReleased = new Promise<void>((resolve) => {
+      releaseBackend = resolve;
     });
     const runtime = defineRuntimeDriver<never, FakeSession>({
       features: createRuntimeTestFeatures({ enabled: ["close"] }),
@@ -3568,16 +3574,17 @@ describe("Expert lifecycle orchestration", () => {
           return result.details as Record<string, unknown>;
         };
         if (expertId === "backend") {
+          backendQueries.push(turn.rawQuery);
           if (turn.rawQuery === "backend-work") {
             markBackendStarted();
-            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+            await backendReleased;
           }
           return { outputText: `backend:${turn.rawQuery}`, runtimeSessionId: session.id };
         }
         if (expertId === "frontend") {
-          const backend = await call("spawn_expert", {
+          const backend = await call("delegate_expert", {
             expertId: "backend",
-            prompt: "backend-work",
+            task: "backend-work",
           });
           await backendStarted;
           const discovery = await call("list_agents", { expertId: "backend" });
@@ -3586,22 +3593,33 @@ describe("Expert lifecycle orchestration", () => {
             activeInvocation: { invocationId: string };
           }>;
           expect(agents).toHaveLength(1);
-          const fallback = await call("steer_expert", {
+          await expect(
+            call("steer_expert", {
+              agentId: agents[0]!.agentId,
+              invocationId: agents[0]!.activeInvocation.invocationId,
+              message: "apply-peer-guidance-immediately",
+            }),
+          ).rejects.toThrow("runtime_unsupported");
+          const message = await call("message_expert", {
             agentId: agents[0]!.agentId,
             invocationId: agents[0]!.activeInvocation.invocationId,
-            message: "apply-peer-guidance",
-            fallback: "followup",
+            message: "first-safe-boundary-guidance",
           });
-          expect(fallback["outcome"]).toBe("followup_queued");
+          expect(message["status"]).toBe("accepted");
+          await call("message_expert", {
+            agentId: agents[0]!.agentId,
+            invocationId: agents[0]!.activeInvocation.invocationId,
+            message: "second-safe-boundary-guidance",
+          });
+          releaseBackend();
           const waited = await call("wait_experts", {
-            invocationIds: [fallback["invocationId"]],
+            invocationIds: [backend["invocationId"]],
           });
-          await call("wait_experts", { invocationIds: [backend["invocationId"]] });
           return { outputText: `frontend:${JSON.stringify(waited)}`, runtimeSessionId: session.id };
         }
-        const frontend = await call("spawn_expert", {
+        const frontend = await call("delegate_expert", {
           expertId: "frontend",
-          prompt: "frontend-work",
+          task: "frontend-work",
         });
         await call("wait_experts", { invocationIds: [frontend["invocationId"]] });
         const discovery = await call("list_agents", {});
@@ -3662,13 +3680,254 @@ describe("Expert lifecycle orchestration", () => {
       expect.arrayContaining([
         "agent.steer.requested",
         "agent.steer.rejected",
-        "agent.steer.fallback_queued",
+        "expert.message.accepted",
+        "expert.message.consumed",
       ]),
+    );
+    const continuationQuery = backendQueries.find((query) =>
+      query.startsWith("[Pragma expert message continuation]"),
+    );
+    if (continuationQuery === undefined) throw new Error("Missing message continuation turn");
+    expect(continuationQuery.indexOf("first-safe-boundary-guidance")).toBeLessThan(
+      continuationQuery.indexOf("second-safe-boundary-guidance"),
+    );
+    expect(events.items.filter((event) => event.type === "expert.message.accepted")).toHaveLength(
+      2,
+    );
+    const consumed = events.items.find((event) => event.type === "expert.message.consumed");
+    expect((consumed?.data as { messageIds?: string[] } | undefined)?.messageIds).toHaveLength(2);
+    const backendResult = await turn.getTree();
+    expect(JSON.stringify(backendResult.children[0]?.children[0]?.invocation.output)).toContain(
+      "second-safe-boundary-guidance",
     );
     await session.close();
   });
 
-  it("lets permitted team peers steer active work and queue FIFO follow-ups", async () => {
+  it("does not lose a message accepted before an Expert wait is registered", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-message-before-wait-"));
+    let markChildDelegated!: () => void;
+    const childDelegated = new Promise<void>((resolve) => {
+      markChildDelegated = resolve;
+    });
+    let markMessageSent!: () => void;
+    const messageSent = new Promise<void>((resolve) => {
+      markMessageSent = resolve;
+    });
+    let releaseChild!: () => void;
+    const childReleased = new Promise<void>((resolve) => {
+      releaseChild = resolve;
+    });
+    const workerQueries: string[] = [];
+    const runtime = defineRuntimeDriver<never, FakeSession>({
+      features: createRuntimeTestFeatures({ enabled: ["close"] }),
+      descriptor: { id: "message-before-wait", kind: "fake", displayName: "Message before wait" },
+      createSession: (context) => ({ context, id: `native-${context.systemSessionId}` }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn(session, turn) {
+        const expertId = session.context.agent.id;
+        const execution = session.context.request.executionContext;
+        const call = async (name: string, input: unknown) => {
+          const tool = session.context.agent.tools?.find((candidate) => candidate.name === name);
+          if (tool === undefined) throw new Error(`Missing collaboration tool: ${name}`);
+          const result = await tool.call(input, turn.signal, { execution });
+          if (result.isError === true) throw new Error(result.text);
+          return result.details as Record<string, unknown>;
+        };
+        if (expertId === "child") {
+          await childReleased;
+          return { outputText: "child:done", runtimeSessionId: session.id };
+        }
+        if (expertId === "worker") {
+          workerQueries.push(turn.rawQuery);
+          if (turn.rawQuery === "worker-work") {
+            const child = await call("delegate_expert", { expertId: "child", task: "child-work" });
+            markChildDelegated();
+            await messageSent;
+            await call("wait_experts", { invocationIds: [child["invocationId"]] });
+          } else if (turn.rawQuery.startsWith("[Pragma expert message continuation]")) {
+            releaseChild();
+          }
+          return { outputText: `worker:${turn.rawQuery}`, runtimeSessionId: session.id };
+        }
+        if (expertId === "messenger") {
+          await childDelegated;
+          const discovery = await call("list_agents", { expertId: "worker" });
+          const worker = (
+            discovery["agents"] as Array<{
+              agentId: string;
+              activeInvocation: { invocationId: string };
+            }>
+          )[0]!;
+          await call("message_expert", {
+            agentId: worker.agentId,
+            invocationId: worker.activeInvocation.invocationId,
+            message: "message-arrived-before-wait-registration",
+          });
+          markMessageSent();
+          return { outputText: "messenger:done", runtimeSessionId: session.id };
+        }
+        const worker = await call("delegate_expert", {
+          expertId: "worker",
+          task: "worker-work",
+        });
+        const messenger = await call("delegate_expert", {
+          expertId: "messenger",
+          task: "messenger-work",
+        });
+        await call("wait_experts", {
+          invocationIds: [worker["invocationId"], messenger["invocationId"]],
+        });
+        return { outputText: "lead:done", runtimeSessionId: session.id };
+      },
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: runtime.descriptor.id,
+      }),
+    });
+    const members = await Promise.all(
+      ["lead", "worker", "messenger", "child"].map(
+        async (id) =>
+          await defineExpert({
+            id,
+            name: id,
+            description: id,
+            tags: [],
+            scope: "test",
+            workspace: home,
+            pragmaHome: home,
+          }),
+      ),
+    );
+    const team = defineExpertTeam({
+      id: "message-before-wait-team",
+      coordinator: members[0]!,
+      members: members.slice(1),
+      delegation: {
+        permissions: {
+          spawn: { worker: ["child"] },
+          interact: { messenger: ["worker"] },
+        },
+        maxConcurrency: 3,
+      },
+    });
+    const session = await app.experts.createSession(team);
+    const turn = await session.prompt("coordinate", { requestId: "message-before-wait" });
+    await expect(turn.result).resolves.toBe("lead:done");
+    expect(workerQueries).toEqual(
+      expect.arrayContaining([expect.stringContaining("message-arrived-before-wait-registration")]),
+    );
+    await session.close();
+  });
+
+  it("atomically clears Expert Inbox and active bindings when an Execution is cancelled", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-cancel-expert-inbox-"));
+    let markWorkerStarted!: () => void;
+    const workerStarted = new Promise<void>((resolve) => {
+      markWorkerStarted = resolve;
+    });
+    let markMessageAccepted!: () => void;
+    const messageAccepted = new Promise<void>((resolve) => {
+      markMessageAccepted = resolve;
+    });
+    const waitForAbort = async (signal: AbortSignal): Promise<never> =>
+      await new Promise<never>((_resolve, reject) => {
+        const abort = () => reject(signal.reason ?? new Error("cancelled"));
+        signal.addEventListener("abort", abort, { once: true });
+        if (signal.aborted) abort();
+      });
+    const runtime = defineRuntimeDriver<never, FakeSession>({
+      features: createRuntimeTestFeatures({ enabled: ["cancellation", "close"] }),
+      descriptor: { id: "cancel-expert-inbox", kind: "fake", displayName: "Cancel inbox" },
+      createSession: (context) => ({ context, id: `native-${context.systemSessionId}` }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn(session, turn) {
+        if (session.context.agent.id === "worker") {
+          markWorkerStarted();
+          return await waitForAbort(turn.signal);
+        }
+        const execution = session.context.request.executionContext;
+        const call = async (name: string, input: unknown) => {
+          const tool = session.context.agent.tools?.find((candidate) => candidate.name === name);
+          if (tool === undefined) throw new Error(`Missing collaboration tool: ${name}`);
+          const result = await tool.call(input, turn.signal, { execution });
+          if (result.isError === true) throw new Error(result.text);
+          return result.details as Record<string, unknown>;
+        };
+        await call("delegate_expert", { expertId: "worker", task: "worker-work" });
+        await workerStarted;
+        const discovery = await call("list_agents", { expertId: "worker" });
+        const worker = (
+          discovery["agents"] as Array<{
+            agentId: string;
+            activeInvocation: { invocationId: string };
+          }>
+        )[0]!;
+        await call("message_expert", {
+          agentId: worker.agentId,
+          invocationId: worker.activeInvocation.invocationId,
+          message: "must-be-cleared-on-cancel",
+        });
+        markMessageAccepted();
+        return await waitForAbort(turn.signal);
+      },
+      mapEvent: () => ({ events: [] }),
+      cancelTurn: () => undefined,
+      closeSession: () => undefined,
+    });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: runtime.descriptor.id,
+      }),
+    });
+    const [lead, worker] = await Promise.all(
+      ["lead", "worker"].map(
+        async (id) =>
+          await defineExpert({
+            id,
+            name: id,
+            description: id,
+            tags: [],
+            scope: "test",
+            workspace: home,
+            pragmaHome: home,
+          }),
+      ),
+    );
+    const team = defineExpertTeam({
+      id: "cancel-expert-inbox-team",
+      coordinator: lead!,
+      members: [worker!],
+      delegation: { maxConcurrency: 1 },
+    });
+    const session = await app.experts.createSession(team);
+    const turn = await session.prompt("coordinate", { requestId: "cancel-expert-inbox" });
+    await messageAccepted;
+    const cancelled = expect(turn.result).rejects.toThrow();
+    await turn.cancel("cancel inbox test");
+    await cancelled;
+
+    const store = createFileExecutionStore({ pragmaHome: home });
+    expect(await store.listInvocations(turn.executionId)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "cancelled", pendingExpertMessages: [] }),
+      ]),
+    );
+    expect(
+      (await store.listAgents(turn.executionId)).every(
+        (agent) => agent.activeInvocationId === undefined,
+      ),
+    ).toBe(true);
+    await session.close();
+  });
+
+  it("lets permitted team peers steer active work and queue FIFO tasks", async () => {
     const home = await mkdtemp(join(tmpdir(), "pragma-peer-interaction-"));
     let markBackendStarted!: () => void;
     let releaseBackend!: () => void;
@@ -3677,6 +3936,14 @@ describe("Expert lifecycle orchestration", () => {
     });
     const backendReleased = new Promise<void>((resolve) => {
       releaseBackend = resolve;
+    });
+    let markSecondBackendStarted!: () => void;
+    let releaseSecondBackend!: () => void;
+    const secondBackendStarted = new Promise<void>((resolve) => {
+      markSecondBackendStarted = resolve;
+    });
+    const secondBackendReleased = new Promise<void>((resolve) => {
+      releaseSecondBackend = resolve;
     });
     const steers: string[] = [];
     const runtime = defineRuntimeDriver<never, FakeSession>({
@@ -3698,6 +3965,9 @@ describe("Expert lifecycle orchestration", () => {
           if (turn.rawQuery === "backend-work") {
             markBackendStarted();
             await backendReleased;
+          } else if (turn.rawQuery === "verify-peer-guidance") {
+            markSecondBackendStarted();
+            await secondBackendReleased;
           }
           return { outputText: `backend:${turn.rawQuery}`, runtimeSessionId: session.id };
         }
@@ -3715,24 +3985,44 @@ describe("Expert lifecycle orchestration", () => {
             message: "apply-peer-guidance",
           });
           expect(steer).toMatchObject({ outcome: "steered", mode: "runtime" });
-          const followup = await call("followup_expert", {
+          const followup = await call("delegate_expert", {
             agentId: backend.agentId,
-            prompt: "verify-peer-guidance",
+            task: "verify-peer-guidance",
           });
           releaseBackend();
+          await call("wait_experts", {
+            invocationIds: [backend.activeInvocation.invocationId],
+          });
+          await secondBackendStarted;
+          const messageTool = session.context.agent.tools?.find(
+            (candidate) => candidate.name === "message_expert",
+          );
+          if (messageTool === undefined) throw new Error("Missing message_expert tool");
+          const stale = await messageTool.call(
+            {
+              agentId: backend.agentId,
+              invocationId: backend.activeInvocation.invocationId,
+              message: "must-not-enter-the-next-invocation",
+            },
+            turn.signal,
+            { execution },
+          );
+          expect(stale.isError).toBe(true);
+          expect(stale.text).toContain("stale_invocation");
+          releaseSecondBackend();
           const waited = await call("wait_experts", {
-            invocationIds: [backend.activeInvocation.invocationId, followup["invocationId"]],
+            invocationIds: [followup["invocationId"]],
           });
           return { outputText: `frontend:${JSON.stringify(waited)}`, runtimeSessionId: session.id };
         }
-        const backend = await call("spawn_expert", {
+        const backend = await call("delegate_expert", {
           expertId: "backend",
-          prompt: "backend-work",
+          task: "backend-work",
         });
         await backendStarted;
-        const frontend = await call("spawn_expert", {
+        const frontend = await call("delegate_expert", {
           expertId: "frontend",
-          prompt: "frontend-work",
+          task: "frontend-work",
         });
         await call("wait_experts", {
           invocationIds: [backend["invocationId"], frontend["invocationId"]],
@@ -3780,15 +4070,194 @@ describe("Expert lifecycle orchestration", () => {
     expect(steers).toEqual(["apply-peer-guidance"]);
     const events = await turn.listEvents({ scope: { kind: "all" }, limit: 1_000 });
     expect(events.items.map((event) => event.type)).toEqual(
-      expect.arrayContaining([
-        "agent.steer.requested",
-        "agent.steer.applied",
-        "agent.followup.queued",
-      ]),
+      expect.arrayContaining(["agent.steer.requested", "agent.steer.applied", "agent.delegated"]),
     );
     expect(events.items.find((event) => event.type === "agent.steer.applied")?.data).toMatchObject({
       content: "apply-peer-guidance",
     });
+    await session.close();
+  });
+
+  it("rejects a delegation that would close the Join and FIFO wait graph", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-wait-cycle-"));
+    let cycleError = "";
+    const runtime = defineRuntimeDriver<never, FakeSession>({
+      features: createRuntimeTestFeatures({ enabled: ["close"] }),
+      descriptor: { id: "wait-cycle", kind: "fake", displayName: "Wait cycle" },
+      createSession: (context) => ({ context, id: `native-${context.systemSessionId}` }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn(session, turn) {
+        const expertId = session.context.agent.id;
+        if (turn.rawQuery.startsWith("[Pragma orchestration continuation]")) {
+          return { outputText: `${expertId}:continued`, runtimeSessionId: session.id };
+        }
+        const execution = session.context.request.executionContext;
+        const tool = (name: string) => {
+          const candidate = session.context.agent.tools?.find((item) => item.name === name);
+          if (candidate === undefined) throw new Error(`Missing collaboration tool: ${name}`);
+          return candidate;
+        };
+        const call = async (name: string, input: unknown) => {
+          const result = await tool(name).call(input, turn.signal, { execution });
+          if (result.isError === true) throw new Error(result.text);
+          return result.details as Record<string, unknown>;
+        };
+        if (expertId === "lead") {
+          const delegated = await call("delegate_expert", { expertId: "member-a", task: "a" });
+          await call("wait_experts", { invocationIds: [delegated["invocationId"]] });
+        } else if (expertId === "member-a") {
+          const delegated = await call("delegate_expert", { expertId: "member-b", task: "b" });
+          await call("wait_experts", { invocationIds: [delegated["invocationId"]] });
+        } else {
+          const discovery = await call("list_agents", { expertId: "member-a" });
+          const target = (discovery["agents"] as Array<{ agentId: string }>)[0]!;
+          const result = await tool("delegate_expert").call(
+            { agentId: target.agentId, task: "cycle" },
+            turn.signal,
+            { execution },
+          );
+          cycleError = result.text;
+          expect(result.isError).toBe(true);
+        }
+        return { outputText: `${expertId}:done`, runtimeSessionId: session.id };
+      },
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: runtime.descriptor.id,
+      }),
+    });
+    const defineMember = async (id: string) =>
+      await defineExpert({
+        id,
+        name: id,
+        description: id,
+        tags: [],
+        scope: "test",
+        workspace: home,
+        pragmaHome: home,
+      });
+    const [lead, memberA, memberB] = await Promise.all(
+      ["lead", "member-a", "member-b"].map(defineMember),
+    );
+    const team = defineExpertTeam({
+      id: "wait-cycle-team",
+      coordinator: lead!,
+      members: [memberA!, memberB!],
+      delegation: {
+        permissions: {
+          spawn: { "member-a": ["member-b"] },
+          interact: { "member-b": ["member-a"] },
+        },
+        maxConcurrency: 2,
+      },
+    });
+
+    const session = await app.experts.createSession(team);
+    const turn = await session.prompt("coordinate", { requestId: "wait-cycle" });
+    await expect(turn.result).resolves.toBe("lead:done");
+    expect(cycleError).toContain("expert_wait_cycle");
+    await session.close();
+  });
+
+  it("revalidates the wait graph after concurrent delegation version conflicts", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-concurrent-wait-cycle-"));
+    const crossDelegationBarrier = createBarrier(2, 5_000);
+    const crossResults: Array<{ isError: boolean | undefined; text: string }> = [];
+    const runtime = defineRuntimeDriver<never, FakeSession>({
+      features: createRuntimeTestFeatures({ enabled: ["close"] }),
+      descriptor: {
+        id: "concurrent-wait-cycle",
+        kind: "fake",
+        displayName: "Concurrent wait cycle",
+      },
+      createSession: (context) => ({ context, id: `native-${context.systemSessionId}` }),
+      readSession: (session) => ({ runtimeSessionId: session.id }),
+      async startTurn(session, turn) {
+        const expertId = session.context.agent.id;
+        const execution = session.context.request.executionContext;
+        const tool = (name: string) => {
+          const candidate = session.context.agent.tools?.find((item) => item.name === name);
+          if (candidate === undefined) throw new Error(`Missing collaboration tool: ${name}`);
+          return candidate;
+        };
+        const call = async (name: string, input: unknown) => {
+          const result = await tool(name).call(input, turn.signal, { execution });
+          if (result.isError === true) throw new Error(result.text);
+          return result.details as Record<string, unknown>;
+        };
+        if (expertId === "lead") {
+          const first = await call("delegate_expert", { expertId: "member-a", task: "cross" });
+          const second = await call("delegate_expert", { expertId: "member-b", task: "cross" });
+          await call("wait_experts", {
+            invocationIds: [first["invocationId"], second["invocationId"]],
+          });
+          return { outputText: "lead:done", runtimeSessionId: session.id };
+        }
+        if (turn.rawQuery === "cross") {
+          await crossDelegationBarrier.arriveAndWait();
+          const targetExpertId = expertId === "member-a" ? "member-b" : "member-a";
+          const discovery = await call("list_agents", { expertId: targetExpertId });
+          const target = (discovery["agents"] as Array<{ agentId: string }>)[0]!;
+          const result = await tool("delegate_expert").call(
+            { agentId: target.agentId, task: `queued-by-${expertId}` },
+            turn.signal,
+            { execution },
+          );
+          crossResults.push({ isError: result.isError, text: result.text });
+        }
+        return { outputText: `${expertId}:done`, runtimeSessionId: session.id };
+      },
+      mapEvent: () => ({ events: [] }),
+      closeSession: () => undefined,
+    });
+    const app = createPragma({
+      pragmaHome: home,
+      runtimes: createStaticRuntimeResolver({
+        runtimes: [runtime],
+        defaultRuntimeId: runtime.descriptor.id,
+      }),
+    });
+    const [lead, memberA, memberB] = await Promise.all(
+      ["lead", "member-a", "member-b"].map(
+        async (id) =>
+          await defineExpert({
+            id,
+            name: id,
+            description: id,
+            tags: [],
+            scope: "test",
+            workspace: home,
+            pragmaHome: home,
+          }),
+      ),
+    );
+    const team = defineExpertTeam({
+      id: "concurrent-wait-cycle-team",
+      coordinator: lead!,
+      members: [memberA!, memberB!],
+      delegation: {
+        permissions: {
+          interact: {
+            "member-a": ["member-b"],
+            "member-b": ["member-a"],
+          },
+        },
+        maxConcurrency: 2,
+      },
+    });
+    const session = await app.experts.createSession(team);
+    const turn = await session.prompt("coordinate", { requestId: "concurrent-wait-cycle" });
+    await expect(turn.result).resolves.toBe("lead:done");
+    expect(crossResults).toHaveLength(2);
+    expect(crossResults.filter((result) => result.isError === true)).toHaveLength(1);
+    expect(crossResults.find((result) => result.isError === true)?.text).toContain(
+      "expert_wait_cycle",
+    );
     await session.close();
   });
 
@@ -3848,8 +4317,8 @@ describe("Expert lifecycle orchestration", () => {
           if (result.isError === true) throw new Error(result.text);
           return result.details as Record<string, unknown>;
         };
-        const first = await call("spawn_expert", { expertId: "member-a", prompt: "first" });
-        const second = await call("spawn_expert", { expertId: "member-b", prompt: "second" });
+        const first = await call("delegate_expert", { expertId: "member-a", task: "first" });
+        const second = await call("delegate_expert", { expertId: "member-b", task: "second" });
         await call("wait_experts", {
           invocationIds: [first["invocationId"], second["invocationId"]],
         });
@@ -4072,10 +4541,10 @@ describe("Expert delegation declarations", () => {
       runtimeByExpert: { [expert.id]: "fake" },
     });
     expect(launcher.tools.map((tool) => tool.name)).toEqual([
-      "spawn_expert",
+      "delegate_expert",
       "wait_experts",
       "list_agents",
-      "followup_expert",
+      "message_expert",
       "steer_expert",
       "interrupt_expert",
     ]);
@@ -4402,15 +4871,30 @@ function sessionRootContext(
 }
 
 async function waitForHumanRequest(
-  execution: Pick<FlowExecution, "listEvents">,
+  execution: Pick<FlowExecution, "listEvents" | "result">,
   index: number,
 ): Promise<ExecutionEvent> {
   let requested: ExecutionEvent | undefined;
-  await waitUntil(async () => {
-    requested = (await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 })).items.filter(
-      (event) => event.type === "human.requested",
-    )[index];
-    return requested !== undefined;
-  });
+  try {
+    await Promise.race([
+      waitUntil(async () => {
+        requested = (
+          await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 })
+        ).items.filter((event) => event.type === "human.requested")[index];
+        return requested !== undefined;
+      }),
+      execution.result.then(() => {
+        throw new Error("Flow completed before the expected human request.");
+      }),
+    ]);
+  } catch (error) {
+    const events = await execution.listEvents({ scope: { kind: "all" }, limit: 1_000 });
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)} Events: ${events.items
+        .map((event) => event.type)
+        .join(", ")}`,
+      { cause: error },
+    );
+  }
   return requested!;
 }

--- a/packages/core/test/expert-orchestrator-recovery.test.ts
+++ b/packages/core/test/expert-orchestrator-recovery.test.ts
@@ -1,0 +1,224 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineExpert } from "../src/agent/expert-agent.ts";
+import { ExpertOrchestrator } from "../src/execution/expert-orchestrator.ts";
+import { createFileExecutionStore } from "../src/execution/execution-store.ts";
+
+const temporaryRoots: string[] = [];
+const now = "2026-08-22T08:00:00.000Z";
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map(async (root) => {
+      await rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("ExpertOrchestrator recovery", () => {
+  it("retains accepted messages until the delivered batch is acknowledged", async () => {
+    const home = await temporaryRoot("pragma-message-handoff-");
+    const store = createFileExecutionStore({ pragmaHome: home });
+    const messages = [
+      expertMessage("00000000-0000-4000-8000-000000000001", "first"),
+      expertMessage("00000000-0000-4000-8000-000000000002", "second"),
+    ];
+    await store.create(executionRecord("message-execution"), {
+      ...invocationRecord(),
+      status: "running",
+      pendingExpertMessages: messages,
+    });
+    const orchestrator = createOrchestrator(store, "message-execution");
+
+    await expect(orchestrator.readPendingMessages("root")).resolves.toEqual(messages);
+    await expect(store.getInvocation("message-execution", "root")).resolves.toMatchObject({
+      pendingExpertMessages: messages,
+    });
+
+    await orchestrator.acknowledgePendingMessages("root", [messages[0]!.messageId]);
+
+    await expect(store.getInvocation("message-execution", "root")).resolves.toMatchObject({
+      pendingExpertMessages: [messages[1]],
+    });
+    await expect(store.readEvents("message-execution")).resolves.toEqual([
+      expect.objectContaining({
+        type: "expert.message.consumed",
+        data: { messageIds: [messages[0]!.messageId] },
+      }),
+    ]);
+  });
+
+  it("rebinds a recovered active Invocation even after its original activation was committed", async () => {
+    const home = await temporaryRoot("pragma-agent-reactivation-");
+    const store = createFileExecutionStore({ pragmaHome: home });
+    await store.create(executionRecord("recovery-execution"), {
+      ...invocationRecord(),
+      agentId: "agent",
+      agentTaskSequence: 1,
+    });
+    await store.commit({
+      commitId: "seed-recovery-agent",
+      executionId: "recovery-execution",
+      contextPuts: [runtimeContext("recovery-execution")],
+      agentPuts: [agentRecord("recovery-execution")],
+    });
+    await store.commit({
+      commitId: "agent-activated:root",
+      executionId: "recovery-execution",
+      agentPatches: [{ agentId: "agent", patch: { activeInvocationId: "root" } }],
+      events: [{ invocationId: "root", type: "agent.task.activated", data: { agentId: "agent" } }],
+    });
+
+    let resolveExecuted!: () => void;
+    const executed = new Promise<void>((resolve) => {
+      resolveExecuted = resolve;
+    });
+    const orchestrator = createOrchestrator(store, "recovery-execution", async ({ agent }) => {
+      expect(agent.activeInvocationId).toBe("root");
+      await store.commit({
+        commitId: "test-recovered-execution-completed",
+        executionId: "recovery-execution",
+        invocationPatches: [
+          { invocationId: "root", patch: { status: "waiting", waitReason: "experts" } },
+        ],
+      });
+      resolveExecuted();
+    });
+    const expert = await defineExpert({
+      id: "worker",
+      name: "Worker",
+      description: "Worker",
+      tags: [],
+      scope: "test",
+      workspace: home,
+      pragmaHome: home,
+    });
+
+    await orchestrator.registerExperts([expert]);
+    await executed;
+    await waitUntil(async () =>
+      (await store.readEvents("recovery-execution")).some(
+        (event) => event.type === "agent.task.released",
+      ),
+    );
+
+    await expect(store.getInvocation("recovery-execution", "root")).resolves.toMatchObject({
+      status: "waiting",
+    });
+    expect(
+      (await store.readEvents("recovery-execution")).filter(
+        (event) => event.type === "agent.task.activated",
+      ),
+    ).toHaveLength(2);
+  });
+});
+
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function createOrchestrator(
+  store: ReturnType<typeof createFileExecutionStore>,
+  executionId: string,
+  execute: ConstructorParameters<typeof ExpertOrchestrator>[0]["execute"] = async () => undefined,
+): ExpertOrchestrator {
+  return new ExpertOrchestrator({
+    executionId,
+    rootInvocationId: "root",
+    scopeInvocationId: "root",
+    store,
+    maxConcurrency: 1,
+    maxDepth: 3,
+    interruptController: {
+      interruptInvocation: async () => false,
+      signalForInvocation: () => new AbortController().signal,
+      steerInvocation: async () => "not_active",
+    },
+    execute,
+  });
+}
+
+function executionRecord(executionId: string) {
+  return {
+    schemaVersion: "pragma.execution/v10" as const,
+    executionId,
+    version: 0,
+    kind: "expert-turn" as const,
+    definition: { id: "worker", kind: "expert" as const },
+    rootInvocationId: "root",
+    status: "running" as const,
+    input: "work",
+    state: {},
+    lastAppliedSequence: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function invocationRecord() {
+  return {
+    invocationId: "root",
+    rootInvocationId: "root",
+    definition: { id: "worker", kind: "expert" as const },
+    executorId: "worker",
+    contextId: "context",
+    status: "queued" as const,
+    pendingExpertMessages: [],
+    input: "work",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function expertMessage(messageId: string, content: string) {
+  return {
+    messageId,
+    senderInvocationId: "sender",
+    content,
+    createdAt: now,
+  };
+}
+
+function runtimeContext(executionId: string) {
+  return {
+    schemaVersion: "pragma.runtime-context/v5" as const,
+    contextId: "context",
+    owner: { type: "flow-execution" as const, ownerId: executionId },
+    origin: { type: "invocation" as const, invocationId: "root" },
+    expert: { id: "worker" },
+    runtime: { runtimeId: "fake", revision: 1, fingerprint: "a".repeat(64) },
+    lifecycle: "open" as const,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function agentRecord(executionId: string) {
+  return {
+    schemaVersion: "pragma.agent-instance/v2" as const,
+    agentId: "agent",
+    executionId,
+    ownerContextId: "owner-context",
+    createdByInvocationId: "root",
+    definition: { id: "worker", kind: "expert" as const },
+    contextId: "context",
+    lifecycle: "open" as const,
+    nextTaskSequence: 2,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function waitUntil(predicate: () => Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!(await predicate())) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for test condition.");
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/core/test/expert-session-transaction-migration.test.ts
+++ b/packages/core/test/expert-session-transaction-migration.test.ts
@@ -1,0 +1,99 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFileExecutionStore } from "../src/execution/execution-store.ts";
+import { createFileExpertSessionStore } from "../src/execution/expert-session-store.ts";
+import { PragmaPaths } from "../src/storage/pragma-paths.ts";
+import { expertSessionTransactionMigrationChain } from "../src/storage/migrations/expert-session-transaction/index.ts";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map(async (root) => {
+      await rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("ExpertSession transaction migration", () => {
+  it("upgrades a historical v8 transaction fixture to v9", async () => {
+    const fixture = await readFixture("expert-session-transaction-v8.json");
+
+    const upgraded = expertSessionTransactionMigrationChain.upgrade(fixture);
+
+    expect(upgraded).toMatchObject({ fromVersion: 8, toVersion: 9, migrated: true });
+    expect(upgraded.value).toMatchObject({
+      schemaVersion: "pragma.expert-session-transaction/v9",
+      execution: { schemaVersion: "pragma.execution/v10" },
+      rootInvocation: { pendingExpertMessages: [] },
+    });
+  });
+
+  it("chains a historical v6 transaction through every supported migration", async () => {
+    const fixture = await readFixture("expert-session-transaction-v6.json");
+
+    expect(expertSessionTransactionMigrationChain.upgrade(fixture)).toMatchObject({
+      fromVersion: 6,
+      toVersion: 9,
+      migrated: true,
+      value: { schemaVersion: "pragma.expert-session-transaction/v9" },
+    });
+  });
+
+  it("treats current v9 state as a no-op and rejects future state", async () => {
+    const fixture = await readFixture("expert-session-transaction-v8.json");
+    const current = expertSessionTransactionMigrationChain.upgrade(fixture).value;
+
+    expect(expertSessionTransactionMigrationChain.upgrade(current)).toMatchObject({
+      fromVersion: 9,
+      toVersion: 9,
+      migrated: false,
+    });
+    expect(() =>
+      expertSessionTransactionMigrationChain.upgrade({
+        ...current,
+        schemaVersion: "pragma.expert-session-transaction/v10",
+      }),
+    ).toThrow(
+      "pragma.expert-session-transaction/v10 is newer than the supported pragma.expert-session-transaction/v9",
+    );
+  });
+
+  it("upgrades and replays an unfinished historical v8 transaction journal", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pragma-session-transaction-v8-"));
+    temporaryRoots.push(home);
+    const paths = new PragmaPaths({ pragmaHome: home });
+    const transactionPath = paths.expertSessionTransaction("historical-session");
+    await mkdir(dirname(transactionPath), { recursive: true });
+    await writeFile(
+      transactionPath,
+      `${JSON.stringify(await readFixture("expert-session-transaction-v8.json"))}\n`,
+      "utf8",
+    );
+    const executions = createFileExecutionStore({ pragmaHome: home });
+    const sessions = createFileExpertSessionStore({ executions, pragmaHome: home });
+
+    await expect(sessions.get("historical-session")).resolves.toMatchObject({
+      sessionId: "historical-session",
+      activeExecutionId: "historical-execution",
+    });
+    await expect(executions.get("historical-execution")).resolves.toMatchObject({
+      schemaVersion: "pragma.execution/v10",
+    });
+    await expect(
+      executions.getInvocation("historical-execution", "historical-execution"),
+    ).resolves.toMatchObject({ pendingExpertMessages: [] });
+    await expect(readFile(transactionPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+async function readFixture(name: string): Promise<unknown> {
+  return JSON.parse(
+    await readFile(fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url)), "utf8"),
+  ) as unknown;
+}

--- a/packages/core/test/fixtures/execution-transaction-v10.json
+++ b/packages/core/test/fixtures/execution-transaction-v10.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "pragma.execution-transaction/v10",
+  "commitId": "historical-v10-commit",
+  "signature": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "execution": {
+    "schemaVersion": "pragma.execution/v9",
+    "executionId": "journal-v10-run",
+    "version": 1,
+    "kind": "expert-turn",
+    "definition": { "id": "expert", "kind": "expert" },
+    "rootInvocationId": "root",
+    "status": "succeeded",
+    "input": "hello",
+    "state": {},
+    "output": { "type": "inline", "value": "journal-v10-result" },
+    "lastAppliedSequence": 0,
+    "createdAt": "2026-07-23T08:00:00.000Z",
+    "updatedAt": "2026-07-23T08:00:00.000Z"
+  },
+  "invocations": [
+    {
+      "invocationId": "root",
+      "rootInvocationId": "root",
+      "definition": { "id": "expert", "kind": "expert" },
+      "executorId": "expert",
+      "contextId": "context",
+      "status": "succeeded",
+      "input": "hello",
+      "output": { "type": "inline", "value": "journal-v10-result" },
+      "createdAt": "2026-07-23T08:00:00.000Z",
+      "updatedAt": "2026-07-23T08:00:00.000Z"
+    }
+  ],
+  "agents": [],
+  "contexts": [],
+  "events": [],
+  "eventIds": []
+}

--- a/packages/core/test/fixtures/execution-v9.json
+++ b/packages/core/test/fixtures/execution-v9.json
@@ -1,0 +1,42 @@
+{
+  "execution": {
+    "schemaVersion": "pragma.execution/v9",
+    "executionId": "v9-run",
+    "version": 4,
+    "kind": "expert-turn",
+    "definition": { "id": "expert", "kind": "expert" },
+    "rootInvocationId": "root",
+    "status": "waiting",
+    "input": "hello",
+    "state": { "fixtureSource": "pragma.execution/v9" },
+    "usage": {
+      "measurement": "reported",
+      "input": 10,
+      "output": 2,
+      "cacheRead": 1,
+      "cacheWrite": 0,
+      "totalTokens": 13,
+      "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "total": 0 }
+    },
+    "lastAppliedSequence": 0,
+    "createdAt": "2026-07-23T08:00:00.000Z",
+    "updatedAt": "2026-07-23T08:00:00.000Z"
+  },
+  "invocations": [
+    {
+      "invocationId": "root",
+      "rootInvocationId": "root",
+      "definition": { "id": "expert", "kind": "expert" },
+      "executorId": "expert",
+      "contextId": "context",
+      "status": "waiting",
+      "input": "hello",
+      "createdAt": "2026-07-23T08:00:00.000Z",
+      "updatedAt": "2026-07-23T08:00:00.000Z"
+    }
+  ],
+  "agents": [],
+  "contexts": [],
+  "commits": [],
+  "events": []
+}

--- a/packages/core/test/fixtures/expert-session-transaction-v6.json
+++ b/packages/core/test/fixtures/expert-session-transaction-v6.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": "pragma.expert-session-transaction/v6",
+  "session": {
+    "schemaVersion": "pragma.expert-session/v5",
+    "sessionId": "historical-chain-session",
+    "expertId": "expert",
+    "definitionFingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "status": "open",
+    "queuedRequestIds": [],
+    "executionIds": [],
+    "rootContextId": "context",
+    "contexts": {
+      "context": {
+        "schemaVersion": "pragma.runtime-context/v5",
+        "contextId": "context",
+        "owner": { "type": "expert-session", "ownerId": "historical-chain-session" },
+        "origin": { "type": "expert-session", "sessionId": "historical-chain-session" },
+        "expert": { "id": "expert" },
+        "runtime": {
+          "runtimeId": "fake",
+          "revision": 1,
+          "fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "lifecycle": "open",
+        "createdAt": "2026-06-01T08:00:00.000Z",
+        "updatedAt": "2026-06-01T08:00:00.000Z"
+      }
+    },
+    "createdAt": "2026-06-01T08:00:00.000Z",
+    "updatedAt": "2026-06-01T08:00:00.000Z"
+  },
+  "prompts": [],
+  "events": []
+}

--- a/packages/core/test/fixtures/expert-session-transaction-v8.json
+++ b/packages/core/test/fixtures/expert-session-transaction-v8.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "pragma.expert-session-transaction/v8",
+  "session": {
+    "schemaVersion": "pragma.expert-session/v5",
+    "sessionId": "historical-session",
+    "expertId": "expert",
+    "definitionFingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "status": "open",
+    "activeExecutionId": "historical-execution",
+    "queuedRequestIds": [],
+    "executionIds": ["historical-execution"],
+    "rootContextId": "context",
+    "contexts": {
+      "context": {
+        "schemaVersion": "pragma.runtime-context/v5",
+        "contextId": "context",
+        "owner": { "type": "expert-session", "ownerId": "historical-session" },
+        "origin": { "type": "expert-session", "sessionId": "historical-session" },
+        "expert": { "id": "expert" },
+        "runtime": {
+          "runtimeId": "fake",
+          "revision": 1,
+          "fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "lifecycle": "open",
+        "createdAt": "2026-08-01T08:00:00.000Z",
+        "updatedAt": "2026-08-01T08:00:00.000Z"
+      }
+    },
+    "createdAt": "2026-08-01T08:00:00.000Z",
+    "updatedAt": "2026-08-01T08:00:00.000Z"
+  },
+  "prompts": [],
+  "events": [],
+  "execution": {
+    "schemaVersion": "pragma.execution/v9",
+    "executionId": "historical-execution",
+    "version": 0,
+    "kind": "expert-turn",
+    "definition": { "id": "expert", "kind": "expert" },
+    "rootInvocationId": "historical-execution",
+    "status": "queued",
+    "input": "historical prompt",
+    "state": {},
+    "lastAppliedSequence": 0,
+    "createdAt": "2026-08-01T08:00:00.000Z",
+    "updatedAt": "2026-08-01T08:00:00.000Z"
+  },
+  "rootInvocation": {
+    "invocationId": "historical-execution",
+    "rootInvocationId": "historical-execution",
+    "definition": { "id": "expert", "kind": "expert" },
+    "executorId": "expert",
+    "contextId": "context",
+    "status": "queued",
+    "input": "historical prompt",
+    "createdAt": "2026-08-01T08:00:00.000Z",
+    "updatedAt": "2026-08-01T08:00:00.000Z"
+  }
+}

--- a/packages/core/test/human-interaction-recovery.test.ts
+++ b/packages/core/test/human-interaction-recovery.test.ts
@@ -200,7 +200,7 @@ describe("ExpertSession human interaction recovery", () => {
     });
     await executions.create(
       {
-        schemaVersion: "pragma.execution/v9",
+        schemaVersion: "pragma.execution/v10",
         executionId,
         version: 0,
         kind: "expert-turn",
@@ -220,6 +220,7 @@ describe("ExpertSession human interaction recovery", () => {
         executorId: expert.id,
         contextId,
         status: "running",
+        pendingExpertMessages: [],
         input: "Continue after the human response.",
         createdAt: now,
         updatedAt: now,

--- a/packages/memory/test/memory-plane.test.ts
+++ b/packages/memory/test/memory-plane.test.ts
@@ -516,7 +516,7 @@ async function createExecution(store: ReturnType<typeof createFileExecutionStore
   const timestamp = new Date().toISOString();
   const definition = { id: "flow", kind: "flow" as const };
   const execution: ExecutionRecord = {
-    schemaVersion: "pragma.execution/v9",
+    schemaVersion: "pragma.execution/v10",
     executionId: "execution",
     version: 0,
     kind: "flow",
@@ -535,6 +535,7 @@ async function createExecution(store: ReturnType<typeof createFileExecutionStore
     contextId: "root-context",
     definition,
     status: "running",
+    pendingExpertMessages: [],
     input: null,
     createdAt: timestamp,
     updatedAt: timestamp,

--- a/packages/runtime/codex/src/session.ts
+++ b/packages/runtime/codex/src/session.ts
@@ -567,9 +567,9 @@ function readAgentCommand(
 function readAgentCommandDelivery(
   toolName: string | undefined,
   item: Record<string, unknown> | undefined,
-): "followup" | "steer" | undefined {
+): "followup" | "message" | "steer" | undefined {
   const segment = toolName?.split(/[./:]/u).at(-1);
-  if (segment === "followup_expert") return "followup";
+  if (segment === "message_expert") return "message";
   if (segment === "steer_expert") return "steer";
   if (segment === "sendInput") {
     if (item?.["interrupt"] === true) return "steer";
@@ -586,6 +586,7 @@ function readAgentCommandAction(
   switch (segment) {
     case "spawnAgent":
     case "spawn_agent":
+    case "delegate_expert":
       return "spawn";
     case "wait":
     case "wait_agent":
@@ -596,7 +597,7 @@ function readAgentCommandAction(
       return "list";
     case "sendInput":
     case "send_message":
-    case "followup_expert":
+    case "message_expert":
     case "steer_expert":
       return "send";
     case "resumeAgent":

--- a/packages/runtime/codex/test/session.test.ts
+++ b/packages/runtime/codex/test/session.test.ts
@@ -622,7 +622,7 @@ describe("Codex tool event mapping", () => {
   });
 
   it.each([
-    ["followup_expert", undefined, "followup"],
+    ["message_expert", undefined, "message"],
     ["steer_expert", undefined, "steer"],
     ["sendInput", false, "followup"],
     ["sendInput", true, "steer"],

--- a/packages/shared/src/execution/execution.schema.ts
+++ b/packages/shared/src/execution/execution.schema.ts
@@ -117,6 +117,16 @@ export const ContextResolutionRecordSchema = z.object({
   disposition: z.enum(["created", "reused"]),
 });
 
+export const InvocationExpertMessageSchema = z.object({
+  messageId: z.string().uuid(),
+  senderInvocationId: z.string().min(1),
+  senderAgentId: z.string().min(1).optional(),
+  content: z.string().min(1),
+  createdAt: z.string().datetime(),
+});
+
+export const InvocationWaitReasonSchema = z.enum(["experts", "human_input"]);
+
 export const InvocationSchema = z.object({
   invocationId: z.string().min(1),
   rootInvocationId: z.string().min(1),
@@ -129,6 +139,8 @@ export const InvocationSchema = z.object({
   contextId: z.string().min(1),
   contextResolution: ContextResolutionRecordSchema.optional(),
   status: ExecutionStatusSchema,
+  waitReason: InvocationWaitReasonSchema.optional(),
+  pendingExpertMessages: z.array(InvocationExpertMessageSchema).default([]),
   input: z.unknown(),
   output: z.unknown().optional(),
   usage: AgentMessageUsageSchema.optional(),
@@ -205,7 +217,7 @@ export const ExecutionOutputItemSchema = z.object({
 });
 
 export const ExecutionRecordSchema = z.object({
-  schemaVersion: z.literal("pragma.execution/v9"),
+  schemaVersion: z.literal("pragma.execution/v10"),
   executionId: z.string().min(1),
   version: z.number().int().nonnegative(),
   kind: ExecutionKindSchema,
@@ -238,6 +250,8 @@ export type RuntimeContextOrigin = z.infer<typeof RuntimeContextOriginSchema>;
 export type RuntimeContextRecord = z.infer<typeof RuntimeContextRecordSchema>;
 export type RuntimeEnvironmentBinding = z.infer<typeof RuntimeEnvironmentBindingSchema>;
 export type ContextResolutionRecord = z.infer<typeof ContextResolutionRecordSchema>;
+export type InvocationExpertMessage = z.infer<typeof InvocationExpertMessageSchema>;
+export type InvocationWaitReason = z.infer<typeof InvocationWaitReasonSchema>;
 export type Invocation = z.infer<typeof InvocationSchema>;
 export type AgentInstance = z.infer<typeof AgentInstanceSchema>;
 export type ExecutionCursor = z.infer<typeof ExecutionCursorSchema>;

--- a/packages/shared/src/stream-event.schema.ts
+++ b/packages/shared/src/stream-event.schema.ts
@@ -189,7 +189,7 @@ export const ExpertAgentCommandEventSchema = ExpertAgentStreamEventBaseSchema.ex
   payload: z.object({
     commandId: z.string().min(1),
     action: z.enum(["spawn", "wait", "list", "send", "resume", "interrupt"]),
-    delivery: z.enum(["followup", "steer"]).optional(),
+    delivery: z.enum(["followup", "message", "steer"]).optional(),
     phase: z.enum(["started", "completed", "failed"]),
     senderSessionId: z.string().min(1).optional(),
     targetSessionIds: z.array(z.string().min(1)).default([]),


### PR DESCRIPTION
## Summary

- replace spawn/followup expert semantics with six focused lifecycle tools
- separate task delegation from invocation-scoped messaging and enforce acyclic join/FIFO wait dependencies
- persist and recover expert inbox messages with deterministic safe-boundary continuation
- make interrupt, cancellation, recovery, and terminal cleanup atomic with active-invocation state
- upgrade execution and transaction schemas with frozen historical schemas, migrations, fixtures, and journal replay coverage
- expose expert vs human-input wait reasons consistently in Desktop and documentation

## Breaking changes

- remove spawn_expert and followup_expert without compatibility aliases
- require agentId and invocationId for message_expert and steer_expert

## Verification

- pnpm check
- pnpm --filter @pragma/core test (296 tests)
- pnpm --filter @pragma/desktop test (873 tests)
- pnpm --filter @pragma/shared test
- pnpm --filter @pragma/runtime-codex test
- pnpm --filter @pragma/memory test
- pnpm --filter @pragma/examples test
- pnpm build
- changed-files Prettier check
- git diff --check

The implementation also received a focused concurrency/recovery code review. Race conditions around message-before-wait, message-vs-terminal commit, human response recovery, and concurrent cycle creation are covered by regression tests.